### PR TITLE
Refactor MTF runner architecture boundaries

### DIFF
--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -93,10 +93,12 @@ services:
 
     # Service Redis réel pour OrderWatcherPublisher (Pub/Sub)
     App\Provider\Redis\RedisPubSubClient:
-        class: Redis
+        class: App\Provider\Redis\RedisPubSubClient
         public: true
-        calls:
-            - [connect, ['%env(string:REDIS_HOST)%', '%env(int:REDIS_PORT)%']]
+        arguments:
+            $host: '%env(string:REDIS_HOST)%'
+            $port: '%env(int:REDIS_PORT)%'
+            $logger: '@monolog.logger.bitmart'
         tags:
             - { name: 'container.hot_path' }
 
@@ -142,8 +144,6 @@ services:
             $lockFactory: '@bitmart.throttle_lock_factory'
             $projectDir: '%kernel.project_dir%'
         public: true
-
-    App\Domain\Ports\Out\TradingProviderPort: '@App\Infrastructure\Trading\BitmartTradingProvider'
 
     # --- Exchange provider registry ---
 

--- a/trading-app/src/Controller/RunnerController.php
+++ b/trading-app/src/Controller/RunnerController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Config\TradeEntryModeContext;
+use App\MtfRunner\Application\RunMtfCycleUseCase;
 use App\MtfRunner\Dto\MtfRunnerRequestDto;
-use App\MtfRunner\Service\MtfRunnerService;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,7 +26,7 @@ class RunnerController extends AbstractController
 //    #[Route('/runner')]
     public function index(
         Request $request,
-        MtfRunnerService $mtfRunnerService,
+        RunMtfCycleUseCase $runMtfCycle,
     ): JsonResponse
     {
         $apiStartTime = microtime(true);
@@ -100,7 +100,7 @@ class RunnerController extends AbstractController
                 'context_mode' => $data['context_mode'] ?? null,
                 'mode' => $data['mode'] ?? null,
             ]);
-            $result = $mtfRunnerService->run($runnerRequest);
+            $result = $runMtfCycle->run($runnerRequest);
 
             // Le résultat est déjà enrichi par MtfRunnerService
             $results = $result['results'] ?? [];

--- a/trading-app/src/MtfRunner/Application/Projection/IndicatorSnapshotPersistenceDispatcher.php
+++ b/trading-app/src/MtfRunner/Application/Projection/IndicatorSnapshotPersistenceDispatcher.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MtfRunner\Application\Projection;
+
+use App\Contract\MtfValidator\MtfValidatorInterface;
+use App\Indicator\Message\IndicatorSnapshotPersistRequestMessage;
+use App\MtfRunner\Dto\MtfRunnerRequestDto;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class IndicatorSnapshotPersistenceDispatcher
+{
+    public function __construct(
+        private readonly MtfValidatorInterface $mtfValidator,
+        private readonly MessageBusInterface $messageBus,
+        private readonly ClockInterface $clock,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string,mixed> $results
+     */
+    public function dispatch(array $results, MtfRunnerRequestDto $request, string $runId): void
+    {
+        $timeframes = $this->resolveTimeframes($request);
+        if ($timeframes === []) {
+            return;
+        }
+
+        $symbols = [];
+        foreach (array_keys($results) as $symbol) {
+            if (!\is_string($symbol) || $symbol === '' || strtoupper($symbol) === 'FINAL') {
+                continue;
+            }
+            $symbols[] = strtoupper($symbol);
+        }
+
+        if ($symbols === []) {
+            return;
+        }
+
+        try {
+            $this->messageBus->dispatch(new IndicatorSnapshotPersistRequestMessage(
+                $symbols,
+                $timeframes,
+                $runId,
+                $request->profile,
+                $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+            ));
+
+            $this->logger->debug('[MTF Runner] Indicator persistence dispatched', [
+                'run_id' => $runId,
+                'symbols_count' => count($symbols),
+                'timeframes' => $timeframes,
+            ]);
+        } catch (\Throwable $exception) {
+            $this->logger->warning('[MTF Runner] Failed to dispatch indicator persistence job', [
+                'run_id' => $runId,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveTimeframes(MtfRunnerRequestDto $request): array
+    {
+        if (\is_string($request->currentTf) && $request->currentTf !== '') {
+            return [$request->currentTf];
+        }
+
+        return $this->mtfValidator->getListTimeframe($request->profile);
+    }
+}

--- a/trading-app/src/MtfRunner/Application/Result/MtfRunResultEnricher.php
+++ b/trading-app/src/MtfRunner/Application/Result/MtfRunResultEnricher.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MtfRunner\Application\Result;
+
+use App\MtfValidator\Service\Helper\OrdersExtractor;
+
+final class MtfRunResultEnricher
+{
+    /**
+     * @param array<string, array<string, mixed>> $results
+     * @return array{
+     *     summary_by_tf: array<string, array<string>>,
+     *     rejected_by: array<string>,
+     *     last_validated: array<int, array{symbol: string, side: mixed, timeframe: string|null}>,
+     *     orders_placed: array{count: array{total: int, submitted: int, simulated: int}, orders: array}
+     * }
+     */
+    public function enrich(array $results): array
+    {
+        $summaryByTfRaw = $this->buildSummaryByTimeframe($results);
+        $summaryByTf = [];
+        foreach (['1m', '5m', '15m', '1h', '4h'] as $tf) {
+            $summaryByTf[$tf] = $summaryByTfRaw[$tf] ?? [];
+        }
+
+        $rejectedBy = [];
+        $lastValidated = [];
+
+        foreach ($results as $symbol => $symbolResult) {
+            if ($symbol === 'FINAL' || !\is_string($symbol) || $symbol === '' || !\is_array($symbolResult)) {
+                continue;
+            }
+
+            $resultStatus = strtoupper((string) ($symbolResult['status'] ?? ''));
+            if (!\in_array($resultStatus, ['SUCCESS', 'COMPLETED', 'READY'], true)) {
+                $rejectedBy[] = $symbol;
+            }
+
+            if ($resultStatus === 'SUCCESS' || $resultStatus === 'COMPLETED') {
+                $executionTf = $symbolResult['execution_tf'] ?? null;
+                $signalSide = $symbolResult['signal_side'] ?? null;
+
+                $lastValidated[] = [
+                    'symbol' => $symbol,
+                    'side' => $signalSide,
+                    'timeframe' => $this->getPreviousTimeframe(\is_string($executionTf) ? $executionTf : null),
+                ];
+            }
+        }
+
+        sort($rejectedBy);
+        usort($lastValidated, static function (array $a, array $b): int {
+            return strcmp((string) ($a['symbol'] ?? ''), (string) ($b['symbol'] ?? ''));
+        });
+
+        return [
+            'summary_by_tf' => $summaryByTf,
+            'rejected_by' => $rejectedBy,
+            'last_validated' => $lastValidated,
+            'orders_placed' => [
+                'count' => OrdersExtractor::countOrdersByStatus($results),
+                'orders' => OrdersExtractor::extractPlacedOrders($results),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $results
+     * @return array<string, array<string>>
+     */
+    private function buildSummaryByTimeframe(array $results): array
+    {
+        $groups = [];
+        foreach ($results as $symbol => $info) {
+            if (!\is_array($info)) {
+                continue;
+            }
+
+            $lastTf = $info['blocking_tf'] ?? $info['failed_timeframe'] ?? ($info['execution_tf'] ?? null);
+            $key = \is_string($lastTf) && $lastTf !== '' ? $lastTf : 'N/A';
+            $groups[$key] ??= [];
+            $groups[$key][] = (string) $symbol;
+        }
+
+        $order = ['4h' => 5, '1h' => 4, '15m' => 3, '5m' => 2, '1m' => 1, 'N/A' => 0];
+        uksort($groups, static function (string $a, string $b) use ($order): int {
+            return ($order[$b] ?? 0) - ($order[$a] ?? 0);
+        });
+
+        return $groups;
+    }
+
+    private function getPreviousTimeframe(?string $timeframe): ?string
+    {
+        if ($timeframe === null || $timeframe === '') {
+            return null;
+        }
+
+        return match (strtolower(trim($timeframe))) {
+            '15m' => '1h',
+            '5m' => '15m',
+            '1m' => 'READY',
+            '1h' => '4h',
+            '4h' => null,
+            default => null,
+        };
+    }
+}

--- a/trading-app/src/MtfRunner/Application/RunMtfCycleUseCase.php
+++ b/trading-app/src/MtfRunner/Application/RunMtfCycleUseCase.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MtfRunner\Application;
+
+use App\MtfRunner\Dto\MtfRunnerRequestDto;
+use App\MtfRunner\Service\MtfRunnerService;
+
+final class RunMtfCycleUseCase
+{
+    public function __construct(
+        private readonly MtfRunnerService $runner,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     summary: array,
+     *     results: array,
+     *     errors: array,
+     *     summary_by_tf: array,
+     *     rejected_by: array,
+     *     last_validated: array,
+     *     orders_placed: array,
+     *     performance: array
+     * }
+     */
+    public function run(MtfRunnerRequestDto $request): array
+    {
+        return $this->runner->run($request);
+    }
+
+    /**
+     * @return array{
+     *     summary: array,
+     *     results: array,
+     *     errors: array,
+     *     summary_by_tf: array,
+     *     rejected_by: array,
+     *     last_validated: array,
+     *     orders_placed: array,
+     *     performance: array
+     * }
+     */
+    public function __invoke(MtfRunnerRequestDto $request): array
+    {
+        return $this->run($request);
+    }
+}

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -16,8 +16,10 @@ use App\Common\Enum\OrderSide;
 use App\Common\Enum\PositionSide;
 use App\Entity\Position;
 use App\MtfRunner\Dto\MtfRunnerRequestDto as RunnerRequestDto;
-use App\Indicator\Message\IndicatorSnapshotPersistRequestMessage;
+use App\MtfRunner\Application\Projection\IndicatorSnapshotPersistenceDispatcher;
+use App\MtfRunner\Application\Result\MtfRunResultEnricher;
 use App\MtfRunner\Service\FuturesOrderSyncService;
+use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
 use App\MtfValidator\Repository\MtfLockRepository;
 use App\MtfValidator\Repository\MtfSwitchRepository;
 use App\MtfValidator\Service\Dto\SymbolResultDto;
@@ -28,14 +30,12 @@ use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
 use App\TradeEntry\Service\TpSlTwoTargetsService;
 use App\TradeEntry\Types\Side as EntrySide;
 use App\MtfValidator\Service\PerformanceProfiler;
-use App\MtfValidator\Service\Helper\OrdersExtractor;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use SplQueue;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Process\Process;
 
 /**
@@ -64,7 +64,9 @@ final class MtfRunnerService
         private readonly LoggerInterface $logger,
         private readonly LoggerInterface $mtfLogger,
         private readonly LoggerInterface $positionsLogger,
-        private readonly MessageBusInterface $messageBus,
+        private readonly TradeDecisionDispatcherInterface $tradeDecisionDispatcher,
+        private readonly IndicatorSnapshotPersistenceDispatcher $indicatorSnapshotPersistenceDispatcher,
+        private readonly MtfRunResultEnricher $resultEnricher,
         #[Autowire('%kernel.project_dir%')]
         private readonly string $projectDir,
         private readonly ClockInterface $clock,
@@ -150,7 +152,7 @@ final class MtfRunnerService
                 : $this->runSequential($symbols, $request, $context);
             $profiler->increment('runner', 'mtf_execution', microtime(true) - $execStart);
 
-            $this->dispatchIndicatorSnapshotPersistence($result['results'] ?? [], $request, $runId);
+            $this->indicatorSnapshotPersistenceDispatcher->dispatch($result['results'] ?? [], $request, $runId);
 
             // 8. Mettre à jour les switches pour les symboles exclus (après traitement)
             if (!empty($excludedSymbols)) {
@@ -178,7 +180,7 @@ final class MtfRunnerService
             // 10. Post-processing : enrichir les résultats
             $postProcessStart = microtime(true);
             $results = $result['results'] ?? [];
-            $enriched = $this->enrichResults($results);
+            $enriched = $this->resultEnricher->enrich($results);
             $profiler->increment('runner', 'post_processing', microtime(true) - $postProcessStart);
 
             $executionTime = microtime(true) - $startTime;
@@ -635,6 +637,7 @@ final class MtfRunnerService
         );
 
         $response = $this->mtfValidator->run($mtfRequest);
+        $this->tradeDecisionDispatcher->dispatchFromResponse($mtfRequest, $response);
 
         $resultsMap = [];
         foreach ($response->results as $entry) {
@@ -1120,61 +1123,6 @@ final class MtfRunnerService
     }
 
     /**
-     * @param array<string,mixed> $results
-     */
-    private function dispatchIndicatorSnapshotPersistence(array $results, RunnerRequestDto $request, string $runId): void
-    {
-        $timeframes = $this->resolvePersistenceTimeframes($request);
-        if ($timeframes === []) {
-            return;
-        }
-
-        $symbols = [];
-        foreach (array_keys($results) as $symbol) {
-            if (!is_string($symbol) || $symbol === '' || strtoupper($symbol) === 'FINAL') {
-                continue;
-            }
-            $symbols[] = strtoupper($symbol);
-        }
-
-        if ($symbols === []) {
-            return;
-        }
-
-        try {
-            $this->messageBus->dispatch(new IndicatorSnapshotPersistRequestMessage(
-                $symbols,
-                $timeframes,
-                $runId,
-                $request->profile,
-                $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
-            ));
-
-            $this->logger->debug('[MTF Runner] Indicator persistence dispatched', [
-                'run_id' => $runId,
-                'symbols_count' => count($symbols),
-                'timeframes' => $timeframes,
-            ]);
-        } catch (\Throwable $exception) {
-            $this->logger->warning('[MTF Runner] Failed to dispatch indicator persistence job', [
-                'run_id' => $runId,
-                'error' => $exception->getMessage(),
-            ]);
-        }
-    }
-
-    /**
-     * @return string[]
-     */
-    private function resolvePersistenceTimeframes(RunnerRequestDto $request): array
-    {
-        if (is_string($request->currentTf) && $request->currentTf !== '') {
-            return [$request->currentTf];
-        }
-        return $this->mtfValidator->getListTimeframe($request->profile);
-    }
-
-    /**
      * Consomme les symboles depuis la queue des switches
      *
      * @return array<string>
@@ -1202,138 +1150,4 @@ final class MtfRunnerService
         return new ExchangeContext($exchange, $marketType);
     }
 
-    /**
-     * Enrichit les résultats avec summary_by_tf, rejected_by, last_validated, orders_placed
-     *
-     * @param array<string, array<string, mixed>> $results
-     * @return array{
-     *     summary_by_tf: array<string, array<string>>,
-     *     rejected_by: array<string>,
-     *     last_validated: array<int, array{symbol: string, side: mixed, timeframe: string|null}>,
-     *     orders_placed: array{count: array{total: int, submitted: int, simulated: int}, orders: array}
-     * }
-     */
-    private function enrichResults(array $results): array
-    {
-        // 1. Calculer summary_by_tf
-        $summaryByTfVrac = $this->buildSummaryByTimeframe($results);
-        $summaryByTf = [];
-        foreach (['1m', '5m', '15m', '1h', '4h'] as $tf) {
-            $summaryByTf[$tf] = $summaryByTfVrac[$tf] ?? [];
-        }
-
-        // 2. Extraire rejected_by et last_validated
-        $rejectedBy = [];
-        $lastValidated = [];
-
-        foreach ($results as $symbol => $symbolResult) {
-            if ($symbol === 'FINAL' || !is_string($symbol) || $symbol === '') {
-                continue;
-            }
-
-            if (!is_array($symbolResult)) {
-                continue;
-            }
-
-            $resultStatus = strtoupper((string)($symbolResult['status'] ?? ''));
-
-            if (!in_array($resultStatus, ['SUCCESS', 'COMPLETED', 'READY'], true)) {
-                $rejectedBy[] = $symbol;
-            }
-
-            if ($resultStatus === 'SUCCESS' || $resultStatus === 'COMPLETED') {
-                $executionTf = $symbolResult['execution_tf'] ?? null;
-                $signalSide = $symbolResult['signal_side'] ?? null;
-
-                $timeframe = $this->getPreviousTimeframe($executionTf);
-
-                $lastValidated[] = [
-                    'symbol' => $symbol,
-                    'side' => $signalSide,
-                    'timeframe' => $timeframe,
-                ];
-            }
-        }
-
-        sort($rejectedBy);
-        usort($lastValidated, function ($a, $b) {
-            return strcmp($a['symbol'] ?? '', $b['symbol'] ?? '');
-        });
-
-        // 3. Extraire orders_placed
-        $ordersPlaced = OrdersExtractor::extractPlacedOrders($results);
-        $ordersCount = OrdersExtractor::countOrdersByStatus($results);
-
-        return [
-            'summary_by_tf' => $summaryByTf,
-            'rejected_by' => $rejectedBy,
-            'last_validated' => $lastValidated,
-            'orders_placed' => [
-                'count' => $ordersCount,
-                'orders' => $ordersPlaced,
-            ],
-        ];
-    }
-
-    /**
-     * Construit un résumé groupé par dernier timeframe atteint
-     *
-     * @param array<string, array<string, mixed>> $results
-     * @return array<string, array<string>>
-     */
-    private function buildSummaryByTimeframe(array $results): array
-    {
-        $groups = [];
-        foreach ($results as $symbol => $info) {
-            if (!is_array($info)) {
-                continue;
-            }
-            $lastTf = $info['blocking_tf'] ?? $info['failed_timeframe'] ?? ($info['execution_tf'] ?? null);
-            $key = is_string($lastTf) && $lastTf !== '' ? $lastTf : 'N/A';
-            if (!isset($groups[$key])) {
-                $groups[$key] = [];
-            }
-            $groups[$key][] = (string)$symbol;
-        }
-
-        // Trier les TF de 4h -> 1m, puis N/A
-        $order = ['4h' => 5, '1h' => 4, '15m' => 3, '5m' => 2, '1m' => 1, 'N/A' => 0];
-        uksort($groups, function($a, $b) use ($order) {
-            return ($order[$b] ?? 0) - ($order[$a] ?? 0);
-        });
-
-        return $groups;
-    }
-
-    /**
-     * Calcule le timeframe précédent (tf-1) pour un timeframe donné.
-     * Retourne 'READY' pour '1m', null pour les timeframes non reconnus ou manquants.
-     *
-     * Mapping :
-     * - '15m' → '1h'
-     * - '5m' → '15m'
-     * - '1m' → 'READY'
-     * - '1h' → '4h'
-     * - '4h' → null (pas de timeframe supérieur)
-     *
-     * @param string|null $timeframe Le timeframe d'exécution
-     * @return string|null Le timeframe précédent ou 'READY' pour 1m
-     */
-    private function getPreviousTimeframe(?string $timeframe): ?string
-    {
-        if ($timeframe === null || $timeframe === '') {
-            return null;
-        }
-
-        $normalized = strtolower(trim($timeframe));
-
-        return match ($normalized) {
-            '15m' => '1h',
-            '5m' => '15m',
-            '1m' => 'READY',
-            '1h' => '4h',
-            '4h' => null,
-            default => null,
-        };
-    }
 }

--- a/trading-app/src/MtfValidator/Application/MtfTradeDecisionDispatcher.php
+++ b/trading-app/src/MtfValidator/Application/MtfTradeDecisionDispatcher.php
@@ -40,19 +40,30 @@ final class MtfTradeDecisionDispatcher implements TradeDecisionDispatcherInterfa
 
             $mtfRun = $this->buildRunDto($request, $response->runId, $result);
 
-            $this->messageBus->dispatch(new MtfTradingDecisionMessage(
-                $response->runId,
-                $mtfRun,
-                $result,
-            ));
+            try {
+                $this->messageBus->dispatch(new MtfTradingDecisionMessage(
+                    $response->runId,
+                    $mtfRun,
+                    $result,
+                ));
 
-            $this->mtfLogger->debug('[MTF Dispatcher] Trading decision dispatched', [
-                'run_id' => $response->runId,
-                'symbol' => $result->symbol,
-                'execution_tf' => $result->executionTimeframe,
-                'side' => $result->side,
-                'dry_run' => $request->dryRun,
-            ]);
+                $this->mtfLogger->debug('[MTF Dispatcher] Trading decision dispatched', [
+                    'run_id' => $response->runId,
+                    'symbol' => $result->symbol,
+                    'execution_tf' => $result->executionTimeframe,
+                    'side' => $result->side,
+                    'dry_run' => $request->dryRun,
+                ]);
+            } catch (\Throwable $exception) {
+                $this->mtfLogger->error('[MTF Dispatcher] Trading decision dispatch failed', [
+                    'run_id' => $response->runId,
+                    'symbol' => $result->symbol,
+                    'execution_tf' => $result->executionTimeframe,
+                    'side' => $result->side,
+                    'dry_run' => $request->dryRun,
+                    'error' => $exception->getMessage(),
+                ]);
+            }
         }
     }
 

--- a/trading-app/src/MtfValidator/Application/MtfTradeDecisionDispatcher.php
+++ b/trading-app/src/MtfValidator/Application/MtfTradeDecisionDispatcher.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MtfValidator\Application;
+
+use App\Contract\MtfValidator\Dto\MtfResultDto;
+use App\Contract\MtfValidator\Dto\MtfRunDto;
+use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
+use App\Contract\MtfValidator\Dto\MtfRunResponseDto;
+use App\MtfValidator\Message\MtfTradingDecisionMessage;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsAlias(id: TradeDecisionDispatcherInterface::class)]
+final class MtfTradeDecisionDispatcher implements TradeDecisionDispatcherInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+        #[Autowire(service: 'monolog.logger.mtf')]
+        private readonly LoggerInterface $mtfLogger,
+        #[Autowire('%app.trade_entry_default_mode%')]
+        private readonly string $defaultProfile,
+    ) {
+    }
+
+    public function dispatchFromResponse(MtfRunRequestDto $request, MtfRunResponseDto $response): void
+    {
+        foreach ($response->results as $entry) {
+            if (!\is_array($entry)) {
+                continue;
+            }
+
+            $result = $entry['result'] ?? null;
+            if (!$result instanceof MtfResultDto || !$result->isTradable) {
+                continue;
+            }
+
+            $mtfRun = $this->buildRunDto($request, $response->runId, $result);
+
+            $this->messageBus->dispatch(new MtfTradingDecisionMessage(
+                $response->runId,
+                $mtfRun,
+                $result,
+            ));
+
+            $this->mtfLogger->debug('[MTF Dispatcher] Trading decision dispatched', [
+                'run_id' => $response->runId,
+                'symbol' => $result->symbol,
+                'execution_tf' => $result->executionTimeframe,
+                'side' => $result->side,
+                'dry_run' => $request->dryRun,
+            ]);
+        }
+    }
+
+    private function buildRunDto(MtfRunRequestDto $request, string $runId, MtfResultDto $result): MtfRunDto
+    {
+        return new MtfRunDto(
+            symbol: $result->symbol,
+            profile: $result->profile !== '' ? $result->profile : ($request->profile ?? $this->defaultProfile),
+            mode: $result->mode ?? $request->mode,
+            now: $result->evaluatedAt,
+            requestId: $runId,
+            dryRun: $request->dryRun,
+            options: [
+                'dry_run' => $request->dryRun,
+                'force_run' => $request->forceRun,
+                'current_tf' => $request->currentTf,
+                'force_timeframe_check' => $request->forceTimeframeCheck,
+                'skip_context' => $request->skipContextValidation,
+                'lock_per_symbol' => $request->lockPerSymbol,
+                'skip_open_state' => $request->skipOpenStateFilter,
+                'user_id' => $request->userId,
+                'ip_address' => $request->ipAddress,
+                'exchange' => $request->exchange?->value,
+                'market_type' => $request->marketType?->value,
+            ],
+        );
+    }
+}

--- a/trading-app/src/MtfValidator/Application/TradeDecisionDispatcherInterface.php
+++ b/trading-app/src/MtfValidator/Application/TradeDecisionDispatcherInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MtfValidator\Application;
+
+use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
+use App\Contract\MtfValidator\Dto\MtfRunResponseDto;
+
+interface TradeDecisionDispatcherInterface
+{
+    public function dispatchFromResponse(MtfRunRequestDto $request, MtfRunResponseDto $response): void;
+}

--- a/trading-app/src/MtfValidator/Command/MtfCoreRunCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfCoreRunCommand.php
@@ -8,6 +8,7 @@ use App\Common\Enum\MarketType;
 use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
 use App\Contract\MtfValidator\Dto\MtfRunResponseDto;
 use App\Contract\MtfValidator\MtfValidatorInterface;
+use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
 use App\Provider\Repository\ContractRepository;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -27,6 +28,7 @@ final class MtfCoreRunCommand extends Command
 {
     public function __construct(
         private readonly MtfValidatorInterface $mtfValidator,
+        private readonly TradeDecisionDispatcherInterface $tradeDecisionDispatcher,
         private readonly ContractRepository $contractRepository,
         private readonly LoggerInterface $mtfLogger,
     ) {
@@ -169,6 +171,7 @@ final class MtfCoreRunCommand extends Command
         try {
             /** @var MtfRunResponseDto $response */
             $response = $this->mtfValidator->run($requestDto);
+            $this->tradeDecisionDispatcher->dispatchFromResponse($requestDto, $response);
         } catch (\Throwable $e) {
             $io->error(sprintf('Erreur lors de l’exécution du validateur MTF: %s', $e->getMessage()));
             $this->mtfLogger->error('mtf:core:run failed', [

--- a/trading-app/src/MtfValidator/Command/MtfCoreTestCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfCoreTestCommand.php
@@ -6,6 +6,7 @@ namespace App\MtfValidator\Command;
 
 use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
 use App\Contract\MtfValidator\MtfValidatorInterface;
+use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -16,6 +17,7 @@ class MtfCoreTestCommand extends Command
 {
     public function __construct(
         private readonly MtfValidatorInterface $mtfValidator,
+        private readonly TradeDecisionDispatcherInterface $tradeDecisionDispatcher,
     ) {
         parent::__construct();
     }
@@ -29,6 +31,7 @@ class MtfCoreTestCommand extends Command
         );
 
         $response = $this->mtfValidator->run($request);
+        $this->tradeDecisionDispatcher->dispatchFromResponse($request, $response);
 
 
         return Command::SUCCESS;

--- a/trading-app/src/MtfValidator/Command/MtfRunCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfRunCommand.php
@@ -30,15 +30,15 @@ use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Config\TradeEntryModeContext;
 use App\Provider\Context\ExchangeContext;
+use App\MtfRunner\Application\RunMtfCycleUseCase;
 use App\MtfRunner\Dto\MtfRunnerRequestDto;
-use App\MtfRunner\Service\MtfRunnerService;
 
     #[AsCommand(name: 'mtf:run', description: 'Exécute un cycle MTF pour une liste de symboles (dry-run par défaut) avec un output détaillé')]
 class MtfRunCommand extends Command
 {
     public function __construct(
         private readonly MtfValidatorInterface $mtfValidator,
-        private readonly MtfRunnerService $mtfRunnerService,
+        private readonly RunMtfCycleUseCase $runMtfCycle,
         private readonly MainProviderInterface $mainProvider,
         private readonly ContractRepository $contractRepository,
         private readonly MtfSwitchRepository $mtfSwitchRepository,
@@ -217,7 +217,7 @@ class MtfRunCommand extends Command
                 'validation_mode' => $validationMode,
             ]);
 
-            $runnerResult = $this->mtfRunnerService->run($runnerRequest);
+            $runnerResult = $this->runMtfCycle->run($runnerRequest);
             $runnerSummary = is_array($runnerResult['summary'] ?? null) ? $runnerResult['summary'] : [];
             $details = is_array($runnerResult['results'] ?? null) ? $runnerResult['results'] : [];
             $errors = is_array($runnerResult['errors'] ?? null) ? $runnerResult['errors'] : [];

--- a/trading-app/src/MtfValidator/Command/MtfRunWorkerCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfRunWorkerCommand.php
@@ -9,6 +9,7 @@ use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
 use App\Contract\MtfValidator\MtfValidatorInterface;
 use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
+use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,7 @@ final class MtfRunWorkerCommand extends Command
 {
     public function __construct(
         private readonly MtfValidatorInterface $mtfValidator,
+        private readonly TradeDecisionDispatcherInterface $tradeDecisionDispatcher,
     )
     {
         parent::__construct();
@@ -99,8 +101,9 @@ final class MtfRunWorkerCommand extends Command
                 'validation_mode' => $validationMode,
             ]);
             $response = $this->mtfValidator->run($request);
+            $this->tradeDecisionDispatcher->dispatchFromResponse($request, $response);
 
-            // Convertir les résultats en map symbol => result (sans décision de trading, elle sera gérée via Messenger)
+            // Convertir les résultats en map symbol => result. Le dispatch trade est déclenché par l'orchestrateur worker.
             $resultsMap = [];
             foreach ($response->results as $entry) {
                 if (!isset($entry['symbol'], $entry['result'])) {

--- a/trading-app/src/MtfValidator/Service/MtfValidatorService.php
+++ b/trading-app/src/MtfValidator/Service/MtfValidatorService.php
@@ -4,27 +4,20 @@ declare(strict_types=1);
 
 namespace App\MtfValidator\Service;
 
-use App\Config\MtfValidationConfig;
 use App\Config\MtfValidationConfigProvider;
 use App\Contract\MtfValidator\Dto\MtfRunDto;
 use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
 use App\Contract\MtfValidator\Dto\MtfRunResponseDto;
 use App\Contract\MtfValidator\MtfValidatorInterface;
-use App\MtfValidator\Message\MtfResultProjectionMessage;
-use App\MtfValidator\Message\MtfTradingDecisionMessage;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 class MtfValidatorService implements MtfValidatorInterface
 {
     public function __construct(
         private readonly MtfValidatorCoreService $core,
         private readonly ClockInterface $clock,
-        private readonly EntityManagerInterface $em,
-        private readonly MessageBusInterface $messageBus,
         private readonly MtfValidationConfigProvider $mtfValidationConfigProvider,
         #[Autowire('%app.trade_entry_default_mode%')]
         private readonly string $defaultProfile,
@@ -79,13 +72,8 @@ class MtfValidatorService implements MtfValidatorInterface
                     'result' => $result,
                 ];
 
-                if (!$request->dryRun) {
-                  //  $this->messageBus->dispatch(new MtfResultProjectionMessage($runId, $mtfRunDto, $result));
-                }
-
                 if ($result->isTradable) {
                     $symbolsSuccessful++;
-                    $this->messageBus->dispatch(new MtfTradingDecisionMessage($runId, $mtfRunDto, $result));
                 } else {
                     $symbolsSkipped++;
                 }
@@ -97,10 +85,6 @@ class MtfValidatorService implements MtfValidatorInterface
                 ];
                 $symbolsFailed++;
             }
-        }
-
-        if (!$request->dryRun && $this->em->isOpen()) {
-            $this->em->flush();
         }
 
         $endedAt = $this->clock->now();

--- a/trading-app/src/Provider/OrderWatcherPublisher.php
+++ b/trading-app/src/Provider/OrderWatcherPublisher.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Provider;
 
+use App\Provider\Redis\RedisPubSubClient;
 use Psr\Log\LoggerInterface;
-use Redis;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -32,7 +32,7 @@ final class OrderWatcherPublisher
 
     public function __construct(
         #[Autowire(service: 'App\Provider\Redis\RedisPubSubClient')]
-        private readonly ?Redis $redis = null,
+        private readonly ?RedisPubSubClient $redis = null,
         #[Autowire(service: 'monolog.logger.bitmart')]
         private readonly ?LoggerInterface $logger = null,
         #[Autowire('%env(string:REDIS_ORDER_WATCH_CHANNEL)%')]
@@ -114,4 +114,3 @@ final class OrderWatcherPublisher
         }
     }
 }
-

--- a/trading-app/src/Provider/Redis/RedisPubSubClient.php
+++ b/trading-app/src/Provider/Redis/RedisPubSubClient.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Redis;
+
+use Psr\Log\LoggerInterface;
+
+final class RedisPubSubClient
+{
+    private ?object $client = null;
+
+    public function __construct(
+        private readonly string $host,
+        private readonly int $port,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+        $this->connect();
+    }
+
+    public function publish(string $channel, string $message): int|false
+    {
+        if ($this->client === null) {
+            $this->logger?->warning('[RedisPubSubClient] Redis extension unavailable, message not published', [
+                'channel' => $channel,
+            ]);
+
+            return 0;
+        }
+
+        try {
+            $result = $this->client->publish($channel, $message);
+
+            return \is_int($result) || $result === false ? $result : (int) $result;
+        } catch (\Throwable $exception) {
+            $this->logger?->error('[RedisPubSubClient] Publish failed', [
+                'channel' => $channel,
+                'error' => $exception->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    private function connect(): void
+    {
+        if (!\class_exists('Redis')) {
+            return;
+        }
+
+        try {
+            $client = new \Redis();
+            $client->connect($this->host, $this->port);
+            $this->client = $client;
+        } catch (\Throwable $exception) {
+            $this->logger?->warning('[RedisPubSubClient] Redis connection failed', [
+                'host' => $this->host,
+                'port' => $this->port,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add application-layer entrypoints for MTF runs and trading-decision dispatch
- extract indicator snapshot persistence and result enrichment out of MtfRunnerService
- make MtfValidatorService return decisions without dispatching Messenger trade messages
- replace direct Redis service wiring with a wrapper that tolerates missing local Redis extension

## Verification
- php -l on changed/new PHP files
- php bin/console lint:container --no-debug
- php bin/console debug:router --show-controllers | rg "/api/mtf/run|RunnerController"

## Notes
- Existing targeted PHPUnit setup is stale/misconfigured: missing KERNEL_CLASS/framework.test and an interface test expecting healthCheck() that is not currently declared.
- out-of-zone-watcher/ was left untracked and is not part of this PR.