### PR TITLE
feat(tpsl): add TP/SL two-targets service + split strategies and endp…

### DIFF
--- a/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
+++ b/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
@@ -30,7 +30,7 @@ final class TradeTpSlTwoTargetsCommand extends Command
             ->addOption('entry', null, InputOption::VALUE_REQUIRED, 'Prix d\'entrée moyen (sinon lu depuis Position)')
             ->addOption('size', null, InputOption::VALUE_REQUIRED, 'Taille (contrats), sinon depuis Position')
             ->addOption('r', null, InputOption::VALUE_REQUIRED, 'R multiple pour TP1', '2.0')
-            ->addOption('split', null, InputOption::VALUE_REQUIRED, 'Fraction du size sur TP1 (0..1)', '0.5')
+            ->addOption('split', null, InputOption::VALUE_REQUIRED, 'Fraction du size sur TP1 (0..1)')
             ->addOption('keep-sl', null, InputOption::VALUE_NONE, 'Ne pas annuler SL existant même si différent')
             ->addOption('keep-tp', null, InputOption::VALUE_NONE, 'Ne pas annuler TP existants')
         ;
@@ -49,13 +49,14 @@ final class TradeTpSlTwoTargetsCommand extends Command
 
         $entry = $input->getOption('entry');
         $size = $input->getOption('size');
+        $split = $input->getOption('split');
         $dto = new TpSlTwoTargetsRequest(
             symbol: $symbol,
             side: $side,
             entryPrice: $entry !== null ? (float)$entry : null,
             size: $size !== null ? (int)$size : null,
             rMultiple: (float)$input->getOption('r'),
-            splitPct: (float)$input->getOption('split'),
+            splitPct: $split !== null ? (float)$split : null,
             cancelExistingStopLossIfDifferent: !$input->getOption('keep-sl'),
             cancelExistingTakeProfits: !$input->getOption('keep-tp'),
         );

--- a/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
+++ b/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
+use App\TradeEntry\Service\TpSlTwoTargetsService;
+use App\TradeEntry\Types\Side;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:trade:tp2', description: 'Attache deux TP (TP1 mécanisme actuel, TP2=R2/S2) et gère SL existant')]
+final class TradeTpSlTwoTargetsCommand extends Command
+{
+    public function __construct(
+        private readonly TpSlTwoTargetsService $service,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('symbol', InputArgument::REQUIRED, 'Symbole, ex: BTCUSDT')
+            ->addArgument('side', InputArgument::REQUIRED, 'long|short')
+            ->addOption('entry', null, InputOption::VALUE_REQUIRED, 'Prix d\'entrée moyen (sinon lu depuis Position)')
+            ->addOption('size', null, InputOption::VALUE_REQUIRED, 'Taille (contrats), sinon depuis Position')
+            ->addOption('r', null, InputOption::VALUE_REQUIRED, 'R multiple pour TP1', '2.0')
+            ->addOption('split', null, InputOption::VALUE_REQUIRED, 'Fraction du size sur TP1 (0..1)', '0.5')
+            ->addOption('keep-sl', null, InputOption::VALUE_NONE, 'Ne pas annuler SL existant même si différent')
+            ->addOption('keep-tp', null, InputOption::VALUE_NONE, 'Ne pas annuler TP existants')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $symbol = (string)$input->getArgument('symbol');
+        $sideRaw = strtolower((string)$input->getArgument('side'));
+        try {
+            $side = Side::from($sideRaw);
+        } catch (\ValueError $e) {
+            $output->writeln('<error>Invalid side, use long|short</error>');
+            return Command::FAILURE;
+        }
+
+        $entry = $input->getOption('entry');
+        $size = $input->getOption('size');
+        $dto = new TpSlTwoTargetsRequest(
+            symbol: $symbol,
+            side: $side,
+            entryPrice: $entry !== null ? (float)$entry : null,
+            size: $size !== null ? (int)$size : null,
+            rMultiple: (float)$input->getOption('r'),
+            splitPct: (float)$input->getOption('split'),
+            cancelExistingStopLossIfDifferent: !$input->getOption('keep-sl'),
+            cancelExistingTakeProfits: !$input->getOption('keep-tp'),
+        );
+
+        try {
+            $result = ($this->service)($dto);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>Failed: ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        $output->writeln(sprintf('SL=%.8f TP1=%.8f TP2=%.8f', $result['sl'], $result['tp1'], $result['tp2']));
+        foreach ($result['submitted'] as $row) {
+            $output->writeln(sprintf(
+                'Submitted %s %s @ %.8f size=%d id=%s cid=%s',
+                $row['type'],
+                $row['side'],
+                $row['price'],
+                $row['size'],
+                $row['order_id'],
+                $row['client_order_id'] ?? 'n/a'
+            ));
+        }
+        if (!empty($result['cancelled'])) {
+            $output->writeln('Cancelled: ' . implode(', ', $result['cancelled']));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/trading-app/src/Controller/TradeTpSlController.php
+++ b/trading-app/src/Controller/TradeTpSlController.php
@@ -43,15 +43,25 @@ final class TradeTpSlController extends AbstractController
             return new JsonResponse(['error' => 'Invalid side value'], 400);
         }
 
+        // Clamp split_pct to [0,1]
+        $split = isset($data['split_pct']) ? (float)$data['split_pct'] : null;
+        if ($split !== null) {
+            if ($split > 1.0 && $split <= 100.0) {
+                $split *= 0.01;
+            }
+            $split = max(0.0, min(1.0, $split));
+        }
+
         $dto = new TpSlTwoTargetsRequest(
             symbol: (string)$data['symbol'],
             side: $side,
             entryPrice: isset($data['entry_price']) ? (float)$data['entry_price'] : null,
             size: isset($data['size']) ? (int)$data['size'] : null,
             rMultiple: isset($data['r_multiple']) ? (float)$data['r_multiple'] : null,
-            splitPct: isset($data['split_pct']) ? (float)$data['split_pct'] : null,
+            splitPct: $split,
             cancelExistingStopLossIfDifferent: isset($data['cancel_sl_if_diff']) ? (bool)$data['cancel_sl_if_diff'] : true,
             cancelExistingTakeProfits: isset($data['cancel_tp']) ? (bool)$data['cancel_tp'] : true,
+            slFullSize: isset($data['sl_full_size']) ? (bool)$data['sl_full_size'] : null,
             momentum: isset($data['momentum']) ? (string)$data['momentum'] : null,
             mtfValidCount: isset($data['mtf_valid_count']) ? (int)$data['mtf_valid_count'] : null,
             pullbackClear: isset($data['pullback_clear']) ? (bool)$data['pullback_clear'] : null,

--- a/trading-app/src/Controller/TradeTpSlController.php
+++ b/trading-app/src/Controller/TradeTpSlController.php
@@ -49,7 +49,7 @@ final class TradeTpSlController extends AbstractController
             entryPrice: isset($data['entry_price']) ? (float)$data['entry_price'] : null,
             size: isset($data['size']) ? (int)$data['size'] : null,
             rMultiple: isset($data['r_multiple']) ? (float)$data['r_multiple'] : null,
-            splitPct: isset($data['split_pct']) ? (float)$data['split_pct'] : 0.5,
+            splitPct: isset($data['split_pct']) ? (float)$data['split_pct'] : null,
             cancelExistingStopLossIfDifferent: isset($data['cancel_sl_if_diff']) ? (bool)$data['cancel_sl_if_diff'] : true,
             cancelExistingTakeProfits: isset($data['cancel_tp']) ? (bool)$data['cancel_tp'] : true,
             momentum: isset($data['momentum']) ? (string)$data['momentum'] : null,

--- a/trading-app/src/Controller/TradeTpSlController.php
+++ b/trading-app/src/Controller/TradeTpSlController.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Config\MtfValidationConfig;
+use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
+use App\TradeEntry\Service\TpSlTwoTargetsService;
+use App\TradeEntry\Types\Side;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[Route('/api/trade-tpsl', name: 'trade_tpsl_')]
+final class TradeTpSlController extends AbstractController
+{
+    public function __construct(
+        private readonly TpSlTwoTargetsService $service,
+        private readonly MtfValidationConfig $mtfConfig,
+    ) {}
+
+    #[Route('/two-targets', name: 'two_targets', methods: ['POST'])]
+    public function twoTargets(Request $request): JsonResponse
+    {
+        $data = json_decode($request->getContent(), true);
+        if (!\is_array($data)) {
+            return new JsonResponse(['error' => 'Invalid JSON'], 400);
+        }
+
+        foreach (['symbol', 'side'] as $field) {
+            if (!isset($data[$field])) {
+                return new JsonResponse(['error' => "Missing field: $field"], 400);
+            }
+        }
+
+        try {
+            $side = is_string($data['side']) ? Side::from(strtolower($data['side'])) : $data['side'];
+        } catch (\ValueError) {
+            return new JsonResponse(['error' => 'Invalid side value'], 400);
+        }
+        if (!$side instanceof Side) {
+            return new JsonResponse(['error' => 'Invalid side value'], 400);
+        }
+
+        $dto = new TpSlTwoTargetsRequest(
+            symbol: (string)$data['symbol'],
+            side: $side,
+            entryPrice: isset($data['entry_price']) ? (float)$data['entry_price'] : null,
+            size: isset($data['size']) ? (int)$data['size'] : null,
+            rMultiple: isset($data['r_multiple']) ? (float)$data['r_multiple'] : null,
+            splitPct: isset($data['split_pct']) ? (float)$data['split_pct'] : 0.5,
+            cancelExistingStopLossIfDifferent: isset($data['cancel_sl_if_diff']) ? (bool)$data['cancel_sl_if_diff'] : true,
+            cancelExistingTakeProfits: isset($data['cancel_tp']) ? (bool)$data['cancel_tp'] : true,
+            momentum: isset($data['momentum']) ? (string)$data['momentum'] : null,
+            mtfValidCount: isset($data['mtf_valid_count']) ? (int)$data['mtf_valid_count'] : null,
+            pullbackClear: isset($data['pullback_clear']) ? (bool)$data['pullback_clear'] : null,
+            lateEntry: isset($data['late_entry']) ? (bool)$data['late_entry'] : null,
+        );
+
+        try {
+            $result = ($this->service)($dto);
+        } catch (\Throwable $e) {
+            return new JsonResponse(['error' => 'Failed: ' . $e->getMessage()], 500);
+        }
+
+        return new JsonResponse([
+            'symbol' => $dto->symbol,
+            'side' => $side->value,
+            'sl' => $result['sl'],
+            'tp1' => $result['tp1'],
+            'tp2' => $result['tp2'],
+            'submitted' => $result['submitted'],
+            'cancelled' => $result['cancelled'],
+        ]);
+    }
+}

--- a/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
@@ -16,6 +16,7 @@ final class TpSlTwoTargetsRequest
         public readonly ?float $splitPct = null,
         public readonly ?bool $cancelExistingStopLossIfDifferent = true,
         public readonly ?bool $cancelExistingTakeProfits = true,
+        public readonly ?bool $slFullSize = null,
         // Hints to drive TpSplitResolver (optional)
         public readonly ?string $momentum = null,        // 'faible'|'moyen'|'fort'
         public readonly ?int $mtfValidCount = null,      // 0..3

--- a/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\Dto;
+
+use App\TradeEntry\Types\Side;
+
+final class TpSlTwoTargetsRequest
+{
+    public function __construct(
+        public readonly string $symbol,
+        public readonly Side $side,
+        public readonly ?float $entryPrice = null,
+        public readonly ?int $size = null,
+        public readonly ?float $rMultiple = null,
+        public readonly ?float $splitPct = 0.5,
+        public readonly ?bool $cancelExistingStopLossIfDifferent = true,
+        public readonly ?bool $cancelExistingTakeProfits = true,
+        // Hints to drive TpSplitResolver (optional)
+        public readonly ?string $momentum = null,        // 'faible'|'moyen'|'fort'
+        public readonly ?int $mtfValidCount = null,      // 0..3
+        public readonly ?bool $pullbackClear = null,
+        public readonly ?bool $lateEntry = null,
+    ) {}
+}

--- a/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
@@ -13,7 +13,7 @@ final class TpSlTwoTargetsRequest
         public readonly ?float $entryPrice = null,
         public readonly ?int $size = null,
         public readonly ?float $rMultiple = null,
-        public readonly ?float $splitPct = 0.5,
+        public readonly ?float $splitPct = null,
         public readonly ?bool $cancelExistingStopLossIfDifferent = true,
         public readonly ?bool $cancelExistingTakeProfits = true,
         // Hints to drive TpSplitResolver (optional)

--- a/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
+++ b/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
@@ -1,0 +1,500 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\Service;
+
+use App\Config\MtfValidationConfig;
+use App\Contract\Provider\MainProviderInterface;
+use App\Entity\Position;
+use App\Repository\PositionRepository;
+use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
+use App\TradeEntry\Policy\PreTradeChecks;
+use App\TradeEntry\RiskSizer\StopLossCalculator;
+use App\TradeEntry\RiskSizer\TakeProfitCalculator;
+use App\TradeEntry\Types\Side as EntrySide;
+use App\TradeEntry\TpSplit\TpSplitResolver;
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+use App\Contract\Indicator\IndicatorProviderInterface;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\Dto\OrderDto;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use App\Runtime\Cache\DbValidationCache;
+
+final class TpSlTwoTargetsService
+{
+    public function __construct(
+        private readonly PreTradeChecks $pretrade,
+        private readonly StopLossCalculator $slc,
+        private readonly TakeProfitCalculator $tpc,
+        private readonly MainProviderInterface $providers,
+        private readonly PositionRepository $positions,
+        private readonly MtfValidationConfig $mtfConfig,
+        #[Autowire(service: 'monolog.logger.order_journey')] private readonly LoggerInterface $journeyLogger,
+        #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
+        private readonly ?TpSplitResolver $tpSplitResolver = null,
+        private readonly ?IndicatorProviderInterface $indicatorProvider = null,
+        private readonly ?DbValidationCache $validationCache = null,
+    ) {}
+
+    /**
+     * Calcule SL + TP1/TP2 (TP2 basé sur R2/S2), annule les ordres existants (SL si différent, TP) et soumet 2 TP.
+     *
+     * @return array{sl: float, tp1: float, tp2: float, submitted: array<int,array{order_id:string,price:float,size:int,type:string,side:string}>, cancelled: array<int,string>}
+     */
+    public function __invoke(TpSlTwoTargetsRequest $req, ?string $decisionKey = null): array
+    {
+        $symbol = strtoupper($req->symbol);
+
+        // 1) Prétraitement/exchange state
+        $dummy = new \App\TradeEntry\Dto\TradeEntryRequest(
+            symbol: $symbol,
+            side: $req->side,
+        );
+        $pre = $this->pretrade->run($dummy);
+
+        $tick = $pre->tickSize;
+        $precision = $pre->pricePrecision;
+        $contractSize = $pre->contractSize;
+        $pivotLevels = is_array($pre->pivotLevels) ? $pre->pivotLevels : [];
+
+        // 2) Résoudre position/entrée/size
+        $entryPrice = $req->entryPrice;
+        $size = $req->size;
+
+        if ($entryPrice === null || $size === null) {
+            $pos = $this->resolvePosition($symbol, $req->side);
+            if ($pos instanceof Position) {
+                if ($entryPrice === null) {
+                    $entryPrice = (float)($pos->getAvgEntryPrice() ?? 0.0);
+                }
+                if ($size === null) {
+                    $size = (int)max(0, (int)($pos->getSize() ?? 0));
+                }
+            }
+        }
+
+        if ($entryPrice === null || $entryPrice <= 0.0 || $size === null || $size <= 0) {
+            throw new \InvalidArgumentException('entryPrice et size requis (ou position introuvable)');
+        }
+
+        // 3) Calcul SL (priorité pivot), TP1 (mécanisme actuel), TP2 (R2/S2)
+        $defaults = $this->mtfConfig->getDefaults();
+        $riskPctDefault = (float)($defaults['risk_pct_percent'] ?? 2.0);
+        $riskPct = $riskPctDefault > 1.0 ? $riskPctDefault / 100.0 : $riskPctDefault;
+        $initMargin = (float)($defaults['initial_margin_usdt'] ?? 100.0);
+        $tpPolicy = (string)($defaults['tp_policy'] ?? 'pivot_conservative');
+        $tpMinKeepRatio = isset($defaults['tp_min_keep_ratio']) ? (float)$defaults['tp_min_keep_ratio'] : 0.95;
+        $tpBufferPct = isset($defaults['tp_buffer_pct']) ? (float)$defaults['tp_buffer_pct'] : null;
+        $tpBufferTicks = isset($defaults['tp_buffer_ticks']) ? (int)$defaults['tp_buffer_ticks'] : null;
+        $pivotSlPolicy = (string)($defaults['pivot_sl_policy'] ?? 'nearest_below');
+        $pivotSlBufferPct = isset($defaults['pivot_sl_buffer_pct']) ? (float)$defaults['pivot_sl_buffer_pct'] : null;
+        $pivotSlMinKeepRatio = isset($defaults['pivot_sl_min_keep_ratio']) ? (float)$defaults['pivot_sl_min_keep_ratio'] : null;
+        $rMultiple = (float)($req->rMultiple ?? ($defaults['r_multiple'] ?? 2.0));
+
+        // Stop par pivot si disponible, sinon par risque
+        if (!empty($pivotLevels)) {
+            $stop = $this->slc->fromPivot(
+                entry: $entryPrice,
+                side: $req->side,
+                pivotLevels: $pivotLevels,
+                policy: $pivotSlPolicy,
+                bufferPct: $pivotSlBufferPct,
+                pricePrecision: $precision,
+            );
+            // Appliquer garde min_keep_ratio si fourni
+            if ($pivotSlMinKeepRatio !== null && $pivotSlMinKeepRatio > 0.0) {
+                $minRisk = max(1e-8, abs($entryPrice - $stop) * $pivotSlMinKeepRatio);
+                if ($req->side === EntrySide::Long) {
+                    if (abs(($entryPrice - $stop)) < $minRisk) {
+                        $stop = max($tick, $entryPrice - $minRisk);
+                    }
+                } else {
+                    if (abs(($stop - $entryPrice)) < $minRisk) {
+                        $stop = $entryPrice + $minRisk;
+                    }
+                }
+            }
+        } else {
+            $riskUsdt = $initMargin * $riskPct;
+            $stop = $this->slc->fromRisk(
+                entry: $entryPrice,
+                side: $req->side,
+                riskUsdt: $riskUsdt,
+                size: $size,
+                contractSize: $contractSize,
+                precision: $precision,
+            );
+        }
+
+        // TP1 = mécanique actuelle (R multiple aligné pivots si dispo)
+        $tp1Base = $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, $rMultiple, $precision);
+        $tp1 = $tp1Base;
+        if (!empty($pivotLevels) && $rMultiple > 0.0) {
+            $tp1 = $this->tpc->alignTakeProfitWithPivot(
+                symbol: $symbol,
+                side: $req->side,
+                entry: $entryPrice,
+                stop: $stop,
+                baseTakeProfit: $tp1Base,
+                rMultiple: $rMultiple,
+                pivotLevels: $pivotLevels,
+                policy: $tpPolicy,
+                bufferPct: $tpBufferPct,
+                bufferTicks: $tpBufferTicks,
+                tick: $tick,
+                pricePrecision: $precision,
+                minKeepRatio: $tpMinKeepRatio,
+                maxExtraR: null,
+                decisionKey: $decisionKey,
+            );
+        }
+
+        // TP2 = R2/S2 si dispo, sinon fallback 2R
+        $tp2 = null;
+        $key = $req->side === EntrySide::Long ? 'r2' : 's2';
+        if (isset($pivotLevels[$key]) && is_finite((float)$pivotLevels[$key]) && (float)$pivotLevels[$key] > 0.0) {
+            $tp2 = (float)$pivotLevels[$key];
+            // appliquer buffer si défini
+            if ($tpBufferPct !== null && $tpBufferPct > 0.0) {
+                $tp2 = $req->side === EntrySide::Long ? $tp2 * (1.0 - $tpBufferPct) : $tp2 * (1.0 + $tpBufferPct);
+            }
+            if ($tpBufferTicks !== null && $tpBufferTicks > 0) {
+                $tp2 = $req->side === EntrySide::Long ? $tp2 - $tpBufferTicks * $tick : $tp2 + $tpBufferTicks * $tick;
+            }
+            // quantifier et assurer >/< entry d'au moins 1 tick
+            if ($req->side === EntrySide::Long) {
+                $tp2 = max($tp2, $entryPrice + $tick);
+                $tp2 = \App\TradeEntry\Pricing\TickQuantizer::quantizeUp($tp2, $precision);
+            } else {
+                $tp2 = min($tp2, $entryPrice - $tick);
+                $tp2 = \App\TradeEntry\Pricing\TickQuantizer::quantize($tp2, $precision);
+            }
+        } else {
+            // Fallback: 2R depuis SL
+            $tp2 = $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, 2.0, $precision);
+        }
+
+        $this->journeyLogger->info('order_journey.tp2sl.compute', [
+            'symbol' => $symbol,
+            'decision_key' => $decisionKey,
+            'entry' => $entryPrice,
+            'stop' => $stop,
+            'tp1' => $tp1,
+            'tp2' => $tp2,
+            'reason' => 'tp_sl_two_targets_computed',
+        ]);
+
+        // 4) Annulations (SL si différent, TP existants)
+        $cancelled = [];
+        $orderProvider = $this->providers->getOrderProvider();
+        $open = $orderProvider->getOpenOrders($symbol);
+
+        // Détermination sens fermeture
+        $closeSide = $req->side === EntrySide::Long ? OrderSide::SELL : OrderSide::BUY;
+        $isSl = function (OrderDto $o) use ($req, $entryPrice): bool {
+            if ($o->price === null) { return false; }
+            $p = (float)$o->price->__toString();
+            return $req->side === EntrySide::Long ? ($p < $entryPrice) : ($p > $entryPrice);
+        };
+        $priceOf = fn(OrderDto $o): ?float => $o->price ? (float)$o->price->__toString() : null;
+
+        /** @var array<int,OrderDto> $closing */
+        $closing = array_values(array_filter($open, fn(OrderDto $o) => $o->side === $closeSide));
+
+        // Annuler SL si différent (tolérance = 1 tick)
+        if ($req->cancelExistingStopLossIfDifferent) {
+            $existingSl = null;
+            foreach ($closing as $o) {
+                if ($isSl($o)) { $existingSl = $o; break; }
+            }
+            if ($existingSl !== null) {
+                $p = $priceOf($existingSl);
+                if ($p !== null && abs($p - $stop) > max($tick, 1e-8)) {
+                    if ($orderProvider->cancelOrder($existingSl->orderId)) {
+                        $cancelled[] = $existingSl->orderId;
+                    }
+                }
+            }
+        }
+
+        // Annuler TP existants
+        if ($req->cancelExistingTakeProfits) {
+            foreach ($closing as $o) {
+                if (!$isSl($o)) {
+                    if ($orderProvider->cancelOrder($o->orderId)) {
+                        $cancelled[] = $o->orderId;
+                    }
+                }
+            }
+        }
+
+        // 5) Soumettre SL (limité) et 2 ordres TP (split du size)
+        // Détermination ratio TP1/TP2: priorité à la requête, sinon resolver basé sur contexte
+        $ratio = $req->splitPct;
+        if ($ratio === null && $this->tpSplitResolver !== null) {
+            // Déduire automatiquement depuis le pipeline MTF si absent
+            $auto = $this->deriveMtfHints($symbol);
+            $momentum = $req->momentum ?? $auto['momentum'];
+            $mtfValid = $req->mtfValidCount ?? $auto['mtf_valid_count'];
+            $pullback = (bool)($req->pullbackClear ?? false);
+            $late = (bool)($req->lateEntry ?? false);
+
+            // ATR% via IndicatorProvider (fallback: estimer depuis EntryZone ATR si dispo)
+            $mark = (float)($pre->markPrice ?? $pre->bestAsk ?? $pre->bestBid ?? 0.0);
+            $atrAbs = null;
+            if ($this->indicatorProvider !== null) {
+                try {
+                    $tf = $this->resolveAtrTimeframe();
+                    $atrAbs = $this->indicatorProvider->getAtr('tp_split', $symbol, $tf);
+                } catch (\Throwable) {
+                    $atrAbs = null;
+                }
+            }
+            $atrPct = ($atrAbs !== null && $mark > 0.0) ? (100.0 * $atrAbs / $mark) : 1.5;
+
+            $ctx = new TpSplitContext(
+                symbol: $symbol,
+                momentum: strtolower($momentum),
+                atrPct: $atrPct,
+                mtfValidCount: max(0, min(3, (int)$mtfValid)),
+                pullbackClear: $pullback,
+                lateEntry: $late,
+            );
+            $ratio = $this->tpSplitResolver->resolve($ctx);
+        }
+        if ($ratio === null) { $ratio = 0.5; }
+        
+        $ratio = max(0.0, min(1.0, $ratio));
+        $size1 = (int)floor($size * $ratio);
+        $size2 = (int)max(0, $size - $size1);
+        if ($size1 <= 0 || $size2 <= 0) {
+            // fallback: tout sur TP1 si insuffisant
+            $size1 = $size;
+            $size2 = 0;
+        }
+
+        // Clip/quantize aux contraintes de volumes échange
+        $minVol = (int)max(1, (int)$pre->minVolume);
+        // Quantifier à un multiple du minVol
+        $size1 = $size1 > 0 ? (int)floor($size1 / $minVol) * $minVol : 0;
+        $size2 = $size2 > 0 ? (int)floor($size2 / $minVol) * $minVol : 0;
+        if ($size1 > 0 && $size1 < $minVol) { $size1 = 0; }
+        if ($size2 > 0 && $size2 < $minVol) { $size2 = 0; }
+
+        $maxVol = $pre->maxVolume;
+        if ($maxVol !== null && $maxVol > 0) {
+            $size1 = (int)min($size1, (int)$maxVol);
+            $size2 = (int)min($size2, (int)$maxVol);
+        }
+
+        $submitted = [];
+        $bitmartCloseSide = ($req->side === EntrySide::Long) ? 2 : 3; // 2=close_long, 3=close_short
+
+        $optionsBase = [
+            'side' => $bitmartCloseSide,
+            // Force reduce-only when supported by provider/API
+            'reduce_only' => true,
+            'reduceOnly' => true,
+        ];
+
+        // SL pleine taille (comportement codé en dur)
+        $slSize = (int)$size;
+        // Préparer un base CID pour tracer les ordres
+        $baseCid = $this->makeBaseCid($symbol, $req->side, $decisionKey);
+
+        if ($slSize > 0) {
+            // Quantifier SL size au multiple minVol
+            $slSize = (int)floor($slSize / $minVol) * $minVol;
+            $options = $optionsBase + ['client_order_id' => $baseCid . '-SL'];
+            // Submit SL as a stop-limit (triggered) by using stopPrice; keep limit price equal to stop for determinism
+            $dto = $orderProvider->placeOrder(
+                symbol: $symbol,
+                side: $closeSide,
+                type: OrderType::LIMIT,
+                quantity: (float)$slSize,
+                price: (float)$stop,
+                stopPrice: (float)$stop,
+                options: $options,
+            );
+            if ($dto instanceof OrderDto) {
+                $submitted[] = [
+                    'order_id' => $dto->orderId,
+                    'price' => (float)($dto->price?->__toString() ?? (string)$stop),
+                    'size' => $slSize,
+                    'type' => 'limit',
+                    'side' => $closeSide->value,
+                    'kind' => 'sl',
+                    'client_order_id' => $options['client_order_id'],
+                ];
+            }
+        }
+
+        // TP1
+        if ($size1 > 0) {
+            $options = $optionsBase + ['client_order_id' => $baseCid . '-TP1'];
+            $dto = $orderProvider->placeOrder(
+                symbol: $symbol,
+                side: $closeSide,
+                type: OrderType::LIMIT,
+                quantity: (float)$size1,
+                price: (float)$tp1,
+                stopPrice: null,
+                options: $options,
+            );
+            if ($dto instanceof OrderDto) {
+                $submitted[] = [
+                    'order_id' => $dto->orderId,
+                    'price' => (float)($dto->price?->__toString() ?? (string)$tp1),
+                    'size' => $size1,
+                    'type' => 'limit',
+                    'side' => $closeSide->value,
+                    'kind' => 'tp1',
+                    'client_order_id' => $options['client_order_id'],
+                ];
+            }
+        }
+
+        // TP2
+        if ($size2 > 0) {
+            $options = $optionsBase + ['client_order_id' => $baseCid . '-TP2'];
+            $dto = $orderProvider->placeOrder(
+                symbol: $symbol,
+                side: $closeSide,
+                type: OrderType::LIMIT,
+                quantity: (float)$size2,
+                price: (float)$tp2,
+                stopPrice: null,
+                options: $options,
+            );
+            if ($dto instanceof OrderDto) {
+                $submitted[] = [
+                    'order_id' => $dto->orderId,
+                    'price' => (float)($dto->price?->__toString() ?? (string)$tp2),
+                    'size' => $size2,
+                    'type' => 'limit',
+                    'side' => $closeSide->value,
+                    'kind' => 'tp2',
+                    'client_order_id' => $options['client_order_id'],
+                ];
+            }
+        }
+
+        $this->journeyLogger->info('order_journey.tp2sl.submit', [
+            'symbol' => $symbol,
+            'decision_key' => $decisionKey,
+            'submitted_count' => \count($submitted),
+            'cancelled_count' => \count($cancelled),
+            'reason' => 'tp_two_targets_submitted',
+        ]);
+
+        return [
+            'sl' => $stop,
+            'tp1' => $tp1,
+            'tp2' => (float)$tp2,
+            'submitted' => $submitted,
+            'cancelled' => $cancelled,
+        ];
+    }
+
+    private function resolvePosition(string $symbol, EntrySide $side): ?Position
+    {
+        // Position entity side is LONG|SHORT
+        $pos = $this->positions->findOneBySymbolSide($symbol, $side === EntrySide::Long ? 'LONG' : 'SHORT');
+        return $pos;
+    }
+
+    private function resolveAtrTimeframe(): string
+    {
+        try {
+            $cfg = $this->mtfConfig->getConfig();
+            // optional override in mtf_validations.yaml: defaults.atr_tf
+            $tf = $cfg['defaults']['atr_tf'] ?? null;
+            if (is_string($tf) && $tf !== '') {
+                return $tf;
+            }
+        } catch (\Throwable) {}
+        return '5m';
+    }
+
+    /**
+     * Déduit momentum et mtf_valid_count depuis le cache MTF si disponible.
+     * Retourne des valeurs par défaut raisonnables sinon.
+     * @return array{momentum:string, mtf_valid_count:int}
+     */
+    private function deriveMtfHints(string $symbol): array
+    {
+        $default = ['momentum' => 'moyen', 'mtf_valid_count' => 2];
+        if ($this->validationCache === null) {
+            return $default;
+        }
+
+        try {
+            $states = $this->validationCache->getValidationStates($symbol);
+            if (empty($states)) {
+                return $default;
+            }
+
+            // Prendre l'état le plus récent
+            usort($states, static function ($a, $b) {
+                $ta = method_exists($a, 'klineTime') ? $a->klineTime : ($a->klineTime ?? null);
+                $tb = method_exists($b, 'klineTime') ? $b->klineTime : ($b->klineTime ?? null);
+                $tsa = $ta instanceof \DateTimeImmutable ? $ta->getTimestamp() : 0;
+                $tsb = $tb instanceof \DateTimeImmutable ? $tb->getTimestamp() : 0;
+                return $tsb <=> $tsa;
+            });
+
+            $latest = $states[0];
+            $details = $latest->details ?? [];
+            $collector = $details['mtf_collector'] ?? [];
+
+            // Déterminer la base TF depuis la config (context) sinon fallback 3 TF usuelles
+            $cfg = $this->mtfConfig->getConfig();
+            $contextTfs = array_map('strtolower', (array)($cfg['validation']['context'] ?? ($cfg['mtf']['context'] ?? [])));
+            if (empty($contextTfs)) {
+                $contextTfs = ['1h','15m','5m'];
+            }
+            $contextSet = array_flip($contextTfs);
+
+            $validCount = 0;
+            foreach ($collector as $row) {
+                $tf = strtolower((string)($row['tf'] ?? $row['timeframe'] ?? ''));
+                $status = strtoupper((string)($row['status'] ?? ''));
+                if ($tf !== '' && isset($contextSet[$tf]) && $status === 'VALID') {
+                    $validCount++;
+                }
+            }
+            $validCount = max(0, min(3, (int)$validCount));
+
+            $momentum = 'moyen';
+            if ($validCount >= 3) {
+                $momentum = 'fort';
+            } elseif ($validCount <= 1) {
+                $momentum = 'faible';
+            }
+
+            return ['momentum' => $momentum, 'mtf_valid_count' => $validCount];
+        } catch (\Throwable) {
+            return $default;
+        }
+    }
+
+    private function makeBaseCid(string $symbol, EntrySide $side, ?string $decisionKey): string
+    {
+        $sideTag = $side === EntrySide::Long ? 'L' : 'S';
+        $base = null;
+        if (\is_string($decisionKey) && $decisionKey !== '') {
+            $san = preg_replace('/[^A-Za-z0-9:_-]/', '', $decisionKey) ?? 'key';
+            $base = sprintf('TPSL-%s-%s-%s', strtoupper($symbol), $sideTag, substr($san, -20));
+        }
+        if ($base === null) {
+            try {
+                $rnd = bin2hex(random_bytes(3));
+            } catch (\Throwable) { $rnd = substr(sha1(uniqid('', true)), 0, 6); }
+            $base = sprintf('TPSL-%s-%s-%s', strtoupper($symbol), $sideTag, $rnd);
+        }
+        // Bitmart allows fairly long IDs; keep under 64 chars to be safe
+        return substr($base, 0, 64);
+    }
+}

--- a/trading-app/src/TradeEntry/TpSplit/Attribute/AsTpSplitStrategy.php
+++ b/trading-app/src/TradeEntry/TpSplit/Attribute/AsTpSplitStrategy.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class AsTpSplitStrategy
+{
+    public function __construct(
+        public ?string $name = null,
+        public int $priority = 0,
+    ) {}
+}
+

--- a/trading-app/src/TradeEntry/TpSplit/Dto/TpSplitContext.php
+++ b/trading-app/src/TradeEntry/TpSplit/Dto/TpSplitContext.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit\Dto;
+
+final class TpSplitContext
+{
+    public function __construct(
+        public readonly string $symbol,
+        public readonly string $momentum,         // 'faible'|'moyen'|'fort'
+        public readonly float $atrPct,            // ATR% (0..100)
+        public readonly int $mtfValidCount,       // 0..3
+        public readonly bool $pullbackClear = false,
+        public readonly bool $lateEntry = false,
+    ) {}
+}
+

--- a/trading-app/src/TradeEntry/TpSplit/Strategy/DoubtfulLateEntrySplitStrategy.php
+++ b/trading-app/src/TradeEntry/TpSplit/Strategy/DoubtfulLateEntrySplitStrategy.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit\Strategy;
+
+use App\TradeEntry\TpSplit\Attribute\AsTpSplitStrategy;
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AsTpSplitStrategy(name: 'doubtful_late_entry', priority: 50)]
+#[AutoconfigureTag('app.trade.tp_split')]
+final class DoubtfulLateEntrySplitStrategy implements TpSplitStrategyInterface
+{
+    public function getName(): string { return 'doubtful_late_entry'; }
+    public function getPriority(): int { return 50; }
+
+    public function supports(TpSplitContext $ctx): bool
+    {
+        return ($ctx->momentum === 'faible') && ($ctx->atrPct > 2.0) && ($ctx->mtfValidCount <= 1) && $ctx->lateEntry;
+    }
+
+    public function ratio(TpSplitContext $ctx): float
+    {
+        return 0.70; // 70 / 30
+    }
+}

--- a/trading-app/src/TradeEntry/TpSplit/Strategy/NeutralSplitStrategy.php
+++ b/trading-app/src/TradeEntry/TpSplit/Strategy/NeutralSplitStrategy.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit\Strategy;
+
+use App\TradeEntry\TpSplit\Attribute\AsTpSplitStrategy;
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AsTpSplitStrategy(name: 'neutral', priority: 10)]
+#[AutoconfigureTag('app.trade.tp_split')]
+final class NeutralSplitStrategy implements TpSplitStrategyInterface
+{
+    public function getName(): string { return 'neutral'; }
+    public function getPriority(): int { return 10; }
+
+    public function supports(TpSplitContext $ctx): bool
+    {
+        $atr = $ctx->atrPct;
+        $mtf = $ctx->mtfValidCount;
+        return ($ctx->momentum === 'moyen') && ($atr >= 1.2 && $atr <= 1.8) && ($mtf >= 2);
+    }
+
+    public function ratio(TpSplitContext $ctx): float
+    {
+        return 0.50; // 50 / 50
+    }
+}
+

--- a/trading-app/src/TradeEntry/TpSplit/Strategy/StrongMomentumSplitStrategy.php
+++ b/trading-app/src/TradeEntry/TpSplit/Strategy/StrongMomentumSplitStrategy.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit\Strategy;
+
+use App\TradeEntry\TpSplit\Attribute\AsTpSplitStrategy;
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AsTpSplitStrategy(name: 'strong_momentum', priority: 40)]
+#[AutoconfigureTag('app.trade.tp_split')]
+final class StrongMomentumSplitStrategy implements TpSplitStrategyInterface
+{
+    public function getName(): string { return 'strong_momentum'; }
+    public function getPriority(): int { return 40; }
+
+    public function supports(TpSplitContext $ctx): bool
+    {
+        return ($ctx->momentum === 'fort') && ($ctx->atrPct < 1.2) && ($ctx->mtfValidCount >= 3) && $ctx->pullbackClear;
+    }
+
+    public function ratio(TpSplitContext $ctx): float
+    {
+        return 0.30; // 30 / 70
+    }
+}
+

--- a/trading-app/src/TradeEntry/TpSplit/Strategy/TpSplitStrategyInterface.php
+++ b/trading-app/src/TradeEntry/TpSplit/Strategy/TpSplitStrategyInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit\Strategy;
+
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+
+interface TpSplitStrategyInterface
+{
+    public function getName(): string;
+    public function getPriority(): int;
+    public function supports(TpSplitContext $ctx): bool;
+    /**
+     * Retourne la part TP1 (0.0..1.0). TP2 = 1 - TP1
+     */
+    public function ratio(TpSplitContext $ctx): float;
+}
+

--- a/trading-app/src/TradeEntry/TpSplit/Strategy/VolatileSplitStrategy.php
+++ b/trading-app/src/TradeEntry/TpSplit/Strategy/VolatileSplitStrategy.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit\Strategy;
+
+use App\TradeEntry\TpSplit\Attribute\AsTpSplitStrategy;
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AsTpSplitStrategy(name: 'volatile', priority: 30)]
+#[AutoconfigureTag('app.trade.tp_split')]
+final class VolatileSplitStrategy implements TpSplitStrategyInterface
+{
+    public function getName(): string { return 'volatile'; }
+    public function getPriority(): int { return 30; }
+
+    public function supports(TpSplitContext $ctx): bool
+    {
+        // fort mais bruité: on approxime par ATR% élevé et confiance faible
+        return ($ctx->atrPct > 1.8) && ($ctx->mtfValidCount <= 1);
+    }
+
+    public function ratio(TpSplitContext $ctx): float
+    {
+        return 0.60; // 60 / 40
+    }
+}
+

--- a/trading-app/src/TradeEntry/TpSplit/TpSplitResolver.php
+++ b/trading-app/src/TradeEntry/TpSplit/TpSplitResolver.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradeEntry\TpSplit;
+
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+use App\TradeEntry\TpSplit\Strategy\TpSplitStrategyInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+
+final class TpSplitResolver
+{
+    /** @var TpSplitStrategyInterface[] */
+    private array $strategies;
+
+    /**
+     * @param iterable<TpSplitStrategyInterface> $strategies
+     */
+    public function __construct(#[TaggedIterator('app.trade.tp_split')] iterable $strategies)
+    {
+        $this->strategies = is_array($strategies) ? $strategies : iterator_to_array($strategies);
+
+        // Trier par priorité décroissante
+        usort($this->strategies, function (TpSplitStrategyInterface $a, TpSplitStrategyInterface $b) {
+            return $b->getPriority() <=> $a->getPriority();
+        });
+    }
+
+    /**
+     * Retourne la part TP1 (0..1). Fallback 0.5 si aucune stratégie ne matche.
+     */
+    public function resolve(TpSplitContext $ctx): float
+    {
+        foreach ($this->strategies as $s) {
+            if ($s->supports($ctx)) {
+                return max(0.0, min(1.0, $s->ratio($ctx)));
+            }
+        }
+        return 0.50;
+    }
+}
+

--- a/trading-app/tests/TradeEntry/TpSplit/TpSplitResolverTest.php
+++ b/trading-app/tests/TradeEntry/TpSplit/TpSplitResolverTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradeEntry\TpSplit;
+
+use PHPUnit\Framework\TestCase;
+use App\TradeEntry\TpSplit\TpSplitResolver;
+use App\TradeEntry\TpSplit\Dto\TpSplitContext;
+use App\TradeEntry\TpSplit\Strategy\NeutralSplitStrategy;
+use App\TradeEntry\TpSplit\Strategy\VolatileSplitStrategy;
+use App\TradeEntry\TpSplit\Strategy\StrongMomentumSplitStrategy;
+use App\TradeEntry\TpSplit\Strategy\DoubtfulLateEntrySplitStrategy;
+
+final class TpSplitResolverTest extends TestCase
+{
+    private TpSplitResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $strategies = [
+            new StrongMomentumSplitStrategy(),
+            new VolatileSplitStrategy(),
+            new DoubtfulLateEntrySplitStrategy(),
+            new NeutralSplitStrategy(),
+        ];
+        $this->resolver = new TpSplitResolver($strategies);
+    }
+
+    public function testNeutralSplit(): void
+    {
+        $ctx = new TpSplitContext(
+            symbol: 'BTCUSDT',
+            momentum: 'moyen',
+            atrPct: 1.5,
+            mtfValidCount: 2,
+            pullbackClear: false,
+            lateEntry: false,
+        );
+        $ratio = $this->resolver->resolve($ctx);
+        $this->assertSame(0.50, $ratio);
+    }
+
+    public function testVolatileSplit(): void
+    {
+        $ctx = new TpSplitContext(
+            symbol: 'BTCUSDT',
+            momentum: 'fort',
+            atrPct: 2.1,
+            mtfValidCount: 1,
+            pullbackClear: false,
+            lateEntry: false,
+        );
+        $ratio = $this->resolver->resolve($ctx);
+        $this->assertSame(0.60, $ratio);
+    }
+
+    public function testStrongMomentumSplit(): void
+    {
+        $ctx = new TpSplitContext(
+            symbol: 'BTCUSDT',
+            momentum: 'fort',
+            atrPct: 1.0,
+            mtfValidCount: 3,
+            pullbackClear: true,
+            lateEntry: false,
+        );
+        $ratio = $this->resolver->resolve($ctx);
+        $this->assertSame(0.30, $ratio);
+    }
+
+    public function testDoubtfulLateEntrySplit(): void
+    {
+        $ctx = new TpSplitContext(
+            symbol: 'BTCUSDT',
+            momentum: 'faible',
+            atrPct: 2.5,
+            mtfValidCount: 1,
+            pullbackClear: false,
+            lateEntry: true,
+        );
+        $ratio = $this->resolver->resolve($ctx);
+        $this->assertSame(0.70, $ratio);
+    }
+
+    public function testFallbackSplit(): void
+    {
+        $ctx = new TpSplitContext(
+            symbol: 'BTCUSDT',
+            momentum: 'moyen',
+            atrPct: 0.8,
+            mtfValidCount: 1,
+            pullbackClear: false,
+            lateEntry: false,
+        );
+        $ratio = $this->resolver->resolve($ctx);
+        $this->assertSame(0.50, $ratio);
+    }
+}
+


### PR DESCRIPTION
…oint/command\n\n- SL stop-limit reduce-only + TP1/TP2 reduce-only\n- TP2 uses R2/S2 pivots; fallback 2R\n- Auto split via MTF momentum/valid-count + ATR%\n- Deterministic client_order_id and minVolume quantization\n- API + CLI + unit tests for split resolver