### PR TITLE
Enhance order submission with fallback mecanism

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,19 @@ services:
   ##################################
   # TRADING-APP (nouvelle application)
   ##################################
+  redis:
+    image: redis:7-alpine
+    container_name: trading_app_redis
+    command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    volumes:
+      - trading-app-redis-data:/data
+    ports:
+      - "6379:6379"
+    networks:
+      - trading-app-net
+      - shared-net
+    restart: unless-stopped
+
   trading-app-php:
     build:
       context: ./trading-app
@@ -335,6 +348,40 @@ services:
         composer install --no-dev --optimize-autoloader --no-interaction; \
       fi; php-fpm"
 
+  trading-app-messenger:
+    build:
+      context: ./trading-app
+      dockerfile: Dockerfile.mtf
+    container_name: trading_app_messenger
+    working_dir: /var/www/html
+    volumes:
+      - ./trading-app:/var/www/html
+      - ./trading-app/php/conf.d:/usr/local/etc/php/conf.d
+    environment:
+      <<: *global-env
+      DATABASE_URL: ${TRADING_APP_DATABASE_URL:-postgresql://postgres:password@trading-app-db:5432/trading_app?serverVersion=15&charset=utf8}
+      LOCK_DSN: postgresql://postgres:password@trading-app-db:5432/trading_app
+      APP_SECRET: d278711c5ab89bfbda10dd7d29427cf6
+      MESSENGER_TRANSPORT_DSN: redis://redis:6379/log-messages
+      WS_WORKER_SHARED_SECRET: ${WS_WORKER_SHARED_SECRET:-change-me}
+      BITMART_PUBLIC_API_URL: ${BITMART_PUBLIC_API_URL}
+    depends_on:
+      trading-app-php:
+        condition: service_started
+      trading-app-db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - trading-app-net
+      - shared-net
+    command: >-
+      sh -c "if [ ! -f vendor/autoload.php ]; then \
+        echo '[trading-app-messenger] vendor missing -> composer install'; \
+        composer install --no-dev --optimize-autoloader --no-interaction; \
+      fi; php bin/console messenger:consume order_timeout --time-limit=0 --sleep=1 --failure-limit=5"
+    restart: unless-stopped
+
   trading-app-nginx:
     image: nginx:latest
     container_name: trading_app_nginx
@@ -374,6 +421,7 @@ services:
 volumes:
 #  mysql-data:
   trading-app-postgres-data:
+  trading-app-redis-data:
 
 networks:
   frontend-net:

--- a/trading-app/README.md
+++ b/trading-app/README.md
@@ -98,6 +98,15 @@ L'application suit une architecture hexagonale avec :
 - [ ] Interface web
 - [ ] Tests unitaires
 
+## ⚙️ Exécution des ordres
+
+- Entrée maker par défaut : les plans LIMIT sont envoyés en `mode=4` (post-only) pour tenter une exécution maker.
+- Fallback automatique : si Bitmart rejette la soumission maker, la même intention est renvoyée immédiatement en ordre `market` (taker) avec le même `client_order_id`.
+- Timeout de 2 minutes : chaque ordre accepté programme une annulation différée via Messenger (`CancelOrderMessage`), afin d'éviter les LIMIT qui stagnent.
+- TP/SL préconfigurés : les prix `preset_*` (stop loss / take profit) sont envoyés autant pour le maker initial que pour le fallback taker, garantissant la couverture dès le fill.
+- Transport Messenger : un container `trading-app-messenger` lance `php bin/console messenger:consume order_timeout` en continu (s'appuie sur le service `redis` embarqué). Si vous faites tourner l'app sans Docker, exécutez la même commande manuellement.
+- Logs utiles : `execution.order_attempt_failed`, `execution.timeout_scheduled`, `trade_entry.timeout.cancel_attempt` documentent les étapes maker → taker et l'annulation différée.
+
 ## 🔧 Développement
 
 ### Structure des fichiers

--- a/trading-app/config/app/mtf_validations.yaml
+++ b/trading-app/config/app/mtf_validations.yaml
@@ -17,7 +17,7 @@ mtf_validation:
         rsi_cap: 70.0
         require_pullback: true
         min_volume_ratio: 1.5
-        initial_margin_usdt: 40.0
+        initial_margin_usdt: 50.0
         risk_pct_percent: 2.0
         r_multiple: 2.0
         order_type: 'limit'

--- a/trading-app/config/packages/messenger.yaml
+++ b/trading-app/config/packages/messenger.yaml
@@ -1,0 +1,19 @@
+framework:
+    messenger:
+        transports:
+            order_timeout:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    auto_setup: true
+            failed_order_timeout:
+                dsn: 'doctrine://default?table_name=messenger_messages_failed'
+                options:
+                    auto_setup: true
+                retry_strategy:
+                    max_retries: 3
+                    delay: 5000 # 5 seconds
+                    multiplier: 2.0
+                    max_delay: 60000
+        failure_transport: failed_order_timeout
+        routing:
+            App\TradeEntry\Message\CancelOrderMessage: order_timeout

--- a/trading-app/config/packages/messenger.yaml.bak
+++ b/trading-app/config/packages/messenger.yaml.bak
@@ -1,0 +1,9 @@
+framework:
+    messenger:
+        transports:
+            order_timeout:
+                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
+                options:
+                    auto_setup: true
+        routing:
+            App\TradeEntry\Message\CancelOrderMessage: order_timeout

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -18,6 +18,7 @@ parameters:
     trading.file: '%kernel.project_dir%/config/trading.yml'
     bitmart_public_base_uri: '%env(string:BITMART_PUBLIC_API_URL)%'
     bitmart_private_base_uri: '%env(string:BITMART_PRIVATE_API_URL)%'
+    trade_entry.order_timeout_seconds: 120
     
     # Configuration TradeEntry - Valeurs par défaut (déplacées dans services_trade_entry.yaml)
 

--- a/trading-app/config/trading.yml
+++ b/trading-app/config/trading.yml
@@ -244,16 +244,16 @@ post_validation:
         vwap_anchor: true
         # Réf. ATR (Average True Range): https://www.investopedia.com/terms/a/atr.asp
         # Réf. VWAP (Volume-Weighted Average Price): https://www.investopedia.com/terms/v/vwap.asp
-        k_atr: 0.70                    # largeur relative à ATR (élargie de 0.35 → 0.50)
-        w_min: 0.0008                  # largeur minimale (0.08% au lieu de 0.05%)
-        w_max: 0.0150                  # largeur maximale (1.50% au lieu de 1.00%)
+        k_atr: 0.30                    # largeur relative à ATR (retour zone modérée)
+        w_min: 0.0005                  # largeur minimale (0.05%)
+        w_max: 0.0100                  # largeur maximale (1.00%)
         spread_bps_max: 2.0            # spread max en bps => n'est pas encore implémenté
         depth_min_usd: 20000           # profondeur minimale en USD => n'est pas encore implémenté
         mark_index_gap_bps_max: 15.0   # écart Mark/Index max en bps => n'est pas encore implémenté
         quantize_to_exchange_step: true # quantification aux pas exchange
 
-    execution_timeframe: # n'esst pas encore implémenté
-        default: "5m"                  # timeframe par défaut
+    execution_timeframe: # n'est pas encore implémenté
+        default: "5m"                  # timeframe par défaut (zone plus stable)
         upshift_to_1m:
             atr_pct_hi: 0.12           # ATR >= 0.12% pour upshift
             spread_bps_max: 2.0        # spread max pour upshift

--- a/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
@@ -141,6 +141,9 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 return isset($response['data']['result']) && $response['data']['result'] === 'success';
             } catch (\Throwable $e) {
                 $lastError = $e;
+            }
+
+            if ($i < self::RETRY_ATTEMPTS - 1) {
                 usleep(self::RETRY_SLEEP_US);
             }
         }
@@ -162,10 +165,14 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 if (isset($response['data'])) {
                     return OrderDto::fromArray($response['data']);
                 }
+                $lastError = new \RuntimeException('Invalid order detail response structure.');
             } catch (\Throwable $e) {
                 $lastError = $e;
             }
-            usleep(self::RETRY_SLEEP_US);
+
+            if ($i < self::RETRY_ATTEMPTS - 1) {
+                usleep(self::RETRY_SLEEP_US);
+            }
         }
         if ($lastError) {
             $this->logger->error("Erreur lors de la récupération de l'ordre", [
@@ -185,9 +192,12 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 if (isset($response['data']['orders'])) {
                     return array_map(fn($order) => OrderDto::fromArray($order), $response['data']['orders']);
                 }
-                return [];
+                $lastError = new \RuntimeException('Invalid open orders response structure.');
             } catch (\Throwable $e) {
                 $lastError = $e;
+            }
+
+            if ($i < self::RETRY_ATTEMPTS - 1) {
                 usleep(self::RETRY_SLEEP_US);
             }
         }
@@ -209,9 +219,12 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 if (isset($response['data']['orders'])) {
                     return array_map(fn($order) => OrderDto::fromArray($order), $response['data']['orders']);
                 }
-                return [];
+                $lastError = new \RuntimeException('Invalid order history response structure.');
             } catch (\Throwable $e) {
                 $lastError = $e;
+            }
+
+            if ($i < self::RETRY_ATTEMPTS - 1) {
                 usleep(self::RETRY_SLEEP_US);
             }
         }

--- a/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
@@ -23,6 +23,9 @@ use Psr\Log\LoggerInterface;
 )]
 final class BitmartOrderProvider implements OrderProviderInterface
 {
+    private const RETRY_ATTEMPTS = 3;
+    private const RETRY_SLEEP_US = 250_000; // 250ms
+
     public function __construct(
         private readonly BitmartHttpClientPrivate $bitmartClient,
         private readonly BitmartHttpClientPublic $bitmartClientPublic,
@@ -131,74 +134,94 @@ final class BitmartOrderProvider implements OrderProviderInterface
 
     public function cancelOrder(string $orderId): bool
     {
-        try {
-            $response = $this->bitmartClient->cancelOrder($orderId);
-
-            return isset($response['data']['result']) && $response['data']['result'] === 'success';
-        } catch (\Exception $e) {
+        $lastError = null;
+        for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
+            try {
+                $response = $this->bitmartClient->cancelOrder($orderId);
+                return isset($response['data']['result']) && $response['data']['result'] === 'success';
+            } catch (\Throwable $e) {
+                $lastError = $e;
+                usleep(self::RETRY_SLEEP_US);
+            }
+        }
+        if ($lastError) {
             $this->logger->error("Erreur lors de l'annulation de l'ordre", [
                 'order_id' => $orderId,
-                'error' => $e->getMessage()
+                'error' => $lastError->getMessage()
             ]);
-            return false;
         }
+        return false;
     }
 
     public function getOrder(string $orderId): ?OrderDto
     {
-        try {
-            $response = $this->bitmartClient->getOrderDetail($orderId);
-
-            if (isset($response['data'])) {
-                return OrderDto::fromArray($response['data']);
+        $lastError = null;
+        for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
+            try {
+                $response = $this->bitmartClient->getOrderDetail($orderId);
+                if (isset($response['data'])) {
+                    return OrderDto::fromArray($response['data']);
+                }
+            } catch (\Throwable $e) {
+                $lastError = $e;
             }
-
-            return null;
-        } catch (\Exception $e) {
+            usleep(self::RETRY_SLEEP_US);
+        }
+        if ($lastError) {
             $this->logger->error("Erreur lors de la récupération de l'ordre", [
                 'order_id' => $orderId,
-                'error' => $e->getMessage()
+                'error' => $lastError->getMessage()
             ]);
-            return null;
         }
+        return null;
     }
 
     public function getOpenOrders(?string $symbol = null): array
     {
-        try {
-            $response = $this->bitmartClient->getOpenOrders($symbol);
-
-            if (isset($response['data']['orders'])) {
-                return array_map(fn($order) => OrderDto::fromArray($order), $response['data']['orders']);
+        $lastError = null;
+        for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
+            try {
+                $response = $this->bitmartClient->getOpenOrders($symbol);
+                if (isset($response['data']['orders'])) {
+                    return array_map(fn($order) => OrderDto::fromArray($order), $response['data']['orders']);
+                }
+                return [];
+            } catch (\Throwable $e) {
+                $lastError = $e;
+                usleep(self::RETRY_SLEEP_US);
             }
-
-            return [];
-        } catch (\Exception $e) {
+        }
+        if ($lastError) {
             $this->logger->error("Erreur lors de la récupération des ordres ouverts", [
                 'symbol' => $symbol,
-                'error' => $e->getMessage()
+                'error' => $lastError->getMessage()
             ]);
-            return [];
         }
+        return [];
     }
 
     public function getOrderHistory(string $symbol, int $limit = 100): array
     {
-        try {
-            $response = $this->bitmartClient->getOrderHistory($symbol, $limit);
-
-            if (isset($response['data']['orders'])) {
-                return array_map(fn($order) => OrderDto::fromArray($order), $response['data']['orders']);
+        $lastError = null;
+        for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
+            try {
+                $response = $this->bitmartClient->getOrderHistory($symbol, $limit);
+                if (isset($response['data']['orders'])) {
+                    return array_map(fn($order) => OrderDto::fromArray($order), $response['data']['orders']);
+                }
+                return [];
+            } catch (\Throwable $e) {
+                $lastError = $e;
+                usleep(self::RETRY_SLEEP_US);
             }
-
-            return [];
-        } catch (\Exception $e) {
+        }
+        if ($lastError) {
             $this->logger->error("Erreur lors de la récupération de l'historique des ordres", [
                 'symbol' => $symbol,
-                'error' => $e->getMessage()
+                'error' => $lastError->getMessage()
             ]);
-            return [];
         }
+        return [];
     }
 
     public function cancelAllOrders(string $symbol): bool

--- a/trading-app/src/TradeEntry/Dto/PreflightReport.php
+++ b/trading-app/src/TradeEntry/Dto/PreflightReport.php
@@ -17,5 +17,7 @@ final class PreflightReport
         public readonly float $availableUsdt,
         public readonly float $spreadPct = 0.0,
         public readonly ?string $modeNote = null,
+        public readonly ?float $lastPrice = null,
+        public readonly ?float $tickSize = null,
     ) {}
 }

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -9,6 +9,10 @@ use App\Contract\Provider\MainProviderInterface;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
 use App\TradeEntry\Dto\{ExecutionResult};
 use App\TradeEntry\Policy\{IdempotencyPolicy, MakerOnlyPolicy};
+use App\TradeEntry\Message\CancelOrderMessage;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class ExecutionBox
 {
@@ -18,6 +22,9 @@ final class ExecutionBox
         private readonly MakerOnlyPolicy $makerOnly,
         private readonly IdempotencyPolicy $idempotency,
         private readonly ExecutionLogger $logger,
+        private readonly MessageBusInterface $messageBus,
+        #[Autowire('%trade_entry.order_timeout_seconds%')]
+        private readonly int $orderTimeoutSeconds,
     ) {}
 
     public function execute(OrderPlanModel $plan, ?string $decisionKey = null): ExecutionResult
@@ -59,7 +66,6 @@ final class ExecutionBox
             4 => OrderSide::SELL,  // open_short
         };
         
-        $payloadWithCorrelation = $payload + ['decision_key' => $decisionKey];
         // Extra visibility before submit
         $this->logger->debug('execution.presubmit_check', [
             'symbol' => $plan->symbol,
@@ -73,39 +79,117 @@ final class ExecutionBox
             'client_order_id' => $payload['client_order_id'],
             'decision_key' => $decisionKey,
         ]);
-        $this->logger->debug('execution.order_submit', $payloadWithCorrelation);
-        $orderResult = $this->providers->getOrderProvider()->placeOrder(
-            symbol: $payload['symbol'],
-            side: $side,
-            type: OrderType::from($payload['type']),
-            quantity: (float) $payload['size'],
-            price: isset($payload['price']) ? (float) $payload['price'] : null,
-            stopPrice: null,
-            options: [
-                'side' => $payload['side'], // Bitmart numeric side for entry (1=open_long, 4=open_short)
-                'mode' => $payload['mode'],
-                'open_type' => $payload['open_type'],
-                'client_order_id' => $payload['client_order_id'],
-                'preset_take_profit_price' => $payload['preset_take_profit_price'],
-                'preset_take_profit_price_type' => $payload['preset_take_profit_price_type'],
-                'preset_stop_loss_price' => $payload['preset_stop_loss_price'],
-                'preset_stop_loss_price_type' => $payload['preset_stop_loss_price_type'],
-            ]
-        );
-        $this->logger->debug('execution.order_response', [
-            'symbol' => $plan->symbol,
-            'result' => $orderResult ? $orderResult->toArray() : null,
-            'decision_key' => $decisionKey,
-        ]);
+
+        $attempts = [];
+        $attempts[] = [
+            'label' => 'maker-limit',
+            'payload' => $payload,
+            'order_type' => OrderType::from($payload['type']),
+            'price' => isset($payload['price']) ? (float) $payload['price'] : null,
+            'options' => $this->extractOrderOptions($payload),
+            'schedule_timeout' => $plan->orderType === 'limit',
+        ];
+
+        if ($plan->orderType === 'limit' && $plan->orderMode === 4) {
+            $fallbackPayload = $payload;
+            $fallbackPayload['type'] = OrderType::MARKET->value;
+            $fallbackPayload['mode'] = 1; // Bitmart GTC (taker) pour fallback
+            unset($fallbackPayload['price']);
+
+            $attempts[] = [
+                'label' => 'taker-market-fallback',
+                'payload' => $fallbackPayload,
+                'order_type' => OrderType::MARKET,
+                'price' => null,
+                'options' => $this->extractOrderOptions($fallbackPayload),
+                'schedule_timeout' => false,
+            ];
+        }
+
+        $attemptCount = count($attempts);
+        $orderResult = null;
+        $selectedAttempt = null;
+
+        foreach ($attempts as $index => $attempt) {
+            $attemptPayload = $attempt['payload'] + [
+                'decision_key' => $decisionKey,
+                'attempt' => $attempt['label'],
+                'attempt_index' => $index + 1,
+                'attempt_total' => $attemptCount,
+            ];
+            $this->logger->debug('execution.order_submit', $attemptPayload);
+
+            $currentResult = $this->providers->getOrderProvider()->placeOrder(
+                symbol: $attempt['payload']['symbol'],
+                side: $side,
+                type: $attempt['order_type'],
+                quantity: (float)$attempt['payload']['size'],
+                price: $attempt['price'],
+                stopPrice: null,
+                options: $attempt['options']
+            );
+
+            $this->logger->debug('execution.order_response', [
+                'symbol' => $plan->symbol,
+                'result' => $currentResult ? $currentResult->toArray() : null,
+                'decision_key' => $decisionKey,
+                'attempt' => $attempt['label'],
+            ]);
+
+            if ($currentResult !== null) {
+                $orderResult = $currentResult;
+                $selectedAttempt = $attempt;
+                break;
+            }
+
+            $this->logger->warning('execution.order_attempt_failed', [
+                'symbol' => $plan->symbol,
+                'attempt' => $attempt['label'],
+                'order_type' => $attempt['order_type']->value,
+                'mode' => $attempt['options']['mode'] ?? null,
+                'decision_key' => $decisionKey,
+            ]);
+        }
 
         $this->logger->info('trade_entry.order_submitted', [
-            'payload' => $payload,
+            'payload' => $selectedAttempt['payload'] ?? $payload,
             'leverage' => $leverageResult,
             'order' => $orderResult ? $orderResult->toArray() : null,
+            'attempt' => $selectedAttempt['label'] ?? null,
         ]);
 
         $orderId = $orderResult?->orderId;
         $isOk = $orderResult !== null;
+
+        if ($isOk && $orderId !== null && $selectedAttempt !== null && $selectedAttempt['schedule_timeout']) {
+            $delayMs = max(1_000, $this->orderTimeoutSeconds * 1_000);
+            try {
+                $this->messageBus->dispatch(
+                    new CancelOrderMessage(
+                        symbol: $plan->symbol,
+                        exchangeOrderId: $orderId,
+                        clientOrderId: $clientOrderId,
+                        decisionKey: $decisionKey
+                    ),
+                    [new DelayStamp($delayMs)]
+                );
+                $this->logger->debug('execution.timeout_scheduled', [
+                    'symbol' => $plan->symbol,
+                    'exchange_order_id' => $orderId,
+                    'client_order_id' => $clientOrderId,
+                    'delay_ms' => $delayMs,
+                    'decision_key' => $decisionKey,
+                ]);
+            } catch (\Throwable $dispatchError) {
+                $this->logger->error('execution.timeout_schedule_failed', [
+                    'symbol' => $plan->symbol,
+                    'exchange_order_id' => $orderId,
+                    'client_order_id' => $clientOrderId,
+                    'decision_key' => $decisionKey,
+                    'error' => $dispatchError->getMessage(),
+                ]);
+            }
+        }
 
         if (!$isOk) {
             $this->logger->error('execution.order_error', [
@@ -120,7 +204,44 @@ final class ExecutionBox
             clientOrderId: $clientOrderId,
             exchangeOrderId: $orderId,
             status: $isOk ? 'submitted' : 'error',
-            raw: ['leverage' => $leverageResult, 'order' => $orderResult ? $orderResult->toArray() : null],
+            raw: [
+                'leverage' => $leverageResult,
+                'order' => $orderResult ? $orderResult->toArray() : null,
+                'attempt' => $selectedAttempt['label'] ?? null,
+            ],
+        );
+    }
+
+    /**
+     * Prépare les options Bitmart pour l'appel placeOrder.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function extractOrderOptions(array $payload): array
+    {
+        $options = [
+            'side' => $payload['side'],
+            'mode' => $payload['mode'] ?? null,
+            'open_type' => $payload['open_type'],
+            'client_order_id' => $payload['client_order_id'],
+        ];
+
+        foreach ([
+            'preset_take_profit_price',
+            'preset_take_profit_price_type',
+            'preset_stop_loss_price',
+            'preset_stop_loss_price_type',
+        ] as $key) {
+            if (isset($payload[$key])) {
+                $options[$key] = $payload[$key];
+            }
+        }
+
+        return array_filter(
+            $options,
+            static fn($value) => $value !== null && $value !== ''
         );
     }
 }

--- a/trading-app/src/TradeEntry/Message/CancelOrderMessage.php
+++ b/trading-app/src/TradeEntry/Message/CancelOrderMessage.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\Message;
+
+final class CancelOrderMessage
+{
+    public function __construct(
+        public readonly string $symbol,
+        public readonly string $exchangeOrderId,
+        public readonly string $clientOrderId,
+        public readonly ?string $decisionKey = null
+    ) {}
+}

--- a/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(fromTransport: 'order_timeout')]
 final class CancelOrderMessageHandler
 {
     public function __construct(

--- a/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
@@ -9,7 +9,9 @@ use App\Contract\Provider\MainProviderInterface;
 use App\TradeEntry\Message\CancelOrderMessage;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler]
 final class CancelOrderMessageHandler
 {
     public function __construct(

--- a/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\MessageHandler;
+
+use App\Common\Enum\OrderStatus;
+use App\Contract\Provider\MainProviderInterface;
+use App\TradeEntry\Message\CancelOrderMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class CancelOrderMessageHandler
+{
+    public function __construct(
+        private readonly MainProviderInterface $provider,
+        #[Autowire(service: 'monolog.logger.positions')]
+        private readonly LoggerInterface $positionsLogger,
+    ) {}
+
+    public function __invoke(CancelOrderMessage $message): void
+    {
+        $orderProvider = $this->provider->getOrderProvider();
+
+        try {
+            $order = $orderProvider->getOrder($message->exchangeOrderId);
+        } catch (\Throwable $e) {
+            $this->positionsLogger->warning('trade_entry.timeout.order_fetch_failed', [
+                'symbol' => $message->symbol,
+                'exchange_order_id' => $message->exchangeOrderId,
+                'client_order_id' => $message->clientOrderId,
+                'decision_key' => $message->decisionKey,
+                'error' => $e->getMessage(),
+            ]);
+            $order = null;
+        }
+
+        if ($order !== null) {
+            $status = $order->status->value;
+
+            if (in_array($status, [OrderStatus::FILLED->value, OrderStatus::PARTIALLY_FILLED->value], true)) {
+                $this->positionsLogger->info('trade_entry.timeout.skip_cancel', [
+                    'symbol' => $message->symbol,
+                    'exchange_order_id' => $message->exchangeOrderId,
+                    'client_order_id' => $message->clientOrderId,
+                    'decision_key' => $message->decisionKey,
+                    'order_status' => $status,
+                ]);
+                return;
+            }
+
+            if (in_array($status, [OrderStatus::CANCELLED->value, OrderStatus::EXPIRED->value, OrderStatus::REJECTED->value], true)) {
+                $this->positionsLogger->info('trade_entry.timeout.already_closed', [
+                    'symbol' => $message->symbol,
+                    'exchange_order_id' => $message->exchangeOrderId,
+                    'client_order_id' => $message->clientOrderId,
+                    'decision_key' => $message->decisionKey,
+                    'order_status' => $status,
+                ]);
+                return;
+            }
+        }
+
+        try {
+            $cancelled = $orderProvider->cancelOrder($message->exchangeOrderId);
+            $this->positionsLogger->info('trade_entry.timeout.cancel_attempt', [
+                'symbol' => $message->symbol,
+                'exchange_order_id' => $message->exchangeOrderId,
+                'client_order_id' => $message->clientOrderId,
+                'decision_key' => $message->decisionKey,
+                'cancelled' => $cancelled,
+                'order_found' => $order !== null,
+            ]);
+        } catch (\Throwable $e) {
+            $this->positionsLogger->error('trade_entry.timeout.cancel_failed', [
+                'symbol' => $message->symbol,
+                'exchange_order_id' => $message->exchangeOrderId,
+                'client_order_id' => $message->clientOrderId,
+                'decision_key' => $message->decisionKey,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/trading-app/src/TradeEntry/Workflow/BuildPreOrder.php
+++ b/trading-app/src/TradeEntry/Workflow/BuildPreOrder.php
@@ -33,6 +33,8 @@ final class BuildPreOrder
                 'best_bid' => $pre->bestBid,
                 'best_ask' => $pre->bestAsk,
                 'price_precision' => $pre->pricePrecision,
+                'last_price' => $pre->lastPrice,
+                'tick_size' => $pre->tickSize,
                 'contract_size' => $pre->contractSize,
                 'min_volume' => $pre->minVolume,
                 'max_leverage' => $pre->maxLeverage,


### PR DESCRIPTION
This pull request introduces significant improvements to the trading application's order execution flow, reliability, and infrastructure. The most important changes are the addition of a fallback mechanism for order execution (maker to taker), automatic order cancellation using Symfony Messenger with Redis, and enhanced retry logic for Bitmart API calls. It also includes configuration updates and documentation to support these features.

**Order Execution Logic Improvements**
* Added automatic fallback from LIMIT (maker, mode=4) orders to MARKET (taker) orders if Bitmart rejects the maker submission. This ensures orders are executed even if the preferred maker route fails.
* Integrated delayed cancellation for accepted LIMIT orders via Symfony Messenger; a `CancelOrderMessage` is scheduled with a configurable timeout (default 2 minutes) to prevent stagnant orders. [[1]](diffhunk://#diff-eadd0f32c8ce0c2993225f1abea168a5d417cbeca862cb5ecdc354ccaf8f3786L76-R193) [[2]](diffhunk://#diff-eadd0f32c8ce0c2993225f1abea168a5d417cbeca862cb5ecdc354ccaf8f3786R25-R27) [[3]](diffhunk://#diff-2d181ad37eb36804cd9ce354adc4df657d4272f0ffbb065584104efed7650099R21)
* Refactored order submission to log attempts, results, and failures, improving debugging and observability of the execution process.

**Infrastructure and Configuration**
* Added a new `trading-app-messenger` service and a Redis container to `docker-compose.yml` for handling Messenger transports and delayed messages. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R296-R308) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R351-R384) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R424)
* Configured Messenger transports in `messenger.yaml` to route `CancelOrderMessage` to Redis, with a fallback transport for failed messages using Doctrine, and set retry strategies. [[1]](diffhunk://#diff-470426ffb1b4e638984aecb981767011abd3952d76332fd3224550763e3d65b8R1-R19) [[2]](diffhunk://#diff-728d0da6cde01e7e241f4369ee85aa8dc8ff2d088e6af7a0d9056e1ecc78b2e7R1-R9)

**Bitmart API Reliability**
* Implemented retry logic (3 attempts with 250ms delay) for Bitmart API methods (`cancelOrder`, `getOrder`, `getOpenOrders`, `getOrderHistory`) to improve robustness against transient errors. [[1]](diffhunk://#diff-eec808efcbe5711f8beb303b199339b8da8dca8f19dc38729165293d25f568dcR26-R28) [[2]](diffhunk://#diff-eec808efcbe5711f8beb303b199339b8da8dca8f19dc38729165293d25f568dcR137-R224)

**Configuration and Documentation**
* Updated documentation (`README.md`) to explain the new order execution flow, fallback, timeout, and Messenger transport.
* Adjusted trading and validation parameters for margin, ATR width, and order timeout to reflect current strategy and improve risk management. [[1]](diffhunk://#diff-3ec7dee428b3511758020c117a0dd7aac014caf31ddaae0f99d896d799d094e4L20-R20) [[2]](diffhunk://#diff-2d4932f3375a35452ff373b522ebaaed3357a78cd4777d4bea80e03dbabc0d6eL247-R256) [[3]](diffhunk://#diff-2d181ad37eb36804cd9ce354adc4df657d4272f0ffbb065584104efed7650099R21)

These changes collectively make the trading app more resilient, transparent, and easier to operate in production environments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds maker-to-taker order fallback with auto-cancel scheduling via Symfony Messenger (Redis), strengthens Bitmart provider with retries, and updates configs/docs.
> 
> - **Trade execution**:
>   - Maker LIMIT submit with automatic fallback to MARKET (taker) on rejection in `ExecutionBox`.
>   - Schedules delayed cancel via `CancelOrderMessage` (configurable timeout) using Messenger.
> - **Messaging/infra**:
>   - New `redis` service and `trading-app-messenger` worker in `docker-compose.yml`; adds `trading-app-redis-data` volume.
>   - `config/packages/messenger.yaml`: Redis transport `order_timeout`, Doctrine failure transport with retry strategy; routes `CancelOrderMessage`.
>   - `config/services.yaml`: parameter `trade_entry.order_timeout_seconds`.
> - **Provider reliability (Bitmart)**:
>   - `BitmartOrderProvider`: retry logic (3x, 250ms) for `cancelOrder`, `getOrder`, `getOpenOrders`, `getOrderHistory`.
>   - `placeOrder` returns minimal pending `OrderDto` if `order-detail` not yet available.
> - **Pre-trade/planning**:
>   - `PreflightReport` extended with `lastPrice`, `tickSize`; computed in `PreTradeChecks`.
>   - `OrderPlanBuilder` uses `lastPrice`/`tickSize` for baseline, quantization, and logging.
>   - New `CancelOrderMessage` and `CancelOrderMessageHandler` (from `order_timeout`).
> - **Strategy/config tweaks**:
>   - `mtf_validations.yaml`: `initial_margin_usdt` 50.0.
>   - `trading.yml`: adjust entry zone (`k_atr`, `w_min`, `w_max`) and execution timeframe default.
> - **Docs**:
>   - `trading-app/README.md` and `ws-worker/README_BITMART.md` updated for fallback, retries, and timeout behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91ab99fb55c792210dbd7a531bce62d4f4f88707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->