### PR TITLE
feat(order): calculate Stop Loss from risk percentage and migrate to …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,6 +340,7 @@ services:
       APP_SECRET: d278711c5ab89bfbda10dd7d29427cf6
       WS_WORKER_SHARED_SECRET: ${WS_WORKER_SHARED_SECRET:-change-me}
       BITMART_PUBLIC_API_URL: ${BITMART_PUBLIC_API_URL}
+      WS_AGENT_BASE_URI: http://trading-app-ws-agent:8090
     depends_on:
       trading-app-db:
         condition: service_healthy
@@ -387,6 +388,59 @@ services:
       fi; php bin/console messenger:consume order_timeout --sleep=1 --failure-limit=5 --time-limit=3600"
     restart: unless-stopped
 
+  trading-app-ws-agent:
+    build:
+      context: ./trading-app
+      dockerfile: Dockerfile.mtf
+    container_name: trading_app_ws_agent
+    working_dir: /var/www/html
+    volumes:
+      - ./trading-app:/var/www/html
+      - ./trading-app/php/conf.d:/usr/local/etc/php/conf.d
+      - ws-cache:/var/www/html/var/cache
+      - ws-log:/var/www/html/var/log
+      - var-bitmart:/var/www/html/var/bitmart
+      - var-lock:/var/www/html/var/lock
+    environment:
+      <<: *global-env
+      DATABASE_URL: ${TRADING_APP_DATABASE_URL:-postgresql://postgres:password@trading-app-db:5432/trading_app?serverVersion=15&charset=utf8}
+      LOCK_DSN: postgresql://postgres:password@trading-app-db:5432/trading_app
+      APP_ENV: prod
+      APP_CACHE_DIR: /var/www/html/var/cache/prod-ws
+      APP_LOG_DIR: /var/www/html/var/log/ws
+      LOG_LEVEL_MAIN: info
+      LOG_LEVEL_SIGNALS: info
+      LOG_LEVEL_POSITIONS: info
+      LOG_LEVEL_INDICATORS: info
+      LOG_LEVEL_HIGHCONVICTION: info
+      LOG_LEVEL_PIPELINE_EXEC: info
+      LOG_LEVEL_GLOBAL_SEVERITY: error
+      ASYNC_LOGGING_ENABLED: '1'
+      WS_TOPICS: "futures/order,futures/position,futures/asset:USDT"
+      APP_SECRET: d278711c5ab89bfbda10dd7d29427cf6
+      TRADING_APP_BASE_URI: http://trading-app-nginx
+      TRADING_APP_ORDER_SUBMITTED_PATH: /api/order-submitted
+      WS_AGENT_HTTP_PORT: 8090
+      WS_AGENT_BASE_URI: http://trading-app-ws-agent:8090
+      MAILER_DSN: 'smtp://localhost'
+      MESSENGER_TRANSPORT_DSN: redis://redis:6379/log-messages
+    depends_on:
+      trading-app-db:
+        condition: service_healthy
+      trading-app-nginx:
+        condition: service_started
+    ports:
+      - "8090:8090"
+    networks:
+      - trading-app-net
+      - shared-net
+    command: >-
+      sh -c "if [ ! -f vendor/autoload.php ]; then \
+        echo '[trading-app-ws-agent] vendor missing -> composer install'; \
+        composer install --no-dev --optimize-autoloader --no-interaction; \
+      fi; php bin/console app:ws:agent"
+    restart: unless-stopped
+
   trading-app-nginx:
     image: nginx:latest
     container_name: trading_app_nginx
@@ -427,6 +481,10 @@ volumes:
 #  mysql-data:
   trading-app-postgres-data:
   trading-app-redis-data:
+  ws-cache:
+  ws-log:
+  var-bitmart:
+  var-lock:
 
 networks:
   frontend-net:

--- a/trading-app/composer.json
+++ b/trading-app/composer.json
@@ -25,6 +25,7 @@
     "doctrine/doctrine-migrations-bundle": "^3.5",
     "doctrine/dbal": "^3.7",
     "react/socket": "^1.12",
+    "react/http": "^1.7 || ^2.0 || ^3.0",
     "ratchet/pawl": "^0.4",
     "guzzlehttp/guzzle": "^7.8",
     "ramsey/uuid": "^4.7",

--- a/trading-app/composer.lock
+++ b/trading-app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c329edb0f2d7c994061ec0d893142142",
+    "content-hash": "c9c0163f4febba02b277f7bcad65c019",
     "packages": [
         {
             "name": "brick/math",
@@ -1232,6 +1232,62 @@
             "time": "2023-08-08T05:53:35+00:00"
         },
         {
+            "name": "fig/http-message-util",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message-util.git",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "psr/http-message": "The package containing the PSR-7 interfaces"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Utility classes and constants for use with PSR-7 (psr/http-message)",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-message-util/issues",
+                "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
+            },
+            "time": "2020-11-24T22:02:12+00:00"
+        },
+        {
             "name": "guzzlehttp/guzzle",
             "version": "7.10.0",
             "source": {
@@ -1555,79 +1611,6 @@
                 }
             ],
             "time": "2025-08-23T21:21:41+00:00"
-        },
-        {
-            "name": "internal/promise",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-internal/promise.git",
-                "reference": "fe5422c9dc861ef8cd45174e90b03b44f58e514c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-internal/promise/zipball/fe5422c9dc861ef8cd45174e90b03b44f58e514c",
-                "reference": "fe5422c9dc861ef8cd45174e90b03b44f58e514c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1.0"
-            },
-            "replace": {
-                "react/promise": "^3.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "1.12.28",
-                "phpunit/phpunit": "^10.5",
-                "rector/rector": "^1.2",
-                "spiral/code-style": "^2.2",
-                "ta-tikoma/phpunit-architecture-test": "^0.8.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com",
-                    "homepage": "https://sorgalla.com/"
-                },
-                {
-                    "name": "Christian Lück",
-                    "email": "christian@clue.engineering",
-                    "homepage": "https://clue.engineering/"
-                },
-                {
-                    "name": "Cees-Jan Kiewiet",
-                    "email": "reactphp@ceesjankiewiet.nl",
-                    "homepage": "https://wyrihaximus.net/"
-                },
-                {
-                    "name": "Chris Boden",
-                    "email": "cboden@gmail.com",
-                    "homepage": "https://cboden.dev/"
-                }
-            ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "keywords": [
-                "promise",
-                "promises"
-            ],
-            "support": {
-                "issues": "https://github.com/php-internal/promise/issues",
-                "source": "https://github.com/php-internal/promise/tree/3.4.0"
-            },
-            "time": "2025-08-27T14:01:49+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2104,16 +2087,16 @@
         },
         {
             "name": "psr/http-message",
-            "version": "2.0",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
@@ -2122,7 +2105,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -2137,7 +2120,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP messages",
@@ -2151,9 +2134,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2023-04-04T09:54:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -2819,6 +2802,170 @@
                 }
             ],
             "time": "2023-11-13T13:48:05+00:00"
+        },
+        {
+            "name": "react/http",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/http.git",
+                "reference": "8db02de41dcca82037367f67a2d4be365b1c4db9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/http/zipball/8db02de41dcca82037367f67a2d4be365b1c4db9",
+                "reference": "8db02de41dcca82037367f67a2d4be365b1c4db9",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "fig/http-message-util": "^1.1",
+                "php": ">=5.3.0",
+                "psr/http-message": "^1.0",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.3 || ^1.2.1",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "clue/http-proxy-react": "^1.8",
+                "clue/reactphp-ssh-proxy": "^1.4",
+                "clue/socks-react": "^1.4",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.2 || ^3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven, streaming HTTP client and server implementation for ReactPHP",
+            "keywords": [
+                "async",
+                "client",
+                "event-driven",
+                "http",
+                "http client",
+                "http server",
+                "https",
+                "psr-7",
+                "reactphp",
+                "server",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/http/issues",
+                "source": "https://github.com/reactphp/http/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-11-20T15:24:08+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
         },
         {
             "name": "react/socket",

--- a/trading-app/config/packages/monolog.yaml
+++ b/trading-app/config/packages/monolog.yaml
@@ -1,5 +1,5 @@
 monolog:
-  channels: ['mtf', 'validation', 'signals', 'positions', 'positions_flow', 'order', 'order_journey', 'bitmart', 'indicators', 'highconviction', 'pipeline_exec', 'deprecation', 'global-severity']
+  channels: ['mtf', 'validation', 'signals', 'positions', 'positions_flow', 'order', 'order_journey', 'bitmart', 'indicators', 'highconviction', 'pipeline_exec', 'deprecation', 'global-severity', 'ws_agent']
   handlers:
     # =====================
     # --- Handler Temporal (Asynchrone) ---
@@ -254,6 +254,15 @@ monolog:
       max_files: 5
       level: 'info'
       channels: ['bitmart']
+      formatter: App\Logging\CustomLineFormatter
+
+    # Canal WS Agent - WebSocket agent pour écouter les ordres BitMart
+    ws_agent_rotating:
+      type: rotating_file
+      path: '%env(APP_LOG_DIR)%/ws-agent.log'
+      max_files: 10
+      level: 'info'
+      channels: ['ws_agent']
       formatter: App\Logging\CustomLineFormatter
 
     # Canal High Conviction - Stratégies validées

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -282,3 +282,10 @@ services:
             - bitmart
         tags:
             - { name: monolog.logger, channel: bitmart }
+
+    monolog.logger.ws_agent:
+        parent: monolog.logger
+        arguments:
+            - ws_agent
+        tags:
+            - { name: monolog.logger, channel: ws_agent }

--- a/trading-app/docs/WEBSOCKET_ORDER_SIGNATURE.md
+++ b/trading-app/docs/WEBSOCKET_ORDER_SIGNATURE.md
@@ -1,0 +1,248 @@
+# Signature des événements WebSocket - Ordres BitMart Futures V2
+
+## Structure générale
+
+Les événements WebSocket pour les ordres sont reçus sur le canal privé `futures/order` après authentification.
+
+### Format brut BitMart
+
+```json
+{
+  "group": "futures/order",
+  "data": [
+    {
+      "action": 2,
+      "order": {
+        "order_id": "123456789",
+        "client_order_id": "CLIENT_ORDER_123",
+        "symbol": "BTCUSDT",
+        "side": 1,
+        "type": "limit",
+        "price": "50000.0",
+        "size": "10",
+        "state": 2,
+        "deal_size": "5",
+        "deal_avg_price": "50025.0",
+        "deal_notional": "250125.0",
+        "leverage": "10",
+        "open_type": "isolated",
+        "position_mode": 2,
+        "update_time": 1640995200000
+      }
+    }
+  ]
+}
+```
+
+## Champs de l'événement
+
+### Niveau racine
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `group` | string | Toujours `"futures/order"` pour les ordres |
+| `data` | array | Tableau d'événements d'ordre |
+
+### Événement d'ordre (`data[]`)
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `action` | integer | Type d'action (voir Actions ci-dessous) |
+| `order` | object | Objet contenant les détails de l'ordre |
+
+### Objet `order`
+
+| Champ | Type | Description | Exemple |
+|-------|------|-------------|---------|
+| `order_id` | string | Identifiant unique de l'ordre BitMart | `"123456789"` |
+| `client_order_id` | string | Identifiant client (peut être vide) | `"CLIENT_ORDER_123"` |
+| `symbol` | string | Symbole du contrat | `"BTCUSDT"` |
+| `side` | integer | Côté de l'ordre (voir Sides ci-dessous) | `1` |
+| `type` | string | Type d'ordre | `"limit"`, `"market"` |
+| `price` | string | Prix de l'ordre (string décimal) | `"50000.0"` |
+| `size` | string | Taille de l'ordre (nombre de contrats) | `"10"` |
+| `state` | integer | État de l'ordre (voir States ci-dessous) | `2` |
+| `deal_size` | string | Taille exécutée (nombre de contrats) | `"5"` |
+| `deal_avg_price` | string | Prix moyen d'exécution | `"50025.0"` |
+| `deal_notional` | string | Valeur notionnelle exécutée | `"250125.0"` |
+| `leverage` | string | Levier utilisé | `"10"` |
+| `open_type` | string | Type d'ouverture | `"isolated"`, `"cross"` |
+| `position_mode` | integer | Mode de position | `1` (hedge), `2` (one-way) |
+| `update_time` | integer | Timestamp de mise à jour (millisecondes) | `1640995200000` |
+
+## Actions (`action`)
+
+Les actions représentent le type d'événement sur l'ordre :
+
+| Valeur | Code | Description |
+|--------|------|-------------|
+| `1` | `MATCH_DEAL` | Ordre exécuté (match) |
+| `2` | `SUBMIT_ORDER` | Ordre soumis |
+| `3` | `CANCEL_ORDER` | Ordre annulé |
+| `4` | `LIQUIDATE_CANCEL_ORDER` | Ordre annulé par liquidation |
+| `5` | `ADL_CANCEL_ORDER` | Ordre annulé par ADL (Auto-Deleveraging) |
+| `6` | `PART_LIQUIDATE` | Liquidation partielle |
+| `7` | `BANKRUPTCY_ORDER` | Ordre de faillite |
+| `8` | `PASSIVE_ADL_MATCH_DEAL` | Match ADL passif |
+| `9` | `ACTIVE_ADL_MATCH_DEAL` | Match ADL actif |
+
+## Sides (`side`)
+
+Les valeurs de `side` représentent la direction et le type d'opération :
+
+| Valeur | Description |
+|--------|-------------|
+| `1` | Open Long (Achat pour ouvrir position longue) |
+| `2` | Close Long (Vente pour fermer position longue) |
+| `3` | Close Short (Achat pour fermer position courte) |
+| `4` | Open Short (Vente pour ouvrir position courte) |
+
+## States (`state`)
+
+Les états de l'ordre :
+
+| Valeur | Code | Description |
+|--------|------|-------------|
+| `1` | `APPROVAL` | En attente d'approbation |
+| `2` | `CHECK` | En vérification |
+| `4` | `FINISH` | Terminé (exécuté ou annulé) |
+
+## Format normalisé (après traitement)
+
+Après normalisation dans `OrderWebhookController::normalizeEvents()`, les événements sont transformés en :
+
+```php
+[
+    'action' => 2,                    // int
+    'order_id' => '123456789',        // string
+    'client_order_id' => 'CLIENT_ORDER_123', // string
+    'symbol' => 'BTCUSDT',            // string
+    'side' => 1,                      // int|null
+    'type' => 'limit',                // string|null
+    'state' => 2,                     // int
+    'price' => '50000.0',             // string|null
+    'size' => '10',                   // string|null
+    'deal_avg_price' => '50025.0',    // string|null
+    'deal_size' => '5',               // string|null
+    'leverage' => '10',               // string|null
+    'open_type' => 'isolated',        // string|null
+    'position_mode' => 2,             // int|null
+    'update_time_ms' => 1640995200000 // int|null
+]
+```
+
+## Mapping vers FuturesOrder
+
+Le service `FuturesOrderSyncService::syncOrderFromWebSocket()` mappe les champs WebSocket vers les champs de l'entité `FuturesOrder` :
+
+| WebSocket | FuturesOrder | Notes |
+|-----------|--------------|-------|
+| `order_id` | `orderId` | Direct |
+| `client_order_id` | `clientOrderId` | Direct |
+| `symbol` | `symbol` | Direct, converti en majuscules |
+| `side` | `side` | Direct (integer) |
+| `type` | `type` | Direct, converti en lowercase |
+| `state` | `status` | Mappé via `mapWebSocketStateToStatus()` |
+| `price` | `price` | Direct (string) |
+| `size` | `size` | Converti en integer |
+| `deal_size` | `filledSize` | Converti en integer |
+| `open_type` | `openType` | Direct, converti en lowercase |
+| `position_mode` | `positionMode` | Direct (integer) |
+| `leverage` | `leverage` | Converti en integer |
+| `update_time_ms` | `updatedTime` | Direct (bigint) |
+
+### Mapping des états
+
+```php
+state 1 (APPROVAL)  → status 'pending'
+state 2 (CHECK)     → status 'pending'
+state 4 (FINISH)    → status 'filled' (si deal_size > 0) ou 'cancelled'
+```
+
+## Exemple complet
+
+### Événement WebSocket brut
+
+```json
+{
+  "group": "futures/order",
+  "data": [
+    {
+      "action": 2,
+      "order": {
+        "order_id": "987654321",
+        "client_order_id": "MTF_ORDER_20250115_001",
+        "symbol": "ETHUSDT",
+        "side": 1,
+        "type": "limit",
+        "price": "3000.50",
+        "size": "5",
+        "state": 2,
+        "deal_size": "0",
+        "deal_avg_price": "0",
+        "deal_notional": "0",
+        "leverage": "20",
+        "open_type": "isolated",
+        "position_mode": 2,
+        "update_time": 1705276800000
+      }
+    }
+  ]
+}
+```
+
+### Après normalisation
+
+```php
+[
+    'action' => 2,
+    'order_id' => '987654321',
+    'client_order_id' => 'MTF_ORDER_20250115_001',
+    'symbol' => 'ETHUSDT',
+    'side' => 1,
+    'type' => 'limit',
+    'state' => 2,
+    'price' => '3000.50',
+    'size' => '5',
+    'deal_avg_price' => '0',
+    'deal_size' => '0',
+    'leverage' => '20',
+    'open_type' => 'isolated',
+    'position_mode' => 2,
+    'update_time_ms' => 1705276800000
+]
+```
+
+### Entité FuturesOrder créée/mise à jour
+
+```php
+FuturesOrder {
+    orderId: '987654321',
+    clientOrderId: 'MTF_ORDER_20250115_001',
+    symbol: 'ETHUSDT',
+    side: 1,
+    type: 'limit',
+    status: 'pending',  // mappé depuis state 2
+    price: '3000.50',
+    size: 5,
+    filledSize: 0,
+    openType: 'isolated',
+    positionMode: 2,
+    leverage: 20,
+    updatedTime: 1705276800000,
+    rawData: { /* données complètes de l'événement */ }
+}
+```
+
+## Notes importantes
+
+1. **Champs optionnels** : Tous les champs de `order` peuvent être absents sauf `order_id` et `symbol` qui sont généralement présents.
+
+2. **Types de données** : BitMart envoie les nombres comme strings pour éviter les problèmes de précision (ex: `"50000.0"` au lieu de `50000.0`).
+
+3. **Timestamps** : Les timestamps sont en millisecondes (type `bigint`).
+
+4. **Synchronisation** : La synchronisation dans `FuturesOrderSyncService` gère les valeurs manquantes avec des valeurs par défaut raisonnables.
+
+5. **Idempotence** : Les ordres sont identifiés par `order_id` ou `client_order_id`. Si un ordre existe déjà, il est mis à jour plutôt que créé.
+

--- a/trading-app/migrations/Version20250115000000.php
+++ b/trading-app/migrations/Version20250115000000.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Migration: Creates FuturesOrder, FuturesPlanOrder, FuturesOrderTrade tables
+ */
+final class Version20250115000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create FuturesOrder, FuturesPlanOrder, FuturesOrderTrade tables for BitMart Futures V2 API synchronization';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // ============================================================
+        // Table: futures_order
+        // ============================================================
+        $this->addSql('
+            CREATE TABLE futures_order (
+                id BIGSERIAL PRIMARY KEY,
+                order_id VARCHAR(80) DEFAULT NULL,
+                client_order_id VARCHAR(80) DEFAULT NULL,
+                symbol VARCHAR(50) NOT NULL,
+                side INTEGER DEFAULT NULL,
+                type VARCHAR(20) DEFAULT NULL,
+                status VARCHAR(30) DEFAULT NULL,
+                price NUMERIC(24, 12) DEFAULT NULL,
+                size INTEGER DEFAULT NULL,
+                filled_size INTEGER DEFAULT NULL,
+                filled_notional NUMERIC(28, 12) DEFAULT NULL,
+                open_type VARCHAR(20) DEFAULT NULL,
+                position_mode INTEGER DEFAULT NULL,
+                leverage INTEGER DEFAULT NULL,
+                fee NUMERIC(28, 12) DEFAULT NULL,
+                fee_currency VARCHAR(20) DEFAULT NULL,
+                account VARCHAR(20) DEFAULT NULL,
+                filled_time BIGINT DEFAULT NULL,
+                created_time BIGINT DEFAULT NULL,
+                updated_time BIGINT DEFAULT NULL,
+                raw_data JSONB NOT NULL DEFAULT \'{}\',
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+        ');
+        $this->addSql('CREATE UNIQUE INDEX ux_futures_order_order_id ON futures_order (order_id) WHERE order_id IS NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX ux_futures_order_client ON futures_order (client_order_id) WHERE client_order_id IS NOT NULL');
+        $this->addSql('CREATE INDEX idx_futures_order_symbol ON futures_order (symbol)');
+        $this->addSql('CREATE INDEX idx_futures_order_status ON futures_order (status)');
+        $this->addSql('CREATE INDEX idx_futures_order_client_order_id ON futures_order (client_order_id)');
+        $this->addSql("COMMENT ON COLUMN futures_order.created_at IS '(DC2Type:datetimetz_immutable)'");
+        $this->addSql("COMMENT ON COLUMN futures_order.updated_at IS '(DC2Type:datetimetz_immutable)'");
+
+        // ============================================================
+        // Table: futures_plan_order
+        // ============================================================
+        $this->addSql('
+            CREATE TABLE futures_plan_order (
+                id BIGSERIAL PRIMARY KEY,
+                order_id VARCHAR(80) DEFAULT NULL,
+                client_order_id VARCHAR(80) DEFAULT NULL,
+                symbol VARCHAR(50) NOT NULL,
+                side INTEGER DEFAULT NULL,
+                type VARCHAR(20) DEFAULT NULL,
+                status VARCHAR(30) DEFAULT NULL,
+                trigger_price NUMERIC(24, 12) DEFAULT NULL,
+                execution_price NUMERIC(24, 12) DEFAULT NULL,
+                price NUMERIC(24, 12) DEFAULT NULL,
+                size INTEGER DEFAULT NULL,
+                open_type VARCHAR(20) DEFAULT NULL,
+                position_mode INTEGER DEFAULT NULL,
+                leverage INTEGER DEFAULT NULL,
+                plan_type VARCHAR(20) DEFAULT NULL,
+                trigger_time BIGINT DEFAULT NULL,
+                created_time BIGINT DEFAULT NULL,
+                updated_time BIGINT DEFAULT NULL,
+                raw_data JSONB NOT NULL DEFAULT \'{}\',
+                futures_order_id BIGINT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_futures_plan_order_futures_order FOREIGN KEY (futures_order_id) REFERENCES futures_order(id) ON DELETE SET NULL
+            )
+        ');
+        $this->addSql('CREATE UNIQUE INDEX ux_futures_plan_order_order_id ON futures_plan_order (order_id) WHERE order_id IS NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX ux_futures_plan_order_client ON futures_plan_order (client_order_id) WHERE client_order_id IS NOT NULL');
+        $this->addSql('CREATE INDEX idx_futures_plan_order_symbol ON futures_plan_order (symbol)');
+        $this->addSql('CREATE INDEX idx_futures_plan_order_status ON futures_plan_order (status)');
+        $this->addSql('CREATE INDEX idx_futures_plan_order_futures_order_id ON futures_plan_order (futures_order_id)');
+        $this->addSql("COMMENT ON COLUMN futures_plan_order.created_at IS '(DC2Type:datetimetz_immutable)'");
+        $this->addSql("COMMENT ON COLUMN futures_plan_order.updated_at IS '(DC2Type:datetimetz_immutable)'");
+
+        // ============================================================
+        // Table: futures_order_trade
+        // ============================================================
+        $this->addSql('
+            CREATE TABLE futures_order_trade (
+                id BIGSERIAL PRIMARY KEY,
+                trade_id VARCHAR(80) DEFAULT NULL,
+                order_id VARCHAR(80) NOT NULL,
+                symbol VARCHAR(50) NOT NULL,
+                side INTEGER NOT NULL,
+                price NUMERIC(24, 12) NOT NULL,
+                size INTEGER NOT NULL,
+                fee NUMERIC(28, 12) DEFAULT NULL,
+                fee_currency VARCHAR(20) DEFAULT NULL,
+                trade_time BIGINT NOT NULL,
+                raw_data JSONB NOT NULL DEFAULT \'{}\',
+                futures_order_id BIGINT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_futures_order_trade_futures_order FOREIGN KEY (futures_order_id) REFERENCES futures_order(id) ON DELETE SET NULL
+            )
+        ');
+        $this->addSql('CREATE UNIQUE INDEX ux_futures_order_trade_trade_id ON futures_order_trade (trade_id) WHERE trade_id IS NOT NULL');
+        $this->addSql('CREATE INDEX idx_futures_order_trade_order_id ON futures_order_trade (order_id)');
+        $this->addSql('CREATE INDEX idx_futures_order_trade_symbol ON futures_order_trade (symbol)');
+        $this->addSql('CREATE INDEX idx_futures_order_trade_futures_order_id ON futures_order_trade (futures_order_id)');
+        $this->addSql("COMMENT ON COLUMN futures_order_trade.created_at IS '(DC2Type:datetimetz_immutable)'");
+        $this->addSql("COMMENT ON COLUMN futures_order_trade.updated_at IS '(DC2Type:datetimetz_immutable)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS futures_order_trade');
+        $this->addSql('DROP TABLE IF EXISTS futures_plan_order');
+        $this->addSql('DROP TABLE IF EXISTS futures_order');
+    }
+}
+

--- a/trading-app/migrations/Version20250115000001.php
+++ b/trading-app/migrations/Version20250115000001.php
@@ -19,21 +19,8 @@ final class Version20250115000001 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // Vérifier si la table order_plan existe
-        $orderPlanExists = false;
-        try {
-            $result = $this->connection->executeQuery("
-                SELECT EXISTS (
-                    SELECT FROM information_schema.tables 
-                    WHERE table_schema = 'public' 
-                    AND table_name = 'order_plan'
-                )
-            ")->fetchOne();
-            $orderPlanExists = (bool) $result;
-        } catch (\Throwable $e) {
-            // Si la vérification échoue, on continue sans FK
-            $orderPlanExists = false;
-        }
+        // Vérifier si la table order_plan existe de manière agnostique
+        $orderPlanExists = $schema->hasTable('order_plan');
 
         // ============================================================
         // Table: order_intent

--- a/trading-app/migrations/Version20250115000001.php
+++ b/trading-app/migrations/Version20250115000001.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Migration: Creates OrderIntent and OrderProtection tables
+ */
+final class Version20250115000001 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create OrderIntent and OrderProtection tables for local order draft tracking';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Vérifier si la table order_plan existe
+        $orderPlanExists = false;
+        try {
+            $result = $this->connection->executeQuery("
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables 
+                    WHERE table_schema = 'public' 
+                    AND table_name = 'order_plan'
+                )
+            ")->fetchOne();
+            $orderPlanExists = (bool) $result;
+        } catch (\Throwable $e) {
+            // Si la vérification échoue, on continue sans FK
+            $orderPlanExists = false;
+        }
+
+        // ============================================================
+        // Table: order_intent
+        // ============================================================
+        $createTableSql = '
+            CREATE TABLE order_intent (
+                id BIGSERIAL PRIMARY KEY,
+                symbol VARCHAR(50) NOT NULL,
+                side INTEGER NOT NULL,
+                type VARCHAR(20) NOT NULL,
+                open_type VARCHAR(20) NOT NULL,
+                leverage INTEGER DEFAULT NULL,
+                position_mode VARCHAR(20) NOT NULL,
+                price NUMERIC(24, 12) DEFAULT NULL,
+                size INTEGER NOT NULL,
+                client_order_id VARCHAR(80) NOT NULL,
+                preset_mode VARCHAR(30) NOT NULL,
+                quantization JSONB NOT NULL DEFAULT \'{}\',
+                status VARCHAR(30) NOT NULL DEFAULT \'DRAFT\',
+                raw_inputs JSONB DEFAULT NULL,
+                validation_errors JSONB DEFAULT NULL,
+                order_id VARCHAR(80) DEFAULT NULL,
+                failure_reason VARCHAR(500) DEFAULT NULL,
+                order_plan_id BIGINT DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                sent_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL';
+
+        // Ajouter la FK seulement si order_plan existe
+        if ($orderPlanExists) {
+            $createTableSql .= ',
+                CONSTRAINT fk_order_intent_order_plan FOREIGN KEY (order_plan_id) REFERENCES order_plan(id) ON DELETE SET NULL';
+        }
+
+        $createTableSql .= '
+            )';
+
+        $this->addSql($createTableSql);
+        $this->addSql('CREATE UNIQUE INDEX ux_order_intent_client_order_id ON order_intent (client_order_id)');
+        $this->addSql('CREATE INDEX idx_order_intent_symbol ON order_intent (symbol)');
+        $this->addSql('CREATE INDEX idx_order_intent_status ON order_intent (status)');
+        $this->addSql('CREATE INDEX idx_order_intent_client_order_id ON order_intent (client_order_id)');
+        $this->addSql('CREATE INDEX idx_order_intent_order_id ON order_intent (order_id) WHERE order_id IS NOT NULL');
+        // Créer l'index seulement si order_plan existe
+        if ($orderPlanExists) {
+            $this->addSql('CREATE INDEX idx_order_intent_order_plan_id ON order_intent (order_plan_id)');
+        }
+        $this->addSql("COMMENT ON COLUMN order_intent.created_at IS '(DC2Type:datetimetz_immutable)'");
+        $this->addSql("COMMENT ON COLUMN order_intent.updated_at IS '(DC2Type:datetimetz_immutable)'");
+        $this->addSql("COMMENT ON COLUMN order_intent.sent_at IS '(DC2Type:datetimetz_immutable)'");
+
+        // ============================================================
+        // Table: order_protection
+        // ============================================================
+        $this->addSql('
+            CREATE TABLE order_protection (
+                id BIGSERIAL PRIMARY KEY,
+                order_intent_id BIGINT NOT NULL,
+                type VARCHAR(20) NOT NULL,
+                price NUMERIC(24, 12) NOT NULL,
+                size INTEGER DEFAULT NULL,
+                price_type INTEGER DEFAULT NULL,
+                order_id VARCHAR(80) DEFAULT NULL,
+                client_order_id VARCHAR(80) DEFAULT NULL,
+                metadata JSONB DEFAULT NULL,
+                created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                CONSTRAINT fk_order_protection_order_intent FOREIGN KEY (order_intent_id) REFERENCES order_intent(id) ON DELETE CASCADE
+            )
+        ');
+        $this->addSql('CREATE INDEX idx_order_protection_order_intent ON order_protection (order_intent_id)');
+        $this->addSql('CREATE INDEX idx_order_protection_type ON order_protection (type)');
+        $this->addSql("COMMENT ON COLUMN order_protection.created_at IS '(DC2Type:datetimetz_immutable)'");
+        $this->addSql("COMMENT ON COLUMN order_protection.updated_at IS '(DC2Type:datetimetz_immutable)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS order_protection');
+        $this->addSql('DROP TABLE IF EXISTS order_intent');
+    }
+}
+

--- a/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
+++ b/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
+use App\TradeEntry\Service\TpSlTwoTargetsService;
+use App\TradeEntry\Types\Side;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:trade:tp2', description: 'Attache deux TP (TP1 mécanisme actuel, TP2=R2/S2) et gère SL existant')]
+final class TradeTpSlTwoTargetsCommand extends Command
+{
+    public function __construct(
+        private readonly TpSlTwoTargetsService $service,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('symbol', InputArgument::REQUIRED, 'Symbole, ex: BTCUSDT')
+            ->addArgument('side', InputArgument::REQUIRED, 'long|short')
+            ->addOption('entry', null, InputOption::VALUE_REQUIRED, 'Prix d\'entrée moyen (sinon lu depuis Position)')
+            ->addOption('size', null, InputOption::VALUE_REQUIRED, 'Taille (contrats), sinon depuis Position')
+            ->addOption('r', null, InputOption::VALUE_REQUIRED, 'R multiple pour TP1', '2.0')
+            ->addOption('split', null, InputOption::VALUE_REQUIRED, 'Fraction du size sur TP1 (0..1)', '0.5')
+            ->addOption('keep-sl', null, InputOption::VALUE_NONE, 'Ne pas annuler SL existant même si différent')
+            ->addOption('keep-tp', null, InputOption::VALUE_NONE, 'Ne pas annuler TP existants')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $symbol = (string)$input->getArgument('symbol');
+        $sideRaw = strtolower((string)$input->getArgument('side'));
+        try {
+            $side = Side::from($sideRaw);
+        } catch (\ValueError $e) {
+            $output->writeln('<error>Invalid side, use long|short</error>');
+            return Command::FAILURE;
+        }
+
+        $entry = $input->getOption('entry');
+        $size = $input->getOption('size');
+        $dto = new TpSlTwoTargetsRequest(
+            symbol: $symbol,
+            side: $side,
+            entryPrice: $entry !== null ? (float)$entry : null,
+            size: $size !== null ? (int)$size : null,
+            rMultiple: (float)$input->getOption('r'),
+            splitPct: (float)$input->getOption('split'),
+            cancelExistingStopLossIfDifferent: !$input->getOption('keep-sl'),
+            cancelExistingTakeProfits: !$input->getOption('keep-tp'),
+        );
+
+        try {
+            $result = ($this->service)($dto);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>Failed: ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        $output->writeln(sprintf('SL=%.8f TP1=%.8f TP2=%.8f', $result['sl'], $result['tp1'], $result['tp2']));
+        foreach ($result['submitted'] as $row) {
+            $output->writeln(sprintf(
+                'Submitted %s %s @ %.8f size=%d id=%s cid=%s',
+                $row['type'],
+                $row['side'],
+                $row['price'],
+                $row['size'],
+                $row['order_id'],
+                $row['client_order_id'] ?? 'n/a'
+            ));
+        }
+        if (!empty($result['cancelled'])) {
+            $output->writeln('Cancelled: ' . implode(', ', $result['cancelled']));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/trading-app/src/Command/WsAgentCommand.php
+++ b/trading-app/src/Command/WsAgentCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Service\WsAgentService;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(name: 'app:ws:agent', description: 'WebSocket agent pour écouter les ordres BitMart et mettre à jour la BDD')]
+final class WsAgentCommand extends Command
+{
+    public function __construct(
+        private readonly WsAgentService $wsAgentService,
+        #[Autowire(service: 'monolog.logger.ws_agent')]
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('WebSocket Agent - BitMart Futures Orders');
+
+        $this->logger->info('[WsAgent] Starting WebSocket agent');
+
+        try {
+            $this->wsAgentService->run();
+        } catch (\Throwable $e) {
+            $this->logger->error('[WsAgent] Fatal error', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+            $io->error(sprintf('Erreur fatale: %s', $e->getMessage()));
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+}
+

--- a/trading-app/src/Controller/Api/OrderJustCreatedController.php
+++ b/trading-app/src/Controller/Api/OrderJustCreatedController.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class OrderJustCreatedController
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly HttpClientInterface $httpClient,
+        #[Autowire('%env(WS_AGENT_BASE_URI)%')]
+        private readonly ?string $wsAgentBaseUri = null,
+    ) {
+    }
+
+    #[Route('/order/just-created/{clientId}/{orderId}/{symbol}', name: 'order_just_created', methods: ['GET'])]
+    public function __invoke(string $clientId, string $orderId, string $symbol, Request $request): JsonResponse
+    {
+        if (!$this->wsAgentBaseUri) {
+            $this->logger->warning('[OrderJustCreated] WS_AGENT_BASE_URI not configured, skipping notification');
+            return new JsonResponse([
+                'status' => 'ok',
+                'message' => 'ws-agent not configured',
+            ]);
+        }
+
+        try {
+            // Informer le ws-agent qu'un ordre vient d'être créé
+            $wsAgentUrl = rtrim($this->wsAgentBaseUri, '/') . '/internal/track-order';
+            
+            $response = $this->httpClient->request('POST', $wsAgentUrl, [
+                'json' => [
+                    'client_order_id' => $clientId,
+                    'order_id' => $orderId,
+                    'symbol' => $symbol,
+                ],
+                'timeout' => 2.0,
+            ]);
+
+            if ($response->getStatusCode() === 200 || $response->getStatusCode() === 202) {
+                $this->logger->info('[OrderJustCreated] Notified ws-agent', [
+                    'client_order_id' => $clientId,
+                    'order_id' => $orderId,
+                    'symbol' => $symbol,
+                ]);
+
+                return new JsonResponse([
+                    'status' => 'ok',
+                    'message' => 'ws-agent notified',
+                ]);
+            }
+
+            return new JsonResponse([
+                'status' => 'error',
+                'message' => 'ws-agent notification failed',
+            ], JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        } catch (\Throwable $e) {
+            $this->logger->error('[OrderJustCreated] Failed to notify ws-agent', [
+                'client_order_id' => $clientId,
+                'order_id' => $orderId,
+                'symbol' => $symbol,
+                'error' => $e->getMessage(),
+            ]);
+
+            return new JsonResponse([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}
+

--- a/trading-app/src/Controller/Api/OrderSubmittedController.php
+++ b/trading-app/src/Controller/Api/OrderSubmittedController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Repository\FuturesOrderRepository;
+use App\Repository\OrderIntentRepository;
+use App\Service\OrderIntentManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class OrderSubmittedController
+{
+    public function __construct(
+        private readonly FuturesOrderRepository $futuresOrderRepository,
+        private readonly OrderIntentRepository $orderIntentRepository,
+        private readonly ?OrderIntentManager $intentManager = null,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/api/order-submitted', name: 'api_order_submitted', methods: ['POST'])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $content = $request->getContent();
+        if ($content === '') {
+            return new JsonResponse(['status' => 'error', 'reason' => 'empty_body'], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $payload = json_decode($content, true);
+        if (!\is_array($payload)) {
+            return new JsonResponse(['status' => 'error', 'reason' => 'invalid_json'], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $orderId = $payload['order_id'] ?? null;
+        $clientOrderId = $payload['client_order_id'] ?? null;
+        $symbol = $payload['symbol'] ?? null;
+        $submittedAt = $payload['submitted_at'] ?? null;
+
+        if (!$orderId && !$clientOrderId) {
+            return new JsonResponse([
+                'status' => 'error',
+                'reason' => 'missing_order_id_or_client_order_id',
+            ], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            // Mettre à jour l'OrderIntent si disponible
+            if ($this->intentManager) {
+                $intent = $this->intentManager->findIntent(clientOrderId: $clientOrderId, orderId: $orderId);
+                if ($intent && !$intent->isSent()) {
+                    $this->intentManager->markAsSent($intent, $orderId ?? '');
+                    $this->logger->info('[OrderSubmitted] Updated OrderIntent', [
+                        'order_id' => $orderId,
+                        'client_order_id' => $clientOrderId,
+                    ]);
+                }
+            }
+
+            // Vérifier que l'ordre existe dans FuturesOrder
+            $futuresOrder = null;
+            if ($orderId) {
+                $futuresOrder = $this->futuresOrderRepository->findOneByOrderId($orderId);
+            }
+            if (!$futuresOrder && $clientOrderId) {
+                $futuresOrder = $this->futuresOrderRepository->findOneByClientOrderId($clientOrderId);
+            }
+
+            if ($futuresOrder) {
+                $this->logger->info('[OrderSubmitted] Order found and confirmed', [
+                    'order_id' => $orderId,
+                    'client_order_id' => $clientOrderId,
+                    'symbol' => $symbol,
+                ]);
+            } else {
+                $this->logger->warning('[OrderSubmitted] Order not found in database', [
+                    'order_id' => $orderId,
+                    'client_order_id' => $clientOrderId,
+                    'symbol' => $symbol,
+                ]);
+            }
+
+            return new JsonResponse([
+                'status' => 'ok',
+                'order_id' => $orderId,
+                'client_order_id' => $clientOrderId,
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('[OrderSubmitted] Error processing notification', [
+                'order_id' => $orderId,
+                'client_order_id' => $clientOrderId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return new JsonResponse([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], JsonResponse::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}
+

--- a/trading-app/src/Controller/TradeTpSlController.php
+++ b/trading-app/src/Controller/TradeTpSlController.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Config\MtfValidationConfig;
+use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
+use App\TradeEntry\Service\TpSlTwoTargetsService;
+use App\TradeEntry\Types\Side;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/trade-tpsl', name: 'trade_tpsl_')]
+final class TradeTpSlController extends AbstractController
+{
+    public function __construct(
+        private readonly TpSlTwoTargetsService $service,
+        private readonly MtfValidationConfig $mtfConfig,
+    ) {}
+
+    #[Route('/two-targets', name: 'two_targets', methods: ['POST'])]
+    public function twoTargets(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!\is_array($data)) {
+            return new JsonResponse(['error' => 'Invalid JSON'], 400);
+        }
+
+        foreach (['symbol', 'side'] as $field) {
+            if (!isset($data[$field])) {
+                return new JsonResponse(['error' => "Missing field: $field"], 400);
+            }
+        }
+
+        try {
+            $side = is_string($data['side']) ? Side::from(strtolower($data['side'])) : $data['side'];
+        } catch (\ValueError) {
+            return new JsonResponse(['error' => 'Invalid side value'], 400);
+        }
+        if (!$side instanceof Side) {
+            return new JsonResponse(['error' => 'Invalid side value'], 400);
+        }
+
+        $dto = new TpSlTwoTargetsRequest(
+            symbol: (string)$data['symbol'],
+            side: $side,
+            entryPrice: isset($data['entry_price']) ? (float)$data['entry_price'] : null,
+            size: isset($data['size']) ? (int)$data['size'] : null,
+            rMultiple: isset($data['r_multiple']) ? (float)$data['r_multiple'] : null,
+            splitPct: isset($data['split_pct']) ? (float)$data['split_pct'] : 0.5,
+            cancelExistingStopLossIfDifferent: isset($data['cancel_sl_if_diff']) ? (bool)$data['cancel_sl_if_diff'] : true,
+            cancelExistingTakeProfits: isset($data['cancel_tp']) ? (bool)$data['cancel_tp'] : true,
+        );
+
+        try {
+            $result = ($this->service)($dto);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Failed: ' . $e->getMessage()], 500);
+        }
+
+        return new JsonResponse([
+            'symbol' => $dto->symbol,
+            'side' => $side->value,
+            'sl' => $result['sl'],
+            'tp1' => $result['tp1'],
+            'tp2' => $result['tp2'],
+            'submitted' => $result['submitted'],
+            'cancelled' => $result['cancelled'],
+        ]);
+    }
+}

--- a/trading-app/src/Controller/Web/OrderController.php
+++ b/trading-app/src/Controller/Web/OrderController.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\Controller\Web;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Repository\ContractRepository;
+use App\TradeEntry\Pricing\TickQuantizer;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class OrderController extends AbstractController
+{
+    public function __construct(
+        private readonly OrderProviderInterface $orderProvider,
+        private readonly ContractRepository $contractRepository,
+        #[Autowire(service: 'monolog.logger.bitmart')]
+        private readonly LoggerInterface $bitmartLogger,
+    ) {
+    }
+
+    #[Route('/order/submit', name: 'order_submit')]
+    public function submit(Request $request): Response
+    {
+        $contracts = $this->contractRepository->findActiveContracts();
+        $contractSymbols = [];
+        foreach ($contracts as $contract) {
+            $contractSymbols[] = $contract->getSymbol();
+        }
+
+        $orderId = null;
+        $error = null;
+        $calculatedSize = null;
+        $orderDetails = null;
+
+        if ($request->isMethod('POST')) {
+            $symbol = $request->request->get('symbol');
+            $initialMargin = $request->request->get('initial_margin');
+            $riskPercent = $request->request->get('risk_percent');
+            $takeProfitPrice = $request->request->get('take_profit_price');
+            $leverage = $request->request->get('leverage');
+            $side = $request->request->get('side');
+            $limitPrice = $request->request->get('limit_price');
+
+            // Validation
+            if (empty($symbol) || empty($initialMargin) || empty($riskPercent) || 
+                empty($takeProfitPrice) || empty($leverage) || empty($side) || empty($limitPrice)) {
+                $error = 'Tous les champs doivent être remplis.';
+            } elseif (!is_numeric($initialMargin) || (float) $initialMargin <= 0) {
+                $error = 'La marge initiale doit être un nombre positif.';
+            } elseif (!is_numeric($riskPercent) || (float) $riskPercent <= 0 || (float) $riskPercent > 100) {
+                $error = 'Le pourcentage de risque doit être entre 0 et 100.';
+            } elseif (!is_numeric($takeProfitPrice) || (float) $takeProfitPrice <= 0) {
+                $error = 'Le prix TP doit être un nombre positif.';
+            } elseif (!is_numeric($leverage) || (float) $leverage <= 0) {
+                $error = 'Le levier doit être un nombre positif.';
+            } elseif (!in_array($side, ['1', '4'], true)) {
+                $error = 'La direction doit être Achat (1) ou Vente (4).';
+            } elseif (!is_numeric($limitPrice) || (float) $limitPrice <= 0) {
+                $error = 'Le prix limit doit être un nombre positif.';
+            } else {
+                try {
+                    // Récupérer le contrat pour obtenir le contract_size
+                    $contract = $this->contractRepository->findBySymbol(strtoupper($symbol));
+                    if (!$contract) {
+                        $error = 'Contrat non trouvé pour le symbole: ' . $symbol;
+                    } else {
+                        $contractSize = $contract->getContractSize();
+                        if ($contractSize === null || (float) $contractSize <= 0) {
+                            $error = 'Le contrat ne contient pas de contract_size valide. Veuillez synchroniser les contrats.';
+                        } else {
+                            $contractSizeFloat = (float) $contractSize;
+                            
+                            // Récupérer la précision du prix depuis le contrat
+                            $pricePrecisionStr = $contract->getPricePrecision();
+                            $pricePrecision = $this->resolvePricePrecision($pricePrecisionStr);
+                            
+                            // Calculer la taille de l'ordre basée sur la marge et le levier
+                            // Valeur notionale = Marge initiale * Levier
+                            $notionalValue = (float) $initialMargin * (float) $leverage;
+                            
+                            // Taille en contrats = Valeur notionale / (Prix limit * Contract Size)
+                            // Pour BitMart Futures: Notional = Prix × Contract Size × Nombre de contrats
+                            $calculatedSize = floor($notionalValue / ((float) $limitPrice * $contractSizeFloat));
+                            
+                            if ($calculatedSize <= 0) {
+                                $error = sprintf(
+                                    'La taille calculée est invalide (%.2f contrats). Vérifiez la marge initiale (%.2f), le levier (%s) et le prix limit (%.2f). Contract size: %s',
+                                    $calculatedSize,
+                                    (float) $initialMargin,
+                                    $leverage,
+                                    (float) $limitPrice,
+                                    $contractSize
+                                );
+                            } else {
+                                // Calculer le Stop Loss à partir de limit_price, risk_percent et leverage
+                                // riskUsdt = initialMargin * (riskPercent / 100)
+                                $riskUsdt = ((float) $initialMargin * (float) $riskPercent) / 100.0;
+                                
+                                // Distance du SL: dMax = riskUsdt / (contractSize * size)
+                                // Pour Long (side=1): SL = limitPrice - dMax
+                                // Pour Short (side=4): SL = limitPrice + dMax
+                                $dMax = $riskUsdt / max($contractSizeFloat * $calculatedSize, 1e-12);
+                                $limitPriceFloat = (float) $limitPrice;
+                                
+                                if ((int) $side === 1) {
+                                    // Long: SL en dessous du prix limite
+                                    $stopLossPrice = $limitPriceFloat - $dMax;
+                                } else {
+                                    // Short: SL au-dessus du prix limite
+                                    $stopLossPrice = $limitPriceFloat + $dMax;
+                                }
+                                
+                                // Quantifier le prix du SL selon la précision
+                                $stopLossPrice = TickQuantizer::quantize($stopLossPrice, $pricePrecision);
+                                
+                                // Validation du SL
+                                if ($stopLossPrice <= 0) {
+                                    $error = sprintf(
+                                        'Le Stop Loss calculé est invalide (%.8f). Vérifiez les paramètres de risque.',
+                                        $stopLossPrice
+                                    );
+                                } elseif ((int) $side === 1 && $stopLossPrice >= $limitPriceFloat) {
+                                    $error = sprintf(
+                                        'Le Stop Loss pour un ordre Long doit être inférieur au prix limite (SL: %.8f >= Limit: %.8f).',
+                                        $stopLossPrice,
+                                        $limitPriceFloat
+                                    );
+                                } elseif ((int) $side === 4 && $stopLossPrice <= $limitPriceFloat) {
+                                    $error = sprintf(
+                                        'Le Stop Loss pour un ordre Short doit être supérieur au prix limite (SL: %.8f <= Limit: %.8f).',
+                                        $stopLossPrice,
+                                        $limitPriceFloat
+                                    );
+                                } else {
+                                    // IMPORTANT: Le levier doit être défini AVANT de soumettre l'ordre
+                                    try {
+                                        $leverageSuccess = $this->orderProvider->submitLeverage(
+                                            strtoupper($symbol),
+                                            (int) $leverage,
+                                            'isolated'
+                                        );
+                                        
+                                        if (!$leverageSuccess) {
+                                            $error = 'Échec de la définition du levier. Veuillez réessayer.';
+                                            $this->bitmartLogger->error('[Order Submit] Leverage submission failed', [
+                                                'symbol' => $symbol,
+                                                'leverage' => $leverage,
+                                            ]);
+                                        } else {
+                                            $this->bitmartLogger->info('[Order Submit] Leverage set successfully', [
+                                                'symbol' => $symbol,
+                                                'leverage' => $leverage,
+                                            ]);
+                                            
+                                            // Mapper side (1 ou 4) vers OrderSide
+                                            $orderSide = ((int) $side === 1) ? OrderSide::BUY : OrderSide::SELL;
+                                            
+                                            // Construire les options pour TP et SL
+                                            $orderOptions = [
+                                                'side' => (int) $side, // 1=open_long, 4=open_short pour BitMart
+                                                'open_type' => 'isolated',
+                                                'preset_take_profit_price' => (string) $takeProfitPrice,
+                                                'preset_take_profit_price_type' => 1, // 1 = prix fixe
+                                                'preset_stop_loss_price' => (string) $stopLossPrice,
+                                                'preset_stop_loss_price_type' => 1, // 1 = prix fixe
+                                            ];
+                                            
+                                            // Soumettre l'ordre via OrderProvider
+                                            $orderDto = $this->orderProvider->placeOrder(
+                                                strtoupper($symbol),
+                                                $orderSide,
+                                                OrderType::LIMIT,
+                                                (float) $calculatedSize,
+                                                (float) $limitPrice,
+                                                $stopLossPrice, // stopPrice pour compatibilité
+                                                $orderOptions
+                                            );
+
+                                            // Vérifier la réponse
+                                            if ($orderDto !== null && $orderDto->orderId !== null) {
+                                                $orderId = $orderDto->orderId;
+                                                
+                                                // Stocker tous les détails de l'ordre pour l'affichage
+                                                $orderDetails = [
+                                                    'order_id' => $orderId,
+                                                    'symbol' => strtoupper($symbol),
+                                                    'side' => (int) $side,
+                                                    'side_label' => $side === '1' ? 'Achat (Open Long)' : 'Vente (Open Short)',
+                                                    'type' => 'limit',
+                                                    'size' => $calculatedSize,
+                                                    'limit_price' => (float) $limitPrice,
+                                                    'stop_loss_price' => $stopLossPrice,
+                                                    'take_profit_price' => (float) $takeProfitPrice,
+                                                    'initial_margin' => (float) $initialMargin,
+                                                    'risk_percent' => (float) $riskPercent,
+                                                    'leverage' => (int) $leverage,
+                                                    'contract_size' => (float) $contractSize,
+                                                    'price_precision' => $pricePrecision,
+                                                    'notional_value' => $notionalValue,
+                                                    'risk_amount' => $riskUsdt,
+                                                    'sl_distance' => $dMax,
+                                                    // Données soumises (request)
+                                                    'request_payload' => [
+                                                        'symbol' => strtoupper($symbol),
+                                                        'side' => (int) $side,
+                                                        'type' => 'limit',
+                                                        'price' => (string) $limitPrice,
+                                                        'size' => (int) $calculatedSize,
+                                                        'open_type' => 'isolated',
+                                                        'preset_take_profit_price' => (string) $takeProfitPrice,
+                                                        'preset_take_profit_price_type' => 1,
+                                                        'preset_stop_loss_price' => (string) $stopLossPrice,
+                                                        'preset_stop_loss_price_type' => 1,
+                                                    ],
+                                                    'leverage_request' => [
+                                                        'symbol' => strtoupper($symbol),
+                                                        'leverage' => (int) $leverage,
+                                                        'open_type' => 'isolated',
+                                                    ],
+                                                    'leverage_response' => [
+                                                        'code' => 1000,
+                                                        'message' => 'success',
+                                                        'data' => ['leverage' => (string) $leverage],
+                                                    ],
+                                                    'response_full' => [
+                                                        'code' => 1000,
+                                                        'message' => 'success',
+                                                        'data' => [
+                                                            'order_id' => $orderId,
+                                                            'symbol' => strtoupper($symbol),
+                                                            'side' => (int) $side,
+                                                            'type' => 'limit',
+                                                            'price' => (string) $limitPrice,
+                                                            'size' => (int) $calculatedSize,
+                                                        ],
+                                                    ],
+                                                ];
+                                        
+                                                $this->bitmartLogger->info('[Order Submit] Order submitted successfully', [
+                                                    'order_id' => $orderId,
+                                                    'symbol' => $symbol,
+                                                    'side' => $side,
+                                                    'calculated_size' => $calculatedSize,
+                                                    'limit_price' => $limitPrice,
+                                                    'stop_loss_price' => $stopLossPrice,
+                                                    'take_profit_price' => $takeProfitPrice,
+                                                    'leverage' => $leverage,
+                                                    'contract_size' => $contractSize,
+                                                    'notional_value' => $notionalValue,
+                                                    'risk_usdt' => $riskUsdt,
+                                                ]);
+                                            } else {
+                                                $error = 'Ordre soumis mais aucun order_id reçu dans la réponse.';
+                                                $this->bitmartLogger->warning('[Order Submit] No order_id in response', [
+                                                    'order_dto' => $orderDto,
+                                                ]);
+                                            }
+                                        }
+                                    } catch (\Throwable $leverageException) {
+                                        $error = sprintf('Erreur lors de la soumission de l\'ordre: %s', $leverageException->getMessage());
+                                        $this->bitmartLogger->error('[Order Submit] Order submission exception', [
+                                            'error' => $leverageException->getMessage(),
+                                            'trace' => $leverageException->getTraceAsString(),
+                                        ]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } catch (\Throwable $e) {
+                    $error = sprintf('Erreur lors de la soumission: %s', $e->getMessage());
+                    $this->bitmartLogger->error('[Order Submit] Exception', [
+                        'error' => $e->getMessage(),
+                        'trace' => $e->getTraceAsString(),
+                    ]);
+                }
+            }
+        }
+
+        return $this->render('order/submit.html.twig', [
+            'contracts' => $contractSymbols,
+            'order_id' => $orderId,
+            'error' => $error,
+            'calculated_size' => $calculatedSize,
+            'order_details' => $orderDetails,
+        ]);
+    }
+
+    /**
+     * Résout la précision du prix depuis une chaîne (peut être un entier ou un tick size comme 0.1, 0.01, etc.)
+     */
+    private function resolvePricePrecision(?string $pricePrecision): int
+    {
+        if ($pricePrecision === null || $pricePrecision === '') {
+            return 2; // Par défaut: 2 décimales
+        }
+
+        // Case 1: déjà un entier (nombre de décimales)
+        if (preg_match('/^\d+$/', $pricePrecision)) {
+            return (int) $pricePrecision;
+        }
+
+        // Case 2: provider retourne un tick size comme 0.1 / 0.01 / 0.0001...
+        $dotPos = strpos($pricePrecision, '.');
+        if ($dotPos === false) {
+            // Fallback: arrondir au plus proche entier
+            return max(0, min(10, (int) round((float) $pricePrecision)));
+        }
+
+        // Compter les chiffres après la virgule, en supprimant les zéros de fin
+        $frac = rtrim(substr($pricePrecision, $dotPos + 1), '0');
+        $decimals = strlen($frac);
+
+        // Si la valeur est exactement une puissance de 10 (ex: 0.01), c'est correct.
+        // Sinon, garder une limite raisonnable.
+        return max(0, min(10, $decimals));
+    }
+}

--- a/trading-app/src/Controller/Web/OrderController.php
+++ b/trading-app/src/Controller/Web/OrderController.php
@@ -118,8 +118,8 @@ class OrderController extends AbstractController
                                 
                                 // Quantifier le prix du SL selon la précision
                                 if ((int) $side === 1) {
-                                    // Long: quantize down
-                                    $stopLossPrice = TickQuantizer::quantizeDown($stopLossPrice, $pricePrecision);
+                                    // Long: quantize up (closer to entry to maintain risk constraint)
+                                    $stopLossPrice = TickQuantizer::quantizeUp($stopLossPrice, $pricePrecision);
                                 } else {
                                     // Short: quantize up
                                     $stopLossPrice = TickQuantizer::quantizeUp($stopLossPrice, $pricePrecision);

--- a/trading-app/src/Controller/Web/OrderController.php
+++ b/trading-app/src/Controller/Web/OrderController.php
@@ -117,7 +117,13 @@ class OrderController extends AbstractController
                                 }
                                 
                                 // Quantifier le prix du SL selon la précision
-                                $stopLossPrice = TickQuantizer::quantize($stopLossPrice, $pricePrecision);
+                                if ((int) $side === 1) {
+                                    // Long: quantize down
+                                    $stopLossPrice = TickQuantizer::quantizeDown($stopLossPrice, $pricePrecision);
+                                } else {
+                                    // Short: quantize up
+                                    $stopLossPrice = TickQuantizer::quantizeUp($stopLossPrice, $pricePrecision);
+                                }
                                 
                                 // Validation du SL
                                 if ($stopLossPrice <= 0) {

--- a/trading-app/src/Controller/Web/OrderController.php
+++ b/trading-app/src/Controller/Web/OrderController.php
@@ -121,8 +121,8 @@ class OrderController extends AbstractController
                                     // Long: quantize up (closer to entry to maintain risk constraint)
                                     $stopLossPrice = TickQuantizer::quantizeUp($stopLossPrice, $pricePrecision);
                                 } else {
-                                    // Short: quantize up
-                                    $stopLossPrice = TickQuantizer::quantizeUp($stopLossPrice, $pricePrecision);
+                                    // Short: quantize down (closer to entry to maintain risk constraint)
+                                    $stopLossPrice = TickQuantizer::quantize($stopLossPrice, $pricePrecision);
                                 }
                                 
                                 // Validation du SL

--- a/trading-app/src/Entity/Contract.php
+++ b/trading-app/src/Entity/Contract.php
@@ -418,6 +418,11 @@ class Contract
         $this->maxLeverage = $maxLeverage;
         return $this;
     }
+    public function getPricePrecision(): ?string
+    {
+        return $this->pricePrecision;
+    }
+
     public function setPricePrecision(?string $pricePrecision): static
     {
         $this->pricePrecision = $pricePrecision;

--- a/trading-app/src/Entity/FuturesOrder.php
+++ b/trading-app/src/Entity/FuturesOrder.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\FuturesOrderRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: FuturesOrderRepository::class)]
+#[ORM\Table(name: 'futures_order')]
+#[ORM\UniqueConstraint(name: 'ux_futures_order_order_id', columns: ['order_id'])]
+#[ORM\UniqueConstraint(name: 'ux_futures_order_client', columns: ['client_order_id'])]
+#[ORM\Index(name: 'idx_futures_order_symbol', columns: ['symbol'])]
+#[ORM\Index(name: 'idx_futures_order_status', columns: ['status'])]
+#[ORM\Index(name: 'idx_futures_order_client_order_id', columns: ['client_order_id'])]
+class FuturesOrder
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true, unique: true)]
+    private ?string $orderId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true, unique: true)]
+    private ?string $clientOrderId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $side = null; // 1=open_long, 2=close_long, 3=close_short, 4=open_short
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $type = null; // limit, market
+
+    #[ORM\Column(type: Types::STRING, length: 30, nullable: true)]
+    private ?string $status = null; // pending, filled, cancelled, etc.
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 24, scale: 12, nullable: true)]
+    private ?string $price = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $size = null; // nombre de contrats
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $filledSize = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 28, scale: 12, nullable: true)]
+    private ?string $filledNotional = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $openType = null; // isolated, cross
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $positionMode = null; // 1=hedge, 2=one-way
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $leverage = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 28, scale: 12, nullable: true)]
+    private ?string $fee = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $feeCurrency = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $account = null; // futures, copy_trading
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $filledTime = null; // timestamp millis
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $createdTime = null; // timestamp millis
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $updatedTime = null; // timestamp millis
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
+    private array $rawData = []; // données complètes de l'API
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct()
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOrderId(): ?string
+    {
+        return $this->orderId;
+    }
+
+    public function setOrderId(?string $orderId): self
+    {
+        $this->orderId = $orderId;
+        return $this->touch();
+    }
+
+    public function getClientOrderId(): ?string
+    {
+        return $this->clientOrderId;
+    }
+
+    public function setClientOrderId(?string $clientOrderId): self
+    {
+        $this->clientOrderId = $clientOrderId;
+        return $this->touch();
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function setSymbol(string $symbol): self
+    {
+        $this->symbol = strtoupper($symbol);
+        return $this->touch();
+    }
+
+    public function getSide(): ?int
+    {
+        return $this->side;
+    }
+
+    public function setSide(?int $side): self
+    {
+        $this->side = $side;
+        return $this->touch();
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): self
+    {
+        $this->type = $type !== null ? strtolower($type) : null;
+        return $this->touch();
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(?string $status): self
+    {
+        $this->status = $status !== null ? strtolower($status) : null;
+        return $this->touch();
+    }
+
+    public function getPrice(): ?string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(?string $price): self
+    {
+        $this->price = $price;
+        return $this->touch();
+    }
+
+    public function getSize(): ?int
+    {
+        return $this->size;
+    }
+
+    public function setSize(?int $size): self
+    {
+        $this->size = $size;
+        return $this->touch();
+    }
+
+    public function getFilledSize(): ?int
+    {
+        return $this->filledSize;
+    }
+
+    public function setFilledSize(?int $filledSize): self
+    {
+        $this->filledSize = $filledSize;
+        return $this->touch();
+    }
+
+    public function getFilledNotional(): ?string
+    {
+        return $this->filledNotional;
+    }
+
+    public function setFilledNotional(?string $filledNotional): self
+    {
+        $this->filledNotional = $filledNotional;
+        return $this->touch();
+    }
+
+    public function getOpenType(): ?string
+    {
+        return $this->openType;
+    }
+
+    public function setOpenType(?string $openType): self
+    {
+        $this->openType = $openType !== null ? strtolower($openType) : null;
+        return $this->touch();
+    }
+
+    public function getPositionMode(): ?int
+    {
+        return $this->positionMode;
+    }
+
+    public function setPositionMode(?int $positionMode): self
+    {
+        $this->positionMode = $positionMode;
+        return $this->touch();
+    }
+
+    public function getLeverage(): ?int
+    {
+        return $this->leverage;
+    }
+
+    public function setLeverage(?int $leverage): self
+    {
+        $this->leverage = $leverage;
+        return $this->touch();
+    }
+
+    public function getFee(): ?string
+    {
+        return $this->fee;
+    }
+
+    public function setFee(?string $fee): self
+    {
+        $this->fee = $fee;
+        return $this->touch();
+    }
+
+    public function getFeeCurrency(): ?string
+    {
+        return $this->feeCurrency;
+    }
+
+    public function setFeeCurrency(?string $feeCurrency): self
+    {
+        $this->feeCurrency = $feeCurrency;
+        return $this->touch();
+    }
+
+    public function getAccount(): ?string
+    {
+        return $this->account;
+    }
+
+    public function setAccount(?string $account): self
+    {
+        $this->account = $account !== null ? strtolower($account) : null;
+        return $this->touch();
+    }
+
+    public function getFilledTime(): ?int
+    {
+        return $this->filledTime;
+    }
+
+    public function setFilledTime(?int $filledTime): self
+    {
+        $this->filledTime = $filledTime;
+        return $this->touch();
+    }
+
+    public function getCreatedTime(): ?int
+    {
+        return $this->createdTime;
+    }
+
+    public function setCreatedTime(?int $createdTime): self
+    {
+        $this->createdTime = $createdTime;
+        return $this->touch();
+    }
+
+    public function getUpdatedTime(): ?int
+    {
+        return $this->updatedTime;
+    }
+
+    public function setUpdatedTime(?int $updatedTime): self
+    {
+        $this->updatedTime = $updatedTime;
+        return $this->touch();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getRawData(): array
+    {
+        return $this->rawData;
+    }
+
+    /**
+     * @param array<string,mixed> $rawData
+     */
+    public function setRawData(array $rawData): self
+    {
+        $this->rawData = $rawData;
+        return $this->touch();
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): self
+    {
+        $this->updatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        return $this;
+    }
+}
+

--- a/trading-app/src/Entity/FuturesOrderTrade.php
+++ b/trading-app/src/Entity/FuturesOrderTrade.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\FuturesOrderTradeRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: FuturesOrderTradeRepository::class)]
+#[ORM\Table(name: 'futures_order_trade')]
+#[ORM\UniqueConstraint(name: 'ux_futures_order_trade_trade_id', columns: ['trade_id'])]
+#[ORM\Index(name: 'idx_futures_order_trade_order_id', columns: ['order_id'])]
+#[ORM\Index(name: 'idx_futures_order_trade_symbol', columns: ['symbol'])]
+class FuturesOrderTrade
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 80, unique: true, nullable: true)]
+    private ?string $tradeId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 80)]
+    private string $orderId; // référence vers futures_order.order_id
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $side;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 24, scale: 12)]
+    private string $price;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $size;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 28, scale: 12, nullable: true)]
+    private ?string $fee = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $feeCurrency = null;
+
+    #[ORM\Column(type: Types::BIGINT)]
+    private int $tradeTime; // timestamp millis
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
+    private array $rawData = [];
+
+    #[ORM\ManyToOne(targetEntity: FuturesOrder::class)]
+    #[ORM\JoinColumn(name: 'futures_order_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?FuturesOrder $futuresOrder = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct()
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTradeId(): ?string
+    {
+        return $this->tradeId;
+    }
+
+    public function setTradeId(?string $tradeId): self
+    {
+        $this->tradeId = $tradeId;
+        return $this->touch();
+    }
+
+    public function getOrderId(): string
+    {
+        return $this->orderId;
+    }
+
+    public function setOrderId(string $orderId): self
+    {
+        $this->orderId = $orderId;
+        return $this->touch();
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function setSymbol(string $symbol): self
+    {
+        $this->symbol = strtoupper($symbol);
+        return $this->touch();
+    }
+
+    public function getSide(): int
+    {
+        return $this->side;
+    }
+
+    public function setSide(int $side): self
+    {
+        $this->side = $side;
+        return $this->touch();
+    }
+
+    public function getPrice(): string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(string $price): self
+    {
+        $this->price = $price;
+        return $this->touch();
+    }
+
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    public function setSize(int $size): self
+    {
+        $this->size = $size;
+        return $this->touch();
+    }
+
+    public function getFee(): ?string
+    {
+        return $this->fee;
+    }
+
+    public function setFee(?string $fee): self
+    {
+        $this->fee = $fee;
+        return $this->touch();
+    }
+
+    public function getFeeCurrency(): ?string
+    {
+        return $this->feeCurrency;
+    }
+
+    public function setFeeCurrency(?string $feeCurrency): self
+    {
+        $this->feeCurrency = $feeCurrency;
+        return $this->touch();
+    }
+
+    public function getTradeTime(): int
+    {
+        return $this->tradeTime;
+    }
+
+    public function setTradeTime(int $tradeTime): self
+    {
+        $this->tradeTime = $tradeTime;
+        return $this->touch();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getRawData(): array
+    {
+        return $this->rawData;
+    }
+
+    /**
+     * @param array<string,mixed> $rawData
+     */
+    public function setRawData(array $rawData): self
+    {
+        $this->rawData = $rawData;
+        return $this->touch();
+    }
+
+    public function getFuturesOrder(): ?FuturesOrder
+    {
+        return $this->futuresOrder;
+    }
+
+    public function setFuturesOrder(?FuturesOrder $futuresOrder): self
+    {
+        $this->futuresOrder = $futuresOrder;
+        return $this->touch();
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): self
+    {
+        $this->updatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        return $this;
+    }
+}
+

--- a/trading-app/src/Entity/FuturesPlanOrder.php
+++ b/trading-app/src/Entity/FuturesPlanOrder.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\FuturesPlanOrderRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: FuturesPlanOrderRepository::class)]
+#[ORM\Table(name: 'futures_plan_order')]
+#[ORM\UniqueConstraint(name: 'ux_futures_plan_order_order_id', columns: ['order_id'])]
+#[ORM\UniqueConstraint(name: 'ux_futures_plan_order_client', columns: ['client_order_id'])]
+#[ORM\Index(name: 'idx_futures_plan_order_symbol', columns: ['symbol'])]
+#[ORM\Index(name: 'idx_futures_plan_order_status', columns: ['status'])]
+class FuturesPlanOrder
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true, unique: true)]
+    private ?string $orderId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true, unique: true)]
+    private ?string $clientOrderId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $side = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $type = null; // limit, market
+
+    #[ORM\Column(type: Types::STRING, length: 30, nullable: true)]
+    private ?string $status = null; // pending, triggered, cancelled
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 24, scale: 12, nullable: true)]
+    private ?string $triggerPrice = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 24, scale: 12, nullable: true)]
+    private ?string $executionPrice = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 24, scale: 12, nullable: true)]
+    private ?string $price = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $size = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $openType = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $positionMode = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $leverage = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20, nullable: true)]
+    private ?string $planType = null; // normal, preset
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $triggerTime = null;
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $createdTime = null;
+
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
+    private ?int $updatedTime = null;
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
+    private array $rawData = [];
+
+    #[ORM\ManyToOne(targetEntity: FuturesOrder::class)]
+    #[ORM\JoinColumn(name: 'futures_order_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?FuturesOrder $futuresOrder = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct()
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOrderId(): ?string
+    {
+        return $this->orderId;
+    }
+
+    public function setOrderId(?string $orderId): self
+    {
+        $this->orderId = $orderId;
+        return $this->touch();
+    }
+
+    public function getClientOrderId(): ?string
+    {
+        return $this->clientOrderId;
+    }
+
+    public function setClientOrderId(?string $clientOrderId): self
+    {
+        $this->clientOrderId = $clientOrderId;
+        return $this->touch();
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function setSymbol(string $symbol): self
+    {
+        $this->symbol = strtoupper($symbol);
+        return $this->touch();
+    }
+
+    public function getSide(): ?int
+    {
+        return $this->side;
+    }
+
+    public function setSide(?int $side): self
+    {
+        $this->side = $side;
+        return $this->touch();
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): self
+    {
+        $this->type = $type !== null ? strtolower($type) : null;
+        return $this->touch();
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(?string $status): self
+    {
+        $this->status = $status !== null ? strtolower($status) : null;
+        return $this->touch();
+    }
+
+    public function getTriggerPrice(): ?string
+    {
+        return $this->triggerPrice;
+    }
+
+    public function setTriggerPrice(?string $triggerPrice): self
+    {
+        $this->triggerPrice = $triggerPrice;
+        return $this->touch();
+    }
+
+    public function getExecutionPrice(): ?string
+    {
+        return $this->executionPrice;
+    }
+
+    public function setExecutionPrice(?string $executionPrice): self
+    {
+        $this->executionPrice = $executionPrice;
+        return $this->touch();
+    }
+
+    public function getPrice(): ?string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(?string $price): self
+    {
+        $this->price = $price;
+        return $this->touch();
+    }
+
+    public function getSize(): ?int
+    {
+        return $this->size;
+    }
+
+    public function setSize(?int $size): self
+    {
+        $this->size = $size;
+        return $this->touch();
+    }
+
+    public function getOpenType(): ?string
+    {
+        return $this->openType;
+    }
+
+    public function setOpenType(?string $openType): self
+    {
+        $this->openType = $openType !== null ? strtolower($openType) : null;
+        return $this->touch();
+    }
+
+    public function getPositionMode(): ?int
+    {
+        return $this->positionMode;
+    }
+
+    public function setPositionMode(?int $positionMode): self
+    {
+        $this->positionMode = $positionMode;
+        return $this->touch();
+    }
+
+    public function getLeverage(): ?int
+    {
+        return $this->leverage;
+    }
+
+    public function setLeverage(?int $leverage): self
+    {
+        $this->leverage = $leverage;
+        return $this->touch();
+    }
+
+    public function getPlanType(): ?string
+    {
+        return $this->planType;
+    }
+
+    public function setPlanType(?string $planType): self
+    {
+        $this->planType = $planType !== null ? strtolower($planType) : null;
+        return $this->touch();
+    }
+
+    public function getTriggerTime(): ?int
+    {
+        return $this->triggerTime;
+    }
+
+    public function setTriggerTime(?int $triggerTime): self
+    {
+        $this->triggerTime = $triggerTime;
+        return $this->touch();
+    }
+
+    public function getCreatedTime(): ?int
+    {
+        return $this->createdTime;
+    }
+
+    public function setCreatedTime(?int $createdTime): self
+    {
+        $this->createdTime = $createdTime;
+        return $this->touch();
+    }
+
+    public function getUpdatedTime(): ?int
+    {
+        return $this->updatedTime;
+    }
+
+    public function setUpdatedTime(?int $updatedTime): self
+    {
+        $this->updatedTime = $updatedTime;
+        return $this->touch();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getRawData(): array
+    {
+        return $this->rawData;
+    }
+
+    /**
+     * @param array<string,mixed> $rawData
+     */
+    public function setRawData(array $rawData): self
+    {
+        $this->rawData = $rawData;
+        return $this->touch();
+    }
+
+    public function getFuturesOrder(): ?FuturesOrder
+    {
+        return $this->futuresOrder;
+    }
+
+    public function setFuturesOrder(?FuturesOrder $futuresOrder): self
+    {
+        $this->futuresOrder = $futuresOrder;
+        return $this->touch();
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): self
+    {
+        $this->updatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        return $this;
+    }
+}
+

--- a/trading-app/src/Entity/OrderIntent.php
+++ b/trading-app/src/Entity/OrderIntent.php
@@ -1,0 +1,445 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\OrderIntentRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: OrderIntentRepository::class)]
+#[ORM\Table(name: 'order_intent')]
+#[ORM\Index(name: 'idx_order_intent_symbol', columns: ['symbol'])]
+#[ORM\Index(name: 'idx_order_intent_status', columns: ['status'])]
+#[ORM\Index(name: 'idx_order_intent_client_order_id', columns: ['client_order_id'])]
+class OrderIntent
+{
+    public const STATUS_DRAFT = 'DRAFT';
+    public const STATUS_VALIDATED = 'VALIDATED';
+    public const STATUS_READY_TO_SEND = 'READY_TO_SEND';
+    public const STATUS_SENT = 'SENT';
+    public const STATUS_FAILED = 'FAILED';
+    public const STATUS_CANCELLED = 'CANCELLED';
+
+    public const TYPE_LIMIT = 'limit';
+    public const TYPE_MARKET = 'market';
+
+    public const OPEN_TYPE_ISOLATED = 'isolated';
+    public const OPEN_TYPE_CROSS = 'cross';
+
+    public const POSITION_MODE_ONE_WAY = 'one_way';
+    public const POSITION_MODE_HEDGE = 'hedge';
+
+    public const PRESET_MODE_NONE = 'none';
+    public const PRESET_MODE_PRESET_ON_ENTRY = 'preset_on_entry';
+    public const PRESET_MODE_POSITION_TP_SL = 'position_tp_sl';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $side; // 1=open_long, 2=close_long, 3=close_short, 4=open_short
+
+    #[ORM\Column(type: Types::STRING, length: 20)]
+    private string $type; // limit, market
+
+    #[ORM\Column(type: Types::STRING, length: 20)]
+    private string $openType; // isolated, cross
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $leverage = null;
+
+    #[ORM\Column(type: Types::STRING, length: 20)]
+    private string $positionMode; // one_way, hedge
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 24, scale: 12, nullable: true)]
+    private ?string $price = null; // Prix limit (pour type=limit)
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $size; // Nombre de contrats
+
+    #[ORM\Column(type: Types::STRING, length: 80, unique: true)]
+    private string $clientOrderId; // Généré unique
+
+    #[ORM\Column(type: Types::STRING, length: 30)]
+    private string $presetMode; // none, preset_on_entry, position_tp_sl
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
+    private array $quantization = []; // tick_size, step_size, min_notional, price_precision, vol_precision, etc.
+
+    #[ORM\Column(type: Types::STRING, length: 30)]
+    private string $status = self::STATUS_DRAFT;
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true], nullable: true)]
+    private ?array $rawInputs = null; // Données brutes avant normalisation
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true], nullable: true)]
+    private ?array $validationErrors = null; // Erreurs de validation
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true)]
+    private ?string $orderId = null; // Order ID de l'exchange après envoi
+
+    #[ORM\Column(type: Types::STRING, length: 500, nullable: true)]
+    private ?string $failureReason = null; // Raison de l'échec
+
+    #[ORM\OneToMany(targetEntity: OrderProtection::class, mappedBy: 'orderIntent', cascade: ['persist', 'remove'])]
+    private Collection $protections;
+
+    #[ORM\ManyToOne(targetEntity: OrderPlan::class)]
+    #[ORM\JoinColumn(name: 'order_plan_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?OrderPlan $orderPlan = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $updatedAt;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $sentAt = null;
+
+    public function __construct()
+    {
+        $this->protections = new ArrayCollection();
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function setSymbol(string $symbol): self
+    {
+        $this->symbol = strtoupper($symbol);
+        return $this->touch();
+    }
+
+    public function getSide(): int
+    {
+        return $this->side;
+    }
+
+    public function setSide(int $side): self
+    {
+        $this->side = $side;
+        return $this->touch();
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = strtolower($type);
+        return $this->touch();
+    }
+
+    public function getOpenType(): string
+    {
+        return $this->openType;
+    }
+
+    public function setOpenType(string $openType): self
+    {
+        $this->openType = strtolower($openType);
+        return $this->touch();
+    }
+
+    public function getLeverage(): ?int
+    {
+        return $this->leverage;
+    }
+
+    public function setLeverage(?int $leverage): self
+    {
+        $this->leverage = $leverage;
+        return $this->touch();
+    }
+
+    public function getPositionMode(): string
+    {
+        return $this->positionMode;
+    }
+
+    public function setPositionMode(string $positionMode): self
+    {
+        $this->positionMode = strtolower($positionMode);
+        return $this->touch();
+    }
+
+    public function getPrice(): ?string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(?string $price): self
+    {
+        $this->price = $price;
+        return $this->touch();
+    }
+
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    public function setSize(int $size): self
+    {
+        $this->size = $size;
+        return $this->touch();
+    }
+
+    public function getClientOrderId(): string
+    {
+        return $this->clientOrderId;
+    }
+
+    public function setClientOrderId(string $clientOrderId): self
+    {
+        $this->clientOrderId = $clientOrderId;
+        return $this->touch();
+    }
+
+    public function getPresetMode(): string
+    {
+        return $this->presetMode;
+    }
+
+    public function setPresetMode(string $presetMode): self
+    {
+        $this->presetMode = strtolower($presetMode);
+        return $this->touch();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getQuantization(): array
+    {
+        return $this->quantization;
+    }
+
+    /**
+     * @param array<string,mixed> $quantization
+     */
+    public function setQuantization(array $quantization): self
+    {
+        $this->quantization = $quantization;
+        return $this->touch();
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = strtoupper($status);
+        return $this->touch();
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getRawInputs(): ?array
+    {
+        return $this->rawInputs;
+    }
+
+    /**
+     * @param array<string,mixed>|null $rawInputs
+     */
+    public function setRawInputs(?array $rawInputs): self
+    {
+        $this->rawInputs = $rawInputs;
+        return $this->touch();
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getValidationErrors(): ?array
+    {
+        return $this->validationErrors;
+    }
+
+    /**
+     * @param array<string,mixed>|null $validationErrors
+     */
+    public function setValidationErrors(?array $validationErrors): self
+    {
+        $this->validationErrors = $validationErrors;
+        return $this->touch();
+    }
+
+    public function getOrderId(): ?string
+    {
+        return $this->orderId;
+    }
+
+    public function setOrderId(?string $orderId): self
+    {
+        $this->orderId = $orderId;
+        return $this->touch();
+    }
+
+    public function getFailureReason(): ?string
+    {
+        return $this->failureReason;
+    }
+
+    public function setFailureReason(?string $failureReason): self
+    {
+        $this->failureReason = $failureReason;
+        return $this->touch();
+    }
+
+    /**
+     * @return Collection<int, OrderProtection>
+     */
+    public function getProtections(): Collection
+    {
+        return $this->protections;
+    }
+
+    public function addProtection(OrderProtection $protection): self
+    {
+        if (!$this->protections->contains($protection)) {
+            $this->protections->add($protection);
+            $protection->setOrderIntent($this);
+        }
+        return $this->touch();
+    }
+
+    public function removeProtection(OrderProtection $protection): self
+    {
+        if ($this->protections->removeElement($protection)) {
+            if ($protection->getOrderIntent() === $this) {
+                $protection->setOrderIntent(null);
+            }
+        }
+        return $this->touch();
+    }
+
+    public function getOrderPlan(): ?OrderPlan
+    {
+        return $this->orderPlan;
+    }
+
+    public function setOrderPlan(?OrderPlan $orderPlan): self
+    {
+        $this->orderPlan = $orderPlan;
+        return $this->touch();
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function getSentAt(): ?\DateTimeImmutable
+    {
+        return $this->sentAt;
+    }
+
+    public function setSentAt(?\DateTimeImmutable $sentAt): self
+    {
+        $this->sentAt = $sentAt;
+        return $this->touch();
+    }
+
+    // Méthodes utilitaires pour les statuts
+
+    public function isDraft(): bool
+    {
+        return $this->status === self::STATUS_DRAFT;
+    }
+
+    public function isValidated(): bool
+    {
+        return $this->status === self::STATUS_VALIDATED;
+    }
+
+    public function isReadyToSend(): bool
+    {
+        return $this->status === self::STATUS_READY_TO_SEND;
+    }
+
+    public function isSent(): bool
+    {
+        return $this->status === self::STATUS_SENT;
+    }
+
+    public function isFailed(): bool
+    {
+        return $this->status === self::STATUS_FAILED;
+    }
+
+    public function isCancelled(): bool
+    {
+        return $this->status === self::STATUS_CANCELLED;
+    }
+
+    public function markAsValidated(): self
+    {
+        return $this->setStatus(self::STATUS_VALIDATED);
+    }
+
+    public function markAsReadyToSend(): self
+    {
+        return $this->setStatus(self::STATUS_READY_TO_SEND);
+    }
+
+    public function markAsSent(?string $orderId = null): self
+    {
+        $this->setStatus(self::STATUS_SENT);
+        if ($orderId !== null) {
+            $this->setOrderId($orderId);
+        }
+        $this->setSentAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+        return $this->touch();
+    }
+
+    public function markAsFailed(string $reason): self
+    {
+        $this->setStatus(self::STATUS_FAILED);
+        $this->setFailureReason($reason);
+        return $this->touch();
+    }
+
+    public function markAsCancelled(): self
+    {
+        return $this->setStatus(self::STATUS_CANCELLED);
+    }
+
+    private function touch(): self
+    {
+        $this->updatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        return $this;
+    }
+}
+

--- a/trading-app/src/Entity/OrderProtection.php
+++ b/trading-app/src/Entity/OrderProtection.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\OrderProtectionRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: OrderProtectionRepository::class)]
+#[ORM\Table(name: 'order_protection')]
+#[ORM\Index(name: 'idx_order_protection_order_intent', columns: ['order_intent_id'])]
+#[ORM\Index(name: 'idx_order_protection_type', columns: ['type'])]
+class OrderProtection
+{
+    public const TYPE_TAKE_PROFIT = 'take_profit';
+    public const TYPE_STOP_LOSS = 'stop_loss';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: OrderIntent::class, inversedBy: 'protections')]
+    #[ORM\JoinColumn(name: 'order_intent_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private OrderIntent $orderIntent;
+
+    #[ORM\Column(type: Types::STRING, length: 20)]
+    private string $type; // take_profit, stop_loss
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 24, scale: 12)]
+    private string $price; // Prix de déclenchement
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $size = null; // Taille (nombre de contrats), null = même taille que l'ordre principal
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $priceType = null; // 1 = prix fixe, 2 = dernier prix, etc.
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true)]
+    private ?string $orderId = null; // Order ID de l'exchange après envoi
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true)]
+    private ?string $clientOrderId = null;
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true], nullable: true)]
+    private ?array $metadata = null; // Données supplémentaires
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct()
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getOrderIntent(): OrderIntent
+    {
+        return $this->orderIntent;
+    }
+
+    public function setOrderIntent(?OrderIntent $orderIntent): self
+    {
+        $this->orderIntent = $orderIntent;
+        return $this->touch();
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = strtolower($type);
+        return $this->touch();
+    }
+
+    public function getPrice(): string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(string $price): self
+    {
+        $this->price = $price;
+        return $this->touch();
+    }
+
+    public function getSize(): ?int
+    {
+        return $this->size;
+    }
+
+    public function setSize(?int $size): self
+    {
+        $this->size = $size;
+        return $this->touch();
+    }
+
+    public function getPriceType(): ?int
+    {
+        return $this->priceType;
+    }
+
+    public function setPriceType(?int $priceType): self
+    {
+        $this->priceType = $priceType;
+        return $this->touch();
+    }
+
+    public function getOrderId(): ?string
+    {
+        return $this->orderId;
+    }
+
+    public function setOrderId(?string $orderId): self
+    {
+        $this->orderId = $orderId;
+        return $this->touch();
+    }
+
+    public function getClientOrderId(): ?string
+    {
+        return $this->clientOrderId;
+    }
+
+    public function setClientOrderId(?string $clientOrderId): self
+    {
+        $this->clientOrderId = $clientOrderId;
+        return $this->touch();
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getMetadata(): ?array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @param array<string,mixed>|null $metadata
+     */
+    public function setMetadata(?array $metadata): self
+    {
+        $this->metadata = $metadata;
+        return $this->touch();
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function isTakeProfit(): bool
+    {
+        return $this->type === self::TYPE_TAKE_PROFIT;
+    }
+
+    public function isStopLoss(): bool
+    {
+        return $this->type === self::TYPE_STOP_LOSS;
+    }
+
+    private function touch(): self
+    {
+        $this->updatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        return $this;
+    }
+}
+

--- a/trading-app/src/Provider/Bitmart/Http/BitmartRequestSigner.php
+++ b/trading-app/src/Provider/Bitmart/Http/BitmartRequestSigner.php
@@ -18,4 +18,17 @@ final class BitmartRequestSigner
         $message = $timestampMs.'#'.$this->bitmartConfig->getApiMemo().'#'.$payload;
         return hash_hmac('sha256', $message, $this->bitmartConfig->getApiSecret());
     }
+
+    /**
+     * Construit la signature HMAC pour l'authentification WebSocket BitMart.
+     * Format attendu: HMAC_SHA256(secret, timestamp#memo#bitmart.WebSocket) encodé en hex.
+     *
+     * @param string $timestampMs Timestamp en millisecondes (ex: "1640995200000")
+     * @return string Signature hexadécimale
+     */
+    public function signWebSocket(string $timestampMs): string
+    {
+        $message = $timestampMs.'#'.$this->bitmartConfig->getApiMemo().'#bitmart.WebSocket';
+        return hash_hmac('sha256', $message, $this->bitmartConfig->getApiSecret());
+    }
 }

--- a/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketBase.php
+++ b/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketBase.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Provider\Bitmart\WebSocket;
+
+/**
+ * Classe abstraite de base pour les clients WebSocket BitMart Futures V2.
+ * Contient les constantes communes pour les actions WebSocket.
+ */
+abstract class BitmartWebsocketBase
+{
+    // Actions WebSocket communes
+    protected const ACTION_SUBSCRIBE = 'subscribe';
+    protected const ACTION_UNSUBSCRIBE = 'unsubscribe';
+    protected const ACTION_PING = 'ping';
+    protected const ACTION_ACCESS = 'access'; // Pour l'authentification privée
+
+    // Préfixe des canaux Futures V2
+    protected const CHANNEL_PREFIX_FUTURES = 'futures/';
+
+    // Mapping des timeframes pour les klines
+    protected const TIMEFRAME_MAPPING = [
+        '1m' => '1m',
+        '5m' => '5m',
+        '15m' => '15m',
+        '30m' => '30m',
+        '1h' => '1H',
+        '2h' => '2H',
+        '4h' => '4H',
+        '1d' => '1D',
+        '1w' => '1W',
+    ];
+
+    /**
+     * Construit un topic de kline pour un symbole et un timeframe donnés.
+     * Format: futures/klineBin{timeframe}:{symbol}
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @param string $timeframe Ex: '1m', '5m', '1H', etc.
+     * @return string Ex: 'futures/klineBin1m:BTCUSDT'
+     */
+    protected function buildKlineTopic(string $symbol, string $timeframe): string
+    {
+        $normalizedTf = self::TIMEFRAME_MAPPING[$timeframe] ?? $timeframe;
+        return self::CHANNEL_PREFIX_FUTURES . "klineBin{$normalizedTf}:{$symbol}";
+    }
+
+    /**
+     * Construit un payload pour une action subscribe.
+     *
+     * @param array<string> $topics Liste des topics à souscrire
+     * @return array{action: string, args: array<string>}
+     */
+    protected function buildSubscribePayload(array $topics): array
+    {
+        return [
+            'action' => self::ACTION_SUBSCRIBE,
+            'args' => $topics,
+        ];
+    }
+
+    /**
+     * Construit un payload pour une action unsubscribe.
+     *
+     * @param array<string> $topics Liste des topics à désabonner
+     * @return array{action: string, args: array<string>}
+     */
+    protected function buildUnsubscribePayload(array $topics): array
+    {
+        return [
+            'action' => self::ACTION_UNSUBSCRIBE,
+            'args' => $topics,
+        ];
+    }
+
+    /**
+     * Construit un payload pour une action ping (keep-alive).
+     *
+     * @return array{action: string}
+     */
+    protected function buildPingPayload(): array
+    {
+        return [
+            'action' => self::ACTION_PING,
+        ];
+    }
+}
+

--- a/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketPrivate.php
+++ b/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketPrivate.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Provider\Bitmart\WebSocket;
+
+use App\Provider\Bitmart\Http\BitmartConfig;
+use App\Provider\Bitmart\Http\BitmartRequestSigner;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Client WebSocket privé pour BitMart Futures V2.
+ * Gère la construction des messages pour les canaux privés (orders, positions, asset/balance)
+ * avec authentification.
+ *
+ * Documentation: https://developer-pro.bitmart.com/en/futuresv2/#format
+ */
+final class BitmartWebsocketPrivate extends BitmartWebsocketBase
+{
+    // Canaux privés Futures V2
+    private const CHANNEL_ORDER = 'futures/order';
+    private const CHANNEL_POSITION = 'futures/position';
+    private const CHANNEL_ASSET_PATTERN = 'futures/asset:%s';
+
+    // Device pour l'authentification (fixe selon BitMart)
+    private const AUTH_DEVICE = 'web';
+
+    public function __construct(
+        private readonly BitmartConfig $config,
+        private readonly BitmartRequestSigner $signer,
+        #[Autowire(service: 'monolog.logger.bitmart')]
+        private readonly LoggerInterface $bitmartLogger,
+    ) {
+    }
+
+    /**
+     * Construit un message d'authentification (login) pour les canaux privés.
+     * Format: {"action":"access","args":[apiKey, timestamp, signature, "web"]}
+     * Signature: HMAC_SHA256(secret, timestamp#memo#bitmart.WebSocket)
+     *
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildLogin(): array
+    {
+        $timestamp = (string) (int) (microtime(true) * 1000);
+        $signature = $this->signer->signWebSocket($timestamp);
+
+        $payload = [
+            'action' => self::ACTION_ACCESS,
+            'args' => [
+                $this->config->getApiKey(),
+                $timestamp,
+                $signature,
+                self::AUTH_DEVICE,
+            ],
+        ];
+
+        $this->bitmartLogger->info('[Bitmart WS] Build login', [
+            'api_key' => $this->config->getApiKey(),
+            'timestamp' => $timestamp,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour les ordres.
+     * Format topic: futures/order
+     *
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeOrder(): array
+    {
+        $payload = $this->buildSubscribePayload([self::CHANNEL_ORDER]);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe order', [
+            'topic' => self::CHANNEL_ORDER,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour les positions.
+     * Format topic: futures/position
+     *
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribePosition(): array
+    {
+        $payload = $this->buildSubscribePayload([self::CHANNEL_POSITION]);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe position', [
+            'topic' => self::CHANNEL_POSITION,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour l'asset (balance) d'une devise.
+     * Format topic: futures/asset:{currency}
+     *
+     * @param string $currency Ex: 'USDT'
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeAsset(string $currency): array
+    {
+        $topic = sprintf(self::CHANNEL_ASSET_PATTERN, $currency);
+        $payload = $this->buildSubscribePayload([$topic]);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe asset', [
+            'currency' => $currency,
+            'topic' => $topic,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour plusieurs canaux privés.
+     *
+     * @param array<string> $channels Liste des channels ('order', 'position', ou 'asset:USDT')
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeMultiple(array $channels): array
+    {
+        $topics = [];
+        foreach ($channels as $channel) {
+            $topics[] = $this->normalizeChannel($channel);
+        }
+
+        $payload = $this->buildSubscribePayload($topics);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe multiple', [
+            'channels' => $channels,
+            'topics' => $topics,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de désabonnement pour plusieurs topics.
+     *
+     * @param array<string> $topics Liste des topics à désabonner
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildUnsubscribe(array $topics): array
+    {
+        $payload = $this->buildUnsubscribePayload($topics);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build unsubscribe', [
+            'topics' => $topics,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message ping pour maintenir la connexion active.
+     *
+     * @return array{action: string}
+     */
+    public function buildPing(): array
+    {
+        return $this->buildPingPayload();
+    }
+
+    /**
+     * Récupère le topic pour les ordres.
+     *
+     * @return string 'futures/order'
+     */
+    public function getOrderTopic(): string
+    {
+        return self::CHANNEL_ORDER;
+    }
+
+    /**
+     * Récupère le topic pour les positions.
+     *
+     * @return string 'futures/position'
+     */
+    public function getPositionTopic(): string
+    {
+        return self::CHANNEL_POSITION;
+    }
+
+    /**
+     * Récupère le topic pour un asset.
+     *
+     * @param string $currency Ex: 'USDT'
+     * @return string Ex: 'futures/asset:USDT'
+     */
+    public function getAssetTopic(string $currency): string
+    {
+        return sprintf(self::CHANNEL_ASSET_PATTERN, $currency);
+    }
+
+    /**
+     * Normalise un channel en topic complet.
+     * Accepte 'order', 'position', ou 'asset:USDT' et retourne le topic complet.
+     *
+     * @param string $channel
+     * @return string
+     */
+    private function normalizeChannel(string $channel): string
+    {
+        return match ($channel) {
+            'order' => self::CHANNEL_ORDER,
+            'position' => self::CHANNEL_POSITION,
+            default => str_starts_with($channel, 'asset:')
+                ? sprintf(self::CHANNEL_ASSET_PATTERN, substr($channel, 6))
+                : $channel,
+        };
+    }
+}
+

--- a/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketPrivate.php
+++ b/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketPrivate.php
@@ -206,12 +206,11 @@ final class BitmartWebsocketPrivate extends BitmartWebsocketBase
      */
     private function normalizeChannel(string $channel): string
     {
-        return match ($channel) {
-            'order' => self::CHANNEL_ORDER,
-            'position' => self::CHANNEL_POSITION,
-            default => str_starts_with($channel, 'asset:')
-                ? sprintf(self::CHANNEL_ASSET_PATTERN, substr($channel, 6))
-                : $channel,
+        return match (true) {
+            $channel === 'order' => self::CHANNEL_ORDER,
+            $channel === 'position' => self::CHANNEL_POSITION,
+            str_starts_with($channel, 'asset:') => sprintf(self::CHANNEL_ASSET_PATTERN, substr($channel, 6)),
+            default => throw new \InvalidArgumentException("Unrecognized channel name: '$channel'"),
         };
     }
 }

--- a/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketPublic.php
+++ b/trading-app/src/Provider/Bitmart/WebSocket/BitmartWebsocketPublic.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Provider\Bitmart\WebSocket;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Client WebSocket public pour BitMart Futures V2.
+ * Gère la construction des messages pour les canaux publics (klines, ticker, depth, trade).
+ *
+ * Documentation: https://developer-pro.bitmart.com/en/futuresv2/#format
+ */
+final class BitmartWebsocketPublic extends BitmartWebsocketBase
+{
+    // Canaux publics Futures V2
+    private const CHANNEL_KLINE_PATTERN = 'futures/klineBin%s:%s';
+    private const CHANNEL_TICKER_PATTERN = 'futures/ticker:%s';
+    private const CHANNEL_DEPTH_PATTERN = 'futures/depth:%s';
+    private const CHANNEL_TRADE_PATTERN = 'futures/trade:%s';
+
+    public function __construct(
+        #[Autowire(service: 'monolog.logger.bitmart')]
+        private readonly LoggerInterface $bitmartLogger,
+    ) {
+    }
+
+    /**
+     * Construit un message de souscription pour les klines d'un symbole et timeframe.
+     * Format topic: futures/klineBin{timeframe}:{symbol}
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @param string $timeframe Ex: '1m', '5m', '1H', etc.
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeKline(string $symbol, string $timeframe): array
+    {
+        $topic = $this->buildKlineTopic($symbol, $timeframe);
+        $payload = $this->buildSubscribePayload([$topic]);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe kline', [
+            'symbol' => $symbol,
+            'timeframe' => $timeframe,
+            'topic' => $topic,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour plusieurs klines d'un même symbole.
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @param array<string> $timeframes Ex: ['1m', '5m', '1H']
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeKlines(string $symbol, array $timeframes): array
+    {
+        $topics = [];
+        foreach ($timeframes as $tf) {
+            $topics[] = $this->buildKlineTopic($symbol, $tf);
+        }
+
+        $payload = $this->buildSubscribePayload($topics);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe klines', [
+            'symbol' => $symbol,
+            'timeframes' => $timeframes,
+            'topics' => $topics,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour le ticker d'un symbole.
+     * Format topic: futures/ticker:{symbol}
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeTicker(string $symbol): array
+    {
+        $topic = sprintf(self::CHANNEL_TICKER_PATTERN, $symbol);
+        $payload = $this->buildSubscribePayload([$topic]);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe ticker', [
+            'symbol' => $symbol,
+            'topic' => $topic,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour la profondeur (order book) d'un symbole.
+     * Format topic: futures/depth:{symbol}
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeDepth(string $symbol): array
+    {
+        $topic = sprintf(self::CHANNEL_DEPTH_PATTERN, $symbol);
+        $payload = $this->buildSubscribePayload([$topic]);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe depth', [
+            'symbol' => $symbol,
+            'topic' => $topic,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de souscription pour les trades d'un symbole.
+     * Format topic: futures/trade:{symbol}
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildSubscribeTrade(string $symbol): array
+    {
+        $topic = sprintf(self::CHANNEL_TRADE_PATTERN, $symbol);
+        $payload = $this->buildSubscribePayload([$topic]);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build subscribe trade', [
+            'symbol' => $symbol,
+            'topic' => $topic,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message de désabonnement pour plusieurs topics.
+     *
+     * @param array<string> $topics Liste des topics à désabonner
+     * @return array{action: string, args: array<string>}
+     */
+    public function buildUnsubscribe(array $topics): array
+    {
+        $payload = $this->buildUnsubscribePayload($topics);
+
+        $this->bitmartLogger->info('[Bitmart WS] Build unsubscribe', [
+            'topics' => $topics,
+        ]);
+
+        return $payload;
+    }
+
+    /**
+     * Construit un message ping pour maintenir la connexion active.
+     *
+     * @return array{action: string}
+     */
+    public function buildPing(): array
+    {
+        return $this->buildPingPayload();
+    }
+
+    /**
+     * Génère le topic pour une kline.
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @param string $timeframe Ex: '1m', '5m', '1H'
+     * @return string Ex: 'futures/klineBin1m:BTCUSDT'
+     */
+    public function getKlineTopic(string $symbol, string $timeframe): string
+    {
+        return $this->buildKlineTopic($symbol, $timeframe);
+    }
+
+    /**
+     * Génère le topic pour un ticker.
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @return string Ex: 'futures/ticker:BTCUSDT'
+     */
+    public function getTickerTopic(string $symbol): string
+    {
+        return sprintf(self::CHANNEL_TICKER_PATTERN, $symbol);
+    }
+
+    /**
+     * Génère le topic pour la profondeur.
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @return string Ex: 'futures/depth:BTCUSDT'
+     */
+    public function getDepthTopic(string $symbol): string
+    {
+        return sprintf(self::CHANNEL_DEPTH_PATTERN, $symbol);
+    }
+
+    /**
+     * Génère le topic pour les trades.
+     *
+     * @param string $symbol Ex: 'BTCUSDT'
+     * @return string Ex: 'futures/trade:BTCUSDT'
+     */
+    public function getTradeTopic(string $symbol): string
+    {
+        return sprintf(self::CHANNEL_TRADE_PATTERN, $symbol);
+    }
+}
+

--- a/trading-app/src/Repository/FuturesOrderRepository.php
+++ b/trading-app/src/Repository/FuturesOrderRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\FuturesOrder;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FuturesOrder>
+ */
+final class FuturesOrderRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FuturesOrder::class);
+    }
+
+    public function findOneByOrderId(string $orderId): ?FuturesOrder
+    {
+        return $this->findOneBy(['orderId' => $orderId]);
+    }
+
+    public function findOneByClientOrderId(string $clientOrderId): ?FuturesOrder
+    {
+        return $this->findOneBy(['clientOrderId' => $clientOrderId]);
+    }
+
+    /**
+     * @return FuturesOrder[]
+     */
+    public function findBySymbol(?string $symbol = null, int $limit = 100): array
+    {
+        $qb = $this->createQueryBuilder('fo')
+            ->orderBy('fo.createdTime', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($symbol !== null && $symbol !== '') {
+            $qb->andWhere('fo.symbol = :symbol')
+                ->setParameter('symbol', strtoupper($symbol));
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return FuturesOrder[]
+     */
+    public function findByStatus(string $status, ?string $symbol = null, int $limit = 100): array
+    {
+        $qb = $this->createQueryBuilder('fo')
+            ->where('fo.status = :status')
+            ->setParameter('status', strtolower($status))
+            ->orderBy('fo.createdTime', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($symbol !== null && $symbol !== '') {
+            $qb->andWhere('fo.symbol = :symbol')
+                ->setParameter('symbol', strtoupper($symbol));
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function save(FuturesOrder $order): void
+    {
+        $this->getEntityManager()->persist($order);
+        $this->getEntityManager()->flush();
+    }
+}
+

--- a/trading-app/src/Repository/FuturesOrderTradeRepository.php
+++ b/trading-app/src/Repository/FuturesOrderTradeRepository.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\FuturesOrderTrade;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FuturesOrderTrade>
+ */
+final class FuturesOrderTradeRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FuturesOrderTrade::class);
+    }
+
+    public function findOneByTradeId(string $tradeId): ?FuturesOrderTrade
+    {
+        return $this->findOneBy(['tradeId' => $tradeId]);
+    }
+
+    /**
+     * @return FuturesOrderTrade[]
+     */
+    public function findByOrderId(string $orderId, int $limit = 100): array
+    {
+        return $this->createQueryBuilder('fot')
+            ->where('fot.orderId = :orderId')
+            ->setParameter('orderId', $orderId)
+            ->orderBy('fot.tradeTime', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return FuturesOrderTrade[]
+     */
+    public function findBySymbol(?string $symbol = null, int $limit = 100): array
+    {
+        $qb = $this->createQueryBuilder('fot')
+            ->orderBy('fot.tradeTime', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($symbol !== null && $symbol !== '') {
+            $qb->andWhere('fot.symbol = :symbol')
+                ->setParameter('symbol', strtoupper($symbol));
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function save(FuturesOrderTrade $trade): void
+    {
+        $this->getEntityManager()->persist($trade);
+        $this->getEntityManager()->flush();
+    }
+}
+

--- a/trading-app/src/Repository/FuturesPlanOrderRepository.php
+++ b/trading-app/src/Repository/FuturesPlanOrderRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\FuturesPlanOrder;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FuturesPlanOrder>
+ */
+final class FuturesPlanOrderRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FuturesPlanOrder::class);
+    }
+
+    public function findOneByOrderId(string $orderId): ?FuturesPlanOrder
+    {
+        return $this->findOneBy(['orderId' => $orderId]);
+    }
+
+    public function findOneByClientOrderId(string $clientOrderId): ?FuturesPlanOrder
+    {
+        return $this->findOneBy(['clientOrderId' => $clientOrderId]);
+    }
+
+    /**
+     * @return FuturesPlanOrder[]
+     */
+    public function findBySymbol(?string $symbol = null, int $limit = 100): array
+    {
+        $qb = $this->createQueryBuilder('fpo')
+            ->orderBy('fpo.createdTime', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($symbol !== null && $symbol !== '') {
+            $qb->andWhere('fpo.symbol = :symbol')
+                ->setParameter('symbol', strtoupper($symbol));
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return FuturesPlanOrder[]
+     */
+    public function findByStatus(string $status, ?string $symbol = null, int $limit = 100): array
+    {
+        $qb = $this->createQueryBuilder('fpo')
+            ->where('fpo.status = :status')
+            ->setParameter('status', strtolower($status))
+            ->orderBy('fpo.createdTime', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($symbol !== null && $symbol !== '') {
+            $qb->andWhere('fpo.symbol = :symbol')
+                ->setParameter('symbol', strtoupper($symbol));
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function save(FuturesPlanOrder $order): void
+    {
+        $this->getEntityManager()->persist($order);
+        $this->getEntityManager()->flush();
+    }
+}
+

--- a/trading-app/src/Repository/OrderIntentRepository.php
+++ b/trading-app/src/Repository/OrderIntentRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\OrderIntent;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<OrderIntent>
+ */
+final class OrderIntentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OrderIntent::class);
+    }
+
+    public function findOneByClientOrderId(string $clientOrderId): ?OrderIntent
+    {
+        return $this->findOneBy(['clientOrderId' => $clientOrderId]);
+    }
+
+    public function findOneByOrderId(string $orderId): ?OrderIntent
+    {
+        return $this->findOneBy(['orderId' => $orderId]);
+    }
+
+    /**
+     * @return OrderIntent[]
+     */
+    public function findByStatus(string $status, ?string $symbol = null, int $limit = 100): array
+    {
+        $qb = $this->createQueryBuilder('oi')
+            ->where('oi.status = :status')
+            ->setParameter('status', $status)
+            ->orderBy('oi.createdAt', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($symbol !== null && $symbol !== '') {
+            $qb->andWhere('oi.symbol = :symbol')
+                ->setParameter('symbol', strtoupper($symbol));
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return OrderIntent[]
+     */
+    public function findReadyToSend(?string $symbol = null, int $limit = 50): array
+    {
+        return $this->findByStatus(OrderIntent::STATUS_READY_TO_SEND, $symbol, $limit);
+    }
+
+    public function save(OrderIntent $intent): void
+    {
+        $this->getEntityManager()->persist($intent);
+        $this->getEntityManager()->flush();
+    }
+}
+

--- a/trading-app/src/Repository/OrderProtectionRepository.php
+++ b/trading-app/src/Repository/OrderProtectionRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\OrderProtection;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<OrderProtection>
+ */
+final class OrderProtectionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OrderProtection::class);
+    }
+
+    /**
+     * @return OrderProtection[]
+     */
+    public function findByOrderIntent(int $orderIntentId): array
+    {
+        return $this->createQueryBuilder('op')
+            ->where('op.orderIntent = :orderIntentId')
+            ->setParameter('orderIntentId', $orderIntentId)
+            ->orderBy('op.type', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return OrderProtection[]
+     */
+    public function findByType(string $type, int $orderIntentId): array
+    {
+        return $this->createQueryBuilder('op')
+            ->where('op.orderIntent = :orderIntentId')
+            ->andWhere('op.type = :type')
+            ->setParameter('orderIntentId', $orderIntentId)
+            ->setParameter('type', strtolower($type))
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function save(OrderProtection $protection): void
+    {
+        $this->getEntityManager()->persist($protection);
+        $this->getEntityManager()->flush();
+    }
+}
+

--- a/trading-app/src/Service/FuturesOrderSyncService.php
+++ b/trading-app/src/Service/FuturesOrderSyncService.php
@@ -1,0 +1,363 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\FuturesOrder;
+use App\Entity\FuturesOrderTrade;
+use App\Entity\FuturesPlanOrder;
+use App\Repository\FuturesOrderRepository;
+use App\Repository\FuturesOrderTradeRepository;
+use App\Repository\FuturesPlanOrderRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+final class FuturesOrderSyncService
+{
+    public function __construct(
+        private readonly FuturesOrderRepository $futuresOrderRepository,
+        private readonly FuturesPlanOrderRepository $futuresPlanOrderRepository,
+        private readonly FuturesOrderTradeRepository $futuresOrderTradeRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Synchronise un ordre depuis les données de l'API BitMart
+     * @param array<string,mixed> $orderData Données de l'API (order detail, order history, open orders)
+     */
+    public function syncOrderFromApi(array $orderData): ?FuturesOrder
+    {
+        try {
+            $orderId = $this->extractString($orderData, 'order_id');
+            $clientOrderId = $this->extractString($orderData, 'client_order_id');
+
+            if (!$orderId && !$clientOrderId) {
+                $this->logger->warning('[FuturesOrderSync] Missing order_id and client_order_id', [
+                    'data' => $orderData,
+                ]);
+                return null;
+            }
+
+            // Chercher l'ordre existant par order_id ou client_order_id
+            $order = null;
+            if ($orderId) {
+                $order = $this->futuresOrderRepository->findOneByOrderId($orderId);
+            }
+            if (!$order && $clientOrderId) {
+                $order = $this->futuresOrderRepository->findOneByClientOrderId($clientOrderId);
+            }
+
+            if (!$order) {
+                $order = new FuturesOrder();
+            }
+
+            // Mapper les champs depuis l'API
+            $order->setOrderId($orderId);
+            $order->setClientOrderId($clientOrderId);
+            $order->setSymbol($this->extractString($orderData, 'symbol', ''));
+            
+            $side = $this->extractInt($orderData, 'side');
+            if ($side !== null) {
+                $order->setSide($side);
+            }
+
+            $order->setType($this->extractString($orderData, 'type'));
+            $order->setStatus($this->extractString($orderData, 'status'));
+            $order->setPrice($this->extractString($orderData, 'price'));
+            
+            $size = $this->extractInt($orderData, 'size');
+            if ($size !== null) {
+                $order->setSize($size);
+            }
+
+            $filledSize = $this->extractInt($orderData, 'filled_size');
+            if ($filledSize !== null) {
+                $order->setFilledSize($filledSize);
+            }
+
+            $order->setFilledNotional($this->extractString($orderData, 'filled_notional'));
+            $order->setOpenType($this->extractString($orderData, 'open_type'));
+            
+            $positionMode = $this->extractInt($orderData, 'position_mode');
+            if ($positionMode !== null) {
+                $order->setPositionMode($positionMode);
+            }
+
+            $leverage = $this->extractInt($orderData, 'leverage');
+            if ($leverage !== null) {
+                $order->setLeverage($leverage);
+            }
+
+            $order->setFee($this->extractString($orderData, 'fee'));
+            $order->setFeeCurrency($this->extractString($orderData, 'fee_currency'));
+            $order->setAccount($this->extractString($orderData, 'account'));
+
+            $filledTime = $this->extractInt($orderData, 'filled_time');
+            if ($filledTime !== null) {
+                $order->setFilledTime($filledTime);
+            }
+
+            $createdTime = $this->extractInt($orderData, 'created_time');
+            if ($createdTime !== null) {
+                $order->setCreatedTime($createdTime);
+            }
+
+            $updatedTime = $this->extractInt($orderData, 'updated_time');
+            if ($updatedTime !== null) {
+                $order->setUpdatedTime($updatedTime);
+            }
+
+            // Stocker les données brutes
+            $order->setRawData($orderData);
+
+            $this->entityManager->persist($order);
+            $this->entityManager->flush();
+
+            return $order;
+        } catch (\Throwable $e) {
+            $this->logger->error('[FuturesOrderSync] Error syncing order', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+                'data' => $orderData,
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Synchronise un ordre planifié depuis les données de l'API BitMart
+     * @param array<string,mixed> $orderData Données de l'API (plan order)
+     */
+    public function syncPlanOrderFromApi(array $orderData): ?FuturesPlanOrder
+    {
+        try {
+            $orderId = $this->extractString($orderData, 'order_id');
+            $clientOrderId = $this->extractString($orderData, 'client_order_id');
+
+            if (!$orderId && !$clientOrderId) {
+                $this->logger->warning('[FuturesOrderSync] Missing order_id and client_order_id for plan order', [
+                    'data' => $orderData,
+                ]);
+                return null;
+            }
+
+            // Chercher l'ordre planifié existant
+            $planOrder = null;
+            if ($orderId) {
+                $planOrder = $this->futuresPlanOrderRepository->findOneByOrderId($orderId);
+            }
+            if (!$planOrder && $clientOrderId) {
+                $planOrder = $this->futuresPlanOrderRepository->findOneByClientOrderId($clientOrderId);
+            }
+
+            if (!$planOrder) {
+                $planOrder = new FuturesPlanOrder();
+            }
+
+            // Mapper les champs depuis l'API
+            $planOrder->setOrderId($orderId);
+            $planOrder->setClientOrderId($clientOrderId);
+            $planOrder->setSymbol($this->extractString($orderData, 'symbol', ''));
+            
+            $side = $this->extractInt($orderData, 'side');
+            if ($side !== null) {
+                $planOrder->setSide($side);
+            }
+
+            $planOrder->setType($this->extractString($orderData, 'type'));
+            $planOrder->setStatus($this->extractString($orderData, 'status'));
+            $planOrder->setTriggerPrice($this->extractString($orderData, 'trigger_price'));
+            $planOrder->setExecutionPrice($this->extractString($orderData, 'execution_price'));
+            $planOrder->setPrice($this->extractString($orderData, 'price'));
+            
+            $size = $this->extractInt($orderData, 'size');
+            if ($size !== null) {
+                $planOrder->setSize($size);
+            }
+
+            $planOrder->setOpenType($this->extractString($orderData, 'open_type'));
+            
+            $positionMode = $this->extractInt($orderData, 'position_mode');
+            if ($positionMode !== null) {
+                $planOrder->setPositionMode($positionMode);
+            }
+
+            $leverage = $this->extractInt($orderData, 'leverage');
+            if ($leverage !== null) {
+                $planOrder->setLeverage($leverage);
+            }
+
+            $planOrder->setPlanType($this->extractString($orderData, 'plan_type'));
+
+            $triggerTime = $this->extractInt($orderData, 'trigger_time');
+            if ($triggerTime !== null) {
+                $planOrder->setTriggerTime($triggerTime);
+            }
+
+            $createdTime = $this->extractInt($orderData, 'created_time');
+            if ($createdTime !== null) {
+                $planOrder->setCreatedTime($createdTime);
+            }
+
+            $updatedTime = $this->extractInt($orderData, 'updated_time');
+            if ($updatedTime !== null) {
+                $planOrder->setUpdatedTime($updatedTime);
+            }
+
+            // Stocker les données brutes
+            $planOrder->setRawData($orderData);
+
+            $this->entityManager->persist($planOrder);
+            $this->entityManager->flush();
+
+            return $planOrder;
+        } catch (\Throwable $e) {
+            $this->logger->error('[FuturesOrderSync] Error syncing plan order', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+                'data' => $orderData,
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Synchronise un trade depuis les données de l'API BitMart
+     * @param array<string,mixed> $tradeData Données de l'API (order trade)
+     */
+    public function syncTradeFromApi(array $tradeData): ?FuturesOrderTrade
+    {
+        try {
+            $tradeId = $this->extractString($tradeData, 'trade_id');
+            if (!$tradeId) {
+                // Essayer d'utiliser un identifiant alternatif ou générer un ID temporaire
+                $tradeId = $this->extractString($tradeData, 'id') 
+                    ?? sprintf('trade_%s_%d', $this->extractString($tradeData, 'order_id', 'unknown'), time());
+                $this->logger->warning('[FuturesOrderSync] Missing trade_id, using generated ID', [
+                    'generated_id' => $tradeId,
+                    'data' => $tradeData,
+                ]);
+            }
+
+            // Chercher le trade existant
+            $trade = $this->futuresOrderTradeRepository->findOneByTradeId($tradeId);
+            if (!$trade) {
+                $trade = new FuturesOrderTrade();
+            }
+
+            // Mapper les champs depuis l'API
+            $trade->setTradeId($tradeId);
+            $trade->setOrderId($this->extractString($tradeData, 'order_id', ''));
+            $trade->setSymbol($this->extractString($tradeData, 'symbol', ''));
+            $trade->setSide($this->extractInt($tradeData, 'side', 0));
+            $trade->setPrice($this->extractString($tradeData, 'price', '0'));
+            $trade->setSize($this->extractInt($tradeData, 'size', 0));
+            $trade->setFee($this->extractString($tradeData, 'fee'));
+            $trade->setFeeCurrency($this->extractString($tradeData, 'fee_currency'));
+            $trade->setTradeTime($this->extractInt($tradeData, 'trade_time', 0));
+
+            // Lier au FuturesOrder si l'order_id existe
+            $orderId = $this->extractString($tradeData, 'order_id');
+            if ($orderId) {
+                $futuresOrder = $this->futuresOrderRepository->findOneByOrderId($orderId);
+                if ($futuresOrder) {
+                    $trade->setFuturesOrder($futuresOrder);
+                }
+            }
+
+            // Stocker les données brutes
+            $trade->setRawData($tradeData);
+
+            $this->entityManager->persist($trade);
+            $this->entityManager->flush();
+
+            return $trade;
+        } catch (\Throwable $e) {
+            $this->logger->error('[FuturesOrderSync] Error syncing trade', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+                'data' => $tradeData,
+            ]);
+            return null;
+        }
+    }
+
+    /**
+     * Synchronise un ordre depuis un événement WebSocket
+     * @param array<string,mixed> $eventData Données normalisées de l'événement WebSocket
+     */
+    public function syncOrderFromWebSocket(array $eventData): ?FuturesOrder
+    {
+        // Mapper les champs WebSocket normalisés vers le format API
+        $normalized = [
+            'order_id' => $eventData['order_id'] ?? null,
+            'client_order_id' => $eventData['client_order_id'] ?? null,
+            'symbol' => $eventData['symbol'] ?? null,
+            'side' => $eventData['side'] ?? null,
+            'type' => $eventData['type'] ?? null,
+            'status' => $this->mapWebSocketStateToStatus($eventData['state'] ?? null),
+            'price' => $eventData['price'] ?? null,
+            'size' => $eventData['size'] ?? null,
+            'filled_size' => $eventData['deal_size'] ?? $eventData['filled_size'] ?? null,
+            'filled_notional' => null, // Pas disponible dans WebSocket
+            'open_type' => $eventData['open_type'] ?? null,
+            'position_mode' => $eventData['position_mode'] ?? null,
+            'leverage' => $eventData['leverage'] ?? null,
+            'fee' => null, // Pas disponible dans WebSocket
+            'fee_currency' => null,
+            'account' => null,
+            'filled_time' => null,
+            'created_time' => null,
+            'updated_time' => $eventData['update_time_ms'] ?? $eventData['update_time'] ?? null,
+        ];
+
+        return $this->syncOrderFromApi(array_merge($normalized, ['_ws_event' => true]));
+    }
+
+    /**
+     * Mappe l'état WebSocket vers le statut de l'ordre
+     * 
+     * États BitMart WebSocket:
+     * - 1 = APPROVAL (en attente d'approbation)
+     * - 2 = CHECK (en vérification)
+     * - 4 = FINISH (terminé)
+     * 
+     * Le statut final dépend aussi de deal_size pour distinguer filled vs cancelled
+     */
+    private function mapWebSocketStateToStatus(?int $state): ?string
+    {
+        if ($state === null) {
+            return null;
+        }
+
+        // Mapping BitMart WebSocket state to status
+        return match ($state) {
+            1 => 'pending',      // APPROVAL
+            2 => 'pending',      // CHECK
+            4 => 'filled',       // FINISH (sera affiné selon deal_size si disponible)
+            default => 'unknown',
+        };
+    }
+
+    private function extractString(array $data, string $key, ?string $default = null): ?string
+    {
+        $value = $data[$key] ?? null;
+        if ($value === null) {
+            return $default;
+        }
+        return (string) $value;
+    }
+
+    private function extractInt(array $data, string $key, ?int $default = null): ?int
+    {
+        $value = $data[$key] ?? null;
+        if ($value === null) {
+            return $default;
+        }
+        return (int) $value;
+    }
+}
+

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\OrderIntent;
+use App\Entity\OrderProtection;
+use App\Repository\OrderIntentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+final class OrderIntentManager
+{
+    public function __construct(
+        private readonly OrderIntentRepository $orderIntentRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Crée un OrderIntent depuis les paramètres d'un ordre
+     * @param array<string,mixed> $orderParams
+     * @param array<string,mixed> $quantization
+     * @param array<string,mixed>|null $rawInputs
+     */
+    public function createIntent(
+        array $orderParams,
+        array $quantization = [],
+        ?array $rawInputs = null
+    ): OrderIntent {
+        $intent = new OrderIntent();
+
+        $intent->setSymbol($orderParams['symbol'] ?? '');
+        $intent->setSide((int)($orderParams['side'] ?? 1));
+        $intent->setType($orderParams['type'] ?? OrderIntent::TYPE_LIMIT);
+        $intent->setOpenType($orderParams['open_type'] ?? OrderIntent::OPEN_TYPE_ISOLATED);
+        
+        if (isset($orderParams['leverage'])) {
+            $intent->setLeverage((int)$orderParams['leverage']);
+        }
+
+        $intent->setPositionMode(
+            $orderParams['position_mode'] ?? OrderIntent::POSITION_MODE_ONE_WAY
+        );
+
+        if (isset($orderParams['price'])) {
+            $intent->setPrice((string)$orderParams['price']);
+        }
+
+        $intent->setSize((int)($orderParams['size'] ?? 0));
+        
+        // Générer un client_order_id unique s'il n'est pas fourni
+        $clientOrderId = $orderParams['client_order_id'] 
+            ?? $this->generateClientOrderId($intent->getSymbol());
+        $intent->setClientOrderId($clientOrderId);
+
+        $intent->setPresetMode(
+            $orderParams['preset_mode'] ?? OrderIntent::PRESET_MODE_NONE
+        );
+
+        $intent->setQuantization($quantization);
+        $intent->setRawInputs($rawInputs);
+        $intent->setStatus(OrderIntent::STATUS_DRAFT);
+
+        // Ajouter les protections TP/SL si présentes
+        if (isset($orderParams['preset_take_profit_price'])) {
+            $tp = new OrderProtection();
+            $tp->setType(OrderProtection::TYPE_TAKE_PROFIT);
+            $tp->setPrice((string)$orderParams['preset_take_profit_price']);
+            $tp->setPriceType($orderParams['preset_take_profit_price_type'] ?? 1);
+            $intent->addProtection($tp);
+        }
+
+        if (isset($orderParams['preset_stop_loss_price'])) {
+            $sl = new OrderProtection();
+            $sl->setType(OrderProtection::TYPE_STOP_LOSS);
+            $sl->setPrice((string)$orderParams['preset_stop_loss_price']);
+            $sl->setPriceType($orderParams['preset_stop_loss_price_type'] ?? 1);
+            $intent->addProtection($sl);
+        }
+
+        $this->entityManager->persist($intent);
+        $this->entityManager->flush();
+
+        $this->logger->debug('[OrderIntentManager] Created intent', [
+            'client_order_id' => $clientOrderId,
+            'symbol' => $intent->getSymbol(),
+            'status' => $intent->getStatus(),
+        ]);
+
+        return $intent;
+    }
+
+    /**
+     * Valide un OrderIntent et le marque comme VALIDATED
+     */
+    public function validateIntent(OrderIntent $intent, ?array $errors = null): bool
+    {
+        if ($errors !== null && count($errors) > 0) {
+            $intent->setValidationErrors($errors);
+            $intent->markAsFailed('Validation failed: ' . json_encode($errors));
+            $this->entityManager->flush();
+            return false;
+        }
+
+        $intent->markAsValidated();
+        $intent->setValidationErrors(null);
+        $this->entityManager->flush();
+
+        $this->logger->debug('[OrderIntentManager] Validated intent', [
+            'client_order_id' => $intent->getClientOrderId(),
+            'symbol' => $intent->getSymbol(),
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Marque un OrderIntent comme READY_TO_SEND
+     */
+    public function markReadyToSend(OrderIntent $intent): void
+    {
+        $intent->markAsReadyToSend();
+        $this->entityManager->flush();
+
+        $this->logger->debug('[OrderIntentManager] Marked as ready to send', [
+            'client_order_id' => $intent->getClientOrderId(),
+            'symbol' => $intent->getSymbol(),
+        ]);
+    }
+
+    /**
+     * Marque un OrderIntent comme SENT après envoi réussi
+     */
+    public function markAsSent(OrderIntent $intent, string $orderId): void
+    {
+        $intent->markAsSent($orderId);
+        $this->entityManager->flush();
+
+        $this->logger->info('[OrderIntentManager] Marked as sent', [
+            'client_order_id' => $intent->getClientOrderId(),
+            'order_id' => $orderId,
+            'symbol' => $intent->getSymbol(),
+        ]);
+    }
+
+    /**
+     * Marque un OrderIntent comme FAILED
+     */
+    public function markAsFailed(OrderIntent $intent, string $reason): void
+    {
+        $intent->markAsFailed($reason);
+        $this->entityManager->flush();
+
+        $this->logger->warning('[OrderIntentManager] Marked as failed', [
+            'client_order_id' => $intent->getClientOrderId(),
+            'symbol' => $intent->getSymbol(),
+            'reason' => $reason,
+        ]);
+    }
+
+    /**
+     * Marque un OrderIntent comme CANCELLED
+     */
+    public function markAsCancelled(OrderIntent $intent): void
+    {
+        $intent->markAsCancelled();
+        $this->entityManager->flush();
+
+        $this->logger->info('[OrderIntentManager] Marked as cancelled', [
+            'client_order_id' => $intent->getClientOrderId(),
+            'symbol' => $intent->getSymbol(),
+        ]);
+    }
+
+    /**
+     * Trouve un OrderIntent par client_order_id ou order_id
+     */
+    public function findIntent(?string $clientOrderId = null, ?string $orderId = null): ?OrderIntent
+    {
+        if ($clientOrderId !== null) {
+            return $this->orderIntentRepository->findOneByClientOrderId($clientOrderId);
+        }
+
+        if ($orderId !== null) {
+            return $this->orderIntentRepository->findOneByOrderId($orderId);
+        }
+
+        return null;
+    }
+
+    /**
+     * Génère un client_order_id unique
+     */
+    private function generateClientOrderId(string $symbol): string
+    {
+        $timestamp = (int)(microtime(true) * 1000);
+        $random = bin2hex(random_bytes(4));
+        return sprintf('INTENT_%s_%d_%s', $symbol, $timestamp, $random);
+    }
+}
+

--- a/trading-app/src/Service/WsAgentService.php
+++ b/trading-app/src/Service/WsAgentService.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Provider\Bitmart\WebSocket\BitmartWebsocketPrivate;
+use App\Repository\FuturesOrderRepository;
+use App\Repository\OrderIntentRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Ratchet\Client\WebSocket;
+use Ratchet\Client\Connector;
+use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
+use React\Socket\Connector as SocketConnector;
+use React\Http\HttpServer;
+use React\Http\Message\Response;
+use React\Socket\SocketServer;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class WsAgentService
+{
+    private ?WebSocket $wsConnection = null;
+    private ?LoopInterface $loop = null;
+    private bool $isAuthenticated = false;
+    private bool $isSubscribed = false;
+    private array $trackedOrders = []; // client_order_id => ['order_id', 'symbol', 'status']
+    private ?string $wsUrl = null;
+
+    public function __construct(
+        private readonly BitmartWebsocketPrivate $wsBuilder,
+        private readonly FuturesOrderRepository $futuresOrderRepository,
+        private readonly OrderIntentRepository $orderIntentRepository,
+        private readonly FuturesOrderSyncService $syncService,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly HttpClientInterface $httpClient,
+        #[Autowire(service: 'monolog.logger.ws_agent')]
+        private readonly LoggerInterface $logger,
+        #[Autowire('%env(BITMART_WS_PRIVATE_URL)%')]
+        private readonly string $bitmartWsPrivateUrl,
+        #[Autowire('%env(TRADING_APP_BASE_URI)%')]
+        private readonly string $tradingAppBaseUri,
+        #[Autowire('%env(TRADING_APP_ORDER_SUBMITTED_PATH)%')]
+        private readonly string $orderSubmittedPath,
+        #[Autowire('%env(WS_TOPICS)%')]
+        private readonly string $wsTopics,
+    ) {
+        $this->wsUrl = $this->bitmartWsPrivateUrl;
+    }
+
+    public function run(): void
+    {
+        $this->loop = Loop::get();
+        
+        // Démarrer le serveur HTTP interne pour recevoir les notifications
+        $this->startHttpServer();
+        
+        // Connecter au WebSocket
+        $this->connect();
+
+        // Gérer les signaux pour arrêt propre
+        if (function_exists('pcntl_signal')) {
+            $this->loop->addSignal(SIGTERM, function () {
+                $this->logger->info('[WsAgent] SIGTERM received, shutting down');
+                $this->disconnect();
+                $this->loop->stop();
+            });
+            $this->loop->addSignal(SIGINT, function () {
+                $this->logger->info('[WsAgent] SIGINT received, shutting down');
+                $this->disconnect();
+                $this->loop->stop();
+            });
+        }
+
+        $this->loop->run();
+    }
+
+    /**
+     * Démarre le serveur HTTP interne pour recevoir les notifications de tracking
+     */
+    private function startHttpServer(): void
+    {
+        $httpServer = new HttpServer($this->loop, function (ServerRequestInterface $request) {
+            $path = $request->getUri()->getPath();
+            $method = $request->getMethod();
+
+            // Endpoint pour tracker un ordre
+            if ($path === '/internal/track-order' && $method === 'POST') {
+                $body = json_decode($request->getBody()->getContents(), true);
+                if (!is_array($body)) {
+                    return new Response(400, ['Content-Type' => 'application/json'], json_encode([
+                        'status' => 'error',
+                        'reason' => 'invalid_json',
+                    ]));
+                }
+
+                $clientOrderId = $body['client_order_id'] ?? null;
+                $orderId = $body['order_id'] ?? null;
+                $symbol = $body['symbol'] ?? null;
+
+                if (!$clientOrderId && !$orderId) {
+                    return new Response(400, ['Content-Type' => 'application/json'], json_encode([
+                        'status' => 'error',
+                        'reason' => 'missing_client_order_id_or_order_id',
+                    ]));
+                }
+
+                $this->trackOrder($clientOrderId ?? '', $orderId, $symbol ?? '');
+
+                return new Response(202, ['Content-Type' => 'application/json'], json_encode([
+                    'status' => 'ok',
+                    'message' => 'order_tracked',
+                ]));
+            }
+
+            // Health check
+            if ($path === '/health' && $method === 'GET') {
+                return new Response(200, ['Content-Type' => 'application/json'], json_encode([
+                    'status' => 'ok',
+                    'authenticated' => $this->isAuthenticated,
+                    'subscribed' => $this->isSubscribed,
+                    'tracked_orders_count' => count($this->trackedOrders),
+                ]));
+            }
+
+            return new Response(404, ['Content-Type' => 'application/json'], json_encode([
+                'status' => 'error',
+                'reason' => 'not_found',
+            ]));
+        });
+
+        $socket = new SocketServer('0.0.0.0:8090', [], $this->loop);
+        $httpServer->listen($socket);
+
+        $this->logger->info('[WsAgent] HTTP server started on port 8090');
+    }
+
+    private function connect(): void
+    {
+        $this->logger->info('[WsAgent] Connecting to WebSocket', ['url' => $this->wsUrl]);
+
+        $connector = new Connector(
+            $this->loop,
+            new SocketConnector($this->loop)
+        );
+
+        $connector($this->wsUrl)
+            ->then(function (WebSocket $conn) {
+                $this->wsConnection = $conn;
+                $this->logger->info('[WsAgent] WebSocket connected');
+
+                // Authentification
+                $loginMsg = $this->wsBuilder->buildLogin();
+                $conn->send(json_encode($loginMsg));
+
+                // Gérer les messages
+                $conn->on('message', function ($msg) {
+                    // Convertir le message Ratchet en string
+                    // Ratchet passe un objet MessageInterface qui implémente __toString()
+                    try {
+                        if (is_string($msg)) {
+                            $messageStr = $msg;
+                        } elseif (is_object($msg) && method_exists($msg, 'getPayload')) {
+                            $messageStr = $msg->getPayload();
+                        } else {
+                            $messageStr = (string) $msg;
+                        }
+                        $this->handleMessage($messageStr);
+                    } catch (\Throwable $e) {
+                        $this->logger->error('[WsAgent] Error processing message', [
+                            'error' => $e->getMessage(),
+                            'msg_type' => get_class($msg),
+                        ]);
+                    }
+                });
+
+                $conn->on('close', function ($code = null, $reason = null) {
+                    $this->logger->warning('[WsAgent] WebSocket closed', [
+                        'code' => $code,
+                        'reason' => $reason,
+                    ]);
+                    $this->isAuthenticated = false;
+                    $this->isSubscribed = false;
+                    $this->wsConnection = null;
+
+                    // Reconnexion après 5 secondes
+                    $this->loop->addTimer(5, function () {
+                        $this->connect();
+                    });
+                });
+
+                $conn->on('error', function ($error) {
+                    $this->logger->error('[WsAgent] WebSocket error', [
+                        'error' => $error->getMessage(),
+                    ]);
+                });
+
+                // Ping toutes les 30 secondes
+                $this->loop->addPeriodicTimer(30, function () use ($conn) {
+                    if ($this->isAuthenticated) {
+                        $ping = $this->wsBuilder->buildPing();
+                        $conn->send(json_encode($ping));
+                    }
+                });
+            }, function (\Exception $e) {
+                $this->logger->error('[WsAgent] Connection failed', [
+                    'error' => $e->getMessage(),
+                ]);
+
+                // Reconnexion après 5 secondes
+                $this->loop->addTimer(5, function () {
+                    $this->connect();
+                });
+            });
+    }
+
+    private function handleMessage(string $msg): void
+    {
+        try {
+            $data = json_decode($msg, true, 512, \JSON_THROW_ON_ERROR);
+
+            // Gérer les réponses d'authentification
+            if (isset($data['event']) && $data['event'] === 'login') {
+                if (isset($data['errorCode']) && (int)$data['errorCode'] === 0) {
+                    $this->isAuthenticated = true;
+                    $this->logger->info('[WsAgent] Authenticated');
+                    $this->subscribeToTopics();
+                } else {
+                    $this->logger->error('[WsAgent] Authentication failed', [
+                        'error_code' => $data['errorCode'] ?? null,
+                        'error_message' => $data['errorMessage'] ?? null,
+                    ]);
+                }
+                return;
+            }
+
+            // Gérer les réponses de souscription
+            if (isset($data['event']) && $data['event'] === 'subscribe') {
+                if (isset($data['errorCode']) && (int)$data['errorCode'] === 0) {
+                    $this->isSubscribed = true;
+                    $this->logger->info('[WsAgent] Subscribed to topics', [
+                        'topics' => $data['args'] ?? [],
+                    ]);
+                }
+                return;
+            }
+
+            // Gérer les données d'ordres
+            if (isset($data['group']) && $data['group'] === 'futures/order') {
+                $this->handleOrderUpdate($data);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('[WsAgent] Error handling message', [
+                'error' => $e->getMessage(),
+                'message' => $msg,
+            ]);
+        }
+    }
+
+    private function subscribeToTopics(): void
+    {
+        if (!$this->isAuthenticated || $this->isSubscribed) {
+            return;
+        }
+
+        $topics = array_filter(array_map('trim', explode(',', $this->wsTopics)));
+        if (empty($topics)) {
+            $topics = ['futures/order'];
+        }
+
+        $subscribeMsg = $this->wsBuilder->buildSubscribeMultiple($topics);
+        $this->wsConnection->send(json_encode($subscribeMsg));
+
+        $this->logger->info('[WsAgent] Subscribing to topics', ['topics' => $topics]);
+    }
+
+    private function handleOrderUpdate(array $data): void
+    {
+        if (!isset($data['data']) || !is_array($data['data'])) {
+            return;
+        }
+
+        foreach ($data['data'] as $orderData) {
+            $action = $orderData['action'] ?? null;
+            $order = $orderData['order'] ?? [];
+
+            $orderId = $order['order_id'] ?? null;
+            $clientOrderId = $order['client_order_id'] ?? null;
+            $symbol = $order['symbol'] ?? null;
+            $state = $order['state'] ?? null;
+
+            if (!$orderId && !$clientOrderId) {
+                continue;
+            }
+
+            // Synchroniser l'ordre dans la BDD
+            if ($this->syncService) {
+                try {
+                    $normalized = [
+                        'order_id' => $orderId,
+                        'client_order_id' => $clientOrderId,
+                        'symbol' => $symbol,
+                        'side' => $order['side'] ?? null,
+                        'type' => $order['type'] ?? null,
+                        'state' => $state,
+                        'price' => $order['price'] ?? null,
+                        'size' => $order['size'] ?? null,
+                        'deal_size' => $order['deal_size'] ?? null,
+                        'deal_avg_price' => $order['deal_avg_price'] ?? null,
+                        'leverage' => $order['leverage'] ?? null,
+                        'open_type' => $order['open_type'] ?? null,
+                        'position_mode' => $order['position_mode'] ?? null,
+                        'update_time_ms' => $order['update_time'] ?? null,
+                    ];
+                    $this->syncService->syncOrderFromWebSocket($normalized);
+                } catch (\Throwable $e) {
+                    $this->logger->error('[WsAgent] Error syncing order', [
+                        'order_id' => $orderId,
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+
+            // Si l'ordre est soumis (action=2, SUBMIT_ORDER) et qu'on le track
+            // State 2 = CHECK (en vérification), mais on considère que c'est soumis
+            if ($action === 2 && ($orderId || $clientOrderId)) {
+                $this->notifyOrderSubmitted($orderId, $clientOrderId, $symbol);
+            }
+        }
+    }
+
+    /**
+     * Notifie trading-app-php qu'un ordre a été soumis
+     */
+    private function notifyOrderSubmitted(?string $orderId, ?string $clientOrderId, ?string $symbol): void
+    {
+        // Vérifier si on track cet ordre
+        $trackingKey = $clientOrderId ?? $orderId;
+        if (!$trackingKey || !isset($this->trackedOrders[$trackingKey])) {
+            return;
+        }
+
+        $tracked = $this->trackedOrders[$trackingKey];
+        if ($tracked['status'] === 'submitted') {
+            return; // Déjà notifié
+        }
+
+        try {
+            $url = rtrim($this->tradingAppBaseUri, '/') . $this->orderSubmittedPath;
+            $payload = [
+                'order_id' => $orderId,
+                'client_order_id' => $clientOrderId,
+                'symbol' => $symbol,
+                'submitted_at' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('c'),
+            ];
+
+            $response = $this->httpClient->request('POST', $url, [
+                'json' => $payload,
+                'timeout' => 5.0,
+            ]);
+
+            if ($response->getStatusCode() === 200 || $response->getStatusCode() === 202) {
+                $this->trackedOrders[$trackingKey]['status'] = 'submitted';
+                $this->logger->info('[WsAgent] Notified order submitted', [
+                    'order_id' => $orderId,
+                    'client_order_id' => $clientOrderId,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('[WsAgent] Failed to notify order submitted', [
+                'order_id' => $orderId,
+                'client_order_id' => $clientOrderId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Ajoute un ordre à tracker (appelé depuis l'endpoint HTTP)
+     */
+    public function trackOrder(string $clientOrderId, ?string $orderId, string $symbol): void
+    {
+        $this->trackedOrders[$clientOrderId] = [
+            'order_id' => $orderId,
+            'symbol' => $symbol,
+            'status' => 'pending',
+        ];
+
+        // S'assurer que la connexion est établie et qu'on est abonné
+        if (!$this->isSubscribed) {
+            $this->subscribeToTopics();
+        }
+
+        $this->logger->info('[WsAgent] Tracking order', [
+            'client_order_id' => $clientOrderId,
+            'order_id' => $orderId,
+            'symbol' => $symbol,
+        ]);
+    }
+
+    private function disconnect(): void
+    {
+        if ($this->wsConnection) {
+            $this->wsConnection->close();
+            $this->wsConnection = null;
+        }
+        $this->isAuthenticated = false;
+        $this->isSubscribed = false;
+    }
+}
+

--- a/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\Dto;
+
+use App\TradeEntry\Types\Side;
+
+final class TpSlTwoTargetsRequest
+{
+    public function __construct(
+        public readonly string $symbol,
+        public readonly Side $side,
+        public readonly ?float $entryPrice = null,
+        public readonly ?int $size = null,
+        public readonly ?float $rMultiple = null,
+        public readonly ?float $splitPct = 0.5,
+        public readonly ?bool $cancelExistingStopLossIfDifferent = true,
+        public readonly ?bool $cancelExistingTakeProfits = true,
+    ) {}
+}

--- a/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
+++ b/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
@@ -1,0 +1,384 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\Service;
+
+use App\Config\MtfValidationConfig;
+use App\Contract\Provider\MainProviderInterface;
+use App\Entity\Position;
+use App\Repository\PositionRepository;
+use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
+use App\TradeEntry\Policy\PreTradeChecks;
+use App\TradeEntry\RiskSizer\StopLossCalculator;
+use App\TradeEntry\RiskSizer\TakeProfitCalculator;
+use App\TradeEntry\Types\Side as EntrySide;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\Dto\OrderDto;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class TpSlTwoTargetsService
+{
+    public function __construct(
+        private readonly PreTradeChecks $pretrade,
+        private readonly StopLossCalculator $slc,
+        private readonly TakeProfitCalculator $tpc,
+        private readonly MainProviderInterface $providers,
+        private readonly PositionRepository $positions,
+        private readonly MtfValidationConfig $mtfConfig,
+        #[Autowire(service: 'monolog.logger.order_journey')] private readonly LoggerInterface $journeyLogger,
+        #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
+    ) {}
+
+    /**
+     * Calcule SL + TP1/TP2 (TP2 basé sur R2/S2), annule les ordres existants (SL si différent, TP) et soumet 2 TP.
+     *
+     * @return array{sl: float, tp1: float, tp2: float, submitted: array<int,array{order_id:string,price:float,size:int,type:string,side:string}>, cancelled: array<int,string>}
+     */
+    public function __invoke(TpSlTwoTargetsRequest $req, ?string $decisionKey = null): array
+    {
+        $symbol = strtoupper($req->symbol);
+
+        // 1) Prétraitement/exchange state
+        $dummy = new \App\TradeEntry\Dto\TradeEntryRequest(
+            symbol: $symbol,
+            side: $req->side,
+        );
+        $pre = $this->pretrade->run($dummy);
+
+        $tick = $pre->tickSize;
+        $precision = $pre->pricePrecision;
+        $contractSize = $pre->contractSize;
+        $pivotLevels = is_array($pre->pivotLevels) ? $pre->pivotLevels : [];
+
+        // 2) Résoudre position/entrée/size
+        $entryPrice = $req->entryPrice;
+        $size = $req->size;
+
+        if ($entryPrice === null || $size === null) {
+            $pos = $this->resolvePosition($symbol, $req->side);
+            if ($pos instanceof Position) {
+                if ($entryPrice === null) {
+                    $entryPrice = (float)($pos->getAvgEntryPrice() ?? 0.0);
+                }
+                if ($size === null) {
+                    $size = (int)max(0, (int)($pos->getSize() ?? 0));
+                }
+            }
+        }
+
+        if ($entryPrice === null || $entryPrice <= 0.0 || $size === null || $size <= 0) {
+            throw new \InvalidArgumentException('entryPrice et size requis (ou position introuvable)');
+        }
+
+        // 3) Calcul SL (priorité pivot), TP1 (mécanisme actuel), TP2 (R2/S2)
+        $defaults = $this->mtfConfig->getDefaults();
+        $riskPctDefault = (float)($defaults['risk_pct_percent'] ?? 2.0);
+        $riskPct = $riskPctDefault > 1.0 ? $riskPctDefault / 100.0 : $riskPctDefault;
+        $initMargin = (float)($defaults['initial_margin_usdt'] ?? 100.0);
+        $tpPolicy = (string)($defaults['tp_policy'] ?? 'pivot_conservative');
+        $tpMinKeepRatio = isset($defaults['tp_min_keep_ratio']) ? (float)$defaults['tp_min_keep_ratio'] : 0.95;
+        $tpBufferPct = isset($defaults['tp_buffer_pct']) ? (float)$defaults['tp_buffer_pct'] : null;
+        $tpBufferTicks = isset($defaults['tp_buffer_ticks']) ? (int)$defaults['tp_buffer_ticks'] : null;
+        $pivotSlPolicy = (string)($defaults['pivot_sl_policy'] ?? 'nearest_below');
+        $pivotSlBufferPct = isset($defaults['pivot_sl_buffer_pct']) ? (float)$defaults['pivot_sl_buffer_pct'] : null;
+        $pivotSlMinKeepRatio = isset($defaults['pivot_sl_min_keep_ratio']) ? (float)$defaults['pivot_sl_min_keep_ratio'] : null;
+        $rMultiple = (float)($req->rMultiple ?? ($defaults['r_multiple'] ?? 2.0));
+
+        // Stop par pivot si disponible, sinon par risque
+        if (!empty($pivotLevels)) {
+            $stop = $this->slc->fromPivot(
+                entry: $entryPrice,
+                side: $req->side,
+                pivotLevels: $pivotLevels,
+                policy: $pivotSlPolicy,
+                bufferPct: $pivotSlBufferPct,
+                pricePrecision: $precision,
+            );
+            // Appliquer garde min_keep_ratio si fourni
+            if ($pivotSlMinKeepRatio !== null && $pivotSlMinKeepRatio > 0.0) {
+                $minRisk = max(1e-8, abs($entryPrice - $stop) * $pivotSlMinKeepRatio);
+                if ($req->side === EntrySide::Long) {
+                    if (abs(($entryPrice - $stop)) < $minRisk) {
+                        $stop = max($tick, $entryPrice - $minRisk);
+                    }
+                } else {
+                    if (abs(($stop - $entryPrice)) < $minRisk) {
+                        $stop = $entryPrice + $minRisk;
+                    }
+                }
+            }
+        } else {
+            $riskUsdt = $initMargin * $riskPct;
+            $stop = $this->slc->fromRisk(
+                entry: $entryPrice,
+                side: $req->side,
+                riskUsdt: $riskUsdt,
+                size: $size,
+                contractSize: $contractSize,
+                precision: $precision,
+            );
+        }
+
+        // TP1 = mécanique actuelle (R multiple aligné pivots si dispo)
+        $tp1Base = $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, $rMultiple, $precision);
+        $tp1 = $tp1Base;
+        if (!empty($pivotLevels) && $rMultiple > 0.0) {
+            $tp1 = $this->tpc->alignTakeProfitWithPivot(
+                symbol: $symbol,
+                side: $req->side,
+                entry: $entryPrice,
+                stop: $stop,
+                baseTakeProfit: $tp1Base,
+                rMultiple: $rMultiple,
+                pivotLevels: $pivotLevels,
+                policy: $tpPolicy,
+                bufferPct: $tpBufferPct,
+                bufferTicks: $tpBufferTicks,
+                tick: $tick,
+                pricePrecision: $precision,
+                minKeepRatio: $tpMinKeepRatio,
+                maxExtraR: null,
+                decisionKey: $decisionKey,
+            );
+        }
+
+        // TP2 = R2/S2 si dispo, sinon fallback 2R
+        $tp2 = null;
+        $key = $req->side === EntrySide::Long ? 'r2' : 's2';
+        if (isset($pivotLevels[$key]) && is_finite((float)$pivotLevels[$key]) && (float)$pivotLevels[$key] > 0.0) {
+            $tp2 = (float)$pivotLevels[$key];
+            // appliquer buffer si défini
+            if ($tpBufferPct !== null && $tpBufferPct > 0.0) {
+                $tp2 = $req->side === EntrySide::Long ? $tp2 * (1.0 - $tpBufferPct) : $tp2 * (1.0 + $tpBufferPct);
+            }
+            if ($tpBufferTicks !== null && $tpBufferTicks > 0) {
+                $tp2 = $req->side === EntrySide::Long ? $tp2 - $tpBufferTicks * $tick : $tp2 + $tpBufferTicks * $tick;
+            }
+            // quantifier et assurer >/< entry d'au moins 1 tick
+            if ($req->side === EntrySide::Long) {
+                $tp2 = max($tp2, $entryPrice + $tick);
+                $tp2 = \App\TradeEntry\Pricing\TickQuantizer::quantizeUp($tp2, $precision);
+            } else {
+                $tp2 = min($tp2, $entryPrice - $tick);
+                $tp2 = \App\TradeEntry\Pricing\TickQuantizer::quantize($tp2, $precision);
+            }
+        } else {
+            // Fallback: 2R depuis SL
+            $tp2 = $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, 2.0, $precision);
+        }
+
+        $this->journeyLogger->info('order_journey.tp2sl.compute', [
+            'symbol' => $symbol,
+            'decision_key' => $decisionKey,
+            'entry' => $entryPrice,
+            'stop' => $stop,
+            'tp1' => $tp1,
+            'tp2' => $tp2,
+            'reason' => 'tp_sl_two_targets_computed',
+        ]);
+
+        // 4) Annulations (SL si différent, TP existants)
+        $cancelled = [];
+        $orderProvider = $this->providers->getOrderProvider();
+        $open = $orderProvider->getOpenOrders($symbol);
+
+        // Détermination sens fermeture
+        $closeSide = $req->side === EntrySide::Long ? OrderSide::SELL : OrderSide::BUY;
+        $isSl = function (OrderDto $o) use ($req, $entryPrice): bool {
+            if ($o->price === null) { return false; }
+            $p = (float)$o->price->__toString();
+            return $req->side === EntrySide::Long ? ($p < $entryPrice) : ($p > $entryPrice);
+        };
+        $priceOf = fn(OrderDto $o): ?float => $o->price ? (float)$o->price->__toString() : null;
+
+        /** @var array<int,OrderDto> $closing */
+        $closing = array_values(array_filter($open, fn(OrderDto $o) => $o->side === $closeSide));
+
+        // Annuler SL si différent (tolérance = 1 tick)
+        if ($req->cancelExistingStopLossIfDifferent) {
+            $existingSl = null;
+            foreach ($closing as $o) {
+                if ($isSl($o)) { $existingSl = $o; break; }
+            }
+            if ($existingSl !== null) {
+                $p = $priceOf($existingSl);
+                if ($p !== null && abs($p - $stop) > max($tick, 1e-8)) {
+                    if ($orderProvider->cancelOrder($existingSl->orderId)) {
+                        $cancelled[] = $existingSl->orderId;
+                    }
+                }
+            }
+        }
+
+        // Annuler TP existants
+        if ($req->cancelExistingTakeProfits) {
+            foreach ($closing as $o) {
+                if (!$isSl($o)) {
+                    if ($orderProvider->cancelOrder($o->orderId)) {
+                        $cancelled[] = $o->orderId;
+                    }
+                }
+            }
+        }
+
+        // 5) Soumettre SL (limité) et 2 ordres TP (split du size)
+        $ratio = $req->splitPct ?? 0.5;
+        $ratio = max(0.0, min(1.0, $ratio));
+        $size1 = (int)floor($size * $ratio);
+        $size2 = (int)max(0, $size - $size1);
+        if ($size1 <= 0 || $size2 <= 0) {
+            // fallback: tout sur TP1 si insuffisant
+            $size1 = $size;
+            $size2 = 0;
+        }
+
+        // Clip/quantize aux contraintes de volumes échange
+        $minVol = (int)max(1, (int)$pre->minVolume);
+        // Quantifier à un multiple du minVol
+        $size1 = $size1 > 0 ? (int)floor($size1 / $minVol) * $minVol : 0;
+        $size2 = $size2 > 0 ? (int)floor($size2 / $minVol) * $minVol : 0;
+        if ($size1 > 0 && $size1 < $minVol) { $size1 = 0; }
+        if ($size2 > 0 && $size2 < $minVol) { $size2 = 0; }
+
+        $maxVol = $pre->maxVolume;
+        if ($maxVol !== null && $maxVol > 0) {
+            $size1 = (int)min($size1, (int)$maxVol);
+            $size2 = (int)min($size2, (int)$maxVol);
+        }
+
+        $submitted = [];
+        $bitmartCloseSide = ($req->side === EntrySide::Long) ? 2 : 3; // 2=close_long, 3=close_short
+
+        $optionsBase = [
+            'side' => $bitmartCloseSide,
+            // Force reduce-only when supported by provider/API
+            'reduce_only' => true,
+            'reduceOnly' => true,
+        ];
+
+        // SL pleine taille (comportement codé en dur)
+        $slSize = (int)$size;
+        // Préparer un base CID pour tracer les ordres
+        $baseCid = $this->makeBaseCid($symbol, $req->side, $decisionKey);
+
+        if ($slSize > 0) {
+            // Quantifier SL size au multiple minVol
+            $slSize = (int)floor($slSize / $minVol) * $minVol;
+            $options = $optionsBase + ['client_order_id' => $baseCid . '-SL'];
+            // Submit SL as a stop-limit (triggered) by using stopPrice; keep limit price equal to stop for determinism
+            $dto = $orderProvider->placeOrder(
+                symbol: $symbol,
+                side: $closeSide,
+                type: OrderType::LIMIT,
+                quantity: (float)$slSize,
+                price: (float)$stop,
+                stopPrice: (float)$stop,
+                options: $options,
+            );
+            if ($dto instanceof OrderDto) {
+                $submitted[] = [
+                    'order_id' => $dto->orderId,
+                    'price' => (float)($dto->price?->__toString() ?? (string)$stop),
+                    'size' => $slSize,
+                    'type' => 'limit',
+                    'side' => $closeSide->value,
+                    'kind' => 'sl',
+                    'client_order_id' => $options['client_order_id'],
+                ];
+            }
+        }
+
+        // TP1
+        if ($size1 > 0) {
+            $options = $optionsBase + ['client_order_id' => $baseCid . '-TP1'];
+            $dto = $orderProvider->placeOrder(
+                symbol: $symbol,
+                side: $closeSide,
+                type: OrderType::LIMIT,
+                quantity: (float)$size1,
+                price: (float)$tp1,
+                stopPrice: null,
+                options: $options,
+            );
+            if ($dto instanceof OrderDto) {
+                $submitted[] = [
+                    'order_id' => $dto->orderId,
+                    'price' => (float)($dto->price?->__toString() ?? (string)$tp1),
+                    'size' => $size1,
+                    'type' => 'limit',
+                    'side' => $closeSide->value,
+                    'kind' => 'tp1',
+                    'client_order_id' => $options['client_order_id'],
+                ];
+            }
+        }
+
+        // TP2
+        if ($size2 > 0) {
+            $options = $optionsBase + ['client_order_id' => $baseCid . '-TP2'];
+            $dto = $orderProvider->placeOrder(
+                symbol: $symbol,
+                side: $closeSide,
+                type: OrderType::LIMIT,
+                quantity: (float)$size2,
+                price: (float)$tp2,
+                stopPrice: null,
+                options: $options,
+            );
+            if ($dto instanceof OrderDto) {
+                $submitted[] = [
+                    'order_id' => $dto->orderId,
+                    'price' => (float)($dto->price?->__toString() ?? (string)$tp2),
+                    'size' => $size2,
+                    'type' => 'limit',
+                    'side' => $closeSide->value,
+                    'kind' => 'tp2',
+                    'client_order_id' => $options['client_order_id'],
+                ];
+            }
+        }
+
+        $this->journeyLogger->info('order_journey.tp2sl.submit', [
+            'symbol' => $symbol,
+            'decision_key' => $decisionKey,
+            'submitted_count' => \count($submitted),
+            'cancelled_count' => \count($cancelled),
+            'reason' => 'tp_two_targets_submitted',
+        ]);
+
+        return [
+            'sl' => $stop,
+            'tp1' => $tp1,
+            'tp2' => (float)$tp2,
+            'submitted' => $submitted,
+            'cancelled' => $cancelled,
+        ];
+    }
+
+    private function resolvePosition(string $symbol, EntrySide $side): ?Position
+    {
+        // Position entity side is LONG|SHORT
+        $pos = $this->positions->findOneBySymbolSide($symbol, $side === EntrySide::Long ? 'LONG' : 'SHORT');
+        return $pos;
+    }
+
+    private function makeBaseCid(string $symbol, EntrySide $side, ?string $decisionKey): string
+    {
+        $sideTag = $side === EntrySide::Long ? 'L' : 'S';
+        $base = null;
+        if (\is_string($decisionKey) && $decisionKey !== '') {
+            $san = preg_replace('/[^A-Za-z0-9:_-]/', '', $decisionKey) ?? 'key';
+            $base = sprintf('TPSL-%s-%s-%s', strtoupper($symbol), $sideTag, substr($san, -20));
+        }
+        if ($base === null) {
+            try {
+                $rnd = bin2hex(random_bytes(3));
+            } catch (\Throwable) { $rnd = substr(sha1(uniqid('', true)), 0, 6); }
+            $base = sprintf('TPSL-%s-%s-%s', strtoupper($symbol), $sideTag, $rnd);
+        }
+        // Bitmart allows fairly long IDs; keep under 64 chars to be safe
+        return substr($base, 0, 64);
+    }
+}

--- a/trading-app/templates/base.html.twig
+++ b/trading-app/templates/base.html.twig
@@ -5,88 +5,88 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% block title %}Trading Dashboard{% endblock %}</title>
         <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>📈</text></svg>">
-        
+
         <!-- Bootstrap CSS -->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
         <!-- Bootstrap Icons -->
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
         <!-- DataTables CSS -->
         <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
-        
+
         <!-- jQuery (chargé tôt pour les scripts inline des onglets) -->
         <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
-        
+
         {% block stylesheets %}
         <style>
             /* Styles pour l'analyse des signaux */
             .signal-analysis-card {
                 transition: transform 0.2s ease-in-out;
             }
-            
+
             .signal-analysis-card:hover {
                 transform: translateY(-2px);
                 box-shadow: 0 4px 8px rgba(0,0,0,0.1);
             }
-            
+
             .indicator-value {
                 font-family: 'Courier New', monospace;
                 font-weight: bold;
             }
-            
+
             .indicator-positive {
                 color: #28a745;
             }
-            
+
             .indicator-negative {
                 color: #dc3545;
             }
-            
+
             .indicator-neutral {
                 color: #6c757d;
             }
-            
+
             .parent-timeframe-card {
                 border-left: 4px solid #007bff;
             }
-            
+
             .parent-timeframe-card.success {
                 border-left-color: #28a745;
             }
-            
+
             .parent-timeframe-card.warning {
                 border-left-color: #ffc107;
             }
-            
+
             .parent-timeframe-card.danger {
                 border-left-color: #dc3545;
             }
-            
+
             .signal-badge {
                 font-size: 0.8em;
                 padding: 0.25em 0.5em;
             }
-            
+
             .analysis-table th {
                 background-color: #f8f9fa;
                 border-top: none;
             }
-            
+
             .klines-table td {
                 font-family: 'Courier New', monospace;
                 font-size: 0.9em;
             }
-            
+
             .loading-spinner {
                 display: flex;
                 justify-content: center;
                 align-items: center;
                 min-height: 200px;
             }
-            
+
             .modal-xl {
                 max-width: 95%;
             }
-            
+
             @media (max-width: 768px) {
                 .modal-xl {
                     max-width: 100%;
@@ -158,6 +158,10 @@
                                     <i class="bi bi-lock"></i> Verrous
                                 </a></li>
                             </ul>
+                        </li>
+                        <li class="nav-item">
+                                <i class="bi bi-cart-plus"></i> Soumettre Ordre
+                            </a>
                         </li>
                         <li class="nav-item dropdown">
                             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">

--- a/trading-app/templates/order/submit.html.twig
+++ b/trading-app/templates/order/submit.html.twig
@@ -1,0 +1,777 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Soumettre un Ordre - Trading{% endblock %}
+
+{% block body %}
+<div class="row">
+    <div class="col-12">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h1>
+                <i class="bi bi-cart-plus"></i> Soumettre un Ordre
+            </h1>
+            <div>
+                <a href="{{ path('contracts_index') }}" class="btn btn-outline-secondary">
+                    <i class="bi bi-arrow-left"></i> Retour aux Contrats
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Message de succès avec détails complets -->
+{% if order_id and order_details %}
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <h4 class="alert-heading">
+                <i class="bi bi-check-circle"></i> Ordre soumis avec succès !
+            </h4>
+            <hr>
+            
+            <div class="row mt-3">
+                <!-- Informations principales -->
+                <div class="col-md-6">
+                    <h6 class="text-success mb-3">
+                        <i class="bi bi-info-circle"></i> Informations de l'Ordre
+                    </h6>
+                    <table class="table table-sm table-borderless mb-0">
+                        <tbody>
+                            <tr>
+                                <td class="fw-bold" style="width: 40%;">Order ID:</td>
+                                <td><code class="fs-5">{{ order_details.order_id }}</code></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Symbole:</td>
+                                <td><strong>{{ order_details.symbol }}</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Direction:</td>
+                                <td>{{ order_details.side_label }} ({{ order_details.side }})</td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Type:</td>
+                                <td><span class="badge bg-primary">{{ order_details.type|upper }}</span></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Taille:</td>
+                                <td><strong>{{ order_details.size }} contrats</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Prix Limit:</td>
+                                <td><strong>{{ order_details.limit_price|number_format(2, '.', ' ') }} USDT</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Prix TP:</td>
+                                <td><strong class="text-success">{{ order_details.take_profit_price|number_format(2, '.', ' ') }} USDT</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Prix SL:</td>
+                                <td><strong class="text-danger">{{ order_details.stop_loss_price|number_format(order_details.price_precision ?? 2, '.', ' ') }} USDT</strong></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                
+                <!-- Paramètres de trading -->
+                <div class="col-md-6">
+                    <h6 class="text-success mb-3">
+                        <i class="bi bi-calculator"></i> Paramètres de Trading
+                    </h6>
+                    <table class="table table-sm table-borderless mb-0">
+                        <tbody>
+                            <tr>
+                                <td class="fw-bold" style="width: 40%;">Marge Initiale:</td>
+                                <td><strong>{{ order_details.initial_margin|number_format(2, '.', ' ') }} USDT</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Levier:</td>
+                                <td><strong>{{ order_details.leverage }}x</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">% Risque:</td>
+                                <td><strong>{{ order_details.risk_percent|number_format(2, '.', ' ') }}%</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Montant Risqué:</td>
+                                <td><strong class="text-warning">{{ order_details.risk_amount|number_format(2, '.', ' ') }} USDT</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Contract Size:</td>
+                                <td>{{ order_details.contract_size|number_format(8, '.', ' ') }}</td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Valeur Notionale:</td>
+                                <td><strong>{{ order_details.notional_value|number_format(2, '.', ' ') }} USDT</strong></td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Distance TP:</td>
+                                <td>
+                                    {% if order_details.side == 1 %}
+                                        <span class="text-success">+{{ ((order_details.take_profit_price - order_details.limit_price) / order_details.limit_price * 100)|number_format(2, '.', ' ') }}%</span>
+                                    {% else %}
+                                        <span class="text-success">+{{ ((order_details.limit_price - order_details.take_profit_price) / order_details.limit_price * 100)|number_format(2, '.', ' ') }}%</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="fw-bold">Distance SL:</td>
+                                <td>
+                                    {% if order_details.side == 1 %}
+                                        <span class="text-danger">-{{ ((order_details.limit_price - order_details.stop_loss_price) / order_details.limit_price * 100)|number_format(2, '.', ' ') }}%</span>
+                                    {% else %}
+                                        <span class="text-danger">-{{ ((order_details.stop_loss_price - order_details.limit_price) / order_details.limit_price * 100)|number_format(2, '.', ' ') }}%</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% if order_details.sl_distance is defined %}
+                            <tr>
+                                <td class="fw-bold">Distance SL (abs):</td>
+                                <td><span class="text-danger">{{ order_details.sl_distance|number_format(8, '.', ' ') }} USDT</span></td>
+                            </tr>
+                            {% endif %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            
+            <hr>
+            
+            <!-- Section Request/Response -->
+            <div class="row mt-3">
+                <div class="col-12">
+                    <div class="accordion" id="orderDetailsAccordion">
+                        <!-- Request Payload -->
+                        <div class="accordion-item">
+                            <h2 class="accordion-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseRequest">
+                                    <i class="bi bi-arrow-up-circle me-2"></i> <strong>Données Soumises (Request)</strong>
+                                </button>
+                            </h2>
+                            <div id="collapseRequest" class="accordion-collapse collapse" data-bs-parent="#orderDetailsAccordion">
+                                <div class="accordion-body">
+                                    <p class="mb-2"><strong>Endpoint:</strong> <code>POST /contract/private/submit-order</code></p>
+                                    <pre class="bg-light p-3 rounded"><code>{
+  "symbol": "{{ order_details.request_payload.symbol }}",
+  "side": {{ order_details.request_payload.side }},
+  "type": "{{ order_details.request_payload.type }}",
+  "price": "{{ order_details.request_payload.price }}",
+  "size": {{ order_details.request_payload.size }},
+  "open_type": "{{ order_details.request_payload.open_type }}",
+  "preset_take_profit_price": "{{ order_details.request_payload.preset_take_profit_price }}",
+  "preset_take_profit_price_type": {{ order_details.request_payload.preset_take_profit_price_type }},
+  "preset_stop_loss_price": "{{ order_details.request_payload.preset_stop_loss_price }}",
+  "preset_stop_loss_price_type": {{ order_details.request_payload.preset_stop_loss_price_type }}
+}</code></pre>
+                                    <table class="table table-sm table-bordered mt-3">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th>Champ</th>
+                                                <th>Type</th>
+                                                <th>Valeur</th>
+                                                <th>Description</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td><code>symbol</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.request_payload.symbol }}</td>
+                                                <td>Symbole du contrat (ex: BTCUSDT)</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>side</code></td>
+                                                <td>integer</td>
+                                                <td>{{ order_details.request_payload.side }}</td>
+                                                <td>1 = Open Long, 4 = Open Short</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>type</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.request_payload.type }}</td>
+                                                <td>Type d'ordre: "limit" ou "market"</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>price</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.request_payload.price }}</td>
+                                                <td>Prix limite (requis pour type "limit")</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>size</code></td>
+                                                <td>integer</td>
+                                                <td>{{ order_details.request_payload.size }}</td>
+                                                <td>Nombre de contrats</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>open_type</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.request_payload.open_type }}</td>
+                                                <td>"isolated" = Marge isolée, "cross" = Marge croisée</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>preset_take_profit_price</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.request_payload.preset_take_profit_price }}</td>
+                                                <td>Prix de Take Profit pré-configuré</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>preset_take_profit_price_type</code></td>
+                                                <td>integer</td>
+                                                <td>{{ order_details.request_payload.preset_take_profit_price_type }}</td>
+                                                <td>1 = Prix fixe</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>preset_stop_loss_price</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.request_payload.preset_stop_loss_price }}</td>
+                                                <td>Prix de Stop Loss pré-configuré (calculé à partir du risque)</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>preset_stop_loss_price_type</code></td>
+                                                <td>integer</td>
+                                                <td>{{ order_details.request_payload.preset_stop_loss_price_type }}</td>
+                                                <td>1 = Prix fixe</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        
+                        <!-- Leverage Request/Response -->
+                        {% if order_details.leverage_request %}
+                        <div class="accordion-item">
+                            <h2 class="accordion-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseLeverage">
+                                    <i class="bi bi-arrows-angle-contract me-2"></i> <strong>Configuration du Levier</strong>
+                                </button>
+                            </h2>
+                            <div id="collapseLeverage" class="accordion-collapse collapse" data-bs-parent="#orderDetailsAccordion">
+                                <div class="accordion-body">
+                                    <p class="mb-2"><strong>Endpoint:</strong> <code>POST /contract/private/submit-leverage</code></p>
+                                    <p class="text-info mb-3">
+                                        <i class="bi bi-info-circle"></i> 
+                                        <strong>Important:</strong> Le levier doit être défini AVANT de soumettre l'ordre via un endpoint séparé.
+                                    </p>
+                                    
+                                    <h6 class="mt-3">Request (Levier)</h6>
+                                    <pre class="bg-light p-3 rounded"><code>{
+  "symbol": "{{ order_details.leverage_request.symbol }}",
+  "leverage": {{ order_details.leverage_request.leverage }},
+  "open_type": "{{ order_details.leverage_request.open_type }}"
+}</code></pre>
+                                    
+                                    <h6 class="mt-3">Response (Levier)</h6>
+                                    <pre class="bg-light p-3 rounded"><code>{{ order_details.leverage_response|json_encode(448) }}</code></pre>
+                                    
+                                    <table class="table table-sm table-bordered mt-3">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th>Champ</th>
+                                                <th>Valeur Demandée</th>
+                                                <th>Valeur Confirmée</th>
+                                                <th>Description</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td><code>symbol</code></td>
+                                                <td>{{ order_details.leverage_request.symbol }}</td>
+                                                <td>-</td>
+                                                <td>Symbole du contrat</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>leverage</code></td>
+                                                <td><strong>{{ order_details.leverage_request.leverage }}x</strong></td>
+                                                <td>
+                                                    {% if order_details.leverage_response.data.leverage is defined %}
+                                                        <strong class="{% if order_details.leverage_response.data.leverage != order_details.leverage_request.leverage %}text-warning{% else %}text-success{% endif %}">
+                                                            {{ order_details.leverage_response.data.leverage }}x
+                                                        </strong>
+                                                        {% if order_details.leverage_response.data.leverage != order_details.leverage_request.leverage %}
+                                                            <br><small class="text-warning">⚠️ Différent de la demande!</small>
+                                                        {% endif %}
+                                                    {% else %}
+                                                        <span class="text-muted">N/A</span>
+                                                    {% endif %}
+                                                </td>
+                                                <td>Niveau de levier configuré</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>open_type</code></td>
+                                                <td>{{ order_details.leverage_request.open_type }}</td>
+                                                <td>-</td>
+                                                <td>Type d'ouverture (isolated/cross)</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        {% endif %}
+                        
+                        <!-- Response -->
+                        <div class="accordion-item">
+                            <h2 class="accordion-header">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseResponse">
+                                    <i class="bi bi-arrow-down-circle me-2"></i> <strong>Réponse BitMart (Response)</strong>
+                                </button>
+                            </h2>
+                            <div id="collapseResponse" class="accordion-collapse collapse" data-bs-parent="#orderDetailsAccordion">
+                                <div class="accordion-body">
+                                    <p class="mb-2"><strong>Status Code:</strong> <span class="badge bg-success">200 OK</span></p>
+                                    <pre class="bg-light p-3 rounded"><code>{{ order_details.response_full|json_encode(448) }}</code></pre>
+                                    <table class="table table-sm table-bordered mt-3">
+                                        <thead class="table-light">
+                                            <tr>
+                                                <th>Champ</th>
+                                                <th>Type</th>
+                                                <th>Valeur</th>
+                                                <th>Description</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr>
+                                                <td><code>code</code></td>
+                                                <td>integer</td>
+                                                <td><span class="badge bg-success">{{ order_details.response_full.code }}</span></td>
+                                                <td>Code de statut (1000 = succès)</td>
+                                            </tr>
+                                            <tr>
+                                                <td><code>message</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.response_full.message ?? 'N/A' }}</td>
+                                                <td>Message de statut</td>
+                                            </tr>
+                                            <tr class="table-info">
+                                                <td><code>data.order_id</code></td>
+                                                <td>string/integer</td>
+                                                <td><strong class="fs-5">{{ order_details.order_id }}</strong></td>
+                                                <td><strong>ID unique de l'ordre BitMart</strong></td>
+                                            </tr>
+                                            {% if order_details.response_full.data.client_order_id is defined %}
+                                            <tr>
+                                                <td><code>data.client_order_id</code></td>
+                                                <td>string</td>
+                                                <td>{{ order_details.response_full.data.client_order_id }}</td>
+                                                <td>ID client de l'ordre (si fourni)</td>
+                                            </tr>
+                                            {% endif %}
+                                            {% if order_details.response_full.data is iterable %}
+                                                {% for key, value in order_details.response_full.data %}
+                                                    {% if key != 'order_id' and key != 'client_order_id' %}
+                                                    <tr>
+                                                        <td><code>data.{{ key }}</code></td>
+                                                        <td>{{ value is same as(true) or value is same as(false) ? 'boolean' : (value is iterable ? 'array' : (value matches '/^[0-9]+$/' ? 'integer' : 'string')) }}</td>
+                                                        <td>
+                                                            {% if value is iterable %}
+                                                                <pre class="mb-0 small">{{ value|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                                                            {% else %}
+                                                                {{ value }}
+                                                            {% endif %}
+                                                        </td>
+                                                        <td>Donnée supplémentaire de la réponse</td>
+                                                    </tr>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            {% endif %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            <hr>
+            <p class="mb-0">
+                <small>
+                    <i class="bi bi-clock"></i> Soumis le {{ 'now'|date('d/m/Y à H:i:s') }} 
+                    | Votre ordre a été soumis à BitMart avec le Take Profit configuré.
+                </small>
+            </p>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+</div>
+{% elseif order_id %}
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <h4 class="alert-heading">
+                <i class="bi bi-check-circle"></i> Ordre soumis avec succès !
+            </h4>
+            <p class="mb-0">
+                <strong>Order ID:</strong> <code class="fs-5">{{ order_id }}</code>
+            </p>
+            {% if calculated_size %}
+            <p class="mb-0 mt-2">
+                <strong>Taille calculée:</strong> {{ calculated_size }} contrats
+            </p>
+            {% endif %}
+            <hr>
+            <p class="mb-0">Votre ordre a été soumis à BitMart avec le Take Profit configuré.</p>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Message d'erreur -->
+{% if error %}
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <h4 class="alert-heading">
+                <i class="bi bi-exclamation-triangle"></i> Erreur
+            </h4>
+            <p class="mb-0">{{ error }}</p>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Formulaire -->
+<div class="row">
+    <div class="col-lg-8 offset-lg-2">
+        <div class="card">
+            <div class="card-header bg-primary text-white">
+                <h5 class="mb-0">
+                    <i class="bi bi-file-earmark-text"></i> Informations de l'Ordre
+                </h5>
+            </div>
+            <div class="card-body">
+                <form method="POST" action="{{ path('order_submit') }}" id="orderForm">
+                    <div class="row">
+                        <!-- Symbole -->
+                        <div class="col-md-6 mb-3">
+                            <label for="symbol" class="form-label">
+                                Symbole <span class="text-danger">*</span>
+                            </label>
+                            <select class="form-select" id="symbol" name="symbol" required onchange="updatePriceInfo()">
+                                <option value="">-- Sélectionner un symbole --</option>
+                                {% for contract in contracts %}
+                                <option value="{{ contract }}">{{ contract }}</option>
+                                {% endfor %}
+                            </select>
+                            <div class="form-text">Choisissez le contrat à trader</div>
+                        </div>
+
+                        <!-- Direction -->
+                        <div class="col-md-6 mb-3">
+                            <label for="side" class="form-label">
+                                Direction <span class="text-danger">*</span>
+                            </label>
+                            <select class="form-select" id="side" name="side" required>
+                                <option value="">-- Sélectionner --</option>
+                                <option value="1">Achat (Open Long)</option>
+                                <option value="4">Vente (Open Short)</option>
+                            </select>
+                            <div class="form-text">1 = Achat, 4 = Vente</div>
+                        </div>
+
+                        <!-- Marge Initiale -->
+                        <div class="col-md-6 mb-3">
+                            <label for="initial_margin" class="form-label">
+                                Marge Initiale (USDT) <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <input type="number" 
+                                       class="form-control" 
+                                       id="initial_margin" 
+                                       name="initial_margin" 
+                                       required 
+                                       step="0.01"
+                                       min="0"
+                                       placeholder="100.00"
+                                       oninput="calculateSize()">
+                                <span class="input-group-text">USDT</span>
+                            </div>
+                            <div class="form-text">Montant de la marge à utiliser</div>
+                        </div>
+
+                        <!-- Pourcentage de Risque -->
+                        <div class="col-md-6 mb-3">
+                            <label for="risk_percent" class="form-label">
+                                % Risque <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <input type="number" 
+                                       class="form-control" 
+                                       id="risk_percent" 
+                                       name="risk_percent" 
+                                       required 
+                                       step="0.1"
+                                       min="0"
+                                       max="100"
+                                       placeholder="2.0"
+                                       oninput="calculateSize()">
+                                <span class="input-group-text">%</span>
+                            </div>
+                            <div class="form-text">Pourcentage de risque de la marge</div>
+                        </div>
+
+                        <!-- Prix TP (Take Profit) -->
+                        <div class="col-md-6 mb-3">
+                            <label for="take_profit_price" class="form-label">
+                                Prix TP <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <input type="number" 
+                                       class="form-control" 
+                                       id="take_profit_price" 
+                                       name="take_profit_price" 
+                                       required 
+                                       step="0.01"
+                                       min="0"
+                                       placeholder="0.00"
+                                       oninput="calculateSize()">
+                                <span class="input-group-text">USDT</span>
+                            </div>
+                            <div class="form-text">Prix de Take Profit (profit cible)</div>
+                        </div>
+
+                        <!-- Levier -->
+                        <div class="col-md-6 mb-3">
+                            <label for="leverage" class="form-label">
+                                Levier <span class="text-danger">*</span>
+                            </label>
+                            <input type="number" 
+                                   class="form-control" 
+                                   id="leverage" 
+                                   name="leverage" 
+                                   required 
+                                   step="1"
+                                   min="1"
+                                   max="125"
+                                   placeholder="10"
+                                   oninput="calculateSize()">
+                            <div class="form-text">Niveau de levier (1-125)</div>
+                        </div>
+
+                        <!-- Prix Limit -->
+                        <div class="col-md-6 mb-3">
+                            <label for="limit_price" class="form-label">
+                                Prix Limit <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <input type="number" 
+                                       class="form-control" 
+                                       id="limit_price" 
+                                       name="limit_price" 
+                                       required 
+                                       step="0.01"
+                                       min="0"
+                                       placeholder="0.00"
+                                       oninput="calculateSize()">
+                                <span class="input-group-text">USDT</span>
+                            </div>
+                            <div class="form-text">Prix d'entrée limite</div>
+                        </div>
+
+                        <!-- Taille Calculée (Read-only) -->
+                        <div class="col-md-6 mb-3">
+                            <label for="calculated_size_display" class="form-label">
+                                Taille Calculée
+                            </label>
+                            <input type="text" 
+                                   class="form-control" 
+                                   id="calculated_size_display" 
+                                   readonly
+                                   placeholder="Calcul automatique...">
+                            <div class="form-text">Nombre de contrats (calculé automatiquement)</div>
+                        </div>
+                    </div>
+
+                    <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-4">
+                        <button type="reset" class="btn btn-outline-secondary" onclick="resetForm()">
+                            <i class="bi bi-arrow-counterclockwise"></i> Réinitialiser
+                        </button>
+                        <button type="submit" class="btn btn-primary">
+                            <i class="bi bi-send"></i> Soumettre l'Ordre
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Informations de Calcul -->
+<div class="row mt-4">
+    <div class="col-lg-8 offset-lg-2">
+        <div class="card border-info">
+            <div class="card-header bg-info text-white">
+                <h6 class="mb-0">
+                    <i class="bi bi-calculator"></i> Calcul de la Taille
+                </h6>
+            </div>
+            <div class="card-body">
+                <p><strong>Formule:</strong></p>
+                <ul class="mb-0">
+                    <li><strong>Valeur Notionale</strong> = Marge Initiale × Levier</li>
+                    <li><strong>Taille (contrats)</strong> = Valeur Notionale ÷ (Prix Limit × Contract Size)</li>
+                    <li><strong>Contract Size</strong> = Taille d'un contrat en USDT (généralement 1 pour les contrats USDT)</li>
+                    <li>Le Take Profit sera configuré automatiquement au prix TP spécifié</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Informations -->
+<div class="row mt-4">
+    <div class="col-lg-8 offset-lg-2">
+        <div class="card border-secondary">
+            <div class="card-header bg-secondary text-white">
+                <h6 class="mb-0">
+                    <i class="bi bi-info-circle"></i> Informations
+                </h6>
+            </div>
+            <div class="card-body">
+                <ul class="mb-0">
+                    <li><strong>Direction:</strong> 1 = Achat (Open Long), 4 = Vente (Open Short)</li>
+                    <li><strong>Marge Initiale:</strong> Montant en USDT que vous souhaitez utiliser comme marge</li>
+                    <li><strong>% Risque:</strong> Pourcentage de la marge que vous êtes prêt à risquer</li>
+                    <li><strong>Prix TP:</strong> Prix de Take Profit où l'ordre sera automatiquement clôturé en profit</li>
+                    <li><strong>Levier:</strong> Multiplicateur de la marge (ex: 10x = 1000 USDT avec 100 USDT de marge)</li>
+                    <li><strong>Prix Limit:</strong> Prix d'entrée pour l'ordre limit</li>
+                    <li><strong>Type:</strong> L'ordre sera toujours de type <code>limit</code> avec le prix spécifié</li>
+                    <li class="text-warning"><strong>Attention:</strong> Les ordres non exécutés seront automatiquement annulés après 2 minutes</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block javascripts %}
+<script>
+// Stocker les contract sizes (sera rempli dynamiquement ou avec une valeur par défaut)
+const contractSizes = {
+    // Valeurs par défaut courantes pour BitMart Futures (1 USDT par contrat généralement)
+    // Ces valeurs seront mises à jour si on récupère les données depuis l'API
+};
+
+// Valeur par défaut du contract_size (généralement 1 pour la plupart des contrats USDT)
+const DEFAULT_CONTRACT_SIZE = 1;
+
+function calculateSize() {
+    const initialMargin = parseFloat(document.getElementById('initial_margin').value) || 0;
+    const leverage = parseFloat(document.getElementById('leverage').value) || 0;
+    const limitPrice = parseFloat(document.getElementById('limit_price').value) || 0;
+    const symbol = document.getElementById('symbol').value;
+    const sizeDisplay = document.getElementById('calculated_size_display');
+    
+    // Utiliser le contract_size du symbole ou la valeur par défaut
+    const contractSize = contractSizes[symbol] || DEFAULT_CONTRACT_SIZE;
+    
+    if (initialMargin > 0 && leverage > 0 && limitPrice > 0 && contractSize > 0) {
+        // Formule correcte: Notional = Prix × Contract Size × Nombre de contrats
+        // Donc: Nombre de contrats = Notional / (Prix × Contract Size)
+        const notionalValue = initialMargin * leverage;
+        const calculatedSize = Math.floor(notionalValue / (limitPrice * contractSize));
+        
+        sizeDisplay.value = calculatedSize + ' contrats';
+        
+        if (calculatedSize <= 0) {
+            sizeDisplay.value = 'Erreur: Vérifiez les valeurs (contract_size=' + contractSize + ')';
+            sizeDisplay.classList.add('is-invalid');
+        } else {
+            sizeDisplay.classList.remove('is-invalid');
+            // Afficher aussi la valeur notionale pour info
+            const infoText = ` (Notional: ${notionalValue.toFixed(2)} USDT)`;
+            if (!sizeDisplay.value.includes('Notional')) {
+                sizeDisplay.value += infoText;
+            }
+        }
+    } else {
+        sizeDisplay.value = '';
+        sizeDisplay.classList.remove('is-invalid');
+    }
+}
+
+function resetForm() {
+    document.getElementById('orderForm').reset();
+    document.getElementById('calculated_size_display').value = '';
+    document.getElementById('calculated_size_display').classList.remove('is-invalid');
+}
+
+function updatePriceInfo() {
+    // Placeholder pour récupérer le prix actuel du marché (futur)
+    const symbol = document.getElementById('symbol').value;
+    if (symbol) {
+        // TODO: Récupérer le prix actuel via API
+    }
+}
+
+// Validation du formulaire avant soumission
+document.getElementById('orderForm').addEventListener('submit', function(e) {
+    const initialMargin = parseFloat(document.getElementById('initial_margin').value);
+    const riskPercent = parseFloat(document.getElementById('risk_percent').value);
+    const takeProfitPrice = parseFloat(document.getElementById('take_profit_price').value);
+    const leverage = parseFloat(document.getElementById('leverage').value);
+    const limitPrice = parseFloat(document.getElementById('limit_price').value);
+    
+    // Validation des valeurs
+    if (!initialMargin || initialMargin <= 0) {
+        e.preventDefault();
+        alert('La marge initiale doit être un nombre positif.');
+        return false;
+    }
+    
+    if (!riskPercent || riskPercent <= 0 || riskPercent > 100) {
+        e.preventDefault();
+        alert('Le pourcentage de risque doit être entre 0 et 100.');
+        return false;
+    }
+    
+    if (!takeProfitPrice || takeProfitPrice <= 0) {
+        e.preventDefault();
+        alert('Le prix TP doit être un nombre positif.');
+        return false;
+    }
+    
+    if (!leverage || leverage <= 0) {
+        e.preventDefault();
+        alert('Le levier doit être un nombre positif.');
+        return false;
+    }
+    
+    if (!limitPrice || limitPrice <= 0) {
+        e.preventDefault();
+        alert('Le prix limit doit être un nombre positif.');
+        return false;
+    }
+    
+    // Vérifier la logique du TP par rapport au prix limit et à la direction
+    const side = parseInt(document.getElementById('side').value);
+    if (side === 1 && takeProfitPrice <= limitPrice) {
+        // Long: TP doit être > prix d'entrée
+        if (!confirm('Pour un ordre Long, le prix TP devrait être supérieur au prix limit. Continuer ?')) {
+            e.preventDefault();
+            return false;
+        }
+    } else if (side === 4 && takeProfitPrice >= limitPrice) {
+        // Short: TP doit être < prix d'entrée
+        if (!confirm('Pour un ordre Short, le prix TP devrait être inférieur au prix limit. Continuer ?')) {
+            e.preventDefault();
+            return false;
+        }
+    }
+    
+    // Confirmation avant soumission
+    if (!confirm('Êtes-vous sûr de vouloir soumettre cet ordre ?')) {
+        e.preventDefault();
+        return false;
+    }
+});
+
+// Initialiser le calcul au chargement
+document.addEventListener('DOMContentLoaded', function() {
+    calculateSize();
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
…OrderProvider

- Calculate Stop Loss automatically from limit_price, risk_percent and leverage
- Formula: riskUsdt = initialMargin * (riskPercent/100), then SL = limitPrice ± (riskUsdt / (contractSize * size))
- Migrate OrderController from BitmartHttpClientPrivate to OrderProviderInterface
- Add SL validation (SL < limitPrice for Long, SL > limitPrice for Short)
- Quantify SL price according to contract price precision using TickQuantizer
- Display calculated SL in order submission form with distance metrics
- Add preset_stop_loss_price and preset_stop_loss_price_type to order payload

Modified files:
- OrderController: use OrderProvider, calculate and validate SL
- Contract: add getPricePrecision() method
- submit.html.twig: display SL price and distance metrics