### PR TITLE
fix: allow auto TP split resolver to execute

### DIFF
--- a/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
+++ b/trading-app/src/Command/TradeTpSlTwoTargetsCommand.php
@@ -30,7 +30,7 @@ final class TradeTpSlTwoTargetsCommand extends Command
             ->addOption('entry', null, InputOption::VALUE_REQUIRED, 'Prix d\'entrée moyen (sinon lu depuis Position)')
             ->addOption('size', null, InputOption::VALUE_REQUIRED, 'Taille (contrats), sinon depuis Position')
             ->addOption('r', null, InputOption::VALUE_REQUIRED, 'R multiple pour TP1', '2.0')
-            ->addOption('split', null, InputOption::VALUE_REQUIRED, 'Fraction du size sur TP1 (0..1)', '0.5')
+            ->addOption('split', null, InputOption::VALUE_REQUIRED, 'Fraction du size sur TP1 (0..1)')
             ->addOption('keep-sl', null, InputOption::VALUE_NONE, 'Ne pas annuler SL existant même si différent')
             ->addOption('keep-tp', null, InputOption::VALUE_NONE, 'Ne pas annuler TP existants')
         ;
@@ -49,13 +49,14 @@ final class TradeTpSlTwoTargetsCommand extends Command
 
         $entry = $input->getOption('entry');
         $size = $input->getOption('size');
+        $split = $input->getOption('split');
         $dto = new TpSlTwoTargetsRequest(
             symbol: $symbol,
             side: $side,
             entryPrice: $entry !== null ? (float)$entry : null,
             size: $size !== null ? (int)$size : null,
             rMultiple: (float)$input->getOption('r'),
-            splitPct: (float)$input->getOption('split'),
+            splitPct: $split !== null ? (float)$split : null,
             cancelExistingStopLossIfDifferent: !$input->getOption('keep-sl'),
             cancelExistingTakeProfits: !$input->getOption('keep-tp'),
         );

--- a/trading-app/src/Controller/TradeTpSlController.php
+++ b/trading-app/src/Controller/TradeTpSlController.php
@@ -49,7 +49,7 @@ final class TradeTpSlController extends AbstractController
             entryPrice: isset($data['entry_price']) ? (float)$data['entry_price'] : null,
             size: isset($data['size']) ? (int)$data['size'] : null,
             rMultiple: isset($data['r_multiple']) ? (float)$data['r_multiple'] : null,
-            splitPct: isset($data['split_pct']) ? (float)$data['split_pct'] : 0.5,
+            splitPct: isset($data['split_pct']) ? (float)$data['split_pct'] : null,
             cancelExistingStopLossIfDifferent: isset($data['cancel_sl_if_diff']) ? (bool)$data['cancel_sl_if_diff'] : true,
             cancelExistingTakeProfits: isset($data['cancel_tp']) ? (bool)$data['cancel_tp'] : true,
             momentum: isset($data['momentum']) ? (string)$data['momentum'] : null,

--- a/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
@@ -13,7 +13,7 @@ final class TpSlTwoTargetsRequest
         public readonly ?float $entryPrice = null,
         public readonly ?int $size = null,
         public readonly ?float $rMultiple = null,
-        public readonly ?float $splitPct = 0.5,
+        public readonly ?float $splitPct = null,
         public readonly ?bool $cancelExistingStopLossIfDifferent = true,
         public readonly ?bool $cancelExistingTakeProfits = true,
         // Hints to drive TpSplitResolver (optional)


### PR DESCRIPTION
## Summary
- allow TpSlTwoTargetsRequest::splitPct to default to null so the resolver can run
- update HTTP controller and CLI command to stop forcing a 50/50 split when the field is omitted
- keep a service-side fallback of 50% for callers that provide no ratio and have no resolver

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690961631c34832494af2dd03a887965