### PR TITLE
Set default order mode to taker

### DIFF
--- a/trading-app/config/app/mtf_validations.yaml
+++ b/trading-app/config/app/mtf_validations.yaml
@@ -22,7 +22,7 @@ mtf_validation:
         r_multiple: 2.0
         order_type: 'limit'
         open_type: 'isolated'
-        order_mode: 4
+        order_mode: 1
         stop_from: 'atr'
         market_max_spread_pct: 0.001
         inside_ticks: 1

--- a/trading-app/src/Controller/TradeEntryController.php
+++ b/trading-app/src/Controller/TradeEntryController.php
@@ -67,7 +67,7 @@ final class TradeEntryController extends AbstractController
                 side: $side,
                 orderType: $data['order_type'] ?? ($defaults['order_type'] ?? 'limit'),
                 openType: $data['open_type'] ?? ($defaults['open_type'] ?? 'isolated'),
-                orderMode: (int)($data['order_mode'] ?? ($defaults['order_mode'] ?? 4)),
+                orderMode: (int)($data['order_mode'] ?? ($defaults['order_mode'] ?? 1)),
                 initialMarginUsdt: (float)($data['initial_margin_usdt'] ?? ($defaults['initial_margin_usdt'] ?? 100.0)),
                 riskPct: $riskPct,
                 rMultiple: isset($data['r_multiple']) ? (float)$data['r_multiple'] : (float)($defaults['r_multiple'] ?? 2.0),

--- a/trading-app/src/EntryTrade/Example/ExampleTradeEntryRunner.php
+++ b/trading-app/src/EntryTrade/Example/ExampleTradeEntryRunner.php
@@ -40,7 +40,7 @@ final class ExampleTradeEntryRunner
             side: $side,
             orderType: 'limit',
             openType: $defaults['open_type'] ?? 'isolated',
-            orderMode: (int)($defaults['order_mode'] ?? 4),
+            orderMode: (int)($defaults['order_mode'] ?? 1),
             initialMarginUsdt: (float)($defaults['initial_margin_usdt'] ?? 100.0),
             riskPct: $riskPct,
             rMultiple: (float)($defaults['r_multiple'] ?? 2.0),

--- a/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
+++ b/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
@@ -357,7 +357,7 @@ final class TradingDecisionHandler
             side: $sideEnum,
             orderType: $orderType,
             openType: $defaults['open_type'] ?? 'isolated',
-            orderMode: (int)($defaults['order_mode'] ?? 4),
+            orderMode: (int)($defaults['order_mode'] ?? 1),
             initialMarginUsdt: $initialMargin,
             riskPct: $riskPct,
             rMultiple: (float)($defaults['r_multiple'] ?? 2.0),


### PR DESCRIPTION
## Summary
- change the default MTF validation order mode to 1 so orders are not submitted as post-only
- update Trade Entry request builders to use order mode 1 when no explicit value is provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907d04b4664832490f821d584509d41