### PR TITLE
Document ExecutionSelector config fallback behavior

### DIFF
--- a/trading-app/src/MtfValidator/Execution/ExecutionSelector.php
+++ b/trading-app/src/MtfValidator/Execution/ExecutionSelector.php
@@ -22,7 +22,8 @@ final class ExecutionSelector
      */
     public function decide(array $context): ExecutionDecision
     {
-        // Utiliser le config dynamique depuis ConditionRegistry si disponible, sinon fallback sur le config statique
+        // Use the dynamic config from ConditionRegistry if available; otherwise, fall back to the static config provided
+        // at construction. This fallback is intentional and applies in all cases, not just during initialization.
         $activeConfig = $this->registry->getCurrentConfig() ?? $this->mtfConfig;
         $cfg = $activeConfig->getConfig();
         $selector = (array)($cfg['execution_selector'] ?? []);


### PR DESCRIPTION
## Summary
- document why ExecutionSelector falls back to the constructor-provided configuration when the registry has no active config

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912775ef8b88324ac0d58f55bb0d094)