### PR TITLE
MTF: enhance PreflightReport and TradeEntryRequest with additional pa…

### DIFF
--- a/trading-app/config/app/mtf_validations.yaml
+++ b/trading-app/config/app/mtf_validations.yaml
@@ -18,13 +18,22 @@ mtf_validation:
         require_pullback: true
         min_volume_ratio: 1.5
         initial_margin_usdt: 50.0
-        risk_pct_percent: 2.0
+        risk_pct_percent: 5.0
         r_multiple: 2.0
         order_type: 'limit'
         open_type: 'isolated'
         order_mode: 4
         stop_from: 'atr'
         market_max_spread_pct: 0.001
+        inside_ticks: 1
+        max_deviation_pct: 0.005
+        implausible_pct: 0.02
+        zone_max_deviation_pct: 0.007
+        tp_policy: 'pivot_conservative'
+        tp_buffer_pct: 0.001
+        tp_buffer_ticks: 0
+        tp_min_keep_ratio: 0.95
+        tp_max_extra_r: 0.5
         timeframe_multipliers:
             '1m': 1.0
             '5m': 0.75

--- a/trading-app/docs/ORDER_FLOW_README.md
+++ b/trading-app/docs/ORDER_FLOW_README.md
@@ -1,0 +1,67 @@
+# Order Flow — Tracking & TP Pivot Rules
+
+## 1. Parcours Signal → Ordre
+
+Consulte `var/log/order-journey-YYYY-MM-DD.log*` pour suivre un symbol. Chaque étape porte `decision_key`.
+
+```
+signal_ready → trade_request.built → trade_entry.dispatch
+  → preflight (fetch carnet + balance, diff mark/bid-ask)
+  → plan.start → plan_builder.entry_selected (entry à ≥1 tick dans le spread)
+  → plan_builder.model_ready (entry/stop/TP/size/leverage)
+  → trade_entry.execution_complete (order_id Bitmart)
+```
+
+Si la zone MTF est trop éloignée, on log `plan_builder.zone_ignored`. Pour les LIMIT validées, on retrouve l’entrée dans `order_plan.model_ready` (positions.log) et l’ID exchange dans `execution_complete`.
+
+## 2. Paramètres utiles (cfg YAML)
+
+- `risk_pct_percent` (cfg MTF) = 5 → le Request transporte le risk en fraction (0.05).  
+- `inside_ticks` (défaut 1), `max_deviation_pct` (~0.5 %), `implausible_pct` (~2 %), `zone_max_deviation_pct` (~0.7 %) : contrôlent la proximité au mark.
+- `tp_policy`, `tp_buffer_pct`, `tp_buffer_ticks`, `tp_min_keep_ratio`, `tp_max_extra_r` pilotent le cadrage TP/pivots.
+
+## 3. Logique du TP (baseline k·R + pivot)
+
+### 3.1 R multiples
+
+1R = distance entry-stop.  
+Long : `R = Entry - Stop > 0`, `TP_kR_th = Entry + k·R`.  
+Short : `R = Stop - Entry > 0`, `TP_kR_th = Entry - k·R`.  
+k∈{1.5, 2.0…}. Cette cible pure R-multiple sert de référence.
+
+### 3.2 Pivots classiques
+
+Calculés sur session précédente (H,L,C) :  
+`PP = (H+L+C)/3`, `R1 = 2·PP - L`, `S1 = 2·PP - H`, `R2 = PP + (H-L)`, `S2 = PP - (H-L)` (etc.).  
+Ils sont publiés en cache/DB pour la journée.
+
+### 3.3 Règle TP = max(k·R, pivot structurant)
+
+*Long* :
+1. Liste des résistances croissantes {PP (si Entry < PP), R1, R2, …}.  
+2. TP théorique = `Entry + k·R`.  
+3. Mode conservateur : prendre le premier pivot ≥ TP_théorique (sinon aggressive = garder k·R si R2 trop loin).  
+4. Appliquer buffer (ex -0.1 % ou -1 tick) sous ce pivot, quantifier.  
+5. Garde-fou : ne pas descendre sous `tp_min_keep_ratio * k·R`. Sinon revenir à TP_théorique.
+
+*Short* : symétrique (pivots {PP si Entry > PP, S1, S2…}, buffer +, garde-fou).
+
+### 3.4 Implémentation
+
+- Exposer les pivots dans `PreflightReport` (PP, R1/S1, R2/S2...).  
+- `TradeEntryRequest` comprend `tpPolicy`, `tpBufferPct`, `tpMinKeepRatio`.  
+- `OrderPlanBuilder` calcule d’abord `TP_kR_th` puis l’aligne sur pivot ou garde k·R selon la politique.
+
+## 4. Exemple
+
+Long 2R : Entry=100, Stop=98 → `R=2`, `TP_2R_th=104`.  
+Pivots : PP=101.5, R1=103.2, R2=104.8.  
+Politique `pivot_conservative`, buffer -0.1 %.  
+→ pivot >= 104 : R2=104.8 → TP=104.8*(1-0.001)=104.6952 (quantifié). Ratio réel ≈2.35R.
+
+## 5. À retenir
+
+- LIMIT se positionnent maintenant à l’intérieur du spread (`inside_ticks`).  
+- Les tailles sont arrondies aux contrats (plus de `computeLeverage(int)` crash).  
+- Nouveau mode TP pivot offrira des objectifs cohérents : R-multiple + niveau de marché.  
+- Pour analyser une commande : `grep "mtf:SYMBOL" var/log/order-journey-info-XXXX.log`.

--- a/trading-app/docs/ORDER_TIMEOUT_MTF_SWITCH.md
+++ b/trading-app/docs/ORDER_TIMEOUT_MTF_SWITCH.md
@@ -1,0 +1,248 @@
+# Gestion du Timeout des Ordres et du MtfSwitch
+
+## Vue d'ensemble
+
+Ce document explique le mécanisme automatique de timeout des ordres et de gestion du MtfSwitch.
+
+## Problématique
+
+Lorsqu'un ordre est placé sur l'exchange :
+1. Le système MTF désactive le symbole pour **4 heures** (via `MtfSwitch`)
+2. Cela empêche toute nouvelle tentative d'entrée immédiate
+3. Si l'ordre n'est pas rempli et est annulé après 2 minutes, le symbole reste bloqué pendant 4 heures
+4. Le système perd donc des opportunités potentielles sur ce symbole
+
+## Solution implémentée
+
+### Architecture
+
+```
+[Order Placed]
+      |
+      v
+[MtfSwitch OFF 4h] ────────────────┐
+      |                             │
+      v                             │
+[Messenger: DelayStamp 120s]       │
+      |                             │
+      v (après 120s)                │
+[CancelOrderMessageHandler]        │
+      |                             │
+      ├─> [Check Order Status]      │
+      |                             │
+      ├─> [If PENDING → Cancel]     │
+      |                             │
+      └─> [If Cancelled → Switch OFF 15m] ← Écrase les 4h
+                                    │
+                                    v
+                              [Réactivation après 15m]
+```
+
+### Composants
+
+#### 1. ExecutionBox
+- Place l'ordre sur l'exchange
+- Programme un message `CancelOrderMessage` avec `DelayStamp` de 120 secondes
+- Désactive le `MtfSwitch` pour 4 heures
+
+#### 2. CancelOrderMessageHandler
+Exécuté après 120 secondes :
+- Vérifie le statut de l'ordre
+- Si l'ordre est `FILLED` ou `PARTIALLY_FILLED` : ne fait rien
+- Si l'ordre est `PENDING` ou `SUBMITTED` : 
+  - Annule l'ordre
+  - **Réactive le MtfSwitch avec un délai réduit de 15 minutes**
+- Si l'ordre est déjà `CANCELLED`/`EXPIRED`/`REJECTED` : ne fait rien
+
+#### 3. MtfSwitchRepository
+Gère les états du MtfSwitch :
+- `turnOffSymbolFor4Hours()` : Désactive pour 4h (ordre initial)
+- `turnOffSymbolForDuration()` : Désactive pour une durée personnalisée (15m après annulation)
+- Les switches expirés sont automatiquement réactivés
+
+## Configuration
+
+### Variables d'environnement
+
+```bash
+# Durée du timeout avant annulation automatique (en secondes)
+# Défaut: 120 secondes (2 minutes)
+TRADE_ENTRY_ORDER_TIMEOUT_SECONDS=120
+
+# Durée de désactivation du MtfSwitch après annulation d'ordre
+# Défaut: 15m (au lieu de 4h)
+ORDER_TIMEOUT_SWITCH_DURATION=15m
+```
+
+### Formats supportés pour la durée
+
+- `15m` : 15 minutes
+- `1h` : 1 heure
+- `30m` : 30 minutes
+- `90m` : 90 minutes (converti automatiquement en 1h 30m)
+
+## Logs
+
+### Positions Log (`var/log/positions-YYYY-MM-DD.log`)
+
+```json
+{
+  "message": "trade_entry.timeout.cancel_attempt",
+  "symbol": "BTCUSDT",
+  "exchange_order_id": "3000237115743112",
+  "client_order_id": "MTF_BTC_20231102_123456",
+  "decision_key": "mtf:BTCUSDT:a1b2c3",
+  "cancelled": true
+}
+
+{
+  "message": "trade_entry.timeout.switch_released",
+  "symbol": "BTCUSDT",
+  "duration": "15m",
+  "reason": "order_cancelled_reduced_cooldown"
+}
+```
+
+### Order Journey Log (`var/log/order-journey-YYYY-MM-DD.log`)
+
+```json
+{
+  "message": "order_journey.timeout.cancel_attempt",
+  "symbol": "BTCUSDT",
+  "decision_key": "mtf:BTCUSDT:a1b2c3",
+  "cancelled": true,
+  "reason": "timeout_triggered_cancel"
+}
+
+{
+  "message": "order_journey.timeout.switch_released",
+  "symbol": "BTCUSDT",
+  "duration": "15m",
+  "reason": "order_cancelled_reduced_cooldown"
+}
+```
+
+## Vérification du fonctionnement
+
+### 1. Vérifier que le worker Messenger tourne
+
+```bash
+docker-compose ps | grep messenger
+# Devrait afficher: trading_app_messenger ... Up
+```
+
+### 2. Vérifier les logs en temps réel
+
+```bash
+# Logs du messenger
+docker-compose logs -f trading-app-messenger
+
+# Logs des positions
+docker-compose exec trading-app-php tail -f var/log/positions-$(date +%Y-%m-%d).log | grep timeout
+
+# Logs du journey
+docker-compose exec trading-app-php tail -f var/log/order-journey-$(date +%Y-%m-%d).log | grep timeout
+```
+
+### 3. Vérifier l'état des MtfSwitch
+
+```bash
+# Via psql
+docker-compose exec trading-app-db psql -U postgres -d trading_app -c \
+  "SELECT switch_key, is_on, expires_at, description FROM mtf_switch WHERE switch_key LIKE 'SYMBOL:%' ORDER BY updated_at DESC LIMIT 10;"
+```
+
+### 4. Tester le flux complet
+
+1. Placer un ordre via MTF
+2. Attendre 2 minutes
+3. Vérifier dans les logs que l'ordre est annulé
+4. Vérifier que le MtfSwitch est réactivé avec une expiration de 15 minutes
+
+```bash
+# Exemple de commande de test
+curl -X POST http://localhost:8082/api/mtf/run \
+  -H "Content-Type: application/json" \
+  -d '{"symbols": ["BTCUSDT"], "workers": 1, "dry_run": false}'
+```
+
+## Avantages de cette approche
+
+1. **Utilisation du Messenger existant** : Pas besoin de Temporal supplémentaire
+2. **Configuration flexible** : Délais configurables via .env
+3. **Optimisation des opportunités** : Réduction du temps de blocage de 4h à 15m après annulation
+4. **Traçabilité complète** : Logs détaillés à chaque étape
+5. **Gestion des erreurs** : Système robuste avec retry automatique
+
+## Cas d'usage
+
+### Scénario 1 : Ordre rempli rapidement
+```
+[00:00] Ordre placé → MtfSwitch OFF 4h
+[00:01] Ordre rempli → FILLED
+[02:00] Timeout atteint → Handler vérifie → Statut FILLED → Aucune action
+[04:00] MtfSwitch se réactive automatiquement
+```
+
+### Scénario 2 : Ordre non rempli (annulation)
+```
+[00:00] Ordre placé → MtfSwitch OFF 4h
+[02:00] Timeout atteint → Handler vérifie → Statut PENDING
+[02:00] Ordre annulé → MtfSwitch écrasé à OFF 15m
+[02:15] MtfSwitch se réactive → Nouvelle opportunité possible
+```
+
+### Scénario 3 : Ordre partiellement rempli
+```
+[00:00] Ordre placé → MtfSwitch OFF 4h
+[01:30] Ordre partiellement rempli → PARTIALLY_FILLED
+[02:00] Timeout atteint → Handler vérifie → Statut PARTIALLY_FILLED → Aucune action
+[04:00] MtfSwitch se réactive automatiquement
+```
+
+## Maintenance
+
+### Redémarrage du worker Messenger
+
+```bash
+docker-compose restart trading-app-messenger
+```
+
+### Vérifier la queue Redis
+
+```bash
+docker-compose exec redis redis-cli
+> KEYS *
+> LLEN messenger:order_timeout
+```
+
+### Forcer la réactivation d'un MtfSwitch
+
+```bash
+curl -X POST http://localhost:8082/api/mtf/switch/on \
+  -H "Content-Type: application/json" \
+  -d '{"symbol": "BTCUSDT"}'
+```
+
+## Références
+
+- `CancelOrderMessageHandler.php` : Handler principal
+- `ExecutionBox.php` : Programme le timeout
+- `MtfSwitchRepository.php` : Gestion des switches
+- `messenger.yaml` : Configuration du transport
+- `docker-compose.yml` : Configuration du worker
+
+## Questions fréquentes
+
+**Q: Pourquoi 15 minutes après annulation ?**  
+R: C'est un compromis entre laisser le marché se calmer et permettre de nouvelles opportunités rapidement.
+
+**Q: Que se passe-t-il si le worker Messenger est arrêté ?**  
+R: Les messages s'accumulent dans Redis. Quand le worker redémarre, ils sont traités dans l'ordre.
+
+**Q: Peut-on modifier les durées sans redémarrer ?**  
+R: Non, il faut redémarrer le container `trading-app-messenger` après modification du .env.
+
+**Q: Que se passe-t-il si Bitmart rejette l'annulation ?**  
+R: L'erreur est loggée mais le MtfSwitch n'est pas modifié (reste à 4h).
+

--- a/trading-app/src/Command/Mtf/MtfRunCommand.php
+++ b/trading-app/src/Command/Mtf/MtfRunCommand.php
@@ -300,8 +300,24 @@ class MtfRunCommand extends Command
                     try {
                         $payload = json_decode($rawOutput, true, 512, JSON_THROW_ON_ERROR);
                     } catch (JsonException $exception) {
-                        $errors[] = sprintf('Worker %s: sortie JSON invalide (%s).', $symbol, $exception->getMessage());
-                        continue;
+                        $jsonStart = strpos($rawOutput, '{');
+                        if ($jsonStart === false) {
+                            $errors[] = sprintf('Worker %s: sortie JSON invalide (%s).', $symbol, $exception->getMessage());
+                            continue;
+                        }
+
+                        $candidate = substr($rawOutput, $jsonStart);
+                        $jsonEnd = strrpos($candidate, '}');
+                        if ($jsonEnd !== false) {
+                            $candidate = substr($candidate, 0, $jsonEnd + 1);
+                        }
+
+                        try {
+                            $payload = json_decode($candidate, true, 512, JSON_THROW_ON_ERROR);
+                        } catch (JsonException $exception2) {
+                            $errors[] = sprintf('Worker %s: sortie JSON invalide (%s).', $symbol, $exception2->getMessage());
+                            continue;
+                        }
                     }
 
                     $final = $payload['final'] ?? null;

--- a/trading-app/src/Repository/ContractRepository.php
+++ b/trading-app/src/Repository/ContractRepository.php
@@ -262,7 +262,7 @@ class ContractRepository extends ServiceEntityRepository
                     if ($contractData instanceof \App\Provider\Bitmart\Dto\ContractDto) {
                         $contractData = $this->contractDtoToArray($contractData);
                     }
-                    
+
                     $this->upsertContract($contractData);
                     $upsertedCount++;
                 } catch (\Exception $e) {
@@ -326,14 +326,14 @@ class ContractRepository extends ServiceEntityRepository
         $maxAgeHours       = (int)    $this->config->getFilter('max_age_hours', 880);
         $openUnit          = (string) $this->config->getFilter('open_unit', 's');   // ✅ seconds
 
-        $topN   = (int) $this->config->getLimit('top_n', 100);
-        $midN   = (int) $this->config->getLimit('mid_n', 50);
+        $topN   = (int) $this->config->getLimit('top_n', 140);
+        $midN   = (int) $this->config->getLimit('mid_n', 40);
         $orderTop = strtoupper($this->config->getOrder('top', 'DESC'));
         $orderMid = strtoupper($this->config->getOrder('mid', 'ASC'));
         $validOrder = ['ASC', 'DESC'];
         if (!in_array($orderTop, $validOrder, true)) $orderTop = 'DESC';
         if (!in_array($orderMid, $validOrder, true)) $orderMid = 'ASC';
-        
+
 
         // --- Horloge & unités ---
         $now    = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'));
@@ -347,8 +347,8 @@ class ContractRepository extends ServiceEntityRepository
         // ✅ ta colonne open_timestamp est en secondes
         $openTsMin = $openTsMinSec; // pas de *1000
         $openTsMinSet = !is_null($openTsMin);
-        
-        
+
+
 
         // --- Expression turnover (caster si stocké en texte) ---
         $turnoverExpr = 'turnover_24h'; // si TEXT: "CAST(turnover_24h AS DECIMAL(38,10))"

--- a/trading-app/src/TradeEntry/Dto/PreflightReport.php
+++ b/trading-app/src/TradeEntry/Dto/PreflightReport.php
@@ -19,5 +19,11 @@ final class PreflightReport
         public readonly ?string $modeNote = null,
         public readonly ?float $lastPrice = null,
         public readonly ?float $tickSize = null,
+        public readonly ?float $markPrice = null,
+        public readonly ?int $volPrecision = null,
+        public readonly ?float $maxVolume = null,
+        public readonly ?float $marketMaxVolume = null,
+        /** @var array<string,float>|null */
+        public readonly ?array $pivotLevels = null,
     ) {}
 }

--- a/trading-app/src/TradeEntry/Dto/TradeEntryRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TradeEntryRequest.php
@@ -20,6 +20,15 @@ final class TradeEntryRequest
         public readonly string $stopFrom = 'risk',
         public readonly ?float $atrValue = null,
         public readonly float $atrK = 1.5,
-        public readonly ?float $marketMaxSpreadPct = 0.001
+        public readonly ?float $marketMaxSpreadPct = 0.001,
+        public readonly ?int $insideTicks = null,
+        public readonly ?float $maxDeviationPct = null,
+        public readonly ?float $implausiblePct = null,
+        public readonly ?float $zoneMaxDeviationPct = null,
+        public readonly string $tpPolicy = 'pivot_conservative',
+        public readonly ?float $tpBufferPct = null,
+        public readonly ?int $tpBufferTicks = null,
+        public readonly float $tpMinKeepRatio = 0.95,
+        public readonly ?float $tpMaxExtraR = null,
     ) {}
 }

--- a/trading-app/src/TradeEntry/EntryZone/EntryZoneFilters.php
+++ b/trading-app/src/TradeEntry/EntryZone/EntryZoneFilters.php
@@ -4,14 +4,26 @@ declare(strict_types=1);
 namespace App\TradeEntry\EntryZone;
 
 use App\TradeEntry\Dto\EntryZone;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class EntryZoneFilters
 {
-    public function __construct() {}
+    public function __construct(
+        #[Autowire(service: 'monolog.logger.order_journey')] private readonly LoggerInterface $journeyLogger,
+    ) {}
 
     /** @param array{request:mixed, preflight:mixed, plan:mixed, zone:EntryZone} $context */
     public function passAll(array $context): bool
     {
+        $symbol = $context['request']->symbol ?? ($context['plan']->symbol ?? null);
+        $decisionKey = $context['decision_key'] ?? null;
+        $this->journeyLogger->debug('order_journey.entry_zone.filters_pass', [
+            'symbol' => $symbol,
+            'decision_key' => $decisionKey,
+            'reason' => 'filters_not_configured_default_pass',
+        ]);
+
         return true; // TODO règles MTF (RSI<70, MA21+2×ATR, pullback confirmé, scaling progressif)
     }
 }

--- a/trading-app/src/TradeEntry/OrderPlan/OrderPlanBox.php
+++ b/trading-app/src/TradeEntry/OrderPlan/OrderPlanBox.php
@@ -5,13 +5,35 @@ namespace App\TradeEntry\OrderPlan;
 
 use App\TradeEntry\Dto\{TradeEntryRequest, PreflightReport};
 use App\TradeEntry\Dto\EntryZone;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class OrderPlanBox
 {
-    public function __construct(private readonly OrderPlanBuilder $builder) {}
+    public function __construct(
+        private readonly OrderPlanBuilder $builder,
+        #[Autowire(service: 'monolog.logger.order_journey')] private readonly LoggerInterface $journeyLogger,
+    ) {}
 
     public function create(TradeEntryRequest $req, PreflightReport $pre, ?string $decisionKey = null, ?EntryZone $zone = null): OrderPlanModel
     {
-        return $this->builder->build($req, $pre, $decisionKey, $zone);
+        $this->journeyLogger->debug('order_journey.plan_box.create', [
+            'symbol' => $req->symbol,
+            'decision_key' => $decisionKey,
+            'has_zone' => $zone !== null,
+            'reason' => 'delegate_to_plan_builder',
+        ]);
+
+        $plan = $this->builder->build($req, $pre, $decisionKey, $zone);
+
+        $this->journeyLogger->debug('order_journey.plan_box.created', [
+            'symbol' => $plan->symbol,
+            'decision_key' => $decisionKey,
+            'entry' => $plan->entry,
+            'size' => $plan->size,
+            'reason' => 'order_plan_built',
+        ]);
+
+        return $plan;
     }
 }

--- a/trading-app/src/TradeEntry/OrderPlan/OrderPlanBuilder.php
+++ b/trading-app/src/TradeEntry/OrderPlan/OrderPlanBuilder.php
@@ -21,134 +21,200 @@ final class OrderPlanBuilder
         private readonly LeverageServiceInterface $leverageService,
         #[Autowire(service: 'monolog.logger.positions_flow')] private readonly LoggerInterface $flowLogger,
         #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
+        #[Autowire(service: 'monolog.logger.order_journey')] private readonly LoggerInterface $journeyLogger,
     ) {}
 
     public function build(TradeEntryRequest $req, PreflightReport $pre, ?string $decisionKey = null, ?EntryZone $zone = null): OrderPlanModel
     {
-        $precision = $pre->pricePrecision;
-        $contractSize = $pre->contractSize;
-        $minVolume = $pre->minVolume;
+        $precision       = $pre->pricePrecision;
+        $contractSize    = $pre->contractSize;
+        $minVolume       = $pre->minVolume;
+        $volPrecision    = $pre->volPrecision ?? 0;
+        $maxVolume       = $pre->maxVolume;
+        $marketMaxVolume = $pre->marketMaxVolume;
 
-        $availableBudget = min(max($req->initialMarginUsdt, 0.0), max($pre->availableUsdt, 0.0));
+        $availableBudget = min(max((float)$req->initialMarginUsdt, 0.0), max((float)$pre->availableUsdt, 0.0));
         if ($availableBudget <= 0.0) {
+            $this->journeyLogger->error('order_journey.plan_builder.no_budget', [
+                'symbol' => $req->symbol,
+                'decision_key' => $decisionKey,
+                'initial_margin_usdt' => $req->initialMarginUsdt,
+                'available_usdt' => $pre->availableUsdt,
+                'reason' => 'insufficient_margin',
+            ]);
             throw new \RuntimeException('Budget indisponible pour construire le plan');
         }
 
-        $riskUsdt = $availableBudget * max($req->riskPct, 0.0);
+        $riskPct = max(0.0, (float)$req->riskPct);
+        if ($riskPct > 1.0) {
+            $riskPct *= 0.01;
+        }
+        $riskPct = min($riskPct, 1.0);
+        $riskUsdt = $availableBudget * $riskPct;
         if ($riskUsdt <= 0.0) {
+            $this->journeyLogger->error('order_journey.plan_builder.invalid_risk', [
+                'symbol' => $req->symbol,
+                'decision_key' => $decisionKey,
+                'risk_pct' => $req->riskPct,
+                'available_budget' => $availableBudget,
+                'reason' => 'computed_risk_zero',
+            ]);
             throw new \RuntimeException('Risk USDT nul, ajuster riskPct ou margin');
         }
 
         $tick = $pre->tickSize ?? TickQuantizer::tick($precision);
+        $sizeStep = $volPrecision > 0 ? pow(10, -$volPrecision) : 1.0;
 
-        $baseline = $pre->lastPrice ?? ($req->side === Side::Long ? $pre->bestBid : $pre->bestAsk);
-        if (!\is_finite($baseline) || $baseline <= 0.0) {
-            $baseline = $req->side === Side::Long ? $pre->bestBid : $pre->bestAsk;
-        }
-        if ($req->side === Side::Long) {
-            $baseline = min($baseline, $pre->bestAsk);
-            $baseline = max($baseline, $tick);
-            $baseline = TickQuantizer::quantize($baseline, $precision);
-        } else {
-            $baseline = max($baseline, $pre->bestBid);
-            $baseline = max($baseline, $tick);
-            $baseline = TickQuantizer::quantizeUp($baseline, $precision);
-        }
+        $bestBid = (float)$pre->bestBid;
+        $bestAsk = (float)$pre->bestAsk;
+        $mid     = 0.5 * ($bestBid + $bestAsk);
+        $mark    = $pre->markPrice ?? $mid;
 
-        $entry = $baseline;
+        $insideTicks         = max(1, (int)($req->insideTicks ?? 1));
+        $maxDeviationPct     = $this->normalizePercent($req->maxDeviationPct ?? 0.005);
+        $implausiblePct      = $this->normalizePercent($req->implausiblePct ?? 0.02);
+        $zoneMaxDeviationPct = $this->normalizePercent($req->zoneMaxDeviationPct ?? 0.007);
+
         if ($req->orderType === 'limit') {
             if ($req->side === Side::Long) {
-                $entry = min($entry, $pre->bestAsk - $tick);
+                $entry = min($bestAsk - $tick, $bestBid + $insideTicks * $tick);
                 if ($req->entryLimitHint !== null) {
-                    $entry = min($entry, $req->entryLimitHint);
+                    $hint = max((float)$req->entryLimitHint, $tick);
+                    $hint = TickQuantizer::quantize($hint, $precision);
+                    $entry = max($entry, $bestBid - 2 * $tick);
+                    $entry = min($entry, $hint);
+                }
+                $dev = abs($entry - $mark) / max($mark, 1e-8);
+                if ($dev > $maxDeviationPct) {
+                    $entry = min($bestAsk - $tick, $bestBid + $tick);
                 }
                 $entry = max($entry, $tick);
                 $entry = TickQuantizer::quantize($entry, $precision);
             } else {
-                $entry = max($entry, $pre->bestBid + $tick);
+                $entry = max($bestBid + $tick, $bestAsk - $insideTicks * $tick);
                 if ($req->entryLimitHint !== null) {
-                    $entry = max($entry, $req->entryLimitHint);
+                    $hint = max((float)$req->entryLimitHint, $tick);
+                    $hint = TickQuantizer::quantizeUp($hint, $precision);
+                    $entry = min($entry, $bestAsk + 2 * $tick);
+                    $entry = max($entry, $hint);
+                }
+                $dev = abs($entry - $mark) / max($mark, 1e-8);
+                if ($dev > $maxDeviationPct) {
+                    $entry = max($bestBid + $tick, $bestAsk - $tick);
                 }
                 $entry = max($entry, $tick);
                 $entry = TickQuantizer::quantizeUp($entry, $precision);
             }
         } else {
-            $entry = $req->side === Side::Long ? $pre->bestAsk : $pre->bestBid;
+            $entry = $req->side === Side::Long ? $bestAsk : $bestBid;
         }
 
         $this->flowLogger->debug('order_plan.entry_price_baseline', [
             'symbol' => $req->symbol,
             'side' => $req->side->value,
-            'baseline' => $baseline,
-            'best_bid' => $pre->bestBid,
-            'best_ask' => $pre->bestAsk,
-            'last_price' => $pre->lastPrice,
-            'tick' => $tick,
+            'best_bid' => $bestBid,
+            'best_ask' => $bestAsk,
+            'mark_price' => $mark,
+            'entry' => $entry,
+            'inside_ticks' => $insideTicks,
+            'max_dev_pct' => $maxDeviationPct,
             'decision_key' => $decisionKey,
         ]);
+        $this->journeyLogger->debug('order_journey.plan_builder.entry_selected', [
+            'symbol' => $req->symbol,
+            'decision_key' => $decisionKey,
+            'entry' => $entry,
+            'side' => $req->side->value,
+            'order_type' => $req->orderType,
+            'reason' => 'entry_price_finalized',
+        ]);
 
-        // If a zone is provided, clamp entry to zone to avoid out-of-zone errors later.
+        if (!\is_finite($entry) || $entry <= 0.0) {
+            $this->journeyLogger->error('order_journey.plan_builder.invalid_entry', [
+                'symbol' => $req->symbol,
+                'decision_key' => $decisionKey,
+                'entry' => $entry,
+                'reason' => 'entry_non_positive',
+            ]);
+            throw new \RuntimeException('Prix d\'entrée invalide');
+        }
+
         if ($zone instanceof EntryZone) {
-            $clamped = max($zone->min, min($entry, $zone->max));
-            if ($clamped !== $entry) {
+            $zoneDeviation = $mark > 0.0 ? max(abs($zone->min - $mark), abs($zone->max - $mark)) / $mark : 0.0;
+            if ($zoneDeviation <= $zoneMaxDeviationPct) {
+                $clamped = max($zone->min, min($entry, $zone->max));
                 $adj = $req->side === Side::Long
                     ? TickQuantizer::quantize($clamped, $precision)
                     : TickQuantizer::quantizeUp($clamped, $precision);
-                $this->flowLogger->info('order_plan.entry_clamped_to_zone', [
+                if ($adj !== $entry) {
+                    $this->flowLogger->info('order_plan.entry_clamped_to_zone', [
+                        'symbol' => $req->symbol,
+                        'entry_before' => $entry,
+                        'entry_after' => $adj,
+                        'zone_min' => $zone->min,
+                        'zone_max' => $zone->max,
+                        'decision_key' => $decisionKey,
+                    ]);
+                    $this->journeyLogger->info('order_journey.plan_builder.entry_clamped', [
+                        'symbol' => $req->symbol,
+                        'decision_key' => $decisionKey,
+                        'entry_before' => $entry,
+                        'entry_after' => $adj,
+                        'zone_min' => $zone->min,
+                        'zone_max' => $zone->max,
+                        'reason' => 'entry_adjusted_to_zone',
+                    ]);
+                    $entry = $adj;
+                }
+            } else {
+                $this->flowLogger->warning('order_plan.zone_ignored_far_from_market', [
                     'symbol' => $req->symbol,
-                    'side' => $req->side->value,
-                    'entry_before' => $entry,
-                    'entry_after' => $adj,
                     'zone_min' => $zone->min,
                     'zone_max' => $zone->max,
+                    'mark' => $mark,
+                    'zone_dev_pct' => $zoneDeviation,
                     'decision_key' => $decisionKey,
                 ]);
-                $entry = $adj;
+                $this->journeyLogger->info('order_journey.plan_builder.zone_ignored', [
+                    'symbol' => $req->symbol,
+                    'decision_key' => $decisionKey,
+                    'zone_dev_pct' => $zoneDeviation,
+                    'reason' => 'zone_far_from_market',
+                ]);
             }
         }
 
-        // Extra guard: if entry looks implausible (e.g., 1.0), fallback to best bid/ask
-        // Rationale: prevent downstream zone checks from failing due to bad pricing hints or precision issues.
-        $mid = 0.5 * ($pre->bestBid + $pre->bestAsk);
-        if (!\is_finite($entry) || $entry <= $tick || $entry < 0.2 * $mid || $entry > 5.0 * $mid) {
-            $fallback = $req->side === Side::Long ? max($pre->bestBid, $pre->bestAsk - $tick) : min($pre->bestAsk, $pre->bestBid + $tick);
-            $fixed = $req->side === Side::Long
+        if ($entry <= $tick || (abs($entry - $mark) / max($mark, 1e-8)) > $implausiblePct) {
+            $fallback = $req->side === Side::Long
+                ? min($bestAsk - $tick, $bestBid + $tick)
+                : max($bestBid + $tick, $bestAsk - $tick);
+            $entry = $req->side === Side::Long
                 ? TickQuantizer::quantize($fallback, $precision)
                 : TickQuantizer::quantizeUp($fallback, $precision);
+
             $this->flowLogger->warning('order_plan.entry_price_fallback', [
                 'symbol' => $req->symbol,
-                'side' => $req->side->value,
-                'entry_before' => $entry,
-                'best_bid' => $pre->bestBid,
-                'best_ask' => $pre->bestAsk,
-                'mid' => $mid,
-                'tick' => $tick,
-                'entry_after' => $fixed,
+                'entry_after' => $entry,
+                'mark' => $mark,
+                'implausible_pct' => $implausiblePct,
                 'decision_key' => $decisionKey,
             ]);
-            $entry = $fixed;
-        }
-
-        $this->flowLogger->debug('order_plan.entry_price_selected', [
-            'symbol' => $req->symbol,
-            'side' => $req->side->value,
-            'order_type' => $req->orderType,
-            'best_bid' => $pre->bestBid,
-            'best_ask' => $pre->bestAsk,
-            'tick' => $tick,
-            'entry_limit_hint' => $req->entryLimitHint,
-            'entry' => $entry,
-            'decision_key' => $decisionKey,
-        ]);
-
-        if ($entry <= 0.0) {
-            throw new \RuntimeException('Prix d\'entrée invalide');
+            $this->journeyLogger->warning('order_journey.plan_builder.entry_fallback', [
+                'symbol' => $req->symbol,
+                'decision_key' => $decisionKey,
+                'entry_after' => $entry,
+                'reason' => 'entry_too_far_from_mark',
+            ]);
         }
 
         $sizingDistance = $tick * 10;
         $stopAtr = null;
-        if ($req->stopFrom === 'atr' && $req->atrValue !== null) {
-            $stopAtr = $this->slc->fromAtr($entry, $req->side, $req->atrValue, $req->atrK, $precision);
+
+        if ($req->stopFrom === 'atr') {
+            if (!\is_finite($req->atrValue) || $req->atrValue <= 0.0 || $req->atrK <= 0.0) {
+                throw new \InvalidArgumentException('ATR invalide pour stopFrom=atr');
+            }
+            $stopAtr = $this->slc->fromAtr($entry, $req->side, (float)$req->atrValue, (float)$req->atrK, $precision);
             $sizingDistance = max(abs($entry - $stopAtr), $tick);
         }
 
@@ -159,17 +225,46 @@ final class OrderPlanBuilder
             ? $this->slc->conservative($req->side, $stopAtr, $stopRisk)
             : $stopRisk;
 
+        $finalDistance = max(abs($entry - $stop), $tick);
+        if (abs($finalDistance - $sizingDistance) > 1e-12) {
+            $size = $this->positionSizer->fromRiskAndDistance($riskUsdt, $finalDistance, $contractSize, $minVolume);
+        }
+
         $this->flowLogger->debug('order_plan.sizing', [
             'symbol' => $req->symbol,
             'risk_usdt' => $riskUsdt,
-            'sizing_distance' => $sizingDistance,
+            'initial_distance' => $sizingDistance,
+            'final_distance' => $finalDistance,
             'contract_size' => $contractSize,
             'min_volume' => $minVolume,
-            'size' => $size,
+            'size_prequant' => $size,
             'decision_key' => $decisionKey,
         ]);
+        $this->journeyLogger->debug('order_journey.plan_builder.sizing', [
+            'symbol' => $req->symbol,
+            'decision_key' => $decisionKey,
+            'risk_usdt' => $riskUsdt,
+            'size_prequant' => $size,
+            'reason' => 'position_size_computed',
+        ]);
 
-        // Assurer un écart minimal d'un tick entre entry et stop après quantification
+        if ($volPrecision === 0) {
+            $size = (float)floor($size);
+        } else {
+            $size = floor($size / $sizeStep) * $sizeStep;
+        }
+        $size = max($size, (float)$minVolume);
+        if ($req->orderType === 'market' && $marketMaxVolume !== null && $marketMaxVolume > 0.0) {
+            $size = min($size, $marketMaxVolume);
+        } elseif ($maxVolume !== null && $maxVolume > 0.0) {
+            $size = min($size, $maxVolume);
+        }
+
+        $sizeContracts = (int)max($minVolume, floor($size));
+        if ($sizeContracts <= 0) {
+            throw new \RuntimeException('Taille calculée invalide');
+        }
+
         $minTick = TickQuantizer::tick($precision);
         if ($stop <= 0.0 || abs($stop - $entry) < $minTick) {
             if ($req->side === Side::Long) {
@@ -182,7 +277,27 @@ final class OrderPlanBuilder
             throw new \RuntimeException('Stop loss invalide');
         }
 
-        $takeProfit = $this->tpc->fromRMultiple($entry, $stop, $req->side, $req->rMultiple, $precision);
+        $takeProfit = $this->tpc->fromRMultiple($entry, $stop, $req->side, (float)$req->rMultiple, $precision);
+
+        if (is_array($pre->pivotLevels) && !empty($pre->pivotLevels) && $req->rMultiple > 0.0) {
+            $takeProfit = $this->alignTakeProfitWithPivot(
+                symbol: $req->symbol,
+                side: $req->side,
+                entry: $entry,
+                stop: $stop,
+                baseTakeProfit: $takeProfit,
+                rMultiple: (float)$req->rMultiple,
+                pivotLevels: $pre->pivotLevels,
+                policy: $req->tpPolicy,
+                bufferPct: $req->tpBufferPct,
+                bufferTicks: $req->tpBufferTicks,
+                tick: $tick,
+                pricePrecision: $precision,
+                minKeepRatio: $req->tpMinKeepRatio,
+                maxExtraR: $req->tpMaxExtraR,
+                decisionKey: $decisionKey,
+            );
+        }
 
         $this->flowLogger->debug('order_plan.stop_and_tp', [
             'symbol' => $req->symbol,
@@ -197,33 +312,73 @@ final class OrderPlanBuilder
             'r_multiple' => $req->rMultiple,
             'decision_key' => $decisionKey,
         ]);
+        $this->journeyLogger->debug('order_journey.plan_builder.stop_tp', [
+            'symbol' => $req->symbol,
+            'decision_key' => $decisionKey,
+            'entry' => $entry,
+            'stop' => $stop,
+            'take_profit' => $takeProfit,
+            'reason' => 'risk_targets_calculated',
+        ]);
 
         $leverage = $this->leverageService->computeLeverage(
             $req->symbol,
             $entry,
             $contractSize,
-            $size,
+            $sizeContracts,
             $req->initialMarginUsdt,
             $pre->availableUsdt,
             $pre->minLeverage,
             $pre->maxLeverage
         );
 
-        // Pre-model budget check for observability
-        $notionalDbg = $entry * $contractSize * $size;
-        $initialMarginDbg = $notionalDbg / max(1, (float)$leverage);
+        $notional = $entry * $contractSize * $sizeContracts;
+        $initialMargin = $notional / max(1.0, (float)$leverage);
+        if ($initialMargin > $availableBudget) {
+            $requiredLeverage = max(1.0, $notional / max($availableBudget, 1e-8));
+            $adjustedLeverage = min(max($requiredLeverage, (float)$pre->minLeverage), (float)$pre->maxLeverage);
+            if ($adjustedLeverage > (float)$leverage) {
+                $leverage = $adjustedLeverage;
+                $initialMargin = $notional / $leverage;
+            }
+            if ($initialMargin > $availableBudget) {
+                $maxNotional = $availableBudget * $leverage;
+                $size = max($minVolume, floor(($maxNotional / max($entry * $contractSize, 1e-8)) / $sizeStep) * $sizeStep);
+                if ($maxVolume !== null && $maxVolume > 0.0) {
+                    $size = min($size, $maxVolume);
+                }
+                if ($req->orderType === 'market' && $marketMaxVolume !== null && $marketMaxVolume > 0.0) {
+                    $size = min($size, $marketMaxVolume);
+                }
+                $sizeContracts = (int)max($minVolume, floor($size));
+                if ($sizeContracts <= 0) {
+                    throw new \RuntimeException('Taille ajustée invalide après contrôle budget');
+                }
+                $notional = $entry * $contractSize * $sizeContracts;
+                $initialMargin = $notional / $leverage;
+            }
+        }
+
         $this->flowLogger->debug('order_plan.budget_check', [
             'symbol' => $req->symbol,
             'risk_usdt' => $riskUsdt,
             'entry' => $entry,
-            'size' => $size,
+            'size' => $sizeContracts,
             'contract_size' => $contractSize,
-            'notional_usdt' => $notionalDbg,
+            'notional_usdt' => $notional,
             'initial_margin_budget' => $req->initialMarginUsdt,
-            'initial_margin_usdt' => $initialMarginDbg,
+            'initial_margin_usdt' => $initialMargin,
             'available_usdt' => $pre->availableUsdt,
             'leverage' => $leverage,
             'decision_key' => $decisionKey,
+        ]);
+        $this->journeyLogger->debug('order_journey.plan_builder.leverage', [
+            'symbol' => $req->symbol,
+            'decision_key' => $decisionKey,
+            'leverage' => $leverage,
+            'notional_usdt' => $notional,
+            'initial_margin_usdt' => $initialMargin,
+            'reason' => 'leverage_and_margin_computed',
         ]);
 
         $orderMode = $req->orderType === 'market' ? 1 : $req->orderMode;
@@ -237,14 +392,11 @@ final class OrderPlanBuilder
             entry: $entry,
             stop: $stop,
             takeProfit: $takeProfit,
-            size: $size,
+            size: $sizeContracts,
             leverage: $leverage,
             pricePrecision: $precision,
             contractSize: $contractSize,
         );
-
-        $notional = $model->entry * $model->contractSize * $model->size;
-        $initialMargin = $notional / max(1, (float)$model->leverage);
 
         $this->positionsLogger->info('order_plan.model_ready', [
             'symbol' => $model->symbol,
@@ -258,11 +410,216 @@ final class OrderPlanBuilder
             'size' => $model->size,
             'leverage' => $model->leverage,
             'contract_size' => $model->contractSize,
-            'notional_usdt' => $notional,
-            'initial_margin_usdt' => $initialMargin,
+            'notional_usdt' => $model->entry * $model->contractSize * $model->size,
+            'initial_margin_usdt' => ($model->entry * $model->contractSize * $model->size) / max(1.0, (float)$model->leverage),
             'decision_key' => $decisionKey,
+        ]);
+        $this->journeyLogger->info('order_journey.plan_builder.model_ready', [
+            'symbol' => $model->symbol,
+            'decision_key' => $decisionKey,
+            'entry' => $model->entry,
+            'stop' => $model->stop,
+            'take_profit' => $model->takeProfit,
+            'size' => $model->size,
+            'leverage' => $model->leverage,
+            'order_mode' => $model->orderMode,
+            'reason' => 'order_plan_ready_for_execution',
         ]);
 
         return $model;
+    }
+
+    private function normalizePercent(float $value): float
+    {
+        $value = max(0.0, $value);
+        if ($value > 1.0) {
+            $value *= 0.01;
+        }
+
+        return min($value, 1.0);
+    }
+
+    private function alignTakeProfitWithPivot(
+        string $symbol,
+        Side $side,
+        float $entry,
+        float $stop,
+        float $baseTakeProfit,
+        float $rMultiple,
+        array $pivotLevels,
+        string $policy,
+        ?float $bufferPct,
+        ?int $bufferTicks,
+        float $tick,
+        int $pricePrecision,
+        float $minKeepRatio,
+        ?float $maxExtraR,
+        ?string $decisionKey
+    ): float {
+        $riskUnit = $side === Side::Long ? $entry - $stop : $stop - $entry;
+        if ($riskUnit <= 0.0) {
+            return $baseTakeProfit;
+        }
+
+        $tpTheoretical = $side === Side::Long
+            ? $entry + $rMultiple * $riskUnit
+            : $entry - $rMultiple * $riskUnit;
+
+        $pivots = $this->collectPivotsForSide($side, $entry, $pivotLevels);
+        $candidate = $this->choosePivotCandidate($pivots, $side, $tpTheoretical, $entry, $riskUnit, $rMultiple, $policy, $maxExtraR);
+
+        $tpRaw = $candidate ?? $tpTheoretical;
+        $tpRaw = $this->applyTpBuffer($side, $tpRaw, $bufferPct, $bufferTicks, $tick);
+
+        if ($side === Side::Long) {
+            $tpRaw = max($tpRaw, $entry + $tick);
+            $tpFinal = TickQuantizer::quantizeUp($tpRaw, $pricePrecision);
+            if ($tpFinal <= $entry) {
+                $tpFinal = TickQuantizer::quantizeUp($entry + $tick, $pricePrecision);
+            }
+        } else {
+            $tpRaw = min($tpRaw, $entry - $tick);
+            $tpFinal = TickQuantizer::quantize($tpRaw, $pricePrecision);
+            if ($tpFinal >= $entry) {
+                $tpFinal = TickQuantizer::quantize($entry - $tick, $pricePrecision);
+            }
+        }
+
+        $effectiveK = abs($tpFinal - $entry) / $riskUnit;
+        if ($effectiveK < $minKeepRatio * $rMultiple) {
+            $tpFinal = $side === Side::Long
+                ? TickQuantizer::quantizeUp(max($tpTheoretical, $entry + $tick), $pricePrecision)
+                : TickQuantizer::quantize(min($tpTheoretical, $entry - $tick), $pricePrecision);
+        }
+
+        $this->flowLogger->info('order_plan.tp_aligned', [
+            'symbol' => $symbol,
+            'side' => $side->value,
+            'entry' => $entry,
+            'stop' => $stop,
+            'risk_unit' => $riskUnit,
+            'tp_theoretical' => $tpTheoretical,
+            'tp_candidate' => $candidate,
+            'tp_final' => $tpFinal,
+            'policy' => $policy,
+            'buffer_pct' => $bufferPct,
+            'buffer_ticks' => $bufferTicks,
+            'effective_k' => $effectiveK,
+            'decision_key' => $decisionKey,
+        ]);
+
+        $this->journeyLogger->info('order_journey.plan_builder.tp_aligned', [
+            'symbol' => $symbol,
+            'decision_key' => $decisionKey,
+            'policy' => $policy,
+            'tp_theoretical' => $tpTheoretical,
+            'tp_candidate' => $candidate,
+            'tp_final' => $tpFinal,
+            'buffer_pct' => $bufferPct,
+            'buffer_ticks' => $bufferTicks,
+            'effective_k' => $effectiveK,
+            'min_keep_ratio' => $minKeepRatio,
+        ]);
+
+        return $tpFinal;
+    }
+
+    /**
+     * @return float[]
+     */
+    private function collectPivotsForSide(Side $side, float $entry, array $pivotLevels): array
+    {
+        $levels = [];
+        $pp = $pivotLevels['pp'] ?? null;
+
+        if ($side === Side::Long) {
+            if ($pp !== null && $entry < $pp) {
+                $levels[] = $pp;
+            }
+            foreach (['r1', 'r2', 'r3'] as $key) {
+                if (isset($pivotLevels[$key])) {
+                    $levels[] = $pivotLevels[$key];
+                }
+            }
+            $levels = array_values(array_filter($levels, static fn($v) => is_finite((float)$v)));
+            sort($levels, SORT_NUMERIC);
+        } else {
+            if ($pp !== null && $entry > $pp) {
+                $levels[] = $pp;
+            }
+            foreach (['s1', 's2', 's3'] as $key) {
+                if (isset($pivotLevels[$key])) {
+                    $levels[] = $pivotLevels[$key];
+                }
+            }
+            $levels = array_values(array_filter($levels, static fn($v) => is_finite((float)$v)));
+            rsort($levels, SORT_NUMERIC);
+        }
+
+        return $levels;
+    }
+
+    private function choosePivotCandidate(
+        array $pivots,
+        Side $side,
+        float $tpTheoretical,
+        float $entry,
+        float $riskUnit,
+        float $rMultiple,
+        string $policy,
+        ?float $maxExtraR
+    ): ?float {
+        if (empty($pivots)) {
+            return null;
+        }
+
+        $candidate = null;
+        if ($side === Side::Long) {
+            foreach ($pivots as $pivot) {
+                if ($pivot >= $tpTheoretical) {
+                    $candidate = $pivot;
+                    break;
+                }
+            }
+        } else {
+            foreach ($pivots as $pivot) {
+                if ($pivot <= $tpTheoretical) {
+                    $candidate = $pivot;
+                    break;
+                }
+            }
+        }
+
+        if ($candidate === null) {
+            return null;
+        }
+
+        if ($policy === 'pivot_aggressive' && $maxExtraR !== null) {
+            $candidateKR = abs($candidate - $entry) / $riskUnit;
+            if ($candidateKR > $rMultiple + $maxExtraR) {
+                return null;
+            }
+        }
+
+        return $candidate;
+    }
+
+    private function applyTpBuffer(Side $side, float $tp, ?float $bufferPct, ?int $bufferTicks, float $tick): float
+    {
+        $result = $tp;
+
+        if ($bufferPct !== null && $bufferPct > 0.0) {
+            $factor = $bufferPct;
+            $result = $side === Side::Long
+                ? $result * (1.0 - $factor)
+                : $result * (1.0 + $factor);
+        }
+
+        if ($bufferTicks !== null && $bufferTicks > 0) {
+            $offset = $bufferTicks * $tick;
+            $result = $side === Side::Long ? $result - $offset : $result + $offset;
+        }
+
+        return $result;
     }
 }

--- a/trading-app/src/TradeEntry/Service/TradeEntryService.php
+++ b/trading-app/src/TradeEntry/Service/TradeEntryService.php
@@ -5,6 +5,8 @@ namespace App\TradeEntry\Service;
 
 use App\TradeEntry\Dto\{TradeEntryRequest, ExecutionResult};
 use App\TradeEntry\Workflow\{BuildPreOrder, BuildOrderPlan, ExecuteOrderPlan};
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class TradeEntryService
 {
@@ -13,6 +15,7 @@ final class TradeEntryService
         private readonly BuildOrderPlan $planner,
         private readonly ExecuteOrderPlan $executor,
         private readonly TradeEntryMetricsService $metrics,
+        #[Autowire(service: 'monolog.logger.order_journey')] private readonly LoggerInterface $orderJourneyLogger,
     ) {}
 
     public function buildAndExecute(TradeEntryRequest $request, ?string $decisionKey = null): ExecutionResult
@@ -26,9 +29,48 @@ final class TradeEntryService
             }
         }
 
+        $this->orderJourneyLogger->info('order_journey.trade_entry.preflight_start', [
+            'symbol' => $request->symbol,
+            'decision_key' => $decisionKey,
+            'reason' => 'pretrade_checks_begin',
+            'order_type' => $request->orderType,
+            'side' => $request->side->value,
+        ]);
+
         $preflight = ($this->preflight)($request, $decisionKey);
+
+        $this->orderJourneyLogger->debug('order_journey.trade_entry.preflight_snapshot', [
+            'symbol' => $preflight->symbol,
+            'decision_key' => $decisionKey,
+            'best_bid' => $preflight->bestBid,
+            'best_ask' => $preflight->bestAsk,
+            'spread_pct' => $preflight->spreadPct,
+            'available_usdt' => $preflight->availableUsdt,
+            'reason' => 'snapshot_after_checks',
+        ]);
+
         $plan = ($this->planner)($request, $preflight, $decisionKey);
+
+        $this->orderJourneyLogger->info('order_journey.trade_entry.plan_ready', [
+            'symbol' => $plan->symbol,
+            'decision_key' => $decisionKey,
+            'entry' => $plan->entry,
+            'size' => $plan->size,
+            'leverage' => $plan->leverage,
+            'order_mode' => $plan->orderMode,
+            'reason' => 'plan_constructed',
+        ]);
+
         $result = ($this->executor)($plan, $decisionKey);
+
+        $this->orderJourneyLogger->info('order_journey.trade_entry.execution_complete', [
+            'symbol' => $plan->symbol,
+            'decision_key' => $decisionKey,
+            'status' => $result->status,
+            'client_order_id' => $result->clientOrderId,
+            'exchange_order_id' => $result->exchangeOrderId,
+            'reason' => 'execution_finished',
+        ]);
 
         $this->metrics->incr($result->status === 'submitted' ? 'submitted' : 'errors');
 
@@ -44,6 +86,12 @@ final class TradeEntryService
                 $decisionKey = uniqid('te:' . $request->symbol . ':', true);
             }
         }
+
+        $this->orderJourneyLogger->info('order_journey.trade_entry.simulation_start', [
+            'symbol' => $request->symbol,
+            'decision_key' => $decisionKey,
+            'reason' => 'simulate_trade_entry',
+        ]);
 
         // Run preflight and planning only (no execution)
         // Propagate decision key for consistent logging across steps

--- a/trading-app/src/TradeEntry/Workflow/BuildPreOrder.php
+++ b/trading-app/src/TradeEntry/Workflow/BuildPreOrder.php
@@ -13,6 +13,7 @@ final class BuildPreOrder
     public function __construct(
         private readonly PreTradeChecks $checks,
         #[Autowire(service: 'monolog.logger.positions_flow')] private readonly LoggerInterface $flowLogger,
+        #[Autowire(service: 'monolog.logger.order_journey')] private readonly LoggerInterface $journeyLogger,
     ) {}
 
     public function __invoke(TradeEntryRequest $req, ?string $decisionKey = null): PreflightReport
@@ -22,6 +23,13 @@ final class BuildPreOrder
             'side' => $req->side->value,
             'order_type' => $req->orderType,
             'decision_key' => $decisionKey,
+        ]);
+        $this->journeyLogger->info('order_journey.preflight.started', [
+            'symbol' => $req->symbol,
+            'decision_key' => $decisionKey,
+            'side' => $req->side->value,
+            'order_type' => $req->orderType,
+            'reason' => 'collect_exchange_state',
         ]);
 
         try {
@@ -34,14 +42,32 @@ final class BuildPreOrder
                 'best_ask' => $pre->bestAsk,
                 'price_precision' => $pre->pricePrecision,
                 'last_price' => $pre->lastPrice,
+                'mark_price' => $pre->markPrice,
                 'tick_size' => $pre->tickSize,
                 'contract_size' => $pre->contractSize,
                 'min_volume' => $pre->minVolume,
+                'vol_precision' => $pre->volPrecision,
+                'max_volume' => $pre->maxVolume,
+                'market_max_volume' => $pre->marketMaxVolume,
                 'max_leverage' => $pre->maxLeverage,
                 'min_leverage' => $pre->minLeverage,
                 'available_usdt' => $pre->availableUsdt,
                 'spread_pct' => $pre->spreadPct,
                 'mode_note' => $pre->modeNote,
+            ]);
+
+            $this->journeyLogger->info('order_journey.preflight.completed', [
+                'symbol' => $pre->symbol,
+                'decision_key' => $decisionKey,
+                'best_bid' => $pre->bestBid,
+                'best_ask' => $pre->bestAsk,
+                'spread_pct' => $pre->spreadPct,
+                'available_usdt' => $pre->availableUsdt,
+                'mark_price' => $pre->markPrice,
+                'vol_precision' => $pre->volPrecision,
+                'max_volume' => $pre->maxVolume,
+                'market_max_volume' => $pre->marketMaxVolume,
+                'reason' => 'pretrade_snapshot_ready',
             ]);
 
             return $pre;
@@ -50,6 +76,12 @@ final class BuildPreOrder
                 'symbol' => $req->symbol,
                 'decision_key' => $decisionKey,
                 'message' => $e->getMessage(),
+            ]);
+            $this->journeyLogger->error('order_journey.preflight.failed', [
+                'symbol' => $req->symbol,
+                'decision_key' => $decisionKey,
+                'reason' => 'exception_during_pretrade_checks',
+                'error' => $e->getMessage(),
             ]);
             throw $e;
         }


### PR DESCRIPTION
…rameters; update risk percentage and introduce pivot levels; improve logging for order journey and timeout handling

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pivot-aware TP and inside-spread LIMIT entries with new preflight/request fields and end-to-end order_journey logging, plus auto MtfSwitch cooldown reduction on order timeout and supporting docs.
> 
> - **Trade Entry pipeline**:
>   - Extend `TradeEntryRequest` and `PreflightReport` with proximity, sizing, and TP policy fields (`inside_ticks`, deviation thresholds, `tp_policy`/buffers, `markPrice`, volume precision/limits, `pivotLevels`).
>   - Rework `OrderPlanBuilder`:
>     - Select LIMIT entry inside spread, clamp to zone, guard against implausible prices; respect mark-based deviation limits.
>     - Size/round by contract volume precision and enforce market/max volume; robust leverage/budget checks.
>     - Compute TP by k·R then align to daily pivots with buffers and safeguards.
>   - `PreTradeChecks`: fetch/index price, volume precisions/limits, daily pivots; block wide-spread MARKET; emit metrics.
>   - `ExecutionBox`/`TpSlAttacher`: enriched presubmit/attempt logging, preset TP/SL; schedule timeout message.
>   - `CancelOrderMessageHandler`: on timeout, cancel pending orders and shorten `MtfSwitch` OFF to configurable duration (default 15m); detailed logs.
> - **Indicators**:
>   - `IndicatorProviderService`: compute/expose classic daily pivot levels; provide `getListPivot` and caching.
> - **Orchestration & logging**:
>   - Add structured `order_journey` logs with `decision_key` across orchestrator, symbol processing, planning, execution, and errors.
>   - `MtfRunCommand`: more robust worker JSON extraction.
> - **Config**:
>   - Update `mtf_validations.yaml`: raise `risk_pct_percent` to `5.0`; add proximity and TP pivot settings.
>   - `ContractRepository`: adjust symbol selection limits (`top_n` 140, `mid_n` 40).
> - **Docs**:
>   - New `docs/ORDER_FLOW_README.md` (order flow + TP pivot rules) and `docs/ORDER_TIMEOUT_MTF_SWITCH.md` (timeout and MtfSwitch cooldown).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95cd88e27997b746c45e78e155a9633bead6829d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->