### PR TITLE
Add PHPDoc for Bitmart cancelAllAfter method

### DIFF
--- a/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
@@ -602,7 +602,19 @@ final class BitmartOrderProvider implements OrderProviderInterface
     }
 
     /**
-     * Programme l'annulation automatique des ordres après un délai (cancel-all-after).
+     * Schedule the Bitmart auto-cancel mechanism (cancel-all-after) for all open orders on a symbol.
+     *
+     * Bitmart expects the timeout in seconds and returns a payload containing a numeric `code` field. A
+     * value of 1000 indicates the request was accepted; any other value represents a failure that should be
+     * logged for further investigation.
+     *
+     * @param string $symbol         The trading pair identifier (e.g. BTC_USDT) for which open orders must be
+     *                               cancelled after the timeout elapses.
+     * @param int    $timeoutSeconds Number of seconds before Bitmart automatically cancels all outstanding
+     *                               orders for the provided symbol.
+     *
+     * @return bool Returns true when Bitmart acknowledges the scheduling request (response code 1000), false
+     *              otherwise.
      */
     public function cancelAllAfter(string $symbol, int $timeoutSeconds): bool
     {


### PR DESCRIPTION
## Summary
- add a detailed PHPDoc block for BitmartOrderProvider::cancelAllAfter
- document parameters, expected timeout units, and the success response code from Bitmart

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912776ffefc832485a8dd7a2b2a4cc8)