### PR TITLE
Fix MTF run summary aggregation

### DIFF
--- a/trading-app/src/MtfValidator/Service/Metrics/RunMetricsAggregator.php
+++ b/trading-app/src/MtfValidator/Service/Metrics/RunMetricsAggregator.php
@@ -6,7 +6,7 @@ namespace App\MtfValidator\Service\Metrics;
 
 use App\Contract\MtfValidator\Dto\MtfRunDto;
 use App\Contract\Runtime\AuditLoggerInterface;
-use App\MtfValidator\Service\Dto\RunSummaryDto;
+use App\MtfValidator\Service\Dto\Internal\InternalRunSummaryDto;
 use App\MtfValidator\Service\Dto\SymbolResultDto;
 use App\TradeEntry\Dto\ExecutionResult;
 use App\TradeEntry\Dto\TradeEntryRequest;
@@ -258,9 +258,9 @@ final class RunMetricsAggregator
         }
     }
 
-    public function completeRun(float $durationSeconds): RunSummaryDto
+    public function completeRun(float $durationSeconds): InternalRunSummaryDto
     {
-        $summary = new RunSummaryDto(
+        $summary = new InternalRunSummaryDto(
             runId: $this->currentRunId ?? 'unknown',
             executionTimeSeconds: round($durationSeconds, 3),
             symbolsRequested: $this->requestedSymbols,
@@ -295,12 +295,12 @@ final class RunMetricsAggregator
         return $summary;
     }
 
-    public function completeWithStatus(string $status, float $durationSeconds): RunSummaryDto
+    public function completeWithStatus(string $status, float $durationSeconds): InternalRunSummaryDto
     {
-        $summary = new RunSummaryDto(
+        $summary = new InternalRunSummaryDto(
             runId: $this->currentRunId ?? 'unknown',
             executionTimeSeconds: round($durationSeconds, 3),
-            symbolsRequested: 0,
+            symbolsRequested: $this->requestedSymbols,
             symbolsProcessed: 0,
             symbolsSuccessful: 0,
             symbolsFailed: 0,

--- a/trading-app/src/MtfValidator/Service/Runner/MtfRunOrchestrator.php
+++ b/trading-app/src/MtfValidator/Service/Runner/MtfRunOrchestrator.php
@@ -7,18 +7,13 @@ namespace App\MtfValidator\Service\Runner;
 use App\Contract\MtfValidator\Dto\MtfRunDto;
 use App\Contract\Runtime\FeatureSwitchInterface;
 use App\Contract\Runtime\LockManagerInterface;
-use App\Config\MtfValidationConfig;
 use App\MtfValidator\Service\Dto\Internal\InternalRunSummaryDto;
-use App\MtfValidator\Service\Dto\MtfRunResultDto;
-use App\MtfValidator\Service\Dto\SymbolResultDto;
 use App\MtfValidator\Service\SymbolProcessor;
 use App\MtfValidator\Service\TradingDecisionHandler;
-use App\MtfValidator\Service\Dto\SymbolResultDto;
 use App\MtfValidator\Service\Metrics\RunMetricsAggregator;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Orchestrateur principal pour l'exécution des cycles MTF


### PR DESCRIPTION
## Summary
- replace the nonexistent RunSummaryDto type with InternalRunSummaryDto in RunMetricsAggregator
- ensure blocked runs report the requested symbol count and clean up unused orchestrator imports

## Testing
- php -l trading-app/src/MtfValidator/Service/Metrics/RunMetricsAggregator.php
- php -l trading-app/src/MtfValidator/Service/Runner/MtfRunOrchestrator.php

------
https://chatgpt.com/codex/tasks/task_e_690af8dfe0b48324a543ccbb6d645dfc