### PR TITLE
Fix messenger registration for cancel order handler

### DIFF
--- a/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/CancelOrderMessageHandler.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
-#[AsMessageHandler]
+#[AsMessageHandler(handles: CancelOrderMessage::class)]
 final class CancelOrderMessageHandler
 {
     public function __construct(


### PR DESCRIPTION
## Summary
- ensure `CancelOrderMessageHandler` is registered with Symfony Messenger by annotating it with `#[AsMessageHandler(handles: CancelOrderMessage::class)]`

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69064fb3f08483249f57e22dd3cde3c4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Register `CancelOrderMessageHandler` with Symfony Messenger by specifying `handles: CancelOrderMessage::class` in the `#[AsMessageHandler]` attribute.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 757230d0e401640f4fdc231448a026876e293fe3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->