### PR TITLE
Alias order mode policy via attribute

### DIFF
--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -8,7 +8,7 @@ use App\Common\Enum\OrderType;
 use App\Contract\Provider\MainProviderInterface;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
 use App\TradeEntry\Dto\{ExecutionResult};
-use App\TradeEntry\Policy\{IdempotencyPolicy, MakerOnlyPolicy};
+use App\TradeEntry\Policy\{IdempotencyPolicy, OrderModePolicyInterface};
 use App\TradeEntry\Message\CancelOrderMessage;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
@@ -20,7 +20,7 @@ final class ExecutionBox
     public function __construct(
         private readonly MainProviderInterface $providers,
         private readonly TpSlAttacher $tpSl,
-        private readonly MakerOnlyPolicy $makerOnly,
+        private readonly OrderModePolicyInterface $orderModePolicy,
         private readonly IdempotencyPolicy $idempotency,
         private readonly ExecutionLogger $logger,
         private readonly MessageBusInterface $messageBus,
@@ -32,7 +32,7 @@ final class ExecutionBox
 
     public function execute(OrderPlanModel $plan, ?string $decisionKey = null): ExecutionResult
     {
-        $this->makerOnly->enforce($plan);
+        $this->orderModePolicy->enforce($plan);
         $this->logger->debug('execution.start', [
             'symbol' => $plan->symbol,
             'side' => $plan->side->value,

--- a/trading-app/src/TradeEntry/Policy/ConfigurableOrderModePolicy.php
+++ b/trading-app/src/TradeEntry/Policy/ConfigurableOrderModePolicy.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\Policy;
+
+use App\Config\MtfValidationConfig;
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: OrderModePolicyInterface::class)]
+final class ConfigurableOrderModePolicy implements OrderModePolicyInterface
+{
+    public function __construct(
+        private readonly MtfValidationConfig $config,
+        private readonly MakerOnlyPolicy $makerOnlyPolicy,
+        private readonly TakerOnlyPolicy $takerOnlyPolicy,
+    ) {
+    }
+
+    public function enforce(OrderPlanModel $plan): void
+    {
+        $defaultMode = (int) $this->config->getDefault('order_mode', 4);
+
+        if ($defaultMode === 1) {
+            $this->takerOnlyPolicy->enforce($plan);
+            return;
+        }
+
+        $this->makerOnlyPolicy->enforce($plan);
+    }
+}

--- a/trading-app/src/TradeEntry/Policy/OrderModePolicyInterface.php
+++ b/trading-app/src/TradeEntry/Policy/OrderModePolicyInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\Policy;
+
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+
+interface OrderModePolicyInterface
+{
+    public function enforce(OrderPlanModel $plan): void;
+}
+

--- a/trading-app/src/TradeEntry/Policy/TakerOnlyPolicy.php
+++ b/trading-app/src/TradeEntry/Policy/TakerOnlyPolicy.php
@@ -3,17 +3,17 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\Policy;
 
-
 use App\TradeEntry\OrderPlan\OrderPlanModel;
 
-final class MakerOnlyPolicy implements OrderModePolicyInterface
+final class TakerOnlyPolicy implements OrderModePolicyInterface
 {
     public function __construct() {}
 
     public function enforce(OrderPlanModel $plan): void
     {
-        if ($plan->orderType === 'limit' && $plan->orderMode !== 4) {
-            throw new \RuntimeException('MakerOnly requis (orderMode=4) pour LIMIT');
+        if ($plan->orderType === 'limit' && $plan->orderMode !== 1) {
+            throw new \RuntimeException('TakerOnly requis (orderMode=1) pour LIMIT');
         }
     }
 }
+

--- a/trading-app/src/TradeEntry/README.md
+++ b/trading-app/src/TradeEntry/README.md
@@ -32,7 +32,10 @@ TradeEntry/
 │   ├── IdempotencyPolicy.php
 │   ├── LiquidationGuard.php
 │   ├── MakerOnlyPolicy.php
-│   └── PreTradeChecks.php
+│   ├── ConfigurableOrderModePolicy.php
+│   ├── OrderModePolicyInterface.php
+│   ├── PreTradeChecks.php
+│   └── TakerOnlyPolicy.php
 ├── Pricing/TickQuantizer.php
 ├── RiskSizer/
 │   ├── PositionSizer.php


### PR DESCRIPTION
## Summary
- replace the order-mode factory with a configurable policy implementation that selects the maker or taker strategy based on the defaults
- register the configurable policy for dependency injection using #[AsAlias] instead of the YAML service definition
- update the TradeEntry README to reference the new policy class

## Testing
- php -l trading-app/src/TradeEntry/Policy/ConfigurableOrderModePolicy.php

------
https://chatgpt.com/codex/tasks/task_e_6907d36a7a508324a340654685170597