### PR TITLE
[API-01] Add API-first exchange adapter contract

### DIFF
--- a/trading-app/docs/API_FIRST_EXCHANGE_ADAPTERS.md
+++ b/trading-app/docs/API_FIRST_EXCHANGE_ADAPTERS.md
@@ -1,0 +1,103 @@
+# API-first exchange adapters
+
+## Objectif
+
+La couche `App\Exchange` definit le contrat applicatif commun entre le moteur de trading et les exchanges. Le code metier doit parler en intentions typpees (`PlaceOrderRequest`, `CancelOrderRequest`, positions, ordres, soldes) et non en payloads Bitmart, Hyperliquid ou OKX.
+
+Cette premiere etape garde Bitmart comme implementation legacy. Elle ajoute le contrat, les DTOs et un adapter Bitmart qui encapsule les providers existants sans changer le flux de production.
+
+## Frontiere de responsabilite
+
+Flux cible:
+
+```text
+TradeEntry / execution service
+  -> ExchangeAdapterRegistryInterface
+  -> ExchangeAdapterInterface
+  -> BitmartExchangeAdapter / future HyperliquidExchangeAdapter / future OkxExchangeAdapter
+  -> providers exchange-specifiques
+```
+
+Regles:
+
+- `App\Common\Enum\Exchange` et `App\Common\Enum\MarketType` restent les identifiants communs.
+- Les enums `App\Exchange\Enum` decrivent les ordres et positions au niveau metier, pas le dialecte REST d'un exchange.
+- Les DTOs `App\Exchange\Dto` ne doivent pas exposer de champ specifique Bitmart/OKX/Hyperliquid.
+- Le champ `metadata` est reserve au debug, a l'audit ou a la conservation du payload brut. Il ne doit pas devenir une API metier.
+- Les conversions exchange-specifiques restent dans l'adapter de l'exchange.
+
+## Contrat commun
+
+`ExchangeAdapterInterface` expose:
+
+- `exchange()` et `marketType()` pour identifier le contexte.
+- `capabilities()` pour annoncer les features supportees.
+- `getBalances()`, `getOpenPositions()`, `getOpenOrders()` et `getOrder()` pour lire l'etat exchange.
+- `placeOrder()` et `cancelOrder()` pour les mutations d'ordres.
+- `getOrderBookTop()` pour garder la compatibilite avec le flux d'execution actuel.
+- `setLeverage()` pour les exchanges qui exigent un appel separe.
+- `reconcile()` comme point d'entree futur pour la reconciliation ordres/positions/fills.
+
+Le registry cle les adapters par paire `exchange::marketType`. Un consommateur doit demander explicitement le contexte voulu au lieu d'injecter un provider Bitmart concret.
+
+## Capabilities
+
+`ExchangeCapabilities` decrit les differences de surface entre exchanges:
+
+- support testnet et WebSocket prive.
+- client order id et annulation par client order id.
+- `postOnly`, `IOC`, `reduceOnly`.
+- SL/TP attaches a l'entree.
+- trigger orders, modification d'ordre.
+- levier separe et levier par symbole.
+
+Les services d'execution doivent utiliser ces flags pour choisir un chemin compatible au lieu de supposer que tous les exchanges se comportent comme Bitmart.
+
+## Adapter Bitmart
+
+`BitmartExchangeAdapter` wrappe `ExchangeProviderRegistryInterface` avec le contexte `BITMART::PERPETUAL`.
+
+La traduction actuelle conserve le comportement legacy:
+
+- `PlaceOrderRequest.side` est mappe vers `App\Common\Enum\OrderSide`.
+- `PlaceOrderRequest.positionSide` et `reduceOnly` sont transformes en code Bitmart legacy:
+  - open long: `1`
+  - close long: `2`
+  - close short: `3`
+  - open short: `4`
+- `postOnly` et `IOC` alimentent le champ legacy `mode`.
+- `clientOrderId`, `reduceOnly`, `postOnly`, SL/TP attaches et levier passent par `options`.
+- `cancelOrder()` annule par exchange order id. L'annulation par client order id est annoncee comme non supportee dans les capabilities.
+
+La methode `reconcile()` est volontairement un placeholder. La reconciliation complete doit etre branchee quand les fills et l'etat local auront leur service dedie.
+
+## Exemple
+
+```php
+$adapter = $registry->get(Exchange::BITMART, MarketType::PERPETUAL);
+
+$result = $adapter->placeOrder(new PlaceOrderRequest(
+    exchange: Exchange::BITMART,
+    marketType: MarketType::PERPETUAL,
+    symbol: 'BTCUSDT',
+    side: ExchangeOrderSide::BUY,
+    positionSide: ExchangePositionSide::LONG,
+    orderType: ExchangeOrderType::LIMIT,
+    timeInForce: ExchangeTimeInForce::GTC,
+    quantity: 10.0,
+    price: 25000.0,
+    stopPrice: null,
+    reduceOnly: false,
+    postOnly: true,
+    leverage: 3,
+    marginMode: 'isolated',
+    clientOrderId: 'trade-entry-...',
+));
+```
+
+## Prochaines etapes
+
+- Brancher le service d'execution TradeEntry sur `ExchangeAdapterRegistryInterface`.
+- Ajouter des adapters paper/fake pour tester le flux sans exchange live.
+- Ajouter Hyperliquid et OKX seulement apres stabilisation du contrat commun.
+- Remplacer progressivement les appels directs aux providers Bitmart dans les services metier.

--- a/trading-app/docs/API_FIRST_EXCHANGE_ADAPTERS.md
+++ b/trading-app/docs/API_FIRST_EXCHANGE_ADAPTERS.md
@@ -62,11 +62,11 @@ La traduction actuelle conserve le comportement legacy:
 - `PlaceOrderRequest.side` est mappe vers `App\Common\Enum\OrderSide`.
 - `PlaceOrderRequest.positionSide` et `reduceOnly` sont transformes en code Bitmart legacy:
   - open long: `1`
-  - close long: `2`
-  - close short: `3`
+  - close short: `2`
+  - close long: `3`
   - open short: `4`
-- `postOnly` et `IOC` alimentent le champ legacy `mode`.
-- `clientOrderId`, `reduceOnly`, `postOnly`, SL/TP attaches et levier passent par `options`.
+- `postOnly`, `FOK` et `IOC` alimentent le champ legacy `mode`.
+- `clientOrderId`, SL/TP attaches et levier passent par `options`; les pseudo-flags `reduceOnly` et `postOnly` ne sont pas forwards tels quels au payload Bitmart.
 - `cancelOrder()` annule par exchange order id. L'annulation par client order id est annoncee comme non supportee dans les capabilities.
 
 La methode `reconcile()` est volontairement un placeholder. La reconciliation complete doit etre branchee quand les fills et l'etat local auront leur service dedie.

--- a/trading-app/docs/API_FIRST_EXCHANGE_ADAPTERS.md
+++ b/trading-app/docs/API_FIRST_EXCHANGE_ADAPTERS.md
@@ -67,6 +67,7 @@ La traduction actuelle conserve le comportement legacy:
   - open short: `4`
 - `postOnly`, `FOK` et `IOC` alimentent le champ legacy `mode`.
 - `clientOrderId`, SL/TP attaches et levier passent par `options`; les pseudo-flags `reduceOnly` et `postOnly` ne sont pas forwards tels quels au payload Bitmart.
+- Les SL/TP attaches ne sont acceptes que pour les entrees limit. Les entrees market doivent utiliser le flux de protection separe apres execution.
 - `cancelOrder()` annule par exchange order id. L'annulation par client order id est annoncee comme non supportee dans les capabilities.
 
 La methode `reconcile()` est volontairement un placeholder. La reconciliation complete doit etre branchee quand les fills et l'etat local auront leur service dedie.

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -68,7 +68,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             supportsAttachedStopLossOnEntry: true,
             supportsAttachedTakeProfitOnEntry: true,
             supportsTriggerOrders: false,
-            supportsModifyOrder: true,
+            supportsModifyOrder: false,
             requiresSeparateLeverageSubmit: true,
             supportsPerSymbolLeverage: true,
         );
@@ -121,11 +121,12 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
     public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
     {
         $this->assertRequestContext($request->exchange, $request->marketType);
+        $providerOrderType = $this->mapOrderTypeToProvider($request->orderType);
 
         $order = $this->bundle()->order()->placeOrder(
             symbol: $request->symbol,
             side: $this->mapOrderSideToProvider($request->side),
-            type: $this->mapOrderTypeToProvider($request->orderType),
+            type: $providerOrderType,
             quantity: $request->quantity,
             price: $request->price,
             stopPrice: $request->stopPrice,
@@ -223,8 +224,6 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             'client_order_id' => $request->clientOrderId,
             'side' => $this->mapPositionIntentToLegacySide($request),
             'open_type' => $request->marginMode,
-            'reduce_only' => $request->reduceOnly,
-            'post_only' => $request->postOnly,
         ];
 
         if ($request->timeInForce === ExchangeTimeInForce::IOC) {
@@ -264,14 +263,18 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
 
     private function mapOrder(OrderDto $order): ExchangeOrderDto
     {
+        [$side, $positionSide] = $this->mapOrderSideFromMetadata($order);
+        $bitmartSide = $this->intMetadata($order->metadata, 'side');
+        $mode = $this->intMetadata($order->metadata, 'mode');
+
         return new ExchangeOrderDto(
             exchange: $this->exchange(),
             marketType: $this->marketType(),
             symbol: $order->symbol,
             exchangeOrderId: $order->orderId,
             clientOrderId: $this->stringMetadata($order->metadata, 'client_order_id'),
-            side: $order->side === OrderSide::SELL ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY,
-            positionSide: null,
+            side: $side,
+            positionSide: $positionSide,
             orderType: $this->mapProviderOrderType($order->type),
             status: $this->mapProviderOrderStatus($order->status),
             quantity: $order->quantity->toFloat(),
@@ -280,9 +283,9 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             price: $order->price?->toFloat(),
             averagePrice: $order->averagePrice?->toFloat(),
             stopPrice: $order->stopPrice?->toFloat(),
-            reduceOnly: (bool) ($order->metadata['reduce_only'] ?? false),
-            postOnly: (bool) ($order->metadata['post_only'] ?? false),
-            timeInForce: null,
+            reduceOnly: \in_array($bitmartSide, [2, 3], true) || $this->boolMetadata($order->metadata, 'reduce_only'),
+            postOnly: $mode === 4 || $this->boolMetadata($order->metadata, 'post_only'),
+            timeInForce: $this->mapModeToTimeInForce($mode),
             createdAt: $order->createdAt,
             updatedAt: $order->updatedAt,
             metadata: $order->metadata,
@@ -322,8 +325,36 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             ExchangeOrderType::MARKET => OrderType::MARKET,
             ExchangeOrderType::STOP_LOSS,
             ExchangeOrderType::TAKE_PROFIT,
-            ExchangeOrderType::TRIGGER => OrderType::STOP,
+            ExchangeOrderType::TRIGGER => throw new \InvalidArgumentException(
+                'Bitmart adapter does not support standalone trigger orders through placeOrder',
+            ),
             ExchangeOrderType::LIMIT => OrderType::LIMIT,
+        };
+    }
+
+    /**
+     * @return array{0: ExchangeOrderSide, 1: ?ExchangePositionSide}
+     */
+    private function mapOrderSideFromMetadata(OrderDto $order): array
+    {
+        return match ($this->intMetadata($order->metadata, 'side')) {
+            1 => [ExchangeOrderSide::BUY, ExchangePositionSide::LONG],
+            2 => [ExchangeOrderSide::BUY, ExchangePositionSide::SHORT],
+            3 => [ExchangeOrderSide::SELL, ExchangePositionSide::LONG],
+            4 => [ExchangeOrderSide::SELL, ExchangePositionSide::SHORT],
+            default => [
+                $order->side === OrderSide::SELL ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY,
+                null,
+            ],
+        };
+    }
+
+    private function mapModeToTimeInForce(?int $mode): ?ExchangeTimeInForce
+    {
+        return match ($mode) {
+            2 => ExchangeTimeInForce::FOK,
+            3 => ExchangeTimeInForce::IOC,
+            default => null,
         };
     }
 
@@ -357,6 +388,29 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
         $value = $metadata[$key] ?? null;
 
         return \is_scalar($value) && $value !== '' ? (string) $value : null;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function intMetadata(array $metadata, string $key): ?int
+    {
+        $value = $metadata[$key] ?? null;
+
+        return \is_scalar($value) && is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function boolMetadata(array $metadata, string $key): bool
+    {
+        $value = $metadata[$key] ?? null;
+        if ($value === null) {
+            return false;
+        }
+
+        return \filter_var($value, \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE) ?? (bool) $value;
     }
 
     private function assertRequestContext(Exchange $exchange, MarketType $marketType): void

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -477,6 +477,10 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             throw new \InvalidArgumentException('attached SL/TP on market orders must use the separate Bitmart protection flow');
         }
 
+        if ($request->reduceOnly && ($request->attachedStopLossPrice !== null || $request->attachedTakeProfitPrice !== null)) {
+            throw new \InvalidArgumentException('attached SL/TP is only supported for entry orders on Bitmart');
+        }
+
         if ($request->postOnly && \in_array($request->timeInForce, [ExchangeTimeInForce::IOC, ExchangeTimeInForce::FOK], true)) {
             throw new \InvalidArgumentException('postOnly cannot be combined with IOC or FOK on Bitmart');
         }

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Adapter;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderStatus as ProviderOrderStatus;
+use App\Common\Enum\OrderType;
+use App\Common\Enum\PositionSide as ProviderPositionSide;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\PositionDto;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Contract\Provider\ExchangeProviderRegistryInterface;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\CancelOrderResult;
+use App\Exchange\Dto\ExchangeBalanceDto;
+use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\ExchangeReconciliationResult;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Provider\Context\ExchangeContext;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.exchange_adapter')]
+final class BitmartExchangeAdapter implements ExchangeAdapterInterface
+{
+    private readonly ExchangeContext $context;
+
+    public function __construct(
+        private readonly ExchangeProviderRegistryInterface $providerRegistry,
+        private readonly ClockInterface $clock,
+    ) {
+        $this->context = new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL);
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->context->exchange;
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->context->marketType;
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return new ExchangeCapabilities(
+            supportsTestnet: false,
+            supportsWebSocketPrivate: true,
+            supportsClientOrderId: true,
+            supportsCancelByClientOrderId: false,
+            supportsPostOnly: true,
+            supportsIoc: true,
+            supportsReduceOnly: true,
+            supportsAttachedStopLossOnEntry: true,
+            supportsAttachedTakeProfitOnEntry: true,
+            supportsTriggerOrders: true,
+            supportsModifyOrder: true,
+            requiresSeparateLeverageSubmit: true,
+            supportsPerSymbolLeverage: true,
+        );
+    }
+
+    public function getBalances(): array
+    {
+        $account = $this->bundle()->account()->getAccountInfo();
+        if ($account !== null) {
+            return [
+                new ExchangeBalanceDto(
+                    exchange: $this->exchange(),
+                    marketType: $this->marketType(),
+                    currency: $account->currency,
+                    available: $account->availableBalance->toFloat(),
+                    total: $account->equity->toFloat(),
+                    equity: $account->equity->toFloat(),
+                    unrealizedPnl: $account->unrealized->toFloat(),
+                    metadata: $account->metadata,
+                ),
+            ];
+        }
+
+        return [
+            new ExchangeBalanceDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                currency: 'USDT',
+                available: $this->bundle()->account()->getAccountBalance('USDT'),
+            ),
+        ];
+    }
+
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return array_values(array_map(
+            fn (PositionDto $position): ExchangePositionDto => $this->mapPosition($position),
+            $this->bundle()->account()->getOpenPositions($symbol),
+        ));
+    }
+
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return array_values(array_map(
+            fn (OrderDto $order): ExchangeOrderDto => $this->mapOrder($order),
+            $this->bundle()->order()->getOpenOrders($symbol),
+        ));
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        $this->assertRequestContext($request->exchange, $request->marketType);
+
+        $order = $this->bundle()->order()->placeOrder(
+            symbol: $request->symbol,
+            side: $this->mapOrderSideToProvider($request->side),
+            type: $this->mapOrderTypeToProvider($request->orderType),
+            quantity: $request->quantity,
+            price: $request->price,
+            stopPrice: $request->stopPrice,
+            options: $this->buildLegacyOrderOptions($request),
+        );
+
+        if (!$order instanceof OrderDto) {
+            return new PlaceOrderResult(
+                accepted: false,
+                symbol: $request->symbol,
+                clientOrderId: $request->clientOrderId,
+                exchangeOrderId: null,
+                status: ExchangeOrderStatus::REJECTED,
+                submittedAt: $this->clock->now(),
+                metadata: ['reason' => 'provider_returned_null'],
+            );
+        }
+
+        $mapped = $this->mapOrder($order);
+
+        return new PlaceOrderResult(
+            accepted: true,
+            symbol: $request->symbol,
+            clientOrderId: $request->clientOrderId,
+            exchangeOrderId: $order->orderId,
+            status: $mapped->status,
+            submittedAt: $this->clock->now(),
+            order: $mapped,
+        );
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        $this->assertRequestContext($request->exchange, $request->marketType);
+
+        $cancelled = false;
+        if ($request->exchangeOrderId !== null && trim($request->exchangeOrderId) !== '') {
+            $cancelled = $this->bundle()->order()->cancelOrder($request->symbol, $request->exchangeOrderId);
+        }
+
+        return new CancelOrderResult(
+            cancelled: $cancelled,
+            symbol: $request->symbol,
+            exchangeOrderId: $request->exchangeOrderId,
+            clientOrderId: $request->clientOrderId,
+            status: $cancelled ? ExchangeOrderStatus::CANCELLED : ExchangeOrderStatus::UNKNOWN,
+            metadata: $request->clientOrderId !== null && !$cancelled
+                ? ['reason' => 'cancel_by_client_order_id_not_supported']
+                : [],
+        );
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        $order = $this->bundle()->order()->getOrder($symbol, $exchangeOrderId);
+
+        return $order instanceof OrderDto ? $this->mapOrder($order) : null;
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->bundle()->order()->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->bundle()->order()->submitLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        $now = $this->clock->now();
+
+        return new ExchangeReconciliationResult(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $symbol,
+            startedAt: $now,
+            completedAt: $now,
+            metadata: ['reason' => 'legacy_bitmart_reconciliation_not_wired_yet'],
+        );
+    }
+
+    private function bundle(): \App\Provider\Registry\ExchangeProviderBundle
+    {
+        return $this->providerRegistry->get($this->context);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildLegacyOrderOptions(PlaceOrderRequest $request): array
+    {
+        $options = [
+            'client_order_id' => $request->clientOrderId,
+            'side' => $this->mapPositionIntentToLegacySide($request),
+            'open_type' => $request->marginMode,
+            'reduce_only' => $request->reduceOnly,
+            'post_only' => $request->postOnly,
+        ];
+
+        if ($request->timeInForce === ExchangeTimeInForce::IOC) {
+            $options['mode'] = 3;
+        } elseif ($request->postOnly) {
+            $options['mode'] = 4;
+        }
+
+        if ($request->leverage !== null) {
+            $options['leverage'] = $request->leverage;
+        }
+        if ($request->attachedStopLossPrice !== null) {
+            $options['preset_stop_loss_price'] = (string) $request->attachedStopLossPrice;
+            $options['preset_stop_loss_price_type'] = 1;
+        }
+        if ($request->attachedTakeProfitPrice !== null) {
+            $options['preset_take_profit_price'] = (string) $request->attachedTakeProfitPrice;
+            $options['preset_take_profit_price_type'] = 1;
+        }
+
+        return $options;
+    }
+
+    private function mapPositionIntentToLegacySide(PlaceOrderRequest $request): int
+    {
+        if ($request->reduceOnly && $request->positionSide === ExchangePositionSide::LONG) {
+            return 2;
+        }
+        if ($request->reduceOnly && $request->positionSide === ExchangePositionSide::SHORT) {
+            return 3;
+        }
+
+        return $request->positionSide === ExchangePositionSide::LONG ? 1 : 4;
+    }
+
+    private function mapOrder(OrderDto $order): ExchangeOrderDto
+    {
+        return new ExchangeOrderDto(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $order->symbol,
+            exchangeOrderId: $order->orderId,
+            clientOrderId: $this->stringMetadata($order->metadata, 'client_order_id'),
+            side: $order->side === OrderSide::SELL ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY,
+            positionSide: null,
+            orderType: $this->mapProviderOrderType($order->type),
+            status: $this->mapProviderOrderStatus($order->status),
+            quantity: $order->quantity->toFloat(),
+            filledQuantity: $order->filledQuantity->toFloat(),
+            remainingQuantity: $order->remainingQuantity->toFloat(),
+            price: $order->price?->toFloat(),
+            averagePrice: $order->averagePrice?->toFloat(),
+            stopPrice: $order->stopPrice?->toFloat(),
+            reduceOnly: (bool) ($order->metadata['reduce_only'] ?? false),
+            postOnly: (bool) ($order->metadata['post_only'] ?? false),
+            timeInForce: null,
+            createdAt: $order->createdAt,
+            updatedAt: $order->updatedAt,
+            metadata: $order->metadata,
+        );
+    }
+
+    private function mapPosition(PositionDto $position): ExchangePositionDto
+    {
+        return new ExchangePositionDto(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $position->symbol,
+            side: $position->side === ProviderPositionSide::SHORT
+                ? ExchangePositionSide::SHORT
+                : ExchangePositionSide::LONG,
+            size: $position->size->toFloat(),
+            entryPrice: $position->entryPrice->toFloat(),
+            markPrice: $position->markPrice->toFloat(),
+            unrealizedPnl: $position->unrealizedPnl->toFloat(),
+            realizedPnl: $position->realizedPnl->toFloat(),
+            margin: $position->margin->toFloat(),
+            leverage: $position->leverage->toFloat(),
+            openedAt: $position->openedAt,
+            updatedAt: $position->closedAt,
+            metadata: $position->metadata,
+        );
+    }
+
+    private function mapOrderSideToProvider(ExchangeOrderSide $side): OrderSide
+    {
+        return $side === ExchangeOrderSide::SELL ? OrderSide::SELL : OrderSide::BUY;
+    }
+
+    private function mapOrderTypeToProvider(ExchangeOrderType $type): OrderType
+    {
+        return match ($type) {
+            ExchangeOrderType::MARKET => OrderType::MARKET,
+            ExchangeOrderType::STOP_LOSS,
+            ExchangeOrderType::TAKE_PROFIT,
+            ExchangeOrderType::TRIGGER => OrderType::STOP,
+            ExchangeOrderType::LIMIT => OrderType::LIMIT,
+        };
+    }
+
+    private function mapProviderOrderType(OrderType $type): ExchangeOrderType
+    {
+        return match ($type) {
+            OrderType::MARKET => ExchangeOrderType::MARKET,
+            OrderType::STOP,
+            OrderType::STOP_LIMIT => ExchangeOrderType::TRIGGER,
+            OrderType::LIMIT => ExchangeOrderType::LIMIT,
+        };
+    }
+
+    private function mapProviderOrderStatus(ProviderOrderStatus $status): ExchangeOrderStatus
+    {
+        return match ($status) {
+            ProviderOrderStatus::FILLED => ExchangeOrderStatus::FILLED,
+            ProviderOrderStatus::PARTIALLY_FILLED => ExchangeOrderStatus::PARTIALLY_FILLED,
+            ProviderOrderStatus::CANCELLED => ExchangeOrderStatus::CANCELLED,
+            ProviderOrderStatus::REJECTED => ExchangeOrderStatus::REJECTED,
+            ProviderOrderStatus::EXPIRED => ExchangeOrderStatus::EXPIRED,
+            ProviderOrderStatus::PENDING => ExchangeOrderStatus::PENDING,
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function stringMetadata(array $metadata, string $key): ?string
+    {
+        $value = $metadata[$key] ?? null;
+
+        return \is_scalar($value) && $value !== '' ? (string) $value : null;
+    }
+
+    private function assertRequestContext(Exchange $exchange, MarketType $marketType): void
+    {
+        if ($exchange !== $this->exchange() || $marketType !== $this->marketType()) {
+            throw new \InvalidArgumentException(sprintf(
+                'Bitmart adapter cannot handle "%s::%s"',
+                $exchange->value,
+                $marketType->value,
+            ));
+        }
+    }
+}

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -470,6 +470,13 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             throw new \InvalidArgumentException('postOnly is only supported for limit orders on Bitmart');
         }
 
+        if (
+            $request->orderType === ExchangeOrderType::MARKET
+            && ($request->attachedStopLossPrice !== null || $request->attachedTakeProfitPrice !== null)
+        ) {
+            throw new \InvalidArgumentException('attached SL/TP on market orders must use the separate Bitmart protection flow');
+        }
+
         if ($request->postOnly && \in_array($request->timeInForce, [ExchangeTimeInForce::IOC, ExchangeTimeInForce::FOK], true)) {
             throw new \InvalidArgumentException('postOnly cannot be combined with IOC or FOK on Bitmart');
         }

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -175,9 +175,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             exchangeOrderId: $request->exchangeOrderId,
             clientOrderId: $request->clientOrderId,
             status: $cancelled ? ExchangeOrderStatus::CANCELLED : ExchangeOrderStatus::UNKNOWN,
-            metadata: $request->clientOrderId !== null && !$cancelled
-                ? ['reason' => 'cancel_by_client_order_id_not_supported']
-                : [],
+            metadata: $this->cancelFailureMetadata($request, $cancelled),
         );
     }
 
@@ -215,6 +213,26 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
     private function bundle(): \App\Provider\Registry\ExchangeProviderBundle
     {
         return $this->providerRegistry->get($this->context);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function cancelFailureMetadata(CancelOrderRequest $request, bool $cancelled): array
+    {
+        if ($cancelled) {
+            return [];
+        }
+
+        if ($request->exchangeOrderId !== null && trim($request->exchangeOrderId) !== '') {
+            return ['reason' => 'exchange_order_cancel_failed'];
+        }
+
+        if ($request->clientOrderId !== null && trim($request->clientOrderId) !== '') {
+            return ['reason' => 'cancel_by_client_order_id_not_supported'];
+        }
+
+        return [];
     }
 
     /**
@@ -375,6 +393,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             1 => ExchangeTimeInForce::GTC,
             2 => ExchangeTimeInForce::FOK,
             3 => ExchangeTimeInForce::IOC,
+            4 => ExchangeTimeInForce::GTC,
             default => null,
         };
     }
@@ -447,6 +466,10 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
 
     private function assertRequestIntent(PlaceOrderRequest $request): void
     {
+        if ($request->postOnly && $request->orderType !== ExchangeOrderType::LIMIT) {
+            throw new \InvalidArgumentException('postOnly is only supported for limit orders on Bitmart');
+        }
+
         if ($request->postOnly && \in_array($request->timeInForce, [ExchangeTimeInForce::IOC, ExchangeTimeInForce::FOK], true)) {
             throw new \InvalidArgumentException('postOnly cannot be combined with IOC or FOK on Bitmart');
         }

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -121,7 +121,9 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
     public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
     {
         $this->assertRequestContext($request->exchange, $request->marketType);
+        $this->assertRequestIntent($request);
         $providerOrderType = $this->mapOrderTypeToProvider($request->orderType);
+        $legacyOptions = $this->buildLegacyOrderOptions($request);
 
         $order = $this->bundle()->order()->placeOrder(
             symbol: $request->symbol,
@@ -130,7 +132,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             quantity: $request->quantity,
             price: $request->price,
             stopPrice: $request->stopPrice,
-            options: $this->buildLegacyOrderOptions($request),
+            options: $legacyOptions,
         );
 
         if (!$order instanceof OrderDto) {
@@ -145,7 +147,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             );
         }
 
-        $mapped = $this->mapOrder($order);
+        $mapped = $this->mapOrder($order, $this->buildSubmittedOrderMetadata($request, $legacyOptions));
 
         return new PlaceOrderResult(
             accepted: true,
@@ -249,6 +251,19 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
         return $options;
     }
 
+    /**
+     * @param array<string,mixed> $legacyOptions
+     * @return array<string,mixed>
+     */
+    private function buildSubmittedOrderMetadata(PlaceOrderRequest $request, array $legacyOptions): array
+    {
+        return $legacyOptions + [
+            'mode' => $request->timeInForce === ExchangeTimeInForce::GTC && !$request->postOnly ? 1 : null,
+            'post_only' => $request->postOnly,
+            'reduce_only' => $request->reduceOnly,
+        ];
+    }
+
     private function mapPositionIntentToLegacySide(PlaceOrderRequest $request): int
     {
         if ($request->reduceOnly && $request->positionSide === ExchangePositionSide::LONG) {
@@ -261,18 +276,22 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
         return $request->positionSide === ExchangePositionSide::LONG ? 1 : 4;
     }
 
-    private function mapOrder(OrderDto $order): ExchangeOrderDto
+    /**
+     * @param array<string,mixed> $submittedMetadata
+     */
+    private function mapOrder(OrderDto $order, array $submittedMetadata = []): ExchangeOrderDto
     {
-        [$side, $positionSide] = $this->mapOrderSideFromMetadata($order);
-        $bitmartSide = $this->intMetadata($order->metadata, 'side');
-        $mode = $this->intMetadata($order->metadata, 'mode');
+        $metadata = array_replace($submittedMetadata, $order->metadata);
+        [$side, $positionSide] = $this->mapOrderSideFromMetadata($order, $metadata);
+        $bitmartSide = $this->intMetadata($metadata, 'side');
+        $mode = $this->intMetadata($metadata, 'mode');
 
         return new ExchangeOrderDto(
             exchange: $this->exchange(),
             marketType: $this->marketType(),
             symbol: $order->symbol,
             exchangeOrderId: $order->orderId,
-            clientOrderId: $this->stringMetadata($order->metadata, 'client_order_id'),
+            clientOrderId: $this->stringMetadata($metadata, 'client_order_id'),
             side: $side,
             positionSide: $positionSide,
             orderType: $this->mapProviderOrderType($order->type),
@@ -283,12 +302,12 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             price: $order->price?->toFloat(),
             averagePrice: $order->averagePrice?->toFloat(),
             stopPrice: $order->stopPrice?->toFloat(),
-            reduceOnly: \in_array($bitmartSide, [2, 3], true) || $this->boolMetadata($order->metadata, 'reduce_only'),
-            postOnly: $mode === 4 || $this->boolMetadata($order->metadata, 'post_only'),
+            reduceOnly: \in_array($bitmartSide, [2, 3], true) || $this->boolMetadata($metadata, 'reduce_only'),
+            postOnly: $mode === 4 || $this->boolMetadata($metadata, 'post_only'),
             timeInForce: $this->mapModeToTimeInForce($mode),
             createdAt: $order->createdAt,
             updatedAt: $order->updatedAt,
-            metadata: $order->metadata,
+            metadata: $metadata,
         );
     }
 
@@ -333,11 +352,12 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
     }
 
     /**
+     * @param array<string,mixed> $metadata
      * @return array{0: ExchangeOrderSide, 1: ?ExchangePositionSide}
      */
-    private function mapOrderSideFromMetadata(OrderDto $order): array
+    private function mapOrderSideFromMetadata(OrderDto $order, array $metadata): array
     {
-        return match ($this->intMetadata($order->metadata, 'side')) {
+        return match ($this->intMetadata($metadata, 'side')) {
             1 => [ExchangeOrderSide::BUY, ExchangePositionSide::LONG],
             2 => [ExchangeOrderSide::BUY, ExchangePositionSide::SHORT],
             3 => [ExchangeOrderSide::SELL, ExchangePositionSide::LONG],
@@ -352,6 +372,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
     private function mapModeToTimeInForce(?int $mode): ?ExchangeTimeInForce
     {
         return match ($mode) {
+            1 => ExchangeTimeInForce::GTC,
             2 => ExchangeTimeInForce::FOK,
             3 => ExchangeTimeInForce::IOC,
             default => null,
@@ -420,6 +441,29 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
                 'Bitmart adapter cannot handle "%s::%s"',
                 $exchange->value,
                 $marketType->value,
+            ));
+        }
+    }
+
+    private function assertRequestIntent(PlaceOrderRequest $request): void
+    {
+        if ($request->postOnly && \in_array($request->timeInForce, [ExchangeTimeInForce::IOC, ExchangeTimeInForce::FOK], true)) {
+            throw new \InvalidArgumentException('postOnly cannot be combined with IOC or FOK on Bitmart');
+        }
+
+        $expectedSide = match ([$request->reduceOnly, $request->positionSide]) {
+            [false, ExchangePositionSide::LONG] => ExchangeOrderSide::BUY,
+            [false, ExchangePositionSide::SHORT] => ExchangeOrderSide::SELL,
+            [true, ExchangePositionSide::LONG] => ExchangeOrderSide::SELL,
+            [true, ExchangePositionSide::SHORT] => ExchangeOrderSide::BUY,
+        };
+
+        if ($request->side !== $expectedSide) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid order side "%s" for %s %s position intent',
+                $request->side->value,
+                $request->reduceOnly ? 'reduce-only' : 'entry',
+                $request->positionSide->value,
             ));
         }
     }

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -67,7 +67,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             supportsReduceOnly: true,
             supportsAttachedStopLossOnEntry: true,
             supportsAttachedTakeProfitOnEntry: true,
-            supportsTriggerOrders: true,
+            supportsTriggerOrders: false,
             supportsModifyOrder: true,
             requiresSeparateLeverageSubmit: true,
             supportsPerSymbolLeverage: true,
@@ -229,6 +229,8 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
 
         if ($request->timeInForce === ExchangeTimeInForce::IOC) {
             $options['mode'] = 3;
+        } elseif ($request->timeInForce === ExchangeTimeInForce::FOK) {
+            $options['mode'] = 2;
         } elseif ($request->postOnly) {
             $options['mode'] = 4;
         }
@@ -251,10 +253,10 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
     private function mapPositionIntentToLegacySide(PlaceOrderRequest $request): int
     {
         if ($request->reduceOnly && $request->positionSide === ExchangePositionSide::LONG) {
-            return 2;
+            return 3;
         }
         if ($request->reduceOnly && $request->positionSide === ExchangePositionSide::SHORT) {
-            return 3;
+            return 2;
         }
 
         return $request->positionSide === ExchangePositionSide::LONG ? 1 : 4;

--- a/trading-app/src/Exchange/Contract/ExchangeAdapterInterface.php
+++ b/trading-app/src/Exchange/Contract/ExchangeAdapterInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Contract;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\CancelOrderResult;
+use App\Exchange\Dto\ExchangeBalanceDto;
+use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\ExchangeReconciliationResult;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+
+interface ExchangeAdapterInterface
+{
+    public function exchange(): Exchange;
+
+    public function marketType(): MarketType;
+
+    public function capabilities(): ExchangeCapabilities;
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array;
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array;
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array;
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult;
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult;
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto;
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto;
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool;
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult;
+}

--- a/trading-app/src/Exchange/Contract/ExchangeAdapterRegistryInterface.php
+++ b/trading-app/src/Exchange/Contract/ExchangeAdapterRegistryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Contract;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+interface ExchangeAdapterRegistryInterface
+{
+    public function get(Exchange $exchange, MarketType $marketType): ExchangeAdapterInterface;
+
+    /**
+     * @return ExchangeAdapterInterface[]
+     */
+    public function all(): array;
+}

--- a/trading-app/src/Exchange/Dto/CancelOrderRequest.php
+++ b/trading-app/src/Exchange/Dto/CancelOrderRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+final readonly class CancelOrderRequest
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $symbol,
+        public ?string $exchangeOrderId = null,
+        public ?string $clientOrderId = null,
+        public array $metadata = [],
+    ) {
+        if (trim($this->symbol) === '') {
+            throw new \InvalidArgumentException('symbol cannot be blank');
+        }
+
+        $hasExchangeOrderId = $this->exchangeOrderId !== null && trim($this->exchangeOrderId) !== '';
+        $hasClientOrderId = $this->clientOrderId !== null && trim($this->clientOrderId) !== '';
+        if (!$hasExchangeOrderId && !$hasClientOrderId) {
+            throw new \InvalidArgumentException('exchangeOrderId or clientOrderId is required');
+        }
+    }
+}

--- a/trading-app/src/Exchange/Dto/CancelOrderResult.php
+++ b/trading-app/src/Exchange/Dto/CancelOrderResult.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Exchange\Enum\ExchangeOrderStatus;
+
+final readonly class CancelOrderResult
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public bool $cancelled,
+        public string $symbol,
+        public ?string $exchangeOrderId,
+        public ?string $clientOrderId,
+        public ExchangeOrderStatus $status,
+        public array $metadata = [],
+    ) {
+        if (trim($symbol) === '') {
+            throw new \InvalidArgumentException('symbol cannot be blank');
+        }
+    }
+}

--- a/trading-app/src/Exchange/Dto/ExchangeBalanceDto.php
+++ b/trading-app/src/Exchange/Dto/ExchangeBalanceDto.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+final readonly class ExchangeBalanceDto
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $currency,
+        public float $available,
+        public ?float $total = null,
+        public ?float $equity = null,
+        public ?float $unrealizedPnl = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Dto/ExchangeCapabilities.php
+++ b/trading-app/src/Exchange/Dto/ExchangeCapabilities.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+final readonly class ExchangeCapabilities
+{
+    public function __construct(
+        public bool $supportsTestnet = false,
+        public bool $supportsWebSocketPrivate = false,
+        public bool $supportsClientOrderId = true,
+        public bool $supportsCancelByClientOrderId = false,
+        public bool $supportsPostOnly = false,
+        public bool $supportsIoc = false,
+        public bool $supportsReduceOnly = false,
+        public bool $supportsAttachedStopLossOnEntry = false,
+        public bool $supportsAttachedTakeProfitOnEntry = false,
+        public bool $supportsTriggerOrders = false,
+        public bool $supportsModifyOrder = false,
+        public bool $requiresSeparateLeverageSubmit = false,
+        public bool $supportsPerSymbolLeverage = false,
+    ) {
+    }
+
+    /**
+     * @return array<string,bool>
+     */
+    public function toArray(): array
+    {
+        return [
+            'supportsTestnet' => $this->supportsTestnet,
+            'supportsWebSocketPrivate' => $this->supportsWebSocketPrivate,
+            'supportsClientOrderId' => $this->supportsClientOrderId,
+            'supportsCancelByClientOrderId' => $this->supportsCancelByClientOrderId,
+            'supportsPostOnly' => $this->supportsPostOnly,
+            'supportsIoc' => $this->supportsIoc,
+            'supportsReduceOnly' => $this->supportsReduceOnly,
+            'supportsAttachedStopLossOnEntry' => $this->supportsAttachedStopLossOnEntry,
+            'supportsAttachedTakeProfitOnEntry' => $this->supportsAttachedTakeProfitOnEntry,
+            'supportsTriggerOrders' => $this->supportsTriggerOrders,
+            'supportsModifyOrder' => $this->supportsModifyOrder,
+            'requiresSeparateLeverageSubmit' => $this->requiresSeparateLeverageSubmit,
+            'supportsPerSymbolLeverage' => $this->supportsPerSymbolLeverage,
+        ];
+    }
+}

--- a/trading-app/src/Exchange/Dto/ExchangeFillDto.php
+++ b/trading-app/src/Exchange/Dto/ExchangeFillDto.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangePositionSide;
+
+final readonly class ExchangeFillDto
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $symbol,
+        public string $exchangeOrderId,
+        public ?string $clientOrderId,
+        public ?string $fillId,
+        public ExchangeOrderSide $side,
+        public ?ExchangePositionSide $positionSide,
+        public float $quantity,
+        public float $price,
+        public ?float $fee,
+        public ?string $feeCurrency,
+        public \DateTimeImmutable $filledAt,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Dto/ExchangeOrderDto.php
+++ b/trading-app/src/Exchange/Dto/ExchangeOrderDto.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+
+final readonly class ExchangeOrderDto
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $symbol,
+        public string $exchangeOrderId,
+        public ?string $clientOrderId,
+        public ExchangeOrderSide $side,
+        public ?ExchangePositionSide $positionSide,
+        public ExchangeOrderType $orderType,
+        public ExchangeOrderStatus $status,
+        public float $quantity,
+        public float $filledQuantity,
+        public float $remainingQuantity,
+        public ?float $price,
+        public ?float $averagePrice,
+        public ?float $stopPrice,
+        public bool $reduceOnly,
+        public bool $postOnly,
+        public ?ExchangeTimeInForce $timeInForce,
+        public \DateTimeImmutable $createdAt,
+        public ?\DateTimeImmutable $updatedAt = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Dto/ExchangePositionDto.php
+++ b/trading-app/src/Exchange/Dto/ExchangePositionDto.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Enum\ExchangePositionSide;
+
+final readonly class ExchangePositionDto
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $symbol,
+        public ExchangePositionSide $side,
+        public float $size,
+        public float $entryPrice,
+        public ?float $markPrice,
+        public ?float $unrealizedPnl,
+        public ?float $realizedPnl,
+        public ?float $margin,
+        public ?float $leverage,
+        public ?\DateTimeImmutable $openedAt = null,
+        public ?\DateTimeImmutable $updatedAt = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Dto/ExchangeReconciliationResult.php
+++ b/trading-app/src/Exchange/Dto/ExchangeReconciliationResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+final readonly class ExchangeReconciliationResult
+{
+    /**
+     * @param string[] $errors
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public ?string $symbol,
+        public \DateTimeImmutable $startedAt,
+        public \DateTimeImmutable $completedAt,
+        public int $ordersChecked = 0,
+        public int $positionsChecked = 0,
+        public int $fillsImported = 0,
+        public int $correctionsApplied = 0,
+        public int $staleOrdersClosed = 0,
+        public int $unknownOrdersDetected = 0,
+        public array $errors = [],
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Dto/PlaceOrderRequest.php
+++ b/trading-app/src/Exchange/Dto/PlaceOrderRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+
+final readonly class PlaceOrderRequest
+{
+    /**
+     * @param array<string,mixed> $metadata Debug-only metadata, never exchange payload.
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $symbol,
+        public ExchangeOrderSide $side,
+        public ExchangePositionSide $positionSide,
+        public ExchangeOrderType $orderType,
+        public ExchangeTimeInForce $timeInForce,
+        public float $quantity,
+        public ?float $price,
+        public ?float $stopPrice,
+        public bool $reduceOnly,
+        public bool $postOnly,
+        public ?int $leverage,
+        public string $marginMode,
+        public string $clientOrderId,
+        public ?float $attachedStopLossPrice = null,
+        public ?float $attachedTakeProfitPrice = null,
+        public array $metadata = [],
+    ) {
+        self::assertNotBlank($this->symbol, 'symbol');
+        self::assertNotBlank($this->clientOrderId, 'clientOrderId');
+        self::assertNotBlank($this->marginMode, 'marginMode');
+
+        if ($this->quantity <= 0.0) {
+            throw new \InvalidArgumentException('quantity must be greater than zero');
+        }
+
+        if ($this->orderType === ExchangeOrderType::LIMIT && ($this->price === null || $this->price <= 0.0)) {
+            throw new \InvalidArgumentException('limit orders require a positive price');
+        }
+
+        foreach ([
+            'price' => $this->price,
+            'stopPrice' => $this->stopPrice,
+            'attachedStopLossPrice' => $this->attachedStopLossPrice,
+            'attachedTakeProfitPrice' => $this->attachedTakeProfitPrice,
+        ] as $field => $value) {
+            if ($value !== null && $value <= 0.0) {
+                throw new \InvalidArgumentException(sprintf('%s must be positive when provided', $field));
+            }
+        }
+
+        if ($this->leverage !== null && $this->leverage <= 0) {
+            throw new \InvalidArgumentException('leverage must be positive when provided');
+        }
+    }
+
+    private static function assertNotBlank(string $value, string $field): void
+    {
+        if (trim($value) === '') {
+            throw new \InvalidArgumentException(sprintf('%s cannot be blank', $field));
+        }
+    }
+}

--- a/trading-app/src/Exchange/Dto/PlaceOrderResult.php
+++ b/trading-app/src/Exchange/Dto/PlaceOrderResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Dto;
+
+use App\Exchange\Enum\ExchangeOrderStatus;
+
+final readonly class PlaceOrderResult
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public bool $accepted,
+        public string $symbol,
+        public string $clientOrderId,
+        public ?string $exchangeOrderId,
+        public ExchangeOrderStatus $status,
+        public \DateTimeImmutable $submittedAt,
+        public ?ExchangeOrderDto $order = null,
+        public array $metadata = [],
+    ) {
+        if (trim($symbol) === '') {
+            throw new \InvalidArgumentException('symbol cannot be blank');
+        }
+        if (trim($clientOrderId) === '') {
+            throw new \InvalidArgumentException('clientOrderId cannot be blank');
+        }
+    }
+}

--- a/trading-app/src/Exchange/Enum/ExchangeOrderSide.php
+++ b/trading-app/src/Exchange/Enum/ExchangeOrderSide.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Enum;
+
+enum ExchangeOrderSide: string
+{
+    case BUY = 'buy';
+    case SELL = 'sell';
+}

--- a/trading-app/src/Exchange/Enum/ExchangeOrderStatus.php
+++ b/trading-app/src/Exchange/Enum/ExchangeOrderStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Enum;
+
+enum ExchangeOrderStatus: string
+{
+    case PENDING = 'pending';
+    case OPEN = 'open';
+    case PARTIALLY_FILLED = 'partially_filled';
+    case FILLED = 'filled';
+    case CANCELLED = 'cancelled';
+    case REJECTED = 'rejected';
+    case EXPIRED = 'expired';
+    case UNKNOWN = 'unknown';
+}

--- a/trading-app/src/Exchange/Enum/ExchangeOrderType.php
+++ b/trading-app/src/Exchange/Enum/ExchangeOrderType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Enum;
+
+enum ExchangeOrderType: string
+{
+    case LIMIT = 'limit';
+    case MARKET = 'market';
+    case STOP_LOSS = 'stop_loss';
+    case TAKE_PROFIT = 'take_profit';
+    case TRIGGER = 'trigger';
+}

--- a/trading-app/src/Exchange/Enum/ExchangePositionSide.php
+++ b/trading-app/src/Exchange/Enum/ExchangePositionSide.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Enum;
+
+enum ExchangePositionSide: string
+{
+    case LONG = 'long';
+    case SHORT = 'short';
+}

--- a/trading-app/src/Exchange/Enum/ExchangeTimeInForce.php
+++ b/trading-app/src/Exchange/Enum/ExchangeTimeInForce.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Enum;
+
+enum ExchangeTimeInForce: string
+{
+    case GTC = 'gtc';
+    case IOC = 'ioc';
+    case FOK = 'fok';
+}

--- a/trading-app/src/Exchange/Registry/ExchangeAdapterNotFoundException.php
+++ b/trading-app/src/Exchange/Registry/ExchangeAdapterNotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Registry;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+final class ExchangeAdapterNotFoundException extends \RuntimeException
+{
+    /**
+     * @param string[] $available
+     */
+    public static function forContext(Exchange $exchange, MarketType $marketType, array $available): self
+    {
+        return new self(sprintf(
+            'No exchange adapter registered for "%s::%s". Available adapters: %s',
+            $exchange->value,
+            $marketType->value,
+            $available === [] ? '(none)' : implode(', ', $available),
+        ));
+    }
+}

--- a/trading-app/src/Exchange/Registry/ExchangeAdapterRegistry.php
+++ b/trading-app/src/Exchange/Registry/ExchangeAdapterRegistry.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Registry;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Component\DependencyInjection\Attribute\TaggedIterator;
+
+#[AsAlias(id: ExchangeAdapterRegistryInterface::class)]
+final class ExchangeAdapterRegistry implements ExchangeAdapterRegistryInterface
+{
+    /**
+     * @var array<string, ExchangeAdapterInterface>
+     */
+    private array $adapters = [];
+
+    /**
+     * @param iterable<ExchangeAdapterInterface> $adapters
+     */
+    public function __construct(
+        #[TaggedIterator('app.exchange_adapter')]
+        iterable $adapters,
+    ) {
+        foreach ($adapters as $adapter) {
+            $this->adapters[$this->key($adapter->exchange(), $adapter->marketType())] = $adapter;
+        }
+    }
+
+    public function get(Exchange $exchange, MarketType $marketType): ExchangeAdapterInterface
+    {
+        $key = $this->key($exchange, $marketType);
+        if (!isset($this->adapters[$key])) {
+            throw ExchangeAdapterNotFoundException::forContext($exchange, $marketType, array_keys($this->adapters));
+        }
+
+        return $this->adapters[$key];
+    }
+
+    public function all(): array
+    {
+        return array_values($this->adapters);
+    }
+
+    private function key(Exchange $exchange, MarketType $marketType): string
+    {
+        return sprintf('%s::%s', $exchange->value, $marketType->value);
+    }
+}

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -176,6 +176,24 @@ final class BitmartExchangeAdapterTest extends TestCase
         ));
     }
 
+    public function testRejectsAttachedProtectionOnReduceOnlyOrders(): void
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->expects($this->never())->method('get');
+        $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('attached SL/TP is only supported for entry orders');
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::SELL,
+            reduceOnly: true,
+            postOnly: false,
+            attachedTakeProfitPrice: 26000.0,
+        ));
+    }
+
     public function testRejectsSidePositionMismatchBeforeProviderSubmission(): void
     {
         $registry = $this->createMock(ExchangeProviderRegistryInterface::class);

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -33,6 +33,16 @@ use Psr\Clock\ClockInterface;
 #[CoversClass(BitmartExchangeAdapter::class)]
 final class BitmartExchangeAdapterTest extends TestCase
 {
+    public function testDoesNotAdvertiseStandaloneTriggerOrders(): void
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+
+        self::assertFalse($adapter->capabilities()->supportsTriggerOrders);
+        self::assertTrue($adapter->capabilities()->supportsAttachedStopLossOnEntry);
+        self::assertTrue($adapter->capabilities()->supportsAttachedTakeProfitOnEntry);
+    }
+
     public function testMapsLongEntryToLegacyOpenLongSide(): void
     {
         $capturedOptions = null;
@@ -57,6 +67,57 @@ final class BitmartExchangeAdapterTest extends TestCase
         $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::SHORT, ExchangeOrderSide::SELL));
 
         self::assertSame(4, $capturedOptions['side'] ?? null);
+    }
+
+    public function testMapsReduceOnlyLongExitToLegacyCloseLongSide(): void
+    {
+        $capturedOptions = null;
+        $adapter = $this->createAdapter(function (array $options) use (&$capturedOptions): void {
+            $capturedOptions = $options;
+        });
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::SELL,
+            reduceOnly: true,
+            postOnly: false,
+        ));
+
+        self::assertSame(3, $capturedOptions['side'] ?? null);
+    }
+
+    public function testMapsReduceOnlyShortExitToLegacyCloseShortSide(): void
+    {
+        $capturedOptions = null;
+        $adapter = $this->createAdapter(function (array $options) use (&$capturedOptions): void {
+            $capturedOptions = $options;
+        });
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::SHORT,
+            side: ExchangeOrderSide::BUY,
+            reduceOnly: true,
+            postOnly: false,
+        ));
+
+        self::assertSame(2, $capturedOptions['side'] ?? null);
+    }
+
+    public function testMapsFokToLegacyMode(): void
+    {
+        $capturedOptions = null;
+        $adapter = $this->createAdapter(function (array $options) use (&$capturedOptions): void {
+            $capturedOptions = $options;
+        });
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::BUY,
+            timeInForce: ExchangeTimeInForce::FOK,
+            postOnly: false,
+        ));
+
+        self::assertSame(2, $capturedOptions['mode'] ?? null);
     }
 
     /**
@@ -95,15 +156,16 @@ final class BitmartExchangeAdapterTest extends TestCase
         $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
         $registry->method('get')->willReturn($bundle);
 
-        return new BitmartExchangeAdapter($registry, new class implements ClockInterface {
-            public function now(): \DateTimeImmutable
-            {
-                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
-            }
-        });
+        return new BitmartExchangeAdapter($registry, $this->fixedClock());
     }
 
-    private function placeOrderRequest(ExchangePositionSide $positionSide, ExchangeOrderSide $side): PlaceOrderRequest
+    private function placeOrderRequest(
+        ExchangePositionSide $positionSide,
+        ExchangeOrderSide $side,
+        ExchangeTimeInForce $timeInForce = ExchangeTimeInForce::GTC,
+        bool $reduceOnly = false,
+        bool $postOnly = true,
+    ): PlaceOrderRequest
     {
         return new PlaceOrderRequest(
             exchange: Exchange::BITMART,
@@ -112,16 +174,26 @@ final class BitmartExchangeAdapterTest extends TestCase
             side: $side,
             positionSide: $positionSide,
             orderType: ExchangeOrderType::LIMIT,
-            timeInForce: ExchangeTimeInForce::GTC,
+            timeInForce: $timeInForce,
             quantity: 10.0,
             price: 25000.0,
             stopPrice: null,
-            reduceOnly: false,
-            postOnly: true,
+            reduceOnly: $reduceOnly,
+            postOnly: $postOnly,
             leverage: 3,
             marginMode: 'isolated',
             clientOrderId: 'cid-1',
         );
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        };
     }
 
     private function providerOrder(): OrderDto

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Adapter;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderStatus;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\ContractProviderInterface;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\ExchangeProviderRegistryInterface;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Contract\Provider\SystemProviderInterface;
+use App\Exchange\Adapter\BitmartExchangeAdapter;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Registry\ExchangeProviderBundle;
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(BitmartExchangeAdapter::class)]
+final class BitmartExchangeAdapterTest extends TestCase
+{
+    public function testMapsLongEntryToLegacyOpenLongSide(): void
+    {
+        $capturedOptions = null;
+        $adapter = $this->createAdapter(function (array $options) use (&$capturedOptions): void {
+            $capturedOptions = $options;
+        });
+
+        $result = $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::LONG, ExchangeOrderSide::BUY));
+
+        self::assertSame(ExchangeOrderStatus::PENDING, $result->status);
+        self::assertSame(1, $capturedOptions['side'] ?? null);
+        self::assertSame('cid-1', $capturedOptions['client_order_id'] ?? null);
+    }
+
+    public function testMapsShortEntryToLegacyOpenShortSide(): void
+    {
+        $capturedOptions = null;
+        $adapter = $this->createAdapter(function (array $options) use (&$capturedOptions): void {
+            $capturedOptions = $options;
+        });
+
+        $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::SHORT, ExchangeOrderSide::SELL));
+
+        self::assertSame(4, $capturedOptions['side'] ?? null);
+    }
+
+    /**
+     * @param callable(array<string,mixed>): void $captureOptions
+     */
+    private function createAdapter(callable $captureOptions): BitmartExchangeAdapter
+    {
+        $orderProvider = $this->createMock(OrderProviderInterface::class);
+        $orderProvider
+            ->expects($this->once())
+            ->method('placeOrder')
+            ->with(
+                'BTCUSDT',
+                $this->isInstanceOf(OrderSide::class),
+                OrderType::LIMIT,
+                10.0,
+                25000.0,
+                null,
+                $this->callback(function (array $options) use ($captureOptions): bool {
+                    $captureOptions($options);
+
+                    return true;
+                }),
+            )
+            ->willReturn($this->providerOrder());
+
+        $bundle = new ExchangeProviderBundle(
+            new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+            $this->createMock(KlineProviderInterface::class),
+            $this->createMock(ContractProviderInterface::class),
+            $orderProvider,
+            $this->createMock(AccountProviderInterface::class),
+            $this->createMock(SystemProviderInterface::class),
+        );
+
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($bundle);
+
+        return new BitmartExchangeAdapter($registry, new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        });
+    }
+
+    private function placeOrderRequest(ExchangePositionSide $positionSide, ExchangeOrderSide $side): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: $side,
+            positionSide: $positionSide,
+            orderType: ExchangeOrderType::LIMIT,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 10.0,
+            price: 25000.0,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-1',
+        );
+    }
+
+    private function providerOrder(): OrderDto
+    {
+        return new OrderDto(
+            orderId: 'ex-1',
+            symbol: 'BTCUSDT',
+            side: OrderSide::BUY,
+            type: OrderType::LIMIT,
+            status: OrderStatus::PENDING,
+            quantity: BigDecimal::of('10'),
+            price: BigDecimal::of('25000'),
+            stopPrice: null,
+            filledQuantity: BigDecimal::of('0'),
+            remainingQuantity: BigDecimal::of('10'),
+            averagePrice: null,
+            createdAt: new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
+            metadata: ['client_order_id' => 'cid-1'],
+        );
+    }
+}

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -158,6 +158,24 @@ final class BitmartExchangeAdapterTest extends TestCase
         ));
     }
 
+    public function testRejectsAttachedProtectionOnMarketOrders(): void
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->expects($this->never())->method('get');
+        $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('attached SL/TP on market orders');
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::BUY,
+            orderType: ExchangeOrderType::MARKET,
+            postOnly: false,
+            attachedStopLossPrice: 24000.0,
+        ));
+    }
+
     public function testRejectsSidePositionMismatchBeforeProviderSubmission(): void
     {
         $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
@@ -371,6 +389,8 @@ final class BitmartExchangeAdapterTest extends TestCase
         ExchangeOrderType $orderType = ExchangeOrderType::LIMIT,
         bool $reduceOnly = false,
         bool $postOnly = true,
+        ?float $attachedStopLossPrice = null,
+        ?float $attachedTakeProfitPrice = null,
     ): PlaceOrderRequest
     {
         return new PlaceOrderRequest(
@@ -389,6 +409,8 @@ final class BitmartExchangeAdapterTest extends TestCase
             leverage: 3,
             marginMode: 'isolated',
             clientOrderId: 'cid-1',
+            attachedStopLossPrice: $attachedStopLossPrice,
+            attachedTakeProfitPrice: $attachedTakeProfitPrice,
         );
     }
 

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -123,6 +123,39 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertSame(2, $capturedOptions['mode'] ?? null);
     }
 
+    public function testRejectsPostOnlyWithIocOrFok(): void
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->expects($this->never())->method('get');
+        $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('postOnly cannot be combined with IOC or FOK');
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::BUY,
+            timeInForce: ExchangeTimeInForce::IOC,
+            postOnly: true,
+        ));
+    }
+
+    public function testRejectsSidePositionMismatchBeforeProviderSubmission(): void
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->expects($this->never())->method('get');
+        $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid order side "buy" for entry short position intent');
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::SHORT,
+            side: ExchangeOrderSide::BUY,
+            postOnly: false,
+        ));
+    }
+
     public function testRejectsStandaloneTriggerOrdersBeforeProviderSubmission(): void
     {
         $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
@@ -134,7 +167,7 @@ final class BitmartExchangeAdapterTest extends TestCase
 
         $adapter->placeOrder($this->placeOrderRequest(
             positionSide: ExchangePositionSide::LONG,
-            side: ExchangeOrderSide::SELL,
+            side: ExchangeOrderSide::BUY,
             orderType: ExchangeOrderType::TRIGGER,
             postOnly: false,
         ));
@@ -181,6 +214,51 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertSame(ExchangePositionSide::LONG, $result->order?->positionSide);
         self::assertTrue($result->order?->reduceOnly);
         self::assertSame(ExchangeTimeInForce::IOC, $result->order?->timeInForce);
+    }
+
+    public function testMapsReturnedGtcMode(): void
+    {
+        $adapter = $this->createAdapter(
+            static function (): void {
+            },
+            $this->providerOrder([
+                'client_order_id' => 'cid-1',
+                'side' => 1,
+                'mode' => 1,
+            ]),
+        );
+
+        $result = $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::LONG, ExchangeOrderSide::BUY));
+
+        self::assertSame(ExchangeTimeInForce::GTC, $result->order?->timeInForce);
+    }
+
+    public function testFallbackSubmitOnlyOrderPreservesSubmittedIntent(): void
+    {
+        $adapter = $this->createAdapter(
+            static function (): void {
+            },
+            $this->providerOrder([
+                'provider' => 'bitmart',
+                'submit_only' => true,
+            ]),
+        );
+
+        $result = $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::SELL,
+            timeInForce: ExchangeTimeInForce::IOC,
+            reduceOnly: true,
+            postOnly: false,
+        ));
+
+        self::assertSame('cid-1', $result->order?->clientOrderId);
+        self::assertSame(ExchangeOrderSide::SELL, $result->order?->side);
+        self::assertSame(ExchangePositionSide::LONG, $result->order?->positionSide);
+        self::assertTrue($result->order?->reduceOnly);
+        self::assertSame(ExchangeTimeInForce::IOC, $result->order?->timeInForce);
+        self::assertSame(3, $result->order?->metadata['side'] ?? null);
+        self::assertTrue($result->order?->metadata['submit_only'] ?? false);
     }
 
     /**

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -17,6 +17,7 @@ use App\Contract\Provider\KlineProviderInterface;
 use App\Contract\Provider\OrderProviderInterface;
 use App\Contract\Provider\SystemProviderInterface;
 use App\Exchange\Adapter\BitmartExchangeAdapter;
+use App\Exchange\Dto\CancelOrderRequest;
 use App\Exchange\Dto\PlaceOrderRequest;
 use App\Exchange\Enum\ExchangeOrderSide;
 use App\Exchange\Enum\ExchangeOrderStatus;
@@ -140,6 +141,23 @@ final class BitmartExchangeAdapterTest extends TestCase
         ));
     }
 
+    public function testRejectsPostOnlyMarketOrders(): void
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->expects($this->never())->method('get');
+        $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('postOnly is only supported for limit orders');
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::BUY,
+            orderType: ExchangeOrderType::MARKET,
+            postOnly: true,
+        ));
+    }
+
     public function testRejectsSidePositionMismatchBeforeProviderSubmission(): void
     {
         $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
@@ -233,6 +251,24 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertSame(ExchangeTimeInForce::GTC, $result->order?->timeInForce);
     }
 
+    public function testMapsReturnedPostOnlyModeAsGtc(): void
+    {
+        $adapter = $this->createAdapter(
+            static function (): void {
+            },
+            $this->providerOrder([
+                'client_order_id' => 'cid-1',
+                'side' => 1,
+                'mode' => 4,
+            ]),
+        );
+
+        $result = $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::LONG, ExchangeOrderSide::BUY));
+
+        self::assertTrue($result->order?->postOnly);
+        self::assertSame(ExchangeTimeInForce::GTC, $result->order?->timeInForce);
+    }
+
     public function testFallbackSubmitOnlyOrderPreservesSubmittedIntent(): void
     {
         $adapter = $this->createAdapter(
@@ -261,6 +297,29 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertTrue($result->order?->metadata['submit_only'] ?? false);
     }
 
+    public function testCancelFailureWithExchangeOrderIdDoesNotReportClientIdUnsupported(): void
+    {
+        $orderProvider = $this->createMock(OrderProviderInterface::class);
+        $orderProvider
+            ->expects($this->once())
+            ->method('cancelOrder')
+            ->with('BTCUSDT', 'ex-1')
+            ->willReturn(false);
+
+        $adapter = $this->createAdapterWithOrderProvider($orderProvider);
+
+        $result = $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: 'ex-1',
+            clientOrderId: 'cid-1',
+        ));
+
+        self::assertFalse($result->cancelled);
+        self::assertSame('exchange_order_cancel_failed', $result->metadata['reason'] ?? null);
+    }
+
     /**
      * @param callable(array<string,mixed>): void $captureOptions
      */
@@ -285,6 +344,11 @@ final class BitmartExchangeAdapterTest extends TestCase
             )
             ->willReturn($providerOrder ?? $this->providerOrder());
 
+        return $this->createAdapterWithOrderProvider($orderProvider);
+    }
+
+    private function createAdapterWithOrderProvider(OrderProviderInterface $orderProvider): BitmartExchangeAdapter
+    {
         $bundle = new ExchangeProviderBundle(
             new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
             $this->createMock(KlineProviderInterface::class),

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -39,6 +39,7 @@ final class BitmartExchangeAdapterTest extends TestCase
         $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
 
         self::assertFalse($adapter->capabilities()->supportsTriggerOrders);
+        self::assertFalse($adapter->capabilities()->supportsModifyOrder);
         self::assertTrue($adapter->capabilities()->supportsAttachedStopLossOnEntry);
         self::assertTrue($adapter->capabilities()->supportsAttachedTakeProfitOnEntry);
     }
@@ -55,6 +56,8 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertSame(ExchangeOrderStatus::PENDING, $result->status);
         self::assertSame(1, $capturedOptions['side'] ?? null);
         self::assertSame('cid-1', $capturedOptions['client_order_id'] ?? null);
+        self::assertArrayNotHasKey('reduce_only', $capturedOptions);
+        self::assertArrayNotHasKey('post_only', $capturedOptions);
     }
 
     public function testMapsShortEntryToLegacyOpenShortSide(): void
@@ -120,10 +123,70 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertSame(2, $capturedOptions['mode'] ?? null);
     }
 
+    public function testRejectsStandaloneTriggerOrdersBeforeProviderSubmission(): void
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->expects($this->never())->method('get');
+        $adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not support standalone trigger orders');
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::SELL,
+            orderType: ExchangeOrderType::TRIGGER,
+            postOnly: false,
+        ));
+    }
+
+    public function testMapsReturnedShortEntryFromRawBitmartSideCode(): void
+    {
+        $adapter = $this->createAdapter(
+            static function (): void {
+            },
+            $this->providerOrder([
+                'client_order_id' => 'cid-1',
+                'side' => 4,
+            ]),
+        );
+
+        $result = $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::SHORT, ExchangeOrderSide::SELL));
+
+        self::assertSame(ExchangeOrderSide::SELL, $result->order?->side);
+        self::assertSame(ExchangePositionSide::SHORT, $result->order?->positionSide);
+        self::assertFalse($result->order?->reduceOnly);
+    }
+
+    public function testMapsReturnedLongExitFromRawBitmartSideCode(): void
+    {
+        $adapter = $this->createAdapter(
+            static function (): void {
+            },
+            $this->providerOrder([
+                'client_order_id' => 'cid-1',
+                'side' => 3,
+                'mode' => 3,
+            ]),
+        );
+
+        $result = $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::SELL,
+            reduceOnly: true,
+            postOnly: false,
+        ));
+
+        self::assertSame(ExchangeOrderSide::SELL, $result->order?->side);
+        self::assertSame(ExchangePositionSide::LONG, $result->order?->positionSide);
+        self::assertTrue($result->order?->reduceOnly);
+        self::assertSame(ExchangeTimeInForce::IOC, $result->order?->timeInForce);
+    }
+
     /**
      * @param callable(array<string,mixed>): void $captureOptions
      */
-    private function createAdapter(callable $captureOptions): BitmartExchangeAdapter
+    private function createAdapter(callable $captureOptions, ?OrderDto $providerOrder = null): BitmartExchangeAdapter
     {
         $orderProvider = $this->createMock(OrderProviderInterface::class);
         $orderProvider
@@ -142,7 +205,7 @@ final class BitmartExchangeAdapterTest extends TestCase
                     return true;
                 }),
             )
-            ->willReturn($this->providerOrder());
+            ->willReturn($providerOrder ?? $this->providerOrder());
 
         $bundle = new ExchangeProviderBundle(
             new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
@@ -163,6 +226,7 @@ final class BitmartExchangeAdapterTest extends TestCase
         ExchangePositionSide $positionSide,
         ExchangeOrderSide $side,
         ExchangeTimeInForce $timeInForce = ExchangeTimeInForce::GTC,
+        ExchangeOrderType $orderType = ExchangeOrderType::LIMIT,
         bool $reduceOnly = false,
         bool $postOnly = true,
     ): PlaceOrderRequest
@@ -173,7 +237,7 @@ final class BitmartExchangeAdapterTest extends TestCase
             symbol: 'BTCUSDT',
             side: $side,
             positionSide: $positionSide,
-            orderType: ExchangeOrderType::LIMIT,
+            orderType: $orderType,
             timeInForce: $timeInForce,
             quantity: 10.0,
             price: 25000.0,
@@ -196,7 +260,10 @@ final class BitmartExchangeAdapterTest extends TestCase
         };
     }
 
-    private function providerOrder(): OrderDto
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function providerOrder(array $metadata = ['client_order_id' => 'cid-1']): OrderDto
     {
         return new OrderDto(
             orderId: 'ex-1',
@@ -211,7 +278,7 @@ final class BitmartExchangeAdapterTest extends TestCase
             remainingQuantity: BigDecimal::of('10'),
             averagePrice: null,
             createdAt: new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
-            metadata: ['client_order_id' => 'cid-1'],
+            metadata: $metadata,
         );
     }
 }

--- a/trading-app/tests/Exchange/Dto/ExchangeCapabilitiesTest.php
+++ b/trading-app/tests/Exchange/Dto/ExchangeCapabilitiesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Dto;
+
+use App\Exchange\Dto\ExchangeCapabilities;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExchangeCapabilities::class)]
+final class ExchangeCapabilitiesTest extends TestCase
+{
+    public function testCapabilitiesExposeStableArrayShape(): void
+    {
+        $capabilities = new ExchangeCapabilities(
+            supportsTestnet: true,
+            supportsWebSocketPrivate: true,
+            supportsClientOrderId: true,
+            supportsIoc: true,
+            supportsReduceOnly: true,
+            requiresSeparateLeverageSubmit: true,
+        );
+
+        self::assertSame([
+            'supportsTestnet' => true,
+            'supportsWebSocketPrivate' => true,
+            'supportsClientOrderId' => true,
+            'supportsCancelByClientOrderId' => false,
+            'supportsPostOnly' => false,
+            'supportsIoc' => true,
+            'supportsReduceOnly' => true,
+            'supportsAttachedStopLossOnEntry' => false,
+            'supportsAttachedTakeProfitOnEntry' => false,
+            'supportsTriggerOrders' => false,
+            'supportsModifyOrder' => false,
+            'requiresSeparateLeverageSubmit' => true,
+            'supportsPerSymbolLeverage' => false,
+        ], $capabilities->toArray());
+    }
+}

--- a/trading-app/tests/Exchange/Dto/PlaceOrderRequestTest.php
+++ b/trading-app/tests/Exchange/Dto/PlaceOrderRequestTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PlaceOrderRequest::class)]
+final class PlaceOrderRequestTest extends TestCase
+{
+    public function testCreatesTypedBusinessOrderIntent(): void
+    {
+        $request = $this->createRequest();
+
+        self::assertSame(Exchange::BITMART, $request->exchange);
+        self::assertSame(MarketType::PERPETUAL, $request->marketType);
+        self::assertSame('BTCUSDT', $request->symbol);
+        self::assertSame(ExchangeOrderSide::BUY, $request->side);
+        self::assertSame(ExchangePositionSide::LONG, $request->positionSide);
+        self::assertSame(ExchangeOrderType::LIMIT, $request->orderType);
+        self::assertSame(ExchangeTimeInForce::GTC, $request->timeInForce);
+        self::assertSame('cid-1', $request->clientOrderId);
+    }
+
+    public function testRejectsBlankClientOrderId(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('clientOrderId cannot be blank');
+
+        $this->createRequest(clientOrderId: ' ');
+    }
+
+    public function testLimitOrderRequiresPrice(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('limit orders require a positive price');
+
+        $this->createRequest(price: null);
+    }
+
+    private function createRequest(?float $price = 25000.0, string $clientOrderId = 'cid-1'): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::LIMIT,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 10.0,
+            price: $price,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+        );
+    }
+}

--- a/trading-app/tests/Exchange/Registry/ExchangeAdapterRegistryTest.php
+++ b/trading-app/tests/Exchange/Registry/ExchangeAdapterRegistryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Registry;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Registry\ExchangeAdapterNotFoundException;
+use App\Exchange\Registry\ExchangeAdapterRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExchangeAdapterRegistry::class)]
+#[CoversClass(ExchangeAdapterNotFoundException::class)]
+final class ExchangeAdapterRegistryTest extends TestCase
+{
+    public function testReturnsAdapterForExchangeAndMarketType(): void
+    {
+        $adapter = $this->createMock(ExchangeAdapterInterface::class);
+        $adapter->method('exchange')->willReturn(Exchange::BITMART);
+        $adapter->method('marketType')->willReturn(MarketType::PERPETUAL);
+
+        $registry = new ExchangeAdapterRegistry([$adapter]);
+
+        self::assertSame($adapter, $registry->get(Exchange::BITMART, MarketType::PERPETUAL));
+    }
+
+    public function testThrowsWhenAdapterIsMissing(): void
+    {
+        $registry = new ExchangeAdapterRegistry([]);
+
+        $this->expectException(ExchangeAdapterNotFoundException::class);
+        $this->expectExceptionMessage('No exchange adapter registered');
+
+        $registry->get(Exchange::BITMART, MarketType::PERPETUAL);
+    }
+}


### PR DESCRIPTION
## Summary
- add typed ExchangeAdapterInterface, registry, DTOs, enums, and capabilities
- add BitmartExchangeAdapter skeleton over the existing provider registry without changing legacy Bitmart flow
- document the API-first exchange boundary and add focused unit tests

## Tests
- find trading-app/src/Exchange trading-app/tests/Exchange -name '*.php' -print0 | xargs -0 -n1 php -l
- php bin/console lint:container --no-debug
- ./vendor/bin/phpunit tests/Exchange

Closes #79