### PR TITLE
Handle missing enabled MTF modes

### DIFF
--- a/trading-app/src/MtfValidator/Service/MtfService.php
+++ b/trading-app/src/MtfValidator/Service/MtfService.php
@@ -1629,8 +1629,10 @@ private function processSymbol(string $symbol, UuidInterface $runId, \DateTimeIm
         $enabledModes = $this->mtfValidationConfigProvider->getEnabledModes();
         
         if (empty($enabledModes)) {
-            $this->logger->warning('[MTF] No enabled modes found, using default config', ['symbol' => $symbol]);
-            return $this->processSymbol($symbol, $runId, $now, $currentTf, $forceTimeframeCheck, $forceRun, $skipContextValidation);
+            throw new \RuntimeException(sprintf(
+                '[MTF] No enabled modes found for symbol "%s". This is likely a configuration error.',
+                $symbol
+            ));
         }
 
         $lastError = null;


### PR DESCRIPTION
## Summary
- throw an exception when no enabled modes are available during MTF symbol processing to surface configuration errors

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691277696ee4832488e42adedfd1293e)