### PR TITLE
Refactor MTF CLI and tests for new validator contracts

### DIFF
--- a/trading-app/docs/MTF_MIGRATION_CHECKLIST.md
+++ b/trading-app/docs/MTF_MIGRATION_CHECKLIST.md
@@ -1,0 +1,25 @@
+# Checklist de migration MTF (Contrats 2024)
+
+Cette checklist permet à l'équipe de valider la bascule vers le nouveau `MtfValidatorInterface`.
+
+## 1. Contrats & dépendances
+- [ ] Remplacer les injections de `MtfRunService` par `MtfValidatorInterface` côté CLI, contrôleurs et workers
+- [ ] Propager les nouveaux champs `skip_context`, `lock_per_symbol`, `user_id`, `ip_address` dans les appels contractuels
+- [ ] Vérifier que les intégrations tierces (Temporal, API REST) consomment `MtfRunRequestDto` / `MtfRunResponseDto`
+- [ ] Mettre à jour les alias/arguments dans `services.yaml` pour garantir l'autowiring façade → orchestrateur → décision
+
+## 2. Tests
+- [ ] Exécuter `php bin/phpunit --testsuite=unit` pour valider les nouveaux tests DTO/stratégie/pipeline
+- [ ] Exécuter `php bin/phpunit --testsuite=integration --filter=MtfValidatorAutowiring` pour vérifier l'autowiring complet
+- [ ] Ajouter des cas de non-régression dans les suites métiers (Temporal / API) en utilisant la nouvelle réponse contractuelle
+
+## 3. Monitoring & observabilité
+- [ ] Créer/adapter les dashboards Kibana/Grafana pour les champs `decision_key`, `user_id`, `ip_address`
+- [ ] Vérifier la présence des logs `order_journey.*` et `positions_flow` pour chaque run MTF
+- [ ] Mettre à jour les alertes (PagerDuty, OpsGenie…) avec les nouveaux statuts (`global_switch_off`, `lock_acquisition_failed`, `no_active_symbols`)
+- [ ] S'assurer que la désactivation auto des symboles (switch 15 minutes) est surveillée côté BDD
+
+## 4. Opérations
+- [ ] Documenter les nouveaux flags CLI (`--lock-per-symbol`, `--user-id`, `--ip-address`)
+- [ ] Former l'équipe support sur le nouveau découpage Application / Infrastructure et les journaux associés
+- [ ] Planifier un rollback (variables d'environnement, feature switches) en cas de régression

--- a/trading-app/docs/MTF_RUN_API.md
+++ b/trading-app/docs/MTF_RUN_API.md
@@ -17,6 +17,12 @@ Cet endpoint exécute manuellement la logique MTF complète en bouclant sur les 
 | `symbols` | array | Non | `['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'SOLUSDT', 'DOTUSDT']` | Liste des symboles à traiter |
 | `dry_run` | boolean | Non | `true` | Mode dry-run (pas de création d'order plans) |
 | `force_run` | boolean | Non | `false` | Forcer l'exécution même si les kill switches sont OFF |
+| `current_tf` | string | Non | `null` | Limiter à un timeframe (`4h`, `1h`, `15m`, `5m`, `1m`) |
+| `force_timeframe_check` | boolean | Non | `false` | Forcer la revalidation même si la dernière kline est fraîche |
+| `skip_context` | boolean | Non | `false` | Bypasser l'alignement de contexte sur les TF d'exécution |
+| `lock_per_symbol` | boolean | Non | `false` | Utiliser un verrou par symbole (utile pour des runs unitaires) |
+| `user_id` | string | Non | `null` | Identifiant métier propagé aux audits/Logs |
+| `ip_address` | string | Non | `null` | IP d'origine pour l'audit |
 
 ### Exemple de requête
 
@@ -26,7 +32,12 @@ curl -X POST http://localhost:8082/api/mtf/run \
   -d '{
     "symbols": ["BTCUSDT", "ETHUSDT"],
     "dry_run": true,
-    "force_run": false
+    "force_run": false,
+    "current_tf": "1h",
+    "force_timeframe_check": true,
+    "lock_per_symbol": true,
+    "user_id": "ops-squad",
+    "ip_address": "192.168.0.15"
   }'
 ```
 

--- a/trading-app/src/MtfValidator/README_REFACTORED_ARCHITECTURE.md
+++ b/trading-app/src/MtfValidator/README_REFACTORED_ARCHITECTURE.md
@@ -141,6 +141,15 @@ class LockManager implements LockManagerInterface
 {
     // Implémentation
 }
+
+// Agrégation des processeurs de timeframe via AutowireIterator
+class MyTimeframeRegistry
+{
+    public function __construct(
+        #[AutowireIterator('app.mtf.timeframe.processor')]
+        private iterable $processors,
+    ) {}
+}
 ```
 
 ## Migration

--- a/trading-app/tests/MtfValidator/Integration/MtfValidatorAutowiringTest.php
+++ b/trading-app/tests/MtfValidator/Integration/MtfValidatorAutowiringTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfValidator\Integration;
+
+use App\Contract\MtfValidator\MtfValidatorInterface;
+use App\Contract\MtfValidator\TimeframeProcessorInterface;
+use App\MtfValidator\Service\MtfRunService;
+use App\MtfValidator\Service\Runner\MtfRunOrchestrator;
+use App\MtfValidator\Service\SymbolProcessor;
+use App\MtfValidator\Service\TradingDecisionHandler;
+use App\MtfValidator\Service\Timeframe\Timeframe15mService;
+use App\MtfValidator\Service\Timeframe\Timeframe1hService;
+use App\MtfValidator\Service\Timeframe\Timeframe1mService;
+use App\MtfValidator\Service\Timeframe\Timeframe4hService;
+use App\MtfValidator\Service\Timeframe\Timeframe5mService;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class MtfValidatorAutowiringTest extends KernelTestCase
+{
+    public function testFacadePipelineAndDecisionAreAutowired(): void
+    {
+        self::bootKernel();
+        $container = self::getContainer();
+
+        $facade = $container->get(MtfValidatorInterface::class);
+        $this->assertInstanceOf(MtfRunService::class, $facade);
+
+        $orchestrator = $container->get(MtfRunOrchestrator::class);
+        $symbolProcessor = $container->get(SymbolProcessor::class);
+        $decisionHandler = $container->get(TradingDecisionHandler::class);
+
+        $this->assertInstanceOf(SymbolProcessor::class, $this->readProperty($orchestrator, 'symbolProcessor'));
+        $this->assertInstanceOf(TradingDecisionHandler::class, $this->readProperty($orchestrator, 'tradingDecisionHandler'));
+        $this->assertSame($symbolProcessor, $this->readProperty($orchestrator, 'symbolProcessor'));
+        $this->assertSame($decisionHandler, $this->readProperty($orchestrator, 'tradingDecisionHandler'));
+
+        $this->assertInstanceOf(MtfRunOrchestrator::class, $this->readProperty($facade, 'orchestrator'));
+
+        foreach ([
+            Timeframe4hService::class,
+            Timeframe1hService::class,
+            Timeframe15mService::class,
+            Timeframe5mService::class,
+            Timeframe1mService::class,
+        ] as $serviceClass) {
+            $processor = $container->get($serviceClass);
+            $this->assertInstanceOf(TimeframeProcessorInterface::class, $processor);
+        }
+    }
+
+    private function readProperty(object $object, string $property): mixed
+    {
+        $ref = new \ReflectionProperty($object, $property);
+        $ref->setAccessible(true);
+
+        return $ref->getValue($object);
+    }
+}

--- a/trading-app/tests/MtfValidator/Service/Dto/DtoMapperTest.php
+++ b/trading-app/tests/MtfValidator/Service/Dto/DtoMapperTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfValidator\Service\Dto;
+
+use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
+use App\Contract\MtfValidator\Dto\TimeframeResultDto;
+use App\Contract\MtfValidator\Dto\ValidationContextDto;
+use App\MtfValidator\Service\Dto\InternalMtfRunDto;
+use App\MtfValidator\Service\Dto\InternalTimeframeResultDto;
+use App\MtfValidator\Service\Dto\ProcessingContextDto;
+use App\MtfValidator\Service\Dto\RunSummaryDto;
+use App\MtfValidator\Service\Dto\SymbolResultDto;
+use PHPUnit\Framework\TestCase;
+
+final class DtoMapperTest extends TestCase
+{
+    public function testInternalMtfRunDtoMapping(): void
+    {
+        $request = new MtfRunRequestDto(
+            symbols: ['BTCUSDT'],
+            dryRun: true,
+            forceRun: false,
+            currentTf: '1h',
+            forceTimeframeCheck: true,
+            skipContextValidation: true,
+            lockPerSymbol: true,
+            userId: 'user42',
+            ipAddress: '10.0.0.1'
+        );
+
+        $internal = InternalMtfRunDto::fromContractRequest('run-123', $request);
+        $this->assertSame('run-123', $internal->runId);
+        $this->assertSame(['BTCUSDT'], $internal->symbols);
+        $this->assertTrue($internal->dryRun);
+        $this->assertTrue($internal->forceTimeframeCheck);
+        $this->assertTrue($internal->lockPerSymbol);
+        $this->assertSame('user42', $internal->userId);
+        $this->assertSame('10.0.0.1', $internal->ipAddress);
+
+        $array = $internal->toArray();
+        $this->assertSame('run-123', $array['run_id']);
+        $this->assertSame(['BTCUSDT'], $array['symbols']);
+        $this->assertSame('user42', $array['user_id']);
+        $this->assertSame('10.0.0.1', $array['ip_address']);
+    }
+
+    public function testInternalTimeframeResultDtoMapping(): void
+    {
+        $internal = new InternalTimeframeResultDto(
+            timeframe: '1h',
+            status: 'VALID',
+            signalSide: 'LONG',
+            klineTime: '2024-01-01 12:00:00',
+            currentPrice: 42000.0,
+            atr: 250.0,
+            indicatorContext: ['macd' => ['hist' => 0.5]],
+            conditionsLong: ['condA'],
+            conditionsShort: [],
+            failedConditionsLong: [],
+            failedConditionsShort: [],
+            reason: null,
+            error: null,
+            metadata: ['from_cache' => true]
+        );
+
+        $contract = $internal->toContractDto();
+        $this->assertInstanceOf(TimeframeResultDto::class, $contract);
+        $this->assertSame('1h', $contract->timeframe);
+        $this->assertSame('VALID', $contract->status);
+        $this->assertSame('LONG', $contract->signalSide);
+
+        $array = $internal->toArray();
+        $this->assertSame('1h', $array['timeframe']);
+        $this->assertSame(42000.0, $array['current_price']);
+        $this->assertSame(['macd' => ['hist' => 0.5]], $array['indicator_context']);
+        $this->assertSame(['from_cache' => true], $array['metadata']);
+    }
+
+    public function testProcessingContextDtoMapping(): void
+    {
+        $contract = new ValidationContextDto(
+            runId: 'run-456',
+            now: new \DateTimeImmutable('2024-01-01 00:00:00'),
+            collector: [['tf' => '4h', 'signal_side' => 'LONG']],
+            forceTimeframeCheck: true,
+            forceRun: false,
+            skipContextValidation: true,
+            userId: 'user',
+            ipAddress: '127.0.0.1'
+        );
+
+        $internal = ProcessingContextDto::fromContractContext('BTCUSDT', $contract);
+        $this->assertSame('BTCUSDT', $internal->symbol);
+        $this->assertTrue($internal->skipContextValidation);
+
+        $backToContract = $internal->toContractContext();
+        $this->assertInstanceOf(ValidationContextDto::class, $backToContract);
+        $this->assertSame('run-456', $backToContract->runId);
+        $this->assertSame('127.0.0.1', $backToContract->ipAddress);
+    }
+
+    public function testSymbolResultDtoHelpers(): void
+    {
+        $dto = new SymbolResultDto(
+            symbol: 'BTCUSDT',
+            status: 'SUCCESS',
+            executionTf: '1m',
+            signalSide: 'LONG',
+            tradingDecision: ['status' => 'ok'],
+            error: null,
+            context: ['trend' => 'bull'],
+            currentPrice: 40000.0,
+            atr: 150.0
+        );
+
+        $this->assertTrue($dto->isSuccess());
+        $this->assertFalse($dto->isError());
+        $this->assertFalse($dto->isSkipped());
+        $this->assertTrue($dto->hasTradingDecision());
+
+        $array = $dto->toArray();
+        $this->assertSame('BTCUSDT', $array['symbol']);
+        $this->assertSame('1m', $array['execution_tf']);
+        $this->assertSame(['status' => 'ok'], $array['trading_decision']);
+    }
+
+    public function testRunSummaryDtoMapping(): void
+    {
+        $now = new \DateTimeImmutable('2024-01-01 12:00:00');
+        $summary = new RunSummaryDto(
+            runId: 'run-789',
+            executionTimeSeconds: 1.234,
+            symbolsRequested: 2,
+            symbolsProcessed: 2,
+            symbolsSuccessful: 1,
+            symbolsFailed: 1,
+            symbolsSkipped: 0,
+            successRate: 50.0,
+            dryRun: false,
+            forceRun: true,
+            currentTf: '1h',
+            timestamp: $now,
+            status: 'completed'
+        );
+
+        $this->assertTrue($summary->isCompleted());
+        $this->assertSame(2, $summary->getProcessedSymbols());
+
+        $array = $summary->toArray();
+        $this->assertSame('run-789', $array['run_id']);
+        $this->assertSame('1h', $array['current_tf']);
+        $this->assertSame('2024-01-01 12:00:00', $array['timestamp']);
+    }
+}

--- a/trading-app/tests/MtfValidator/Service/SymbolProcessorTest.php
+++ b/trading-app/tests/MtfValidator/Service/SymbolProcessorTest.php
@@ -231,7 +231,12 @@ class SymbolProcessorTest extends TestCase
 }
 
     /**
-     * @param array<int,array<string,mixed>> $yields
+     * Creates a generator for testing purposes that yields each value in the provided array,
+     * and then returns the specified final result.
+     *
+     * @param array<int,array<string,mixed>> $yields Array of values to yield from the generator.
+     * @param mixed $return The final value to return when the generator is exhausted.
+     * @return \Generator Yields each value in $yields and returns $return.
      */
     private function createGenerator(array $yields, mixed $return): \Generator
     {

--- a/trading-app/tests/MtfValidator/Service/SymbolProcessorTest.php
+++ b/trading-app/tests/MtfValidator/Service/SymbolProcessorTest.php
@@ -19,17 +19,20 @@ class SymbolProcessorTest extends TestCase
     private MtfService $mtfService;
     private LoggerInterface $logger;
     private ClockInterface $clock;
+    private LoggerInterface $orderJourneyLogger;
 
     protected function setUp(): void
     {
         $this->mtfService = $this->createMock(MtfService::class);
         $this->logger = $this->createMock(LoggerInterface::class);
         $this->clock = $this->createMock(ClockInterface::class);
-        
+        $this->orderJourneyLogger = $this->createMock(LoggerInterface::class);
+
         $this->symbolProcessor = new SymbolProcessor(
             $this->mtfService,
             $this->logger,
-            $this->clock
+            $this->clock,
+            $this->orderJourneyLogger
         );
     }
 
@@ -48,15 +51,10 @@ class SymbolProcessorTest extends TestCase
             'atr' => 100.0
         ];
 
-        $generator = $this->createMock(\Generator::class);
-        $generator->expects($this->once())
-            ->method('getReturn')
-            ->willReturn($mtfResult);
-
         $this->mtfService->expects($this->once())
             ->method('runForSymbol')
-            ->with($runId, $symbol, $now, null, false, false)
-            ->willReturn($generator);
+            ->with($runId, $symbol, $now, null, false, false, false)
+            ->willReturn($this->createGenerator([['result' => $mtfResult]], $mtfResult));
 
         $this->logger->expects($this->once())
             ->method('debug')
@@ -107,14 +105,9 @@ class SymbolProcessorTest extends TestCase
         $dto = new MtfRunDto(symbols: [$symbol]);
         $now = new \DateTimeImmutable('2024-01-01 12:00:00');
 
-        $generator = $this->createMock(\Generator::class);
-        $generator->expects($this->once())
-            ->method('getReturn')
-            ->willReturn(null);
-
         $this->mtfService->expects($this->once())
             ->method('runForSymbol')
-            ->willReturn($generator);
+            ->willReturn($this->createGenerator([], null));
 
         $result = $this->symbolProcessor->processSymbol($symbol, $runId, $dto, $now);
 
@@ -132,15 +125,10 @@ class SymbolProcessorTest extends TestCase
         $dto = new MtfRunDto(symbols: [$symbol], forceRun: true);
         $now = new \DateTimeImmutable('2024-01-01 12:00:00');
 
-        $generator = $this->createMock(\Generator::class);
-        $generator->expects($this->once())
-            ->method('getReturn')
-            ->willReturn(['status' => 'SUCCESS']);
-
         $this->mtfService->expects($this->once())
             ->method('runForSymbol')
-            ->with($runId, $symbol, $now, null, false, true)
-            ->willReturn($generator);
+            ->with($runId, $symbol, $now, null, false, true, false)
+            ->willReturn($this->createGenerator([['result' => ['status' => 'SUCCESS']]], ['status' => 'SUCCESS']));
 
         $result = $this->symbolProcessor->processSymbol($symbol, $runId, $dto, $now);
 
@@ -155,15 +143,10 @@ class SymbolProcessorTest extends TestCase
         $dto = new MtfRunDto(symbols: [$symbol], forceTimeframeCheck: true);
         $now = new \DateTimeImmutable('2024-01-01 12:00:00');
 
-        $generator = $this->createMock(\Generator::class);
-        $generator->expects($this->once())
-            ->method('getReturn')
-            ->willReturn(['status' => 'SUCCESS']);
-
         $this->mtfService->expects($this->once())
             ->method('runForSymbol')
-            ->with($runId, $symbol, $now, null, true, false)
-            ->willReturn($generator);
+            ->with($runId, $symbol, $now, null, true, false, false)
+            ->willReturn($this->createGenerator([['result' => ['status' => 'SUCCESS']]], ['status' => 'SUCCESS']));
 
         $result = $this->symbolProcessor->processSymbol($symbol, $runId, $dto, $now);
 
@@ -178,15 +161,10 @@ class SymbolProcessorTest extends TestCase
         $dto = new MtfRunDto(symbols: [$symbol], currentTf: '1h');
         $now = new \DateTimeImmutable('2024-01-01 12:00:00');
 
-        $generator = $this->createMock(\Generator::class);
-        $generator->expects($this->once())
-            ->method('getReturn')
-            ->willReturn(['status' => 'SUCCESS']);
-
         $this->mtfService->expects($this->once())
             ->method('runForSymbol')
-            ->with($runId, $symbol, $now, '1h', false, false)
-            ->willReturn($generator);
+            ->with($runId, $symbol, $now, '1h', false, false, false)
+            ->willReturn($this->createGenerator([['result' => ['status' => 'SUCCESS']]], ['status' => 'SUCCESS']));
 
         $result = $this->symbolProcessor->processSymbol($symbol, $runId, $dto, $now);
 
@@ -201,14 +179,9 @@ class SymbolProcessorTest extends TestCase
         $dto = new MtfRunDto(symbols: [$symbol], forceRun: true, forceTimeframeCheck: true);
         $now = new \DateTimeImmutable('2024-01-01 12:00:00');
 
-        $generator = $this->createMock(\Generator::class);
-        $generator->expects($this->once())
-            ->method('getReturn')
-            ->willReturn(['status' => 'SUCCESS']);
-
         $this->mtfService->expects($this->once())
             ->method('runForSymbol')
-            ->willReturn($generator);
+            ->willReturn($this->createGenerator([['result' => ['status' => 'SUCCESS']]], ['status' => 'SUCCESS']));
 
         $this->logger->expects($this->once())
             ->method('debug')
@@ -241,14 +214,9 @@ class SymbolProcessorTest extends TestCase
             'trading_decision' => ['status' => 'pending']
         ];
 
-        $generator = $this->createMock(\Generator::class);
-        $generator->expects($this->once())
-            ->method('getReturn')
-            ->willReturn($mtfResult);
-
         $this->mtfService->expects($this->once())
             ->method('runForSymbol')
-            ->willReturn($generator);
+            ->willReturn($this->createGenerator([['result' => $mtfResult]], $mtfResult));
 
         $result = $this->symbolProcessor->processSymbol($symbol, $runId, $dto, $now);
 
@@ -260,5 +228,17 @@ class SymbolProcessorTest extends TestCase
         $this->assertEquals(150.0, $result->atr);
         $this->assertEquals(['trend' => 'bearish'], $result->context);
         $this->assertEquals(['status' => 'pending'], $result->tradingDecision);
+}
+
+    /**
+     * @param array<int,array<string,mixed>> $yields
+     */
+    private function createGenerator(array $yields, mixed $return): \Generator
+    {
+        foreach ($yields as $yield) {
+            yield $yield;
+        }
+
+        return $return;
     }
 }

--- a/trading-app/tests/MtfValidator/Strategy/HighConvictionValidationTest.php
+++ b/trading-app/tests/MtfValidator/Strategy/HighConvictionValidationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfValidator\Strategy;
+
+use App\MtfValidator\Strategy\HighConvictionValidation;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class HighConvictionValidationTest extends TestCase
+{
+    public function testValidateReturnsOkWhenAllConditionsMet(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $strategy = new HighConvictionValidation($logger);
+
+        $ctx = [
+            '4h' => ['signal' => 'LONG', 'ema_fast' => 10, 'ema_slow' => 9, 'macd' => ['hist' => 1.2]],
+            '1h' => ['signal' => 'LONG', 'ema_fast' => 11, 'ema_slow' => 9, 'macd' => ['hist' => 1.1]],
+            '15m' => ['signal' => 'LONG', 'ema_fast' => 12, 'ema_slow' => 10, 'macd' => ['hist' => 1.0], 'vwap' => 100, 'close' => 101],
+            '5m' => ['signal' => 'LONG', 'ema_fast' => 13, 'ema_slow' => 11, 'macd' => ['hist' => 0.9], 'vwap' => 100, 'close' => 101],
+            '1m' => ['signal' => 'LONG', 'ema_fast' => 14, 'ema_slow' => 12, 'macd' => ['hist' => 0.8], 'vwap' => 100, 'close' => 101],
+        ];
+        $metrics = [
+            'adx_1h' => 30.0,
+            'adx_15m' => 35.0,
+            'breakout_confirmed' => true,
+            'macro_no_event' => true,
+            'valid_retest' => true,
+            'rr' => 2.5,
+            'liq_ratio' => 4.0,
+        ];
+
+        $result = $strategy->validate($ctx, $metrics);
+
+        $this->assertTrue($result['ok']);
+        $this->assertArrayHasKey('flags', $result);
+        $this->assertTrue($result['flags']['high_conviction']);
+    }
+
+    public function testValidateReturnsReasonsWhenChecksFail(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $strategy = new HighConvictionValidation($logger);
+
+        $ctx = [
+            '4h' => ['signal' => 'SHORT', 'ema_fast' => 9, 'ema_slow' => 10, 'macd' => ['hist' => -0.2]],
+            '1h' => ['signal' => 'LONG', 'ema_fast' => 9, 'ema_slow' => 10, 'macd' => ['hist' => -0.2]],
+            '15m' => ['signal' => 'SHORT', 'ema_fast' => 8, 'ema_slow' => 10, 'macd' => ['hist' => -0.5], 'vwap' => 100, 'close' => 99],
+            '5m' => ['signal' => 'SHORT', 'ema_fast' => 7, 'ema_slow' => 10, 'macd' => ['hist' => -0.6], 'vwap' => 100, 'close' => 99],
+            '1m' => ['signal' => 'SHORT', 'ema_fast' => 6, 'ema_slow' => 10, 'macd' => ['hist' => -0.8], 'vwap' => 100, 'close' => 99],
+        ];
+        $metrics = [
+            'adx_1h' => 10.0,
+            'adx_15m' => 8.0,
+            'breakout_confirmed' => false,
+            'macro_no_event' => false,
+            'valid_retest' => false,
+            'rr' => 1.0,
+            'liq_ratio' => 1.5,
+        ];
+
+        $result = $strategy->validate($ctx, $metrics);
+
+        $this->assertFalse($result['ok']);
+        $this->assertContains('multi_timeframe_alignment', $result['reasons']);
+        $this->assertContains('trend_strength_insufficient', $result['reasons']);
+        $this->assertContains('breakout_with_volume_not_confirmed', $result['reasons']);
+        $this->assertContains('macro_event_veto', $result['reasons']);
+        $this->assertContains('rr_guard', $result['reasons']);
+        $this->assertContains('liquidation_guard', $result['reasons']);
+    }
+}


### PR DESCRIPTION
## Summary
- align the mtf:run and mtf:run-worker commands with the new MtfValidatorInterface request/response workflow and expose the extra runtime flags
- refresh the MtfValidator usage example and operational documentation with the application/infrastructure split, decision-flow diagrams, and a migration checklist
- add unit tests for DTO mappers, timeframe strategy and pipeline plus a KernelTestCase autowiring integration test

## Testing
- php -l trading-app/tests/MtfValidator/Service/Dto/DtoMapperTest.php
- php -l trading-app/tests/MtfValidator/Strategy/HighConvictionValidationTest.php
- php -l trading-app/tests/MtfValidator/Integration/MtfValidatorAutowiringTest.php
- php bin/phpunit --testsuite=unit *(fails: vendor not installed because Composer requires GitHub token/redis extension)*

------
https://chatgpt.com/codex/tasks/task_e_690a900be2288324ac494606f8b6af49