### PR TITLE
[API-02] Scope storage by exchange and market type

### DIFF
--- a/trading-app/config/packages/test/doctrine.yaml
+++ b/trading-app/config/packages/test/doctrine.yaml
@@ -18,3 +18,8 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
+            Provider:
+                is_bundle: false
+                dir: '%kernel.project_dir%/src/Provider/Entity'
+                prefix: 'App\Provider\Entity'
+                alias: Provider

--- a/trading-app/migrations/Version20260531010000.php
+++ b/trading-app/migrations/Version20260531010000.php
@@ -29,6 +29,7 @@ final class Version20260531010000 extends AbstractMigration
             'order_protection',
             'indicator_snapshots',
             'trade_zone_events',
+            'mtf_state',
         ];
 
         foreach ($tables as $table) {
@@ -66,6 +67,7 @@ final class Version20260531010000 extends AbstractMigration
             'order_protection',
             'indicator_snapshots',
             'trade_zone_events',
+            'mtf_state',
         ];
 
         foreach ($tables as $table) {
@@ -102,6 +104,8 @@ final class Version20260531010000 extends AbstractMigration
             'idx_ind_snap_symbol_tf',
             'ux_ind_snap_symbol_tf_time',
             'idx_zone_symbol',
+            'idx_mtf_state_symbol',
+            'ux_mtf_state_symbol',
             'idx_trade_lifecycle_symbol_happened_at',
             'uniq_trade_lifecycle_event_dedup',
         ];
@@ -117,6 +121,7 @@ final class Version20260531010000 extends AbstractMigration
             $this->addSql(sprintf('ALTER TABLE order_intent DROP CONSTRAINT IF EXISTS %s', $name));
             $this->addSql(sprintf('ALTER TABLE indicator_snapshots DROP CONSTRAINT IF EXISTS %s', $name));
             $this->addSql(sprintf('ALTER TABLE trade_zone_events DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE mtf_state DROP CONSTRAINT IF EXISTS %s', $name));
             $this->addSql(sprintf('ALTER TABLE trade_lifecycle_event DROP CONSTRAINT IF EXISTS %s', $name));
             $this->addSql(sprintf('DROP INDEX IF EXISTS %s', $name));
         }
@@ -153,6 +158,8 @@ final class Version20260531010000 extends AbstractMigration
         $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_ind_snap_exchange_market_symbol_tf_time ON indicator_snapshots (exchange, market_type, symbol, timeframe, kline_time)');
 
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_zone_exchange_market_symbol ON trade_zone_events (exchange, market_type, symbol)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_mtf_state_exchange_market_symbol ON mtf_state (exchange, market_type, symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_mtf_state_exchange_market_symbol ON mtf_state (exchange, market_type, symbol)');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lifecycle_exchange_market_symbol_happened_at ON trade_lifecycle_event (exchange, market_type, symbol, happened_at DESC)');
         $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_trade_lifecycle_event_dedup ON trade_lifecycle_event (exchange, market_type, account_id, run_id, symbol, event_type, order_id, happened_at)');
     }
@@ -180,6 +187,8 @@ final class Version20260531010000 extends AbstractMigration
             'idx_ind_snap_exchange_market_symbol_tf',
             'ux_ind_snap_exchange_market_symbol_tf_time',
             'idx_zone_exchange_market_symbol',
+            'idx_mtf_state_exchange_market_symbol',
+            'ux_mtf_state_exchange_market_symbol',
             'idx_trade_lifecycle_exchange_market_symbol_happened_at',
             'uniq_trade_lifecycle_event_dedup',
         ];
@@ -210,6 +219,8 @@ final class Version20260531010000 extends AbstractMigration
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_ind_snap_symbol_tf ON indicator_snapshots (symbol, timeframe)');
         $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_ind_snap_symbol_tf_time ON indicator_snapshots (symbol, timeframe, kline_time)');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_zone_symbol ON trade_zone_events (symbol)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_mtf_state_symbol ON mtf_state (symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_mtf_state_symbol ON mtf_state (symbol)');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lifecycle_symbol_happened_at ON trade_lifecycle_event (symbol, happened_at DESC)');
         $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_trade_lifecycle_event_dedup ON trade_lifecycle_event (exchange, account_id, run_id, symbol, event_type, order_id, happened_at)');
     }
@@ -227,6 +238,7 @@ final class Version20260531010000 extends AbstractMigration
             ['futures_order_trade', 'trade_id', 'trade_id IS NOT NULL'],
             ['order_intent', 'client_order_id', 'client_order_id IS NOT NULL'],
             ['indicator_snapshots', 'symbol, timeframe, kline_time', 'symbol IS NOT NULL AND timeframe IS NOT NULL AND kline_time IS NOT NULL'],
+            ['mtf_state', 'symbol', 'symbol IS NOT NULL'],
             ['trade_lifecycle_event', 'exchange, account_id, run_id, symbol, event_type, order_id, happened_at', 'exchange IS NOT NULL AND run_id IS NOT NULL AND symbol IS NOT NULL AND event_type IS NOT NULL AND happened_at IS NOT NULL'],
         ];
 

--- a/trading-app/migrations/Version20260531010000.php
+++ b/trading-app/migrations/Version20260531010000.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260531010000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Scope symbol-based storage by exchange and market type with Bitmart perpetual legacy defaults.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $tables = [
+            'contracts',
+            'klines',
+            'positions',
+            'futures_order',
+            'futures_plan_order',
+            'futures_order_trade',
+            'futures_transaction',
+            'order_intent',
+            'order_protection',
+            'indicator_snapshots',
+            'trade_zone_events',
+        ];
+
+        foreach ($tables as $table) {
+            $this->addSql(sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS exchange VARCHAR(32) NOT NULL DEFAULT 'bitmart'", $table));
+            $this->addSql(sprintf("ALTER TABLE %s ADD COLUMN IF NOT EXISTS market_type VARCHAR(32) NOT NULL DEFAULT 'perpetual'", $table));
+            $this->addSql(sprintf("UPDATE %s SET exchange = COALESCE(NULLIF(exchange, ''), 'bitmart'), market_type = COALESCE(NULLIF(market_type, ''), 'perpetual')", $table));
+        }
+
+        $this->addSql("ALTER TABLE trade_lifecycle_event ADD COLUMN IF NOT EXISTS market_type VARCHAR(32) NOT NULL DEFAULT 'perpetual'");
+        $this->addSql("UPDATE trade_lifecycle_event SET exchange = COALESCE(NULLIF(exchange, ''), 'bitmart'), market_type = COALESCE(NULLIF(market_type, ''), 'perpetual')");
+        $this->addSql("ALTER TABLE trade_lifecycle_event ALTER COLUMN exchange SET DEFAULT 'bitmart'");
+        $this->addSql("ALTER TABLE trade_lifecycle_event ALTER COLUMN exchange SET NOT NULL");
+
+        $this->dropOldIndexes();
+        $this->createScopedIndexes();
+        $this->refreshKlineIngestFunction();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->dropScopedIndexes();
+        $this->createLegacyIndexes();
+
+        $tables = [
+            'contracts',
+            'klines',
+            'positions',
+            'futures_order',
+            'futures_plan_order',
+            'futures_order_trade',
+            'futures_transaction',
+            'order_intent',
+            'order_protection',
+            'indicator_snapshots',
+            'trade_zone_events',
+        ];
+
+        foreach ($tables as $table) {
+            $this->addSql(sprintf('ALTER TABLE %s DROP COLUMN IF EXISTS market_type', $table));
+            $this->addSql(sprintf('ALTER TABLE %s DROP COLUMN IF EXISTS exchange', $table));
+        }
+
+        $this->addSql('ALTER TABLE trade_lifecycle_event DROP COLUMN IF EXISTS market_type');
+        $this->addSql('ALTER TABLE trade_lifecycle_event ALTER COLUMN exchange DROP DEFAULT');
+        $this->addSql('ALTER TABLE trade_lifecycle_event ALTER COLUMN exchange DROP NOT NULL');
+
+        $this->refreshLegacyKlineIngestFunction();
+    }
+
+    private function dropOldIndexes(): void
+    {
+        $names = [
+            'ux_contracts_symbol',
+            'idx_klines_symbol_tf',
+            'ux_klines_symbol_tf_open',
+            'idx_positions_symbol',
+            'ux_positions_symbol_side',
+            'ux_futures_order_order_id',
+            'ux_futures_order_client',
+            'idx_futures_order_symbol',
+            'ux_futures_plan_order_order_id',
+            'ux_futures_plan_order_client',
+            'idx_futures_plan_order_symbol',
+            'ux_futures_order_trade_trade_id',
+            'idx_futures_order_trade_symbol',
+            'idx_futures_tx_symbol',
+            'ux_order_intent_client_order_id',
+            'idx_order_intent_symbol',
+            'idx_ind_snap_symbol_tf',
+            'ux_ind_snap_symbol_tf_time',
+            'idx_zone_symbol',
+            'idx_trade_lifecycle_symbol_happened_at',
+            'uniq_trade_lifecycle_event_dedup',
+        ];
+
+        foreach ($names as $name) {
+            $this->addSql(sprintf('ALTER TABLE contracts DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE klines DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE positions DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE futures_order DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE futures_plan_order DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE futures_order_trade DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE futures_transaction DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE order_intent DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE indicator_snapshots DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE trade_zone_events DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('ALTER TABLE trade_lifecycle_event DROP CONSTRAINT IF EXISTS %s', $name));
+            $this->addSql(sprintf('DROP INDEX IF EXISTS %s', $name));
+        }
+    }
+
+    private function createScopedIndexes(): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_contracts_exchange_market_symbol ON contracts (exchange, market_type, symbol)');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_klines_exchange_market_symbol_tf ON klines (exchange, market_type, symbol, timeframe)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_klines_exchange_market_symbol_tf_open ON klines (exchange, market_type, symbol, timeframe, open_time)');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_positions_exchange_market_symbol ON positions (exchange, market_type, symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_positions_exchange_market_symbol_side ON positions (exchange, market_type, symbol, side)');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_order_exchange_market_symbol ON futures_order (exchange, market_type, symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_order_exchange_market_order_id ON futures_order (exchange, market_type, order_id) WHERE order_id IS NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_order_exchange_market_client ON futures_order (exchange, market_type, client_order_id) WHERE client_order_id IS NOT NULL');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_plan_order_exchange_market_symbol ON futures_plan_order (exchange, market_type, symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_plan_order_exchange_market_order_id ON futures_plan_order (exchange, market_type, order_id) WHERE order_id IS NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_plan_order_exchange_market_client ON futures_plan_order (exchange, market_type, client_order_id) WHERE client_order_id IS NOT NULL');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_order_trade_exchange_market_symbol ON futures_order_trade (exchange, market_type, symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_order_trade_exchange_market_trade_id ON futures_order_trade (exchange, market_type, trade_id) WHERE trade_id IS NOT NULL');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_tx_exchange_market_symbol ON futures_transaction (exchange, market_type, symbol)');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_order_intent_exchange_market_symbol ON order_intent (exchange, market_type, symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_order_intent_exchange_market_client_order_id ON order_intent (exchange, market_type, client_order_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_order_protection_exchange_market ON order_protection (exchange, market_type)');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_ind_snap_exchange_market_symbol_tf ON indicator_snapshots (exchange, market_type, symbol, timeframe)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_ind_snap_exchange_market_symbol_tf_time ON indicator_snapshots (exchange, market_type, symbol, timeframe, kline_time)');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_zone_exchange_market_symbol ON trade_zone_events (exchange, market_type, symbol)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lifecycle_exchange_market_symbol_happened_at ON trade_lifecycle_event (exchange, market_type, symbol, happened_at DESC)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_trade_lifecycle_event_dedup ON trade_lifecycle_event (exchange, market_type, account_id, run_id, symbol, event_type, order_id, happened_at)');
+    }
+
+    private function dropScopedIndexes(): void
+    {
+        $names = [
+            'ux_contracts_exchange_market_symbol',
+            'idx_klines_exchange_market_symbol_tf',
+            'ux_klines_exchange_market_symbol_tf_open',
+            'idx_positions_exchange_market_symbol',
+            'ux_positions_exchange_market_symbol_side',
+            'idx_futures_order_exchange_market_symbol',
+            'ux_futures_order_exchange_market_order_id',
+            'ux_futures_order_exchange_market_client',
+            'idx_futures_plan_order_exchange_market_symbol',
+            'ux_futures_plan_order_exchange_market_order_id',
+            'ux_futures_plan_order_exchange_market_client',
+            'idx_futures_order_trade_exchange_market_symbol',
+            'ux_futures_order_trade_exchange_market_trade_id',
+            'idx_futures_tx_exchange_market_symbol',
+            'idx_order_intent_exchange_market_symbol',
+            'ux_order_intent_exchange_market_client_order_id',
+            'idx_order_protection_exchange_market',
+            'idx_ind_snap_exchange_market_symbol_tf',
+            'ux_ind_snap_exchange_market_symbol_tf_time',
+            'idx_zone_exchange_market_symbol',
+            'idx_trade_lifecycle_exchange_market_symbol_happened_at',
+            'uniq_trade_lifecycle_event_dedup',
+        ];
+
+        foreach ($names as $name) {
+            $this->addSql(sprintf('DROP INDEX IF EXISTS %s', $name));
+        }
+    }
+
+    private function createLegacyIndexes(): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_contracts_symbol ON contracts (symbol)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_klines_symbol_tf ON klines (symbol, timeframe)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_klines_symbol_tf_open ON klines (symbol, timeframe, open_time)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_positions_symbol ON positions (symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_positions_symbol_side ON positions (symbol, side)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_order_symbol ON futures_order (symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_order_order_id ON futures_order (order_id) WHERE order_id IS NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_order_client ON futures_order (client_order_id) WHERE client_order_id IS NOT NULL');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_plan_order_symbol ON futures_plan_order (symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_plan_order_order_id ON futures_plan_order (order_id) WHERE order_id IS NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_plan_order_client ON futures_plan_order (client_order_id) WHERE client_order_id IS NOT NULL');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_order_trade_symbol ON futures_order_trade (symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_futures_order_trade_trade_id ON futures_order_trade (trade_id) WHERE trade_id IS NOT NULL');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_futures_tx_symbol ON futures_transaction (symbol)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_order_intent_client_order_id ON order_intent (client_order_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_order_intent_symbol ON order_intent (symbol)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_ind_snap_symbol_tf ON indicator_snapshots (symbol, timeframe)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_ind_snap_symbol_tf_time ON indicator_snapshots (symbol, timeframe, kline_time)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_zone_symbol ON trade_zone_events (symbol)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lifecycle_symbol_happened_at ON trade_lifecycle_event (symbol, happened_at DESC)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_trade_lifecycle_event_dedup ON trade_lifecycle_event (exchange, account_id, run_id, symbol, event_type, order_id, happened_at)');
+    }
+
+    private function refreshKlineIngestFunction(): void
+    {
+        $this->addSql(<<<'SQL'
+CREATE OR REPLACE FUNCTION ingest_klines_json(p_payload jsonb)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+INSERT INTO klines (
+    id, exchange, market_type, symbol, timeframe, open_time,
+    open_price, high_price, low_price, close_price, volume,
+    source, inserted_at, updated_at
+)
+SELECT
+    nextval('klines_id_seq'),
+    COALESCE(NULLIF(t.exchange, ''), 'bitmart'),
+    COALESCE(NULLIF(t.market_type, ''), 'perpetual'),
+    t.symbol,
+    t.timeframe,
+    (t.open_time)::timestamptz,
+    (t.open_price)::numeric,
+    (t.high_price)::numeric,
+    (t.low_price)::numeric,
+    (t.close_price)::numeric,
+    (t.volume)::numeric,
+    COALESCE(t.source, 'REST'),
+    now(),
+    now()
+FROM jsonb_to_recordset(p_payload) AS t(
+    exchange text,
+    market_type text,
+    symbol text,
+    timeframe text,
+    open_time text,
+    open_price text,
+    high_price text,
+    low_price text,
+    close_price text,
+    volume text,
+    source text
+)
+ON CONFLICT (exchange, market_type, symbol, timeframe, open_time) DO UPDATE SET
+    open_price = EXCLUDED.open_price,
+    high_price = EXCLUDED.high_price,
+    low_price = EXCLUDED.low_price,
+    close_price = EXCLUDED.close_price,
+    volume = EXCLUDED.volume,
+    source = EXCLUDED.source,
+    updated_at = EXCLUDED.updated_at;
+END;
+$$;
+SQL);
+    }
+
+    private function refreshLegacyKlineIngestFunction(): void
+    {
+        $this->addSql(<<<'SQL'
+CREATE OR REPLACE FUNCTION ingest_klines_json(p_payload jsonb)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+INSERT INTO klines (
+    id, symbol, timeframe, open_time,
+    open_price, high_price, low_price, close_price, volume,
+    source, inserted_at, updated_at
+)
+SELECT
+    nextval('klines_id_seq'),
+    t.symbol,
+    t.timeframe,
+    (t.open_time)::timestamptz,
+    (t.open_price)::numeric,
+    (t.high_price)::numeric,
+    (t.low_price)::numeric,
+    (t.close_price)::numeric,
+    (t.volume)::numeric,
+    COALESCE(t.source, 'REST'),
+    now(),
+    now()
+FROM jsonb_to_recordset(p_payload) AS t(
+    symbol text,
+    timeframe text,
+    open_time text,
+    open_price text,
+    high_price text,
+    low_price text,
+    close_price text,
+    volume text,
+    source text
+)
+ON CONFLICT (symbol, timeframe, open_time) DO NOTHING;
+END;
+$$;
+SQL);
+    }
+}

--- a/trading-app/migrations/Version20260531010000.php
+++ b/trading-app/migrations/Version20260531010000.php
@@ -6,6 +6,7 @@ namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
 
 final class Version20260531010000 extends AbstractMigration
 {
@@ -48,6 +49,8 @@ final class Version20260531010000 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->abortDownIfLegacyDuplicatesExist();
+
         $this->dropScopedIndexes();
         $this->createLegacyIndexes();
 
@@ -209,6 +212,41 @@ final class Version20260531010000 extends AbstractMigration
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_zone_symbol ON trade_zone_events (symbol)');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lifecycle_symbol_happened_at ON trade_lifecycle_event (symbol, happened_at DESC)');
         $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS uniq_trade_lifecycle_event_dedup ON trade_lifecycle_event (exchange, account_id, run_id, symbol, event_type, order_id, happened_at)');
+    }
+
+    private function abortDownIfLegacyDuplicatesExist(): void
+    {
+        $checks = [
+            ['contracts', 'symbol', 'symbol IS NOT NULL'],
+            ['klines', 'symbol, timeframe, open_time', 'symbol IS NOT NULL AND timeframe IS NOT NULL AND open_time IS NOT NULL'],
+            ['positions', 'symbol, side', 'symbol IS NOT NULL AND side IS NOT NULL'],
+            ['futures_order', 'order_id', 'order_id IS NOT NULL'],
+            ['futures_order', 'client_order_id', 'client_order_id IS NOT NULL'],
+            ['futures_plan_order', 'order_id', 'order_id IS NOT NULL'],
+            ['futures_plan_order', 'client_order_id', 'client_order_id IS NOT NULL'],
+            ['futures_order_trade', 'trade_id', 'trade_id IS NOT NULL'],
+            ['order_intent', 'client_order_id', 'client_order_id IS NOT NULL'],
+            ['indicator_snapshots', 'symbol, timeframe, kline_time', 'symbol IS NOT NULL AND timeframe IS NOT NULL AND kline_time IS NOT NULL'],
+            ['trade_lifecycle_event', 'exchange, account_id, run_id, symbol, event_type, order_id, happened_at', 'exchange IS NOT NULL AND run_id IS NOT NULL AND symbol IS NOT NULL AND event_type IS NOT NULL AND happened_at IS NOT NULL'],
+        ];
+
+        foreach ($checks as [$table, $legacyKey, $where]) {
+            $sql = sprintf(
+                "SELECT COUNT(*) FROM (SELECT %s FROM %s WHERE %s GROUP BY %s HAVING COUNT(DISTINCT exchange || ':' || market_type) > 1) duplicates",
+                $legacyKey,
+                $table,
+                $where,
+                $legacyKey,
+            );
+
+            if ((int) $this->connection->fetchOne($sql) > 0) {
+                throw new IrreversibleMigration(sprintf(
+                    'Cannot rollback exchange/market scoping: table "%s" contains rows that would collide on the legacy key (%s).',
+                    $table,
+                    $legacyKey,
+                ));
+            }
+        }
     }
 
     private function refreshKlineIngestFunction(): void

--- a/trading-app/migrations/sql/ingest_klines_json.sql
+++ b/trading-app/migrations/sql/ingest_klines_json.sql
@@ -5,12 +5,14 @@ AS $$
 BEGIN
 /*
   But : insérer un batch de klines Bitmart en JSON dans la table 'klines'
-  Idempotent grâce à (symbol, timeframe, open_time) unique.
+  Idempotent grâce à (exchange, market_type, symbol, timeframe, open_time) unique.
 
   Exemple de JSON :
   [
     {
       "symbol": "BTCUSDT",
+      "exchange": "bitmart",
+      "market_type": "perpetual",
       "timeframe": "15m",
       "open_time": "2025-10-14T09:45:00Z",
       "open_price": "111954.0",
@@ -24,12 +26,14 @@ BEGIN
 */
 
 INSERT INTO klines (
-    id, symbol, timeframe, open_time,
+    id, exchange, market_type, symbol, timeframe, open_time,
     open_price, high_price, low_price, close_price, volume,
     source, inserted_at, updated_at
 )
 SELECT
     nextval('klines_id_seq'),
+    COALESCE(NULLIF(t.exchange, ''), 'bitmart'),
+    COALESCE(NULLIF(t.market_type, ''), 'perpetual'),
     t.symbol,
     t.timeframe,
     (t.open_time)::timestamptz,
@@ -42,6 +46,8 @@ SELECT
     now(),
     now()
 FROM jsonb_to_recordset(p_payload) AS t(
+    exchange text,
+    market_type text,
     symbol text,
     timeframe text,
     open_time text,
@@ -52,6 +58,6 @@ FROM jsonb_to_recordset(p_payload) AS t(
     volume text,
     source text
   )
-ON CONFLICT (symbol, timeframe, open_time) DO NOTHING; -- idempotent, ignore doublons
+ON CONFLICT (exchange, market_type, symbol, timeframe, open_time) DO NOTHING; -- idempotent, ignore doublons
 END;
 $$;

--- a/trading-app/migrations/sql/missing_gab_routines.sql
+++ b/trading-app/migrations/sql/missing_gab_routines.sql
@@ -62,7 +62,9 @@ RETURN QUERY
 SELECT e.open_time
 FROM expected e
          LEFT JOIN klines k
-                   ON k.symbol = p_symbol
+                   ON k.exchange = 'bitmart'
+                       AND k.market_type = 'perpetual'
+                       AND k.symbol = p_symbol
                        AND k.timeframe = p_timeframe
                        AND k.open_time = e.open_time
 WHERE k.open_time IS NULL
@@ -91,4 +93,3 @@ END;
 $$;
 
 alter function missing_kline_opentimes(text, text, timestamp, timestamp) owner to postgres;
-

--- a/trading-app/migrations/sql/seed_atr_dataset.sql
+++ b/trading-app/migrations/sql/seed_atr_dataset.sql
@@ -4,15 +4,19 @@
 BEGIN;
 
 -- Contrat pour fournir un tick_size (utilisé par le plancher ATR = tick*2)
-INSERT INTO contracts(symbol, tick_size, min_size, inserted_at, updated_at)
-VALUES ('ATRTEST', 0.1, 0.001, now(), now())
-ON CONFLICT (symbol) DO UPDATE SET
+INSERT INTO contracts(exchange, market_type, symbol, tick_size, min_size, inserted_at, updated_at)
+VALUES ('bitmart', 'perpetual', 'ATRTEST', 0.1, 0.001, now(), now())
+ON CONFLICT (exchange, market_type, symbol) DO UPDATE SET
   tick_size = EXCLUDED.tick_size,
   min_size = EXCLUDED.min_size,
   updated_at = now();
 
 -- Purge préalable
-DELETE FROM klines WHERE symbol = 'ATRTEST' AND timeframe IN ('1m','5m');
+DELETE FROM klines
+WHERE exchange = 'bitmart'
+  AND market_type = 'perpetual'
+  AND symbol = 'ATRTEST'
+  AND timeframe IN ('1m','5m');
 
 -- Paramètres
 -- Fenêtre: 180 bougies 1m (~3h)
@@ -106,8 +110,10 @@ volumes AS (
     i
   FROM outlier
 )
-INSERT INTO klines(symbol, timeframe, open_time, open_price, high_price, low_price, close_price, volume, source)
+INSERT INTO klines(exchange, market_type, symbol, timeframe, open_time, open_price, high_price, low_price, close_price, volume, source)
 SELECT
+  'bitmart',
+  'perpetual',
   symbol,
   '1m'::timeframe,
   open_time,
@@ -139,8 +145,10 @@ ohlc AS (
     j
   FROM series
 )
-INSERT INTO klines(symbol, timeframe, open_time, open_price, high_price, low_price, close_price, volume, source)
+INSERT INTO klines(exchange, market_type, symbol, timeframe, open_time, open_price, high_price, low_price, close_price, volume, source)
 SELECT
+  'bitmart',
+  'perpetual',
   symbol,
   '5m'::timeframe,
   open_time,
@@ -157,4 +165,3 @@ COMMIT;
 
 -- Utilisation:
 -- psql "$DATABASE_URL" -f trading-app/migrations/sql/seed_atr_dataset.sql
-

--- a/trading-app/phpunit.xml.dist
+++ b/trading-app/phpunit.xml.dist
@@ -15,6 +15,7 @@
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
+        <server name="LOCK_DSN" value="flock" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
         <server name="SYMFONY_PHPUNIT_VERSION" value="10.1" />

--- a/trading-app/src/Common/Enum/Exchange.php
+++ b/trading-app/src/Common/Enum/Exchange.php
@@ -7,6 +7,7 @@ namespace App\Common\Enum;
 enum Exchange: string
 {
     case BITMART = 'bitmart';
+    case BINANCE = 'binance';
 
     /**
      * Human readable label for logging/UI.
@@ -15,7 +16,7 @@ enum Exchange: string
     {
         return match ($this) {
             self::BITMART => 'Bitmart',
+            self::BINANCE => 'Binance',
         };
     }
 }
-

--- a/trading-app/src/Contract/Indicator/IndicatorProviderInterface.php
+++ b/trading-app/src/Contract/Indicator/IndicatorProviderInterface.php
@@ -6,15 +6,23 @@ namespace App\Contract\Indicator;
 
 use App\Common\Dto\IndicatorSnapshotDto;
 use App\Contract\Indicator\Dto\ListIndicatorDto;
+use App\Provider\Context\ExchangeContext;
 
 interface IndicatorProviderInterface
 {
-    public function getSnapshot(string $symbol, string $timeframe): IndicatorSnapshotDto;
+    public function getSnapshot(
+        string $symbol,
+        string $timeframe,
+        ?ExchangeContext $context = null,
+    ): IndicatorSnapshotDto;
 
     /**
      * Persist a snapshot of indicator values.
      */
-    public function saveIndicatorSnapshot(IndicatorSnapshotDto $snapshot): void;
+    public function saveIndicatorSnapshot(
+        IndicatorSnapshotDto $snapshot,
+        ?ExchangeContext $context = null,
+    ): void;
 
     /**
      * Calcule une liste d'indicateurs techniques à partir de klines (objets ou arrays normalisés).
@@ -25,15 +33,29 @@ interface IndicatorProviderInterface
      * Évalue les conditions associées au timeframe
      * et retourne les résultats individuels (nom => ConditionResult)
      */
-    public function evaluateConditions(string $symbol, string $timeframe): array;
+    public function evaluateConditions(
+        string $symbol,
+        string $timeframe,
+        ?ExchangeContext $context = null,
+    ): array;
 
     /**
      * Retourne un ATR mis en cache par clé "symbol_tf_period".
      * Si $key est null, il est construit à partir de $symbol/$tf et de la période par défaut.
      */
-    public function getAtr(?string $key = null, ?string $symbol = null, ?string $tf = null): ?float;
+    public function getAtr(
+        ?string $key = null,
+        ?string $symbol = null,
+        ?string $tf = null,
+        ?ExchangeContext $context = null,
+    ): ?float;
 
-    public function getListPivot(?string $key = null, ?string $symbol = null, ?string $tf = null): ?ListIndicatorDto;
+    public function getListPivot(
+        ?string $key = null,
+        ?string $symbol = null,
+        ?string $tf = null,
+        ?ExchangeContext $context = null,
+    ): ?ListIndicatorDto;
 
     public function clearCaches(): void;
 
@@ -47,7 +69,8 @@ interface IndicatorProviderInterface
     public function getIndicatorsForSymbolAndTimeframes(
         string $symbol,
         array $timeframes,
-        \DateTimeInterface $at
+        \DateTimeInterface $at,
+        ?ExchangeContext $context = null,
     ): array;
 
 }

--- a/trading-app/src/Contract/MtfValidator/Dto/MtfRunRequestDto.php
+++ b/trading-app/src/Contract/MtfValidator/Dto/MtfRunRequestDto.php
@@ -64,12 +64,12 @@ final class MtfRunRequestDto
 
         $exchange = null;
         if (is_string($exchangeRaw) && $exchangeRaw !== '') {
-            $exchange = Exchange::tryFrom(strtoupper($exchangeRaw)) ?? null;
+            $exchange = Exchange::tryFrom(strtolower($exchangeRaw)) ?? null;
         }
 
         $marketType = null;
         if (is_string($marketTypeRaw) && $marketTypeRaw !== '') {
-            $marketType = MarketType::tryFrom(strtoupper($marketTypeRaw)) ?? null;
+            $marketType = MarketType::tryFrom(strtolower($marketTypeRaw)) ?? null;
         }
 
         return new self(

--- a/trading-app/src/Contract/Provider/ContextualOrderProviderInterface.php
+++ b/trading-app/src/Contract/Provider/ContextualOrderProviderInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contract\Provider;
+
+use App\Contract\Provider\Dto\OrderDto;
+use App\Provider\Context\ExchangeContext;
+
+interface ContextualOrderProviderInterface extends OrderProviderInterface
+{
+    public function cancelOrder(string $symbol, string $orderId, ?ExchangeContext $context = null): bool;
+
+    public function getOrder(string $symbol, string $orderId, ?ExchangeContext $context = null): ?OrderDto;
+
+    public function getOpenOrders(?string $symbol = null, ?ExchangeContext $context = null): array;
+
+    public function getOrderHistory(string $symbol, int $limit = 100, ?ExchangeContext $context = null): array;
+}

--- a/trading-app/src/Contract/Provider/KlineProviderInterface.php
+++ b/trading-app/src/Contract/Provider/KlineProviderInterface.php
@@ -6,6 +6,7 @@ namespace App\Contract\Provider;
 
 use App\Common\Enum\Timeframe;
 use App\Contract\Provider\Dto\KlineDto;
+use App\Provider\Context\ExchangeContext;
 
 /**
  * Interface pour les providers de klines
@@ -15,7 +16,12 @@ interface KlineProviderInterface
     /**
      * Récupère les klines pour un symbole et timeframe
      */
-    public function getKlines(string $symbol, Timeframe $timeframe, int $limit = 490): array;
+    public function getKlines(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 490,
+        ?ExchangeContext $context = null,
+    ): array;
 
     /**
      * Récupère les klines dans une fenêtre de temps
@@ -25,31 +31,49 @@ interface KlineProviderInterface
         Timeframe $timeframe,
         \DateTimeImmutable $start,
         \DateTimeImmutable $end,
-        int $limit = 500
+        int $limit = 500,
+        ?ExchangeContext $context = null,
     ): array;
 
     /**
      * Récupère la dernière kline
      */
-    public function getLastKline(string $symbol, Timeframe $timeframe): ?KlineDto;
+    public function getLastKline(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?KlineDto;
 
     /**
      * Sauvegarde une kline
      */
-    public function saveKline(KlineDto $kline): void;
+    public function saveKline(KlineDto $kline, ?ExchangeContext $context = null): void;
 
     /**
      * Sauvegarde plusieurs klines
      */
-    public function saveKlines(array $klines, string $symbol, Timeframe $timeframe): void;
+    public function saveKlines(
+        array $klines,
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): void;
 
     /**
      * Vérifie s'il y a des gaps dans les données
      */
-    public function hasGaps(string $symbol, Timeframe $timeframe): bool;
+    public function hasGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): bool;
 
     /**
      * Récupère les gaps dans les données
      */
-    public function getGaps(string $symbol, Timeframe $timeframe): array;
+    public function getGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): array;
 }

--- a/trading-app/src/Contract/Provider/OrderProviderDecoratorInterface.php
+++ b/trading-app/src/Contract/Provider/OrderProviderDecoratorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contract\Provider;
+
+interface OrderProviderDecoratorInterface extends OrderProviderInterface
+{
+    public function innerOrderProvider(): OrderProviderInterface;
+}

--- a/trading-app/src/Entity/FuturesOrder.php
+++ b/trading-app/src/Entity/FuturesOrder.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\FuturesOrderRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: FuturesOrderRepository::class)]
 #[ORM\Table(name: 'futures_order')]
-#[ORM\UniqueConstraint(name: 'ux_futures_order_order_id', columns: ['order_id'])]
-#[ORM\UniqueConstraint(name: 'ux_futures_order_client', columns: ['client_order_id'])]
-#[ORM\Index(name: 'idx_futures_order_symbol', columns: ['symbol'])]
+#[ORM\UniqueConstraint(name: 'ux_futures_order_exchange_market_order_id', columns: ['exchange', 'market_type', 'order_id'])]
+#[ORM\UniqueConstraint(name: 'ux_futures_order_exchange_market_client', columns: ['exchange', 'market_type', 'client_order_id'])]
+#[ORM\Index(name: 'idx_futures_order_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 #[ORM\Index(name: 'idx_futures_order_status', columns: ['status'])]
 #[ORM\Index(name: 'idx_futures_order_client_order_id', columns: ['client_order_id'])]
 class FuturesOrder
@@ -27,6 +29,12 @@ class FuturesOrder
 
     #[ORM\Column(type: Types::STRING, length: 80, nullable: true)]
     private ?string $clientOrderId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -119,6 +127,28 @@ class FuturesOrder
     public function setClientOrderId(?string $clientOrderId): self
     {
         $this->clientOrderId = $clientOrderId;
+        return $this->touch();
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
         return $this->touch();
     }
 
@@ -342,4 +372,3 @@ class FuturesOrder
         return $this;
     }
 }
-

--- a/trading-app/src/Entity/FuturesOrderTrade.php
+++ b/trading-app/src/Entity/FuturesOrderTrade.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\FuturesOrderTradeRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: FuturesOrderTradeRepository::class)]
 #[ORM\Table(name: 'futures_order_trade')]
-#[ORM\UniqueConstraint(name: 'ux_futures_order_trade_trade_id', columns: ['trade_id'])]
+#[ORM\UniqueConstraint(name: 'ux_futures_order_trade_exchange_market_trade_id', columns: ['exchange', 'market_type', 'trade_id'])]
 #[ORM\Index(name: 'idx_futures_order_trade_order_id', columns: ['order_id'])]
-#[ORM\Index(name: 'idx_futures_order_trade_symbol', columns: ['symbol'])]
+#[ORM\Index(name: 'idx_futures_order_trade_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 class FuturesOrderTrade
 {
     #[ORM\Id]
@@ -25,6 +27,12 @@ class FuturesOrderTrade
 
     #[ORM\Column(type: Types::STRING, length: 80)]
     private string $orderId; // référence vers futures_order.order_id
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -91,6 +99,28 @@ class FuturesOrderTrade
     public function setOrderId(string $orderId): self
     {
         $this->orderId = $orderId;
+        return $this->touch();
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
         return $this->touch();
     }
 
@@ -215,4 +245,3 @@ class FuturesOrderTrade
         return $this;
     }
 }
-

--- a/trading-app/src/Entity/FuturesPlanOrder.php
+++ b/trading-app/src/Entity/FuturesPlanOrder.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\FuturesPlanOrderRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: FuturesPlanOrderRepository::class)]
 #[ORM\Table(name: 'futures_plan_order')]
-#[ORM\UniqueConstraint(name: 'ux_futures_plan_order_order_id', columns: ['order_id'])]
-#[ORM\UniqueConstraint(name: 'ux_futures_plan_order_client', columns: ['client_order_id'])]
-#[ORM\Index(name: 'idx_futures_plan_order_symbol', columns: ['symbol'])]
+#[ORM\UniqueConstraint(name: 'ux_futures_plan_order_exchange_market_order_id', columns: ['exchange', 'market_type', 'order_id'])]
+#[ORM\UniqueConstraint(name: 'ux_futures_plan_order_exchange_market_client', columns: ['exchange', 'market_type', 'client_order_id'])]
+#[ORM\Index(name: 'idx_futures_plan_order_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 #[ORM\Index(name: 'idx_futures_plan_order_status', columns: ['status'])]
 class FuturesPlanOrder
 {
@@ -26,6 +28,12 @@ class FuturesPlanOrder
 
     #[ORM\Column(type: Types::STRING, length: 80, nullable: true)]
     private ?string $clientOrderId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -116,6 +124,28 @@ class FuturesPlanOrder
     public function setClientOrderId(?string $clientOrderId): self
     {
         $this->clientOrderId = $clientOrderId;
+        return $this->touch();
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
         return $this->touch();
     }
 
@@ -328,4 +358,3 @@ class FuturesPlanOrder
         return $this;
     }
 }
-

--- a/trading-app/src/Entity/FuturesTransaction.php
+++ b/trading-app/src/Entity/FuturesTransaction.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\FuturesTransactionRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: FuturesTransactionRepository::class)]
 #[ORM\Table(name: 'futures_transaction')]
-#[ORM\Index(name: 'idx_futures_tx_symbol', columns: ['symbol'])]
+#[ORM\Index(name: 'idx_futures_tx_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 #[ORM\Index(name: 'idx_futures_tx_flow_type', columns: ['flow_type'])]
 #[ORM\Index(name: 'idx_futures_tx_happened_at', columns: ['happened_at'])]
 class FuturesTransaction
@@ -19,6 +21,12 @@ class FuturesTransaction
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -82,6 +90,28 @@ class FuturesTransaction
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+        return $this->touch();
     }
 
     public function getSymbol(): string

--- a/trading-app/src/Entity/IndicatorSnapshot.php
+++ b/trading-app/src/Entity/IndicatorSnapshot.php
@@ -4,21 +4,29 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\IndicatorSnapshotRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: IndicatorSnapshotRepository::class)]
 #[ORM\Table(name: 'indicator_snapshots')]
-#[ORM\Index(name: 'idx_ind_snap_symbol_tf', columns: ['symbol', 'timeframe'])]
+#[ORM\Index(name: 'idx_ind_snap_symbol_tf', columns: ['exchange', 'market_type', 'symbol', 'timeframe'])]
 #[ORM\Index(name: 'idx_ind_snap_kline_time', columns: ['kline_time'])]
-#[ORM\UniqueConstraint(name: 'ux_ind_snap_symbol_tf_time', columns: ['symbol', 'timeframe', 'kline_time'])]
+#[ORM\UniqueConstraint(name: 'ux_ind_snap_exchange_market_symbol_tf_time', columns: ['exchange', 'market_type', 'symbol', 'timeframe', 'kline_time'])]
 class IndicatorSnapshot
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -32,7 +40,7 @@ class IndicatorSnapshot
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE)]
     private \DateTimeImmutable $klineTime;
 
-    #[ORM\Column(type: Types::JSON)]
+    #[ORM\Column(name: '`values`', type: Types::JSON)]
     private array $values = [];
 
     #[ORM\Column(type: Types::STRING, length: 50)]
@@ -57,6 +65,28 @@ class IndicatorSnapshot
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): static
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): static
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+        return $this;
     }
 
     public function getSymbol(): string

--- a/trading-app/src/Entity/MtfState.php
+++ b/trading-app/src/Entity/MtfState.php
@@ -4,20 +4,28 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\MtfStateRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: MtfStateRepository::class)]
 #[ORM\Table(name: 'mtf_state')]
-#[ORM\Index(name: 'idx_mtf_state_symbol', columns: ['symbol'])]
-#[ORM\UniqueConstraint(name: 'ux_mtf_state_symbol', columns: ['symbol'])]
+#[ORM\Index(name: 'idx_mtf_state_exchange_market_symbol', columns: ['exchange', 'market_type', 'symbol'])]
+#[ORM\UniqueConstraint(name: 'ux_mtf_state_exchange_market_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 class MtfState
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -53,6 +61,30 @@ class MtfState
         return $this->id;
     }
 
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): static
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+
+        return $this;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): static
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+
+        return $this;
+    }
+
     public function getSymbol(): string
     {
         return $this->symbol;
@@ -60,7 +92,7 @@ class MtfState
 
     public function setSymbol(string $symbol): static
     {
-        $this->symbol = $symbol;
+        $this->symbol = strtoupper($symbol);
         return $this;
     }
 

--- a/trading-app/src/Entity/OrderIntent.php
+++ b/trading-app/src/Entity/OrderIntent.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\OrderIntentRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -12,7 +14,8 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: OrderIntentRepository::class)]
 #[ORM\Table(name: 'order_intent')]
-#[ORM\Index(name: 'idx_order_intent_symbol', columns: ['symbol'])]
+#[ORM\UniqueConstraint(name: 'ux_order_intent_exchange_market_client_order_id', columns: ['exchange', 'market_type', 'client_order_id'])]
+#[ORM\Index(name: 'idx_order_intent_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 #[ORM\Index(name: 'idx_order_intent_status', columns: ['status'])]
 #[ORM\Index(name: 'idx_order_intent_client_order_id', columns: ['client_order_id'])]
 class OrderIntent
@@ -42,6 +45,12 @@ class OrderIntent
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
 
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
+
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
 
@@ -66,7 +75,7 @@ class OrderIntent
     #[ORM\Column(type: Types::INTEGER)]
     private int $size; // Nombre de contrats
 
-    #[ORM\Column(type: Types::STRING, length: 80, unique: true)]
+    #[ORM\Column(type: Types::STRING, length: 80)]
     private string $clientOrderId; // Généré unique
 
     #[ORM\Column(type: Types::STRING, length: 30)]
@@ -113,6 +122,28 @@ class OrderIntent
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+        return $this->touch();
     }
 
     public function getSymbol(): string
@@ -338,6 +369,8 @@ class OrderIntent
     {
         if (!$this->protections->contains($protection)) {
             $this->protections->add($protection);
+            $protection->setExchange($this->exchange);
+            $protection->setMarketType($this->marketType);
             $protection->setOrderIntent($this);
         }
         return $this->touch();

--- a/trading-app/src/Entity/OrderProtection.php
+++ b/trading-app/src/Entity/OrderProtection.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\OrderProtectionRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: OrderProtectionRepository::class)]
 #[ORM\Table(name: 'order_protection')]
+#[ORM\Index(name: 'idx_order_protection_exchange_market', columns: ['exchange', 'market_type'])]
 #[ORM\Index(name: 'idx_order_protection_order_intent', columns: ['order_intent_id'])]
 #[ORM\Index(name: 'idx_order_protection_type', columns: ['type'])]
 class OrderProtection
@@ -21,6 +24,12 @@ class OrderProtection
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\ManyToOne(targetEntity: OrderIntent::class, inversedBy: 'protections')]
     #[ORM\JoinColumn(name: 'order_intent_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
@@ -63,6 +72,28 @@ class OrderProtection
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+        return $this->touch();
     }
 
     public function getOrderIntent(): OrderIntent
@@ -185,4 +216,3 @@ class OrderProtection
         return $this;
     }
 }
-

--- a/trading-app/src/Entity/Position.php
+++ b/trading-app/src/Entity/Position.php
@@ -4,20 +4,28 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\PositionRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: PositionRepository::class)]
 #[ORM\Table(name: 'positions')]
-#[ORM\UniqueConstraint(name: 'ux_positions_symbol_side', columns: ['symbol', 'side'])]
-#[ORM\Index(name: 'idx_positions_symbol', columns: ['symbol'])]
+#[ORM\UniqueConstraint(name: 'ux_positions_exchange_market_symbol_side', columns: ['exchange', 'market_type', 'symbol', 'side'])]
+#[ORM\Index(name: 'idx_positions_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 class Position
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -49,8 +57,15 @@ class Position
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
     private \DateTimeImmutable $updatedAt;
 
-    public function __construct(string $symbol, string $side)
+    public function __construct(
+        string $symbol,
+        string $side,
+        Exchange|string $exchange = Exchange::BITMART,
+        MarketType|string $marketType = MarketType::PERPETUAL,
+    )
     {
+        $this->setExchange($exchange);
+        $this->setMarketType($marketType);
         $this->symbol = strtoupper($symbol);
         $this->side = strtoupper($side);
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
@@ -61,6 +76,28 @@ class Position
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+        return $this;
     }
 
     public function getSymbol(): string
@@ -155,5 +192,4 @@ class Position
         return $this;
     }
 }
-
 

--- a/trading-app/src/Entity/TradeLifecycleEvent.php
+++ b/trading-app/src/Entity/TradeLifecycleEvent.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\TradeLifecycleEventRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -56,8 +58,11 @@ class TradeLifecycleEvent
     #[ORM\Column(length: 64, nullable: true)]
     private ?string $planId = null;
 
-    #[ORM\Column(length: 32, nullable: true)]
-    private ?string $exchange = null;
+    #[ORM\Column(length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(length: 64, nullable: true)]
     private ?string $accountId = null;
@@ -225,14 +230,26 @@ class TradeLifecycleEvent
         return $this;
     }
 
-    public function getExchange(): ?string
+    public function getExchange(): string
     {
         return $this->exchange;
     }
 
-    public function setExchange(?string $exchange): self
+    public function setExchange(Exchange|string|null $exchange): self
     {
-        $this->exchange = $exchange;
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange ?? 'bitmart');
+
+        return $this;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string|null $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType ?? 'perpetual');
 
         return $this;
     }

--- a/trading-app/src/Entity/TradeZoneEvent.php
+++ b/trading-app/src/Entity/TradeZoneEvent.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Repository\TradeZoneEventRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: TradeZoneEventRepository::class)]
 #[ORM\Table(name: 'trade_zone_events')]
-#[ORM\Index(name: 'idx_zone_symbol', columns: ['symbol'])]
+#[ORM\Index(name: 'idx_zone_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 #[ORM\Index(name: 'idx_zone_reason', columns: ['reason'])]
 #[ORM\Index(name: 'idx_zone_happened_at', columns: ['happened_at'])]
 class TradeZoneEvent
@@ -19,6 +21,12 @@ class TradeZoneEvent
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -103,6 +111,30 @@ class TradeZoneEvent
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+
+        return $this;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+
+        return $this;
     }
 
     public function getSymbol(): string

--- a/trading-app/src/Indicator/Message/IndicatorSnapshotPersistRequestMessage.php
+++ b/trading-app/src/Indicator/Message/IndicatorSnapshotPersistRequestMessage.php
@@ -16,6 +16,8 @@ final class IndicatorSnapshotPersistRequestMessage
         public readonly ?string $runId = null,
         public readonly ?string $profile = null,
         public readonly ?string $requestedAt = null,
+        public readonly string $exchange = 'bitmart',
+        public readonly string $marketType = 'perpetual',
     ) {
     }
 }

--- a/trading-app/src/Indicator/Message/IndicatorSnapshotProjectionMessage.php
+++ b/trading-app/src/Indicator/Message/IndicatorSnapshotProjectionMessage.php
@@ -16,6 +16,8 @@ final class IndicatorSnapshotProjectionMessage
         public readonly array $values,
         public readonly string $source = 'PHP',
         public readonly ?string $runId = null,
+        public readonly string $exchange = 'bitmart',
+        public readonly string $marketType = 'perpetual',
     ) {
     }
 }

--- a/trading-app/src/Indicator/MessageHandler/IndicatorSnapshotPersistRequestMessageHandler.php
+++ b/trading-app/src/Indicator/MessageHandler/IndicatorSnapshotPersistRequestMessageHandler.php
@@ -66,6 +66,8 @@ final class IndicatorSnapshotPersistRequestMessageHandler
                         $values,
                         'MTF_RUNNER',
                         $message->runId,
+                        $message->exchange,
+                        $message->marketType,
                     ));
                 } catch (\Throwable $exception) {
                     $this->logger->warning('[IndicatorPersistence] Projection failed', [

--- a/trading-app/src/Indicator/MessageHandler/IndicatorSnapshotPersistRequestMessageHandler.php
+++ b/trading-app/src/Indicator/MessageHandler/IndicatorSnapshotPersistRequestMessageHandler.php
@@ -8,6 +8,7 @@ use App\Contract\Indicator\IndicatorProviderInterface;
 use App\Indicator\Message\IndicatorSnapshotPersistRequestMessage;
 use App\Indicator\Message\IndicatorSnapshotProjectionMessage;
 use App\Indicator\Service\IndicatorSnapshotProjector;
+use App\Provider\Context\ExchangeContext;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -33,6 +34,7 @@ final class IndicatorSnapshotPersistRequestMessageHandler
         }
 
         $referenceTime = $this->resolveReferenceTime($message->requestedAt);
+        $exchangeContext = ExchangeContext::fromValues($message->exchange, $message->marketType);
 
         foreach ($symbols as $symbol) {
             try {
@@ -40,10 +42,13 @@ final class IndicatorSnapshotPersistRequestMessageHandler
                     $symbol,
                     $timeframes,
                     $referenceTime,
+                    $exchangeContext,
                 );
             } catch (\Throwable $exception) {
                 $this->logger->warning('[IndicatorPersistence] Failed to fetch indicators', [
                     'symbol' => $symbol,
+                    'exchange' => $exchangeContext->exchange->value,
+                    'market_type' => $exchangeContext->marketType->value,
                     'timeframes' => $timeframes,
                     'error' => $exception->getMessage(),
                 ]);

--- a/trading-app/src/Indicator/Provider/IndicatorProviderService.php
+++ b/trading-app/src/Indicator/Provider/IndicatorProviderService.php
@@ -24,6 +24,7 @@ use App\Indicator\Core\Trend\Sma as CoreSma;
 use App\Indicator\Core\Volatility\Bollinger as CoreBollinger;
 use App\Indicator\Core\Volume\Vwap as CoreVwap;
 use App\Indicator\Registry\ConditionRegistry;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\IndicatorSnapshotRepository;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
@@ -120,10 +121,15 @@ final class IndicatorProviderService implements IndicatorProviderInterface
         }
 
 
-        public function getSnapshot(string $symbol, string $timeframe): IndicatorSnapshotDto
+        public function getSnapshot(
+            string $symbol,
+            string $timeframe,
+            ?ExchangeContext $context = null,
+        ): IndicatorSnapshotDto
         {
+            $context = ExchangeContext::resolve($context);
             $tf = Timeframe::from($timeframe);
-            $existing = $this->getSnapshotFromDatabaseOnly($symbol, $tf->value);
+            $existing = $this->getSnapshotFromDatabaseOnly($symbol, $tf->value, $context);
             if ($existing instanceof IndicatorSnapshotDto) {
                 $now = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'));
                 if (!$this->isSnapshotStale($existing, $now, $tf)) {
@@ -131,7 +137,7 @@ final class IndicatorProviderService implements IndicatorProviderInterface
                 }
             }
 
-            $klines = $this->klineProvider->getKlines($symbol, $tf, 251);
+            $klines = $this->klineProvider->getKlines($symbol, $tf, 251, $context);
             if (empty($klines)) {
                 throw new \RuntimeException("Aucune kline pour $symbol/$timeframe");
             }
@@ -197,21 +203,29 @@ final class IndicatorProviderService implements IndicatorProviderInterface
                 source: 'PHP'
             );
 
-            $this->saveIndicatorSnapshot($snapshot);
+            $this->saveIndicatorSnapshot($snapshot, $context);
 
             return $snapshot;
         }
 
-        public function saveIndicatorSnapshot(IndicatorSnapshotDto $snapshotDto): void
+        public function saveIndicatorSnapshot(
+            IndicatorSnapshotDto $snapshotDto,
+            ?ExchangeContext $context = null,
+        ): void
         {
+            $context = ExchangeContext::resolve($context);
             $this->logger?->debug('[IndicatorProvider] Preparing snapshot persistence', [
                 'symbol' => $snapshotDto->symbol,
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
                 'timeframe' => $snapshotDto->timeframe->value,
                 'kline_time' => $snapshotDto->klineTime->format('Y-m-d H:i:s'),
                 'source' => $snapshotDto->source,
             ]);
 
             $snapshot = (new IndicatorSnapshot())
+                ->setExchange($context->exchange)
+                ->setMarketType($context->marketType)
                 ->setSymbol($snapshotDto->symbol)
                 ->setTimeframe($snapshotDto->timeframe)
                 ->setKlineTime($snapshotDto->klineTime)
@@ -236,10 +250,12 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             $snapshot->setValue('meta', $snapshotDto->meta);
             $snapshot->setUpdatedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
 
-            $this->snapshotRepository->upsert($snapshot);
+            $this->snapshotRepository->upsert($snapshot, $context);
 
             $this->logger?->info('[IndicatorProvider] Snapshot persisted', [
                 'symbol' => $snapshotDto->symbol,
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
                 'timeframe' => $snapshotDto->timeframe->value,
                 'kline_time' => $snapshotDto->klineTime->format('Y-m-d H:i:s'),
                 'run_id' => $snapshotDto->meta['run_id'] ?? null,
@@ -375,13 +391,18 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             ];
         }
 
-        public function evaluateConditions(string $symbol, string $timeframe): array
+        public function evaluateConditions(
+            string $symbol,
+            string $timeframe,
+            ?ExchangeContext $context = null,
+        ): array
         {
+            $context = ExchangeContext::resolve($context);
             // 1️⃣ Convertit le timeframe string en enum
             $timeframeEnum = Timeframe::from($timeframe);
 
             // 2️⃣ Récupère les klines normalisées
-            $klines = $this->klineProvider->getKlines($symbol, $timeframeEnum, 150);
+            $klines = $this->klineProvider->getKlines($symbol, $timeframeEnum, 150, $context);
 
             // 2️⃣ Convertit les klines en format array pour le contexte
             $klinesArray = [];
@@ -420,12 +441,18 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             return $results;
         }
 
-        public function getAtr(?string $key = null, ?string $symbol = null, ?string $tf = null): ?float
+        public function getAtr(
+            ?string $key = null,
+            ?string $symbol = null,
+            ?string $tf = null,
+            ?ExchangeContext $context = null,
+        ): ?float
         {
+            $context = ExchangeContext::resolve($context);
             $period = 14; // défaut (trading.yml)
             $method = 'wilder';
 
-            $cacheKey = sprintf('%s|%s|%s', $key ?? '*', $symbol ?? '*', $tf ?? '*');
+            $cacheKey = sprintf('%s|%s|%s|%s', $context->key(), $key ?? '*', $symbol ?? '*', $tf ?? '*');
             if (array_key_exists($cacheKey, $this->atrList)) {
                 $cached = $this->atrList[$cacheKey];
                 return is_numeric($cached) ? (float)$cached : null;
@@ -437,7 +464,7 @@ final class IndicatorProviderService implements IndicatorProviderInterface
 
             try {
                 $tfEnum = Timeframe::from((string)$tf);
-                $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 250);
+                $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 250, $context);
                 if (empty($klines)) {
                     return null;
                 }
@@ -462,9 +489,15 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             }
         }
 
-            public function getListPivot(?string $key = null, ?string $symbol = null, ?string $tf = null): ?ListIndicatorDto
+            public function getListPivot(
+                ?string $key = null,
+                ?string $symbol = null,
+                ?string $tf = null,
+                ?ExchangeContext $context = null,
+            ): ?ListIndicatorDto
             {
-                $cacheKey = sprintf('%s|%s|%s', $key ?? '*', $symbol ?? '*', $tf ?? '*');
+                $context = ExchangeContext::resolve($context);
+                $cacheKey = sprintf('%s|%s|%s|%s', $context->key(), $key ?? '*', $symbol ?? '*', $tf ?? '*');
                 if ($symbol === null || $tf === null) {
                     return null;
                 }
@@ -483,7 +516,7 @@ final class IndicatorProviderService implements IndicatorProviderInterface
                 }
 
                 try {
-                    $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 250);
+                    $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 250, $context);
                     if (empty($klines)) {
                         return null;
                     }
@@ -577,22 +610,24 @@ final class IndicatorProviderService implements IndicatorProviderInterface
     public function getIndicatorsForSymbolAndTimeframes(
         string $symbol,
         array $timeframes,
-        \DateTimeInterface $at
+        \DateTimeInterface $at,
+        ?ExchangeContext $context = null,
     ): array {
+        $context = ExchangeContext::resolve($context);
         $result = [];
 
         foreach ($timeframes as $tf) {
             try {
-                $snapshot = $this->getSnapshotFromDatabaseOnly($symbol, $tf);
+                $snapshot = $this->getSnapshotFromDatabaseOnly($symbol, $tf, $context);
 
                 // 1️⃣ si rien en DB → on calcule à partir des klines
                 if ($snapshot === null || $this->isSnapshotStale($snapshot, $at, Timeframe::from((string)$tf))) {
-                    $snapshot = $this->getSnapshot($symbol, (string)$tf);
+                    $snapshot = $this->getSnapshot($symbol, (string)$tf, $context);
                 }
 
                 // 2️⃣ mapping vers le format attendu par le MTF
                 $tfEnum = Timeframe::from((string)$tf);
-                $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 251);
+                $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 251, $context);
 
                 $klinesCount = count($klines);
                 if ($klinesCount < 249) {
@@ -629,6 +664,8 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             } catch (\Throwable $e) {
                 $this->logger->warning('IndicatorProvider: failed to fetch indicators', [
                     'symbol'    => $symbol,
+                    'exchange' => $context->exchange->value,
+                    'market_type' => $context->marketType->value,
                     'timeframe' => $tf,
                     'error'     => $e->getMessage(),
                 ]);
@@ -644,21 +681,28 @@ final class IndicatorProviderService implements IndicatorProviderInterface
     /**
      * Snapshot indicateurs depuis la base UNIQUEMENT (aucun appel Bitmart).
      */
-    private function getSnapshotFromDatabaseOnly(string $symbol, string $timeframe): ?IndicatorSnapshotDto
+    private function getSnapshotFromDatabaseOnly(
+        string $symbol,
+        string $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?IndicatorSnapshotDto
     {
+        $context = ExchangeContext::resolve($context);
         try {
             $tfEnum = Timeframe::from($timeframe);
         } catch (\ValueError $e) {
             // TF inconnu par l'enum → on log et on sort
             $this->logger->warning('IndicatorProvider: invalid timeframe', [
                 'symbol'    => $symbol,
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
                 'timeframe' => $timeframe,
             ]);
 
             return null;
         }
 
-        $entity = $this->snapshotRepository->findLastBySymbolAndTimeframe($symbol, $tfEnum);
+        $entity = $this->snapshotRepository->findLastBySymbolAndTimeframe($symbol, $tfEnum, $context);
 
         if ($entity === null) {
             return null;

--- a/trading-app/src/Indicator/Service/IndicatorSnapshotProjector.php
+++ b/trading-app/src/Indicator/Service/IndicatorSnapshotProjector.php
@@ -27,6 +27,8 @@ final class IndicatorSnapshotProjector
         $traceId = $this->traceIdProvider->getOrCreate($message->symbol);
 
         $snapshot = (new IndicatorSnapshot())
+            ->setExchange($message->exchange)
+            ->setMarketType($message->marketType)
             ->setSymbol(strtoupper($message->symbol))
             ->setTimeframe($timeframe)
             ->setKlineTime($klineTime->setTimezone(new \DateTimeZone('UTC')))
@@ -39,6 +41,8 @@ final class IndicatorSnapshotProjector
         $this->snapshotRepository->upsert($snapshot);
 
         $this->logger->info('[IndicatorSnapshotProjector] Snapshot persisted', [
+            'exchange' => $message->exchange,
+            'market_type' => $message->marketType,
             'symbol' => strtoupper($message->symbol),
             'timeframe' => $message->timeframe,
             'kline_time' => $message->klineTime,

--- a/trading-app/src/Logging/TradeLifecycleLogger.php
+++ b/trading-app/src/Logging/TradeLifecycleLogger.php
@@ -34,10 +34,12 @@ final class TradeLifecycleLogger
         ?string $configProfile = null,
         ?string $configVersion = null,
         ?string $planId = null,
+        ?string $marketType = null,
     ): void {
         $event = $this->newEvent($symbol, TradeLifecycleEventType::ORDER_SUBMITTED)
             ->setRunId($runId)
             ->setExchange($exchange)
+            ->setMarketType($marketType)
             ->setAccountId($accountId)
             ->setOrderId($orderId)
             ->setClientOrderId($clientOrderId)
@@ -66,10 +68,12 @@ final class TradeLifecycleLogger
         ?string $exchange = null,
         ?string $accountId = null,
         array $extra = [],
+        ?string $marketType = null,
     ): void {
         $event = $this->newEvent($symbol, TradeLifecycleEventType::ORDER_EXPIRED)
             ->setRunId($runId)
             ->setExchange($exchange)
+            ->setMarketType($marketType)
             ->setAccountId($accountId)
             ->setOrderId($orderId)
             ->setClientOrderId($clientOrderId)
@@ -93,10 +97,12 @@ final class TradeLifecycleLogger
         ?string $exchange = null,
         ?string $accountId = null,
         array $extra = [],
+        ?string $marketType = null,
     ): void {
         $event = $this->newEvent($symbol, TradeLifecycleEventType::POSITION_OPENED)
             ->setRunId($runId)
             ->setExchange($exchange)
+            ->setMarketType($marketType)
             ->setAccountId($accountId)
             ->setPositionId($positionId)
             ->setSide($side)
@@ -118,9 +124,13 @@ final class TradeLifecycleLogger
         ?string $configProfile = null,
         ?string $configVersion = null,
         array $extra = [],
+        ?string $exchange = null,
+        ?string $marketType = null,
     ): void {
         $event = $this->newEvent($symbol, TradeLifecycleEventType::SYMBOL_SKIPPED)
             ->setRunId($runId)
+            ->setExchange($exchange)
+            ->setMarketType($marketType)
             ->setReasonCode($reasonCode)
             ->setTimeframe($timeframe)
             ->setConfigProfile($configProfile)
@@ -139,12 +149,14 @@ final class TradeLifecycleLogger
         ?string $accountId = null,
         ?string $reasonCode = null,
         ?array $extra = null,
+        ?string $marketType = null,
     ): void {
         $event = $this->newEvent($symbol, TradeLifecycleEventType::POSITION_CLOSED)
             ->setPositionId($positionId)
             ->setSide($side)
             ->setRunId($runId)
             ->setExchange($exchange)
+            ->setMarketType($marketType)
             ->setAccountId($accountId)
             ->setReasonCode($reasonCode);
 

--- a/trading-app/src/MtfRunner/Application/Projection/IndicatorSnapshotPersistenceDispatcher.php
+++ b/trading-app/src/MtfRunner/Application/Projection/IndicatorSnapshotPersistenceDispatcher.php
@@ -50,10 +50,14 @@ final class IndicatorSnapshotPersistenceDispatcher
                 $runId,
                 $request->profile,
                 $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+                $request->exchange?->value ?? 'bitmart',
+                $request->marketType?->value ?? 'perpetual',
             ));
 
             $this->logger->debug('[MTF Runner] Indicator persistence dispatched', [
                 'run_id' => $runId,
+                'exchange' => $request->exchange?->value ?? 'bitmart',
+                'market_type' => $request->marketType?->value ?? 'perpetual',
                 'symbols_count' => count($symbols),
                 'timeframes' => $timeframes,
             ]);

--- a/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
@@ -111,6 +111,7 @@ final class MtfRunnerRequestDto
     {
         return match (strtolower(trim($value))) {
             'bitmart' => Exchange::BITMART,
+            'binance' => Exchange::BINANCE,
             default => throw new \InvalidArgumentException(sprintf('Unsupported exchange "%s"', $value)),
         };
     }
@@ -165,4 +166,3 @@ final class MtfRunnerRequestDto
         return [$profile, $mode];
     }
 }
-

--- a/trading-app/src/MtfRunner/Service/FuturesOrderSyncService.php
+++ b/trading-app/src/MtfRunner/Service/FuturesOrderSyncService.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\MtfRunner\Service;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Entity\FuturesOrder;
 use App\Entity\FuturesOrderTrade;
 use App\Entity\FuturesPlanOrder;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\FuturesOrderRepository;
 use App\Repository\FuturesOrderTradeRepository;
 use App\Repository\FuturesPlanOrderRepository;
@@ -33,6 +36,7 @@ class FuturesOrderSyncService
         try {
             $orderId = $this->extractString($orderData, 'order_id');
             $clientOrderId = $this->extractString($orderData, 'client_order_id');
+            $context = $this->resolveContext($orderData);
 
             if (!$orderId && !$clientOrderId) {
                 $this->logger->warning('[FuturesOrderSync] Missing order_id and client_order_id', [
@@ -44,10 +48,10 @@ class FuturesOrderSyncService
             // Chercher l'ordre existant par order_id ou client_order_id
             $order = null;
             if ($orderId) {
-                $order = $this->futuresOrderRepository->findOneByOrderId($orderId);
+                $order = $this->futuresOrderRepository->findOneByOrderId($orderId, $context);
             }
             if (!$order && $clientOrderId) {
-                $order = $this->futuresOrderRepository->findOneByClientOrderId($clientOrderId);
+                $order = $this->futuresOrderRepository->findOneByClientOrderId($clientOrderId, $context);
             }
 
             if (!$order) {
@@ -55,6 +59,8 @@ class FuturesOrderSyncService
             }
 
             // Mapper les champs depuis l'API
+            $order->setExchange($context->exchange);
+            $order->setMarketType($context->marketType);
             $order->setOrderId($orderId);
             $order->setClientOrderId($clientOrderId);
             $order->setSymbol($this->extractString($orderData, 'symbol', ''));
@@ -136,6 +142,7 @@ class FuturesOrderSyncService
         try {
             $orderId = $this->extractString($orderData, 'order_id');
             $clientOrderId = $this->extractString($orderData, 'client_order_id');
+            $context = $this->resolveContext($orderData);
 
             if (!$orderId && !$clientOrderId) {
                 $this->logger->warning('[FuturesOrderSync] Missing order_id and client_order_id for plan order', [
@@ -147,10 +154,10 @@ class FuturesOrderSyncService
             // Chercher l'ordre planifié existant
             $planOrder = null;
             if ($orderId) {
-                $planOrder = $this->futuresPlanOrderRepository->findOneByOrderId($orderId);
+                $planOrder = $this->futuresPlanOrderRepository->findOneByOrderId($orderId, $context);
             }
             if (!$planOrder && $clientOrderId) {
-                $planOrder = $this->futuresPlanOrderRepository->findOneByClientOrderId($clientOrderId);
+                $planOrder = $this->futuresPlanOrderRepository->findOneByClientOrderId($clientOrderId, $context);
             }
 
             if (!$planOrder) {
@@ -158,6 +165,8 @@ class FuturesOrderSyncService
             }
 
             // Mapper les champs depuis l'API
+            $planOrder->setExchange($context->exchange);
+            $planOrder->setMarketType($context->marketType);
             $planOrder->setOrderId($orderId);
             $planOrder->setClientOrderId($clientOrderId);
             $planOrder->setSymbol($this->extractString($orderData, 'symbol', ''));
@@ -232,6 +241,7 @@ class FuturesOrderSyncService
     {
         try {
             $tradeId = $this->extractString($tradeData, 'trade_id');
+            $context = $this->resolveContext($tradeData);
             if (!$tradeId) {
                 // Essayer d'utiliser un identifiant alternatif ou générer un ID temporaire
                 $tradeId = $this->extractString($tradeData, 'id') 
@@ -243,12 +253,14 @@ class FuturesOrderSyncService
             }
 
             // Chercher le trade existant
-            $trade = $this->futuresOrderTradeRepository->findOneByTradeId($tradeId);
+            $trade = $this->futuresOrderTradeRepository->findOneByTradeId($tradeId, $context);
             if (!$trade) {
                 $trade = new FuturesOrderTrade();
             }
 
             // Mapper les champs depuis l'API
+            $trade->setExchange($context->exchange);
+            $trade->setMarketType($context->marketType);
             $trade->setTradeId($tradeId);
             $trade->setOrderId($this->extractString($tradeData, 'order_id', ''));
             $trade->setSymbol($this->extractString($tradeData, 'symbol', ''));
@@ -262,7 +274,7 @@ class FuturesOrderSyncService
             // Lier au FuturesOrder si l'order_id existe
             $orderId = $this->extractString($tradeData, 'order_id');
             if ($orderId) {
-                $futuresOrder = $this->futuresOrderRepository->findOneByOrderId($orderId);
+                $futuresOrder = $this->futuresOrderRepository->findOneByOrderId($orderId, $context);
                 if ($futuresOrder) {
                     $trade->setFuturesOrder($futuresOrder);
                 }
@@ -295,6 +307,8 @@ class FuturesOrderSyncService
         $filledSize = $eventData['deal_size'] ?? $eventData['filled_size'] ?? null;
 
         $normalized = [
+            'exchange' => $eventData['exchange'] ?? null,
+            'market_type' => $eventData['market_type'] ?? $eventData['marketType'] ?? null,
             'order_id' => $eventData['order_id'] ?? null,
             'client_order_id' => $eventData['client_order_id'] ?? null,
             'symbol' => $eventData['symbol'] ?? null,
@@ -382,6 +396,19 @@ class FuturesOrderSyncService
         }
         return (int) $value;
     }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function resolveContext(array $data): ExchangeContext
+    {
+        try {
+            return new ExchangeContext(
+                Exchange::from(strtolower((string)($data['exchange'] ?? ExchangeContext::exchangeValue(null)))),
+                MarketType::from(strtolower((string)($data['market_type'] ?? $data['marketType'] ?? ExchangeContext::marketTypeValue(null)))),
+            );
+        } catch (\ValueError) {
+            return ExchangeContext::legacyDefault();
+        }
+    }
 }
-
-

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -104,13 +104,13 @@ final class MtfRunnerService
         ]);
 
         try {
-            // 1. Résoudre les symboles
-            $resolveStart = microtime(true);
-            $symbols = $this->resolveSymbols($request->symbols, $request->profile);
-            $profiler->increment('runner', 'resolve_symbols', microtime(true) - $resolveStart);
-
-            // 2. Créer le contexte
+            // 1. Créer le contexte
             $context = $this->createContext($request);
+
+            // 2. Résoudre les symboles
+            $resolveStart = microtime(true);
+            $symbols = $this->resolveSymbols($request->symbols, $request->profile, $context);
+            $profiler->increment('runner', 'resolve_symbols', microtime(true) - $resolveStart);
 
             // 3. Synchroniser les tables depuis l'exchange (si demandé)
             $syncTables = true;
@@ -225,7 +225,7 @@ final class MtfRunnerService
      * @param string|null $profile Profil de configuration à utiliser pour récupérer les contrats actifs
      * @return string[]
      */
-    public function resolveSymbols(array $inputSymbols, ?string $profile = null): array
+    public function resolveSymbols(array $inputSymbols, ?string $profile = null, ?ExchangeContext $context = null): array
     {
         $symbols = [];
 
@@ -241,7 +241,7 @@ final class MtfRunnerService
         // Si aucun symbole fourni, récupérer depuis la base de données
         if (empty($symbols)) {
             try {
-                $fetched = $this->contractRepository->allActiveSymbolNames([], false, $profile);
+                $fetched = $this->contractRepository->allActiveSymbolNames([], false, $profile, $context);
                 if (!empty($fetched)) {
                     $symbols = array_values(array_unique(array_map('strval', $fetched)));
                 }
@@ -515,7 +515,7 @@ final class MtfRunnerService
 
             // 1. Synchroniser les positions
             if ($accountProvider) {
-                $openPositions = $this->syncPositions($accountProvider);
+                $openPositions = $this->syncPositions($accountProvider, $context);
             }
 
             // 2. Synchroniser les ordres
@@ -539,7 +539,7 @@ final class MtfRunnerService
     /**
      * Synchronise les positions depuis l'exchange vers la table positions
      */
-    private function syncPositions($accountProvider): array
+    private function syncPositions($accountProvider, ExchangeContext $context): array
     {
         $openPositions = [];
 
@@ -555,9 +555,9 @@ final class MtfRunnerService
                     $side = strtoupper($positionDto->side->value);
 
                     // Chercher ou créer la position
-                    $position = $this->positionRepository->findOneBySymbolSide($symbol, $side);
+                    $position = $this->positionRepository->findOneBySymbolSide($symbol, $side, $context);
                     if (!$position) {
-                        $position = new Position($symbol, $side);
+                        $position = new Position($symbol, $side, $context->exchange, $context->marketType);
                     }
 
                     // Mettre à jour les données
@@ -567,6 +567,8 @@ final class MtfRunnerService
                     $position->setUnrealizedPnl($positionDto->unrealizedPnl->__toString());
                     $position->setStatus('OPEN');
                     $position->mergePayload([
+                        'exchange' => $context->exchange->value,
+                        'market_type' => $context->marketType->value,
                         'mark_price' => $positionDto->markPrice->__toString(),
                         'margin' => $positionDto->margin->__toString(),
                         'realized_pnl' => $positionDto->realizedPnl->__toString(),

--- a/trading-app/src/MtfValidator/Command/ListOpenPositionsOrdersCommand.php
+++ b/trading-app/src/MtfValidator/Command/ListOpenPositionsOrdersCommand.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\MtfValidator\Command;
 
 use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\OrderProviderDecoratorInterface;
 use App\Contract\Provider\OrderProviderInterface;
 use App\Contract\Provider\MainProviderInterface;
 use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
+use App\Provider\Bitmart\BitmartOrderProvider;
 use App\Provider\Context\ExchangeContext;
 use Brick\Math\RoundingMode;
 use Psr\Log\LoggerInterface;
@@ -26,8 +28,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class ListOpenPositionsOrdersCommand extends Command
 {
     public function __construct(
-        private readonly ?AccountProviderInterface $accountProvider = null,
         private readonly LoggerInterface $mtfLogger,
+        private readonly ?AccountProviderInterface $accountProvider = null,
         private readonly ?OrderProviderInterface $orderProvider = null,
         private readonly ?MainProviderInterface $mainProvider = null,
     ) {
@@ -249,10 +251,9 @@ Exemples:
                 try {
                     $planOrders = [];
                     // Vérifier si le provider supporte getPlanOrders (méthode spécifique BitMart)
-                    if ($orderProvider instanceof \App\Provider\Bitmart\BitmartOrderProvider) {
-                        /** @var \App\Provider\Bitmart\BitmartOrderProvider $orderProvider */
-                        $orderProvider = $orderProvider;
-                        $planOrders = $orderProvider->getPlanOrders($symbol);
+                    $bitmartProvider = $this->unwrapOrderProvider($orderProvider);
+                    if ($bitmartProvider instanceof BitmartOrderProvider) {
+                        $planOrders = $bitmartProvider->getPlanOrders($symbol);
                     } else {
                         $io->note('Le provider ne supporte pas la récupération des ordres planifiés (TP/SL)');
                         $data['plan_orders'] = [];
@@ -359,5 +360,14 @@ Exemples:
 
             return Command::FAILURE;
         }
+    }
+
+    private function unwrapOrderProvider(OrderProviderInterface $provider): OrderProviderInterface
+    {
+        while ($provider instanceof OrderProviderDecoratorInterface) {
+            $provider = $provider->innerOrderProvider();
+        }
+
+        return $provider;
     }
 }

--- a/trading-app/src/MtfValidator/Command/MtfCoreRunCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfCoreRunCommand.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\MtfValidator\Command;
 
+use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
 use App\Contract\MtfValidator\Dto\MtfRunResponseDto;
 use App\Contract\MtfValidator\MtfValidatorInterface;
 use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
+use App\Provider\Context\ExchangeContext;
 use App\Provider\Repository\ContractRepository;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -129,6 +131,9 @@ final class MtfCoreRunCommand extends Command
         $exchange         = (string) $input->getOption('exchange');
         $marketType       = (string) $input->getOption('market-type');
         $mtfProfile       = (string) $input->getOption('mtf-profile');
+        $exchangeEnum     = Exchange::tryFrom(strtolower($exchange)) ?? Exchange::BITMART;
+        $marketTypeEnum   = MarketType::tryFrom(strtolower($marketType)) ?? MarketType::PERPETUAL;
+        $context          = new ExchangeContext($exchangeEnum, $marketTypeEnum);
 
         $symbolLimit = null;
         if ($symbolLimitInput !== null && $symbolLimitInput !== '') {
@@ -136,7 +141,7 @@ final class MtfCoreRunCommand extends Command
         }
 
         // 1) Récupération des symboles
-        $symbols = $this->resolveSymbolsList($symbolsOption, $mtfProfile, $symbolLimit, $io);
+        $symbols = $this->resolveSymbolsList($symbolsOption, $mtfProfile, $symbolLimit, $io, $context);
         if ($symbols === []) {
             $io->warning('Aucun symbole à traiter (liste vide).');
             return Command::SUCCESS;
@@ -164,7 +169,8 @@ final class MtfCoreRunCommand extends Command
             skipContextValidation: $skipContext,
             userId: $userId,
             ipAddress: $ipAddress,
-            marketType: MarketType::tryFrom($marketType),
+            exchange: $exchangeEnum,
+            marketType: $marketTypeEnum,
         );
 
         // 3) Exécution du validateur MTF
@@ -304,7 +310,8 @@ final class MtfCoreRunCommand extends Command
         string $symbolsOption,
         string $mtfProfile,
         ?int $limit,
-        SymfonyStyle $io
+        SymfonyStyle $io,
+        ExchangeContext $context,
     ): array {
         if ($symbolsOption !== '') {
             $symbols = \array_filter(
@@ -334,7 +341,7 @@ final class MtfCoreRunCommand extends Command
         // Sinon on va chercher les contrats actifs compatibles avec le profil MTF
         $io->writeln('Aucun symbole fourni, récupération des contrats actifs via ContractRepository...');
 
-        $contracts = $this->contractRepository->findActiveContracts($mtfProfile);
+        $contracts = $this->contractRepository->findActiveContracts($mtfProfile, $context);
 
         $symbols = [];
         foreach ($contracts as $contract) {

--- a/trading-app/src/MtfValidator/Command/MtfRunCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfRunCommand.php
@@ -182,7 +182,7 @@ class MtfRunCommand extends Command
 
             if (empty($symbols)) {
                 // Utiliser ignoreLimits=true pour récupérer TOUS les symboles actifs sans limite top_n/mid_n
-                $symbols = $this->contractRepository->allActiveSymbolNames([], false, $profile);
+                $symbols = $this->contractRepository->allActiveSymbolNames([], false, $profile, $context);
                 if ($limit > 0) {
                     $symbols = array_slice($symbols, 0, $limit);
                 }

--- a/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
+++ b/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
@@ -671,11 +671,27 @@ CASE
 END
 SQL;
 
+        $scopeExpression = <<<SQL
+COALESCE(
+  NULLIF(details->>'exchange', ''),
+  NULLIF(details->'extra'->'options'->>'exchange', ''),
+  'bitmart'
+) AS exchange,
+COALESCE(
+  NULLIF(details->>'market_type', ''),
+  NULLIF(details->>'marketType', ''),
+  NULLIF(details->'extra'->'options'->>'market_type', ''),
+  NULLIF(details->'extra'->'options'->>'marketType', ''),
+  'perpetual'
+) AS market_type
+SQL;
+
         $successSql = <<<SQL
 WITH success_events AS (
   SELECT
     id,
     symbol,
+    {$scopeExpression},
     {$caseExpression} AS timeframe,
     -- event_ts = candle_open_ts + durée du timeframe (pour obtenir le closeTime)
     COALESCE(
@@ -701,17 +717,19 @@ ranked_success AS (
   SELECT
     id,
     symbol,
+    exchange,
+    market_type,
     timeframe,
     event_ts,
     candle_open_ts,
     created_at,
     cause,
     details,
-    ROW_NUMBER() OVER (PARTITION BY symbol, timeframe ORDER BY event_ts DESC, created_at DESC) AS rn
+    ROW_NUMBER() OVER (PARTITION BY exchange, market_type, symbol, timeframe ORDER BY event_ts DESC, created_at DESC) AS rn
   FROM success_events
   WHERE timeframe IS NOT NULL
 )
-SELECT id, symbol, timeframe, event_ts, candle_open_ts, created_at, cause, details
+SELECT id, symbol, exchange, market_type, timeframe, event_ts, candle_open_ts, created_at, cause, details
 FROM ranked_success
 WHERE rn = 1
 SQL;
@@ -730,6 +748,7 @@ WITH failure_events AS (
   SELECT
     id,
     symbol,
+    {$scopeExpression},
     {$caseExpression} AS timeframe,
     -- event_ts = candle_open_ts + durée du timeframe (pour obtenir le closeTime)
     COALESCE(
@@ -754,16 +773,18 @@ ranked_failure AS (
   SELECT
     id,
     symbol,
+    exchange,
+    market_type,
     timeframe,
     event_ts,
     candle_open_ts,
     created_at,
     cause,
-    ROW_NUMBER() OVER (PARTITION BY symbol, timeframe ORDER BY event_ts DESC, created_at DESC) AS rn
+    ROW_NUMBER() OVER (PARTITION BY exchange, market_type, symbol, timeframe ORDER BY event_ts DESC, created_at DESC) AS rn
   FROM failure_events
   WHERE timeframe IS NOT NULL
 )
-SELECT id, symbol, timeframe, event_ts, candle_open_ts, created_at, cause
+SELECT id, symbol, exchange, market_type, timeframe, event_ts, candle_open_ts, created_at, cause
 FROM ranked_failure
 WHERE rn = 1
 SQL;
@@ -775,6 +796,7 @@ WITH ready_events AS (
   SELECT
     id,
     symbol,
+    {$scopeExpression},
     -- Pour READY, on utilise directement candle_open_ts (pas de timeframe spécifique)
     COALESCE(candle_open_ts, NULLIF(details->>'kline_time', '')::timestamp AT TIME ZONE 'UTC') AS event_ts,
     created_at
@@ -789,12 +811,14 @@ ranked_ready AS (
   SELECT
     id,
     symbol,
+    exchange,
+    market_type,
     event_ts,
     created_at,
-    ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY event_ts DESC, created_at DESC) AS rn
+    ROW_NUMBER() OVER (PARTITION BY exchange, market_type, symbol ORDER BY event_ts DESC, created_at DESC) AS rn
   FROM ready_events
 )
-SELECT id, symbol, event_ts, created_at
+SELECT id, symbol, exchange, market_type, event_ts, created_at
 FROM ranked_ready
 WHERE rn = 1
 SQL;
@@ -805,14 +829,19 @@ SQL;
 
         foreach ($successRows as $row) {
             $symbol = (string)($row['symbol'] ?? '');
+            $exchange = $this->normalizeScopeValue($row['exchange'] ?? null, 'bitmart');
+            $marketType = $this->normalizeScopeValue($row['market_type'] ?? null, 'perpetual');
+            $resultKey = $this->auditScopeKey($symbol, $exchange, $marketType);
             $timeframe = (string)($row['timeframe'] ?? '');
             if ($symbol === '' || !in_array($timeframe, $normalizedTfs, true)) {
                 continue;
             }
 
-            if (!isset($results[$symbol])) {
-                $results[$symbol] = [
+            if (!isset($results[$resultKey])) {
+                $results[$resultKey] = [
                     'symbol' => $symbol,
+                    'exchange' => $exchange,
+                    'market_type' => $marketType,
                     'timeframes' => [],
                     'ready' => null,
                 ];
@@ -825,7 +854,7 @@ SQL;
                 $latestDt = $createdDt;
             }
 
-            $results[$symbol]['timeframes'][$timeframe] = [
+            $results[$resultKey]['timeframes'][$timeframe] = [
                 'status' => 'success',
                 'event_ts' => $this->normalizeTimestamp($row['event_ts'] ?? null),
                 'created_at' => $this->normalizeTimestamp($row['created_at'] ?? null),
@@ -838,14 +867,19 @@ SQL;
 
         foreach ($failureRows as $row) {
             $symbol = (string)($row['symbol'] ?? '');
+            $exchange = $this->normalizeScopeValue($row['exchange'] ?? null, 'bitmart');
+            $marketType = $this->normalizeScopeValue($row['market_type'] ?? null, 'perpetual');
+            $resultKey = $this->auditScopeKey($symbol, $exchange, $marketType);
             $timeframe = (string)($row['timeframe'] ?? '');
             if ($symbol === '' || !in_array($timeframe, $normalizedTfs, true)) {
                 continue;
             }
 
-            if (!isset($results[$symbol])) {
-                $results[$symbol] = [
+            if (!isset($results[$resultKey])) {
+                $results[$resultKey] = [
                     'symbol' => $symbol,
+                    'exchange' => $exchange,
+                    'market_type' => $marketType,
                     'timeframes' => [],
                     'ready' => null,
                 ];
@@ -859,12 +893,12 @@ SQL;
             }
             $latestTimestamp = $latestDt?->getTimestamp();
 
-            $existing = $results[$symbol]['timeframes'][$timeframe] ?? null;
+            $existing = $results[$resultKey]['timeframes'][$timeframe] ?? null;
             $existingTimestamp = is_array($existing) ? ($existing['_latest_ts'] ?? null) : null;
 
             if ($latestTimestamp === null) {
                 if ($existing === null) {
-                    $results[$symbol]['timeframes'][$timeframe] = [
+                    $results[$resultKey]['timeframes'][$timeframe] = [
                         'status' => 'failed',
                         'event_ts' => $this->normalizeTimestamp($row['event_ts'] ?? null),
                         'created_at' => $this->normalizeTimestamp($row['created_at'] ?? null),
@@ -878,7 +912,7 @@ SQL;
                 || $existingTimestamp === null
                 || $latestTimestamp >= $existingTimestamp
             ) {
-                $results[$symbol]['timeframes'][$timeframe] = [
+                $results[$resultKey]['timeframes'][$timeframe] = [
                     'status' => 'failed',
                     'event_ts' => $this->normalizeTimestamp($row['event_ts'] ?? null),
                     'created_at' => $this->normalizeTimestamp($row['created_at'] ?? null),
@@ -891,19 +925,24 @@ SQL;
 
         foreach ($readyRows as $row) {
             $symbol = (string)($row['symbol'] ?? '');
+            $exchange = $this->normalizeScopeValue($row['exchange'] ?? null, 'bitmart');
+            $marketType = $this->normalizeScopeValue($row['market_type'] ?? null, 'perpetual');
+            $resultKey = $this->auditScopeKey($symbol, $exchange, $marketType);
             if ($symbol === '') {
                 continue;
             }
 
-            if (!isset($results[$symbol])) {
-                $results[$symbol] = [
+            if (!isset($results[$resultKey])) {
+                $results[$resultKey] = [
                     'symbol' => $symbol,
+                    'exchange' => $exchange,
+                    'market_type' => $marketType,
                     'timeframes' => [],
                     'ready' => null,
                 ];
             }
 
-            $results[$symbol]['ready'] = [
+            $results[$resultKey]['ready'] = [
                 'event_ts' => $this->normalizeTimestamp($row['event_ts'] ?? null),
                 'created_at' => $this->normalizeTimestamp($row['created_at'] ?? null),
                 'audit_id' => isset($row['id']) ? (int)$row['id'] : null,
@@ -941,7 +980,7 @@ SQL;
                                 $entry['symbol'],
                                 $tf,
                                 $expectedOpenTime,
-                                $this->resolveExchangeContextFromDetails($tfData['details'] ?? null),
+                                ExchangeContext::fromValues($entry['exchange'] ?? null, $entry['market_type'] ?? null),
                             );
                             $tfData['kline_id'] = $klineId;
                             // Conserver l'indicateur d'existence si possible via klines (id non null)
@@ -1334,32 +1373,19 @@ SQL;
         return null;
     }
 
+    private function auditScopeKey(string $symbol, string $exchange, string $marketType): string
+    {
+        return sprintf('%s|%s|%s', strtoupper($symbol), strtolower($exchange), strtolower($marketType));
+    }
+
+    private function normalizeScopeValue(mixed $value, string $fallback): string
+    {
+        return \is_string($value) && $value !== '' ? strtolower($value) : $fallback;
+    }
+
     /**
      * Retourne l'ID de la bougie (table klines) si elle existe pour (symbol, timeframe, open_time).
      */
-    private function resolveExchangeContextFromDetails(mixed $details): ExchangeContext
-    {
-        if (\is_string($details) && $details !== '') {
-            try {
-                $decoded = json_decode($details, true, 512, JSON_THROW_ON_ERROR);
-                $details = \is_array($decoded) ? $decoded : [];
-            } catch (\JsonException) {
-                $details = [];
-            }
-        }
-
-        if (!\is_array($details)) {
-            return ExchangeContext::legacyDefault();
-        }
-
-        $options = $details['extra']['options'] ?? $details['options'] ?? null;
-        if (\is_array($options)) {
-            return ExchangeContext::fromArray($options);
-        }
-
-        return ExchangeContext::fromArray($details);
-    }
-
     private function findKlineId(
         string $symbol,
         string $timeframe,

--- a/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
+++ b/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
@@ -660,13 +660,24 @@ SQL;
             $symbolClause = ' AND UPPER(symbol) LIKE :search';
         }
 
-        $caseExpression = <<<SQL
+        $successCaseExpression = <<<SQL
 CASE
   WHEN UPPER(step) = '4H_VALIDATION_SUCCESS' THEN '4h'
   WHEN UPPER(step) = '1H_VALIDATION_SUCCESS' THEN '1h'
   WHEN UPPER(step) = '15M_VALIDATION_SUCCESS' THEN '15m'
   WHEN UPPER(step) = '5M_VALIDATION_SUCCESS' THEN '5m'
   WHEN UPPER(step) = '1M_VALIDATION_SUCCESS' THEN '1m'
+  ELSE NULL
+END
+SQL;
+
+        $failureCaseExpression = <<<SQL
+CASE
+  WHEN UPPER(step) = '4H_VALIDATION_FAILED' THEN '4h'
+  WHEN UPPER(step) = '1H_VALIDATION_FAILED' THEN '1h'
+  WHEN UPPER(step) = '15M_VALIDATION_FAILED' THEN '15m'
+  WHEN UPPER(step) = '5M_VALIDATION_FAILED' THEN '5m'
+  WHEN UPPER(step) = '1M_VALIDATION_FAILED' THEN '1m'
   ELSE NULL
 END
 SQL;
@@ -692,15 +703,15 @@ WITH success_events AS (
     id,
     symbol,
     {$scopeExpression},
-    {$caseExpression} AS timeframe,
+    {$successCaseExpression} AS timeframe,
     -- event_ts = candle_open_ts + durée du timeframe (pour obtenir le closeTime)
     COALESCE(
       CASE
-        WHEN {$caseExpression} = '4h' THEN candle_open_ts + INTERVAL '4 hours'
-        WHEN {$caseExpression} = '1h' THEN candle_open_ts + INTERVAL '1 hour'
-        WHEN {$caseExpression} = '15m' THEN candle_open_ts + INTERVAL '15 minutes'
-        WHEN {$caseExpression} = '5m' THEN candle_open_ts + INTERVAL '5 minutes'
-        WHEN {$caseExpression} = '1m' THEN candle_open_ts + INTERVAL '1 minute'
+        WHEN {$successCaseExpression} = '4h' THEN candle_open_ts + INTERVAL '4 hours'
+        WHEN {$successCaseExpression} = '1h' THEN candle_open_ts + INTERVAL '1 hour'
+        WHEN {$successCaseExpression} = '15m' THEN candle_open_ts + INTERVAL '15 minutes'
+        WHEN {$successCaseExpression} = '5m' THEN candle_open_ts + INTERVAL '5 minutes'
+        WHEN {$successCaseExpression} = '1m' THEN candle_open_ts + INTERVAL '1 minute'
         ELSE NULL
       END,
       NULLIF(details->>'kline_time', '')::timestamp AT TIME ZONE 'UTC'
@@ -749,15 +760,15 @@ WITH failure_events AS (
     id,
     symbol,
     {$scopeExpression},
-    {$caseExpression} AS timeframe,
+    {$failureCaseExpression} AS timeframe,
     -- event_ts = candle_open_ts + durée du timeframe (pour obtenir le closeTime)
     COALESCE(
       CASE
-        WHEN {$caseExpression} = '4h' THEN candle_open_ts + INTERVAL '4 hours'
-        WHEN {$caseExpression} = '1h' THEN candle_open_ts + INTERVAL '1 hour'
-        WHEN {$caseExpression} = '15m' THEN candle_open_ts + INTERVAL '15 minutes'
-        WHEN {$caseExpression} = '5m' THEN candle_open_ts + INTERVAL '5 minutes'
-        WHEN {$caseExpression} = '1m' THEN candle_open_ts + INTERVAL '1 minute'
+        WHEN {$failureCaseExpression} = '4h' THEN candle_open_ts + INTERVAL '4 hours'
+        WHEN {$failureCaseExpression} = '1h' THEN candle_open_ts + INTERVAL '1 hour'
+        WHEN {$failureCaseExpression} = '15m' THEN candle_open_ts + INTERVAL '15 minutes'
+        WHEN {$failureCaseExpression} = '5m' THEN candle_open_ts + INTERVAL '5 minutes'
+        WHEN {$failureCaseExpression} = '1m' THEN candle_open_ts + INTERVAL '1 minute'
         ELSE NULL
       END,
       NULLIF(details->>'kline_time', '')::timestamp AT TIME ZONE 'UTC'

--- a/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
+++ b/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
@@ -6,6 +6,7 @@ namespace App\MtfValidator\Repository;
 
 use App\Entity\MtfState;
 use App\MtfValidator\Entity\MtfAudit;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\ParameterType;
@@ -690,7 +691,8 @@ WITH success_events AS (
     ) AS event_ts,
     candle_open_ts,
     created_at,
-    cause
+    cause,
+    details
   FROM mtf_audit
   WHERE UPPER(step) IN (:step_values)
   {$symbolClause}
@@ -704,11 +706,12 @@ ranked_success AS (
     candle_open_ts,
     created_at,
     cause,
+    details,
     ROW_NUMBER() OVER (PARTITION BY symbol, timeframe ORDER BY event_ts DESC, created_at DESC) AS rn
   FROM success_events
   WHERE timeframe IS NOT NULL
 )
-SELECT id, symbol, timeframe, event_ts, candle_open_ts, created_at, cause
+SELECT id, symbol, timeframe, event_ts, candle_open_ts, created_at, cause, details
 FROM ranked_success
 WHERE rn = 1
 SQL;
@@ -828,6 +831,7 @@ SQL;
                 'created_at' => $this->normalizeTimestamp($row['created_at'] ?? null),
                 'cause' => $row['cause'] ?? null,
                 'audit_id' => isset($row['id']) ? (int)$row['id'] : null,
+                'details' => $row['details'] ?? null,
                 '_latest_ts' => $latestDt?->getTimestamp(),
             ];
         }
@@ -933,7 +937,12 @@ SQL;
                         $tfSeconds = $tfSecondsMap[$tf] ?? 0;
                         if ($tfSeconds > 0) {
                             $expectedOpenTime = $eventTs->modify("-{$tfSeconds} seconds");
-                            $klineId = $this->findKlineId($entry['symbol'], $tf, $expectedOpenTime);
+                            $klineId = $this->findKlineId(
+                                $entry['symbol'],
+                                $tf,
+                                $expectedOpenTime,
+                                $this->resolveExchangeContextFromDetails($tfData['details'] ?? null),
+                            );
                             $tfData['kline_id'] = $klineId;
                             // Conserver l'indicateur d'existence si possible via klines (id non null)
                             $tfData['kline_exists'] = $klineId !== null ? true : ($tfData['kline_exists'] ?? null);
@@ -943,6 +952,9 @@ SQL;
                 $ordered[$tf] = $tfData;
                 if (is_array($ordered[$tf]) && array_key_exists('_latest_ts', $ordered[$tf])) {
                     unset($ordered[$tf]['_latest_ts']);
+                }
+                if (is_array($ordered[$tf]) && array_key_exists('details', $ordered[$tf])) {
+                    unset($ordered[$tf]['details']);
                 }
             }
             $entry['timeframes'] = $ordered;
@@ -1325,20 +1337,51 @@ SQL;
     /**
      * Retourne l'ID de la bougie (table klines) si elle existe pour (symbol, timeframe, open_time).
      */
-    private function findKlineId(string $symbol, string $timeframe, \DateTimeImmutable $openTime): ?int
+    private function resolveExchangeContextFromDetails(mixed $details): ExchangeContext
     {
+        if (\is_string($details) && $details !== '') {
+            try {
+                $decoded = json_decode($details, true, 512, JSON_THROW_ON_ERROR);
+                $details = \is_array($decoded) ? $decoded : [];
+            } catch (\JsonException) {
+                $details = [];
+            }
+        }
+
+        if (!\is_array($details)) {
+            return ExchangeContext::legacyDefault();
+        }
+
+        $options = $details['extra']['options'] ?? $details['options'] ?? null;
+        if (\is_array($options)) {
+            return ExchangeContext::fromArray($options);
+        }
+
+        return ExchangeContext::fromArray($details);
+    }
+
+    private function findKlineId(
+        string $symbol,
+        string $timeframe,
+        \DateTimeImmutable $openTime,
+        ?ExchangeContext $context = null,
+    ): ?int
+    {
+        $context = ExchangeContext::resolve($context);
         try {
             $sql = <<<SQL
 SELECT id
 FROM klines
-WHERE exchange = 'bitmart'
-  AND market_type = 'perpetual'
+WHERE exchange = :exchange
+  AND market_type = :market_type
   AND symbol = :symbol
   AND timeframe = :timeframe
   AND open_time = :open_time
 LIMIT 1
 SQL;
             $id = $this->conn->fetchOne($sql, [
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
                 'symbol' => $symbol,
                 'timeframe' => $timeframe,
                 'open_time' => $openTime->format('Y-m-d H:i:sP'),

--- a/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
+++ b/trading-app/src/MtfValidator/Repository/MtfAuditRepository.php
@@ -1331,7 +1331,9 @@ SQL;
             $sql = <<<SQL
 SELECT id
 FROM klines
-WHERE symbol = :symbol
+WHERE exchange = 'bitmart'
+  AND market_type = 'perpetual'
+  AND symbol = :symbol
   AND timeframe = :timeframe
   AND open_time = :open_time
 LIMIT 1

--- a/trading-app/src/MtfValidator/Service/MtfResultProjector.php
+++ b/trading-app/src/MtfValidator/Service/MtfResultProjector.php
@@ -11,6 +11,7 @@ use App\Repository\MtfStateRepository;
 use App\Repository\SignalRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use App\Logging\TraceIdProvider;
+use App\Provider\Context\ExchangeContext;
 use Ramsey\Uuid\Uuid;
 
 final class MtfResultProjector
@@ -74,9 +75,12 @@ final class MtfResultProjector
         $audit->setTraceId($traceId);
 
         // Details JSON : on met un résumé exploitable
+        $exchangeContext = ExchangeContext::fromArray($input->options);
         $details = [
             'profile'      => $result->profile,
             'mode'         => $result->mode,
+            'exchange'     => $exchangeContext->exchange->value,
+            'market_type'  => $exchangeContext->marketType->value,
             'is_tradable'  => $result->isTradable,
             'side'         => $result->side,
             'execution_tf' => $result->executionTimeframe,

--- a/trading-app/src/MtfValidator/Service/MtfResultProjector.php
+++ b/trading-app/src/MtfValidator/Service/MtfResultProjector.php
@@ -127,8 +127,9 @@ final class MtfResultProjector
 
     private function projectState(string $runId, MtfRunDto $input, MtfResultDto $result): void
     {
+        $exchangeContext = ExchangeContext::fromArray($input->options);
         // On récupère ou crée l'état pour le symbole
-        $state = $this->mtfStateRepository->getOrCreateForSymbol($result->symbol);
+        $state = $this->mtfStateRepository->getOrCreateForSymbol($result->symbol, $exchangeContext);
 
         $evaluatedAt = $result->evaluatedAt;
 

--- a/trading-app/src/MtfValidator/Service/MtfValidatorCoreService.php
+++ b/trading-app/src/MtfValidator/Service/MtfValidatorCoreService.php
@@ -12,6 +12,7 @@ use App\Contract\MtfValidator\Dto\MtfResultDto;
 use App\Contract\MtfValidator\Dto\MtfRunDto;
 use App\Contract\Runtime\AuditLoggerInterface;
 use App\Indicator\Exception\NotEnoughKlinesException;
+use App\Provider\Context\ExchangeContext;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 
@@ -31,6 +32,7 @@ class MtfValidatorCoreService
     public function validate(MtfRunDto $input): MtfResultDto
     {
         $now = $input->now ?? $this->clock->now();
+        $exchangeContext = ExchangeContext::fromArray($input->options);
 
         // 1. Config
         $rawConfig = $this->configProvider->getConfigForProfile($input->profile);
@@ -71,10 +73,13 @@ class MtfValidatorCoreService
                 $input->symbol,
                 $allTimeframes,
                 $now,
+                $exchangeContext,
             );
         } catch (NotEnoughKlinesException $e) {
             $this->mtfLogger->info('MTF not enough klines', [
                 'symbol'             => $input->symbol,
+                'exchange'           => $exchangeContext->exchange->value,
+                'market_type'         => $exchangeContext->marketType->value,
                 'profile'            => $input->profile,
                 'mode'               => $mode,
                 'timeframe'          => $e->getTimeframe(),

--- a/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
+++ b/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
@@ -138,6 +138,7 @@ final class TradingDecisionHandler
             $symbolResult->currentPrice,
             (\is_float($atrForTf) && $atrForTf > 0.0) ? $atrForTf : $forcedAtr5m,
             $resolvedMode, // Passer le mode (même mécanisme que validations.{mode}.yaml)
+            exchangeContext: $exchangeContext,
         );
 
         if ($tradeRequest === null) {

--- a/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
+++ b/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
@@ -16,6 +16,7 @@ use App\TradeEntry\Service\TradeEntryService;
 use App\Contract\Provider\MainProviderInterface;
 use App\Common\Enum\Timeframe;
 use App\Logging\LifecycleContextFactory;
+use App\Provider\Context\ExchangeContext;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -55,6 +56,7 @@ final class TradingDecisionHandler
         }
 
         $decisionKey = $this->generateDecisionKey($symbolResult->symbol);
+        $exchangeContext = ExchangeContext::fromArray($mtfRunDto->options);
         // trade_id global pour ce cycle de trade (zone → ouverture → clôture)
         try {
             $tradeId = sprintf(
@@ -66,7 +68,7 @@ final class TradingDecisionHandler
             $tradeId = uniqid('trd:' . strtolower($symbolResult->symbol) . ':', true);
         }
         // Force ATR to the 5m timeframe so downstream sizing/guards stay consistent across execution TFs.
-        $forcedAtr5m = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: '5m');
+        $forcedAtr5m = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: '5m', context: $exchangeContext);
 
         $resolvedMode = $this->tradeEntryConfigResolver->resolveMode($symbolResult->tradeEntryModeUsed);
         $tradeEntryConfig = $this->tradeEntryConfigResolver->resolve($symbolResult->tradeEntryModeUsed);
@@ -100,12 +102,12 @@ final class TradingDecisionHandler
         
         // ATR du TF d'exécution (fallbacks hiérarchiques)
         $atrForTf = null;
-        try { $atrForTf = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: $effectiveTf); } catch (\Throwable) {}
+        try { $atrForTf = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: $effectiveTf, context: $exchangeContext); } catch (\Throwable) {}
         if (!\is_float($atrForTf) || $atrForTf <= 0.0) {
             // Fallbacks : 5m puis 15m
-            try { $atrForTf = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: '5m'); } catch (\Throwable) {}
+            try { $atrForTf = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: '5m', context: $exchangeContext); } catch (\Throwable) {}
             if (!\is_float($atrForTf) || $atrForTf <= 0.0) {
-                try { $atrForTf = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: '15m'); } catch (\Throwable) {}
+                try { $atrForTf = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: '15m', context: $exchangeContext); } catch (\Throwable) {}
             }
         }
 
@@ -293,6 +295,8 @@ final class TradingDecisionHandler
         ?TradeEntryConfig $tradeEntryConfig = null
     ): bool
     {
+        $exchangeContext = ExchangeContext::fromArray($mtfRunDto->options);
+
         if ($symbolResult->executionTf === null) {
             $this->mtfLogger->info('order_journey.preconditions.blocked', [
                 'symbol' => $symbolResult->symbol,
@@ -393,7 +397,7 @@ final class TradingDecisionHandler
         $symbol = $symbolResult->symbol;
         $price = $symbolResult->currentPrice ?? null;
         $atr15m = null;
-        try { $atr15m = $this->indicatorProvider->getAtr(symbol: $symbol, tf: '15m'); } catch (\Throwable) {}
+        try { $atr15m = $this->indicatorProvider->getAtr(symbol: $symbol, tf: '15m', context: $exchangeContext); } catch (\Throwable) {}
         $atrPct15mBps = ($atr15m !== null && $price !== null && $price > 0.0)
             ? (10000.0 * $atr15m / $price) : null;
 
@@ -424,7 +428,7 @@ final class TradingDecisionHandler
             // Fallback: récupérer la dernière close kline 15m via MainProvider si disponible
             try {
                 if ($this->mainProvider !== null) {
-                    $klines = $this->mainProvider->getKlineProvider()->getKlines($symbol, Timeframe::TF_15M, 2);
+                    $klines = $this->mainProvider->getKlineProvider()->getKlines($symbol, Timeframe::TF_15M, 2, $exchangeContext);
                     if (!empty($klines)) {
                         $last = end($klines);
                         if (\is_object($last) && isset($last->close)) {
@@ -444,7 +448,7 @@ final class TradingDecisionHandler
         $atrForMa21 = null;
 
         try {
-            $snap = $this->indicatorProvider->getSnapshot($symbol, '15m');
+            $snap = $this->indicatorProvider->getSnapshot($symbol, '15m', $exchangeContext);
             // rsi
             if (isset($snap->rsi) && is_float($snap->rsi)) {
                 $context['rsi'] = $snap->rsi;
@@ -513,7 +517,7 @@ final class TradingDecisionHandler
 
         // ADX 1h
         try {
-            $list1h = $this->indicatorProvider->getListPivot(symbol: $symbol, tf: '1h');
+            $list1h = $this->indicatorProvider->getListPivot(symbol: $symbol, tf: '1h', context: $exchangeContext);
             if ($list1h !== null) {
                 $ind = $list1h->toArray();
                 $adx1h = $ind['adx'] ?? null;
@@ -527,7 +531,7 @@ final class TradingDecisionHandler
 
         // ADX 5m for forbid_drop_to_5m_if_any.adx_5m_lt
         try {
-            $list5m = $this->indicatorProvider->getListPivot(symbol: $symbol, tf: '5m');
+            $list5m = $this->indicatorProvider->getListPivot(symbol: $symbol, tf: '5m', context: $exchangeContext);
             if ($list5m !== null) {
                 $ind5m = $list5m->toArray();
                 $adx5m = $ind5m['adx'] ?? null;
@@ -570,7 +574,7 @@ final class TradingDecisionHandler
 
         // Volume ratio derived from recent klines if available
         if ($context['volume_ratio'] === null) {
-            $volumeRatio = $this->computeVolumeRatio($symbol);
+            $volumeRatio = $this->computeVolumeRatio($symbol, $exchangeContext);
             if ($volumeRatio !== null) {
                 $context['volume_ratio'] = $volumeRatio;
             }
@@ -581,7 +585,7 @@ final class TradingDecisionHandler
 
     private function estimateEntryZoneWidthPct(string $symbol, ?float $referencePrice, ?float $atr15m, ?TradeEntryConfig $tradeEntryConfig = null): ?float
     {
-        [$pivotCandidate, $atrFromSnapshot] = $this->fetchEntryZonePivotAndAtr($symbol);
+        [$pivotCandidate, $atrFromSnapshot] = $this->fetchEntryZonePivotAndAtr($symbol, $exchangeContext);
         $pivot = $pivotCandidate ?? $referencePrice;
         if (!\is_finite((float) ($pivot ?? 0)) || $pivot === null || $pivot <= 0.0) {
             return null;
@@ -620,13 +624,13 @@ final class TradingDecisionHandler
     /**
      * @return array{0:?float,1:?float}
      */
-    private function fetchEntryZonePivotAndAtr(string $symbol): array
+    private function fetchEntryZonePivotAndAtr(string $symbol, ExchangeContext $context): array
     {
         $pivot = null;
         $atr = null;
 
         try {
-            $snap5m = $this->indicatorProvider->getSnapshot($symbol, '5m');
+            $snap5m = $this->indicatorProvider->getSnapshot($symbol, '5m', $context);
             if ($snap5m->vwap !== null) {
                 $pivot = (float) ((string) $snap5m->vwap);
             }
@@ -689,14 +693,14 @@ final class TradingDecisionHandler
         return 10000.0 * ($ask - $bid) / $mid;
     }
 
-    private function computeVolumeRatio(string $symbol): ?float
+    private function computeVolumeRatio(string $symbol, ExchangeContext $context): ?float
     {
         if ($this->mainProvider === null) {
             return null;
         }
 
         try {
-            $klines = $this->mainProvider->getKlineProvider()->getKlines($symbol, Timeframe::TF_15M, 25);
+            $klines = $this->mainProvider->getKlineProvider()->getKlines($symbol, Timeframe::TF_15M, 25, $context);
         } catch (\Throwable) {
             return null;
         }

--- a/trading-app/src/Provider/Bitmart/BitmartKlineProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartKlineProvider.php
@@ -11,6 +11,7 @@ use App\Provider\Entity\Kline;
 use App\Provider\Bitmart\Dto\KlineDto as BitmartRawKlineDto;
 use App\Provider\Bitmart\Dto\ListKlinesDto;
 use App\Provider\Bitmart\Http\BitmartHttpClientPublic;
+use App\Provider\Context\ExchangeContext;
 use App\Provider\Repository\KlineRepository;
 use Brick\Math\BigDecimal;
 use Psr\Clock\ClockInterface;
@@ -34,9 +35,19 @@ final class BitmartKlineProvider implements KlineProviderInterface
         private readonly ClockInterface $clock,
     ) {}
 
-    public function getKlines(string $symbol, Timeframe $timeframe, int $limit = 499): array
+    public function getKlines(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 499,
+        ?ExchangeContext $context = null,
+    ): array
     {
-        $dbKlines = $this->klineRepository->getKlines($symbol, $timeframe, $limit);
+        $context = ExchangeContext::resolve($context);
+        $dbKlines = $this->klineRepository->getKlines($symbol, $timeframe, $limit, $context);
+
+        if (!$context->isLegacyDefault()) {
+            return $this->mapEntitiesToDtos($dbKlines);
+        }
 
         if ($this->isDatasetFresh($dbKlines, $timeframe, $limit)) {
             return $this->mapEntitiesToDtos($dbKlines);
@@ -55,7 +66,7 @@ final class BitmartKlineProvider implements KlineProviderInterface
             $klines = $this->mapFetchedKlines($klinesDataAsc, $symbol, $timeframe);
 
             if (!empty($klines)) {
-                $this->klineRepository->upsertKlines($klines);
+                $this->klineRepository->upsertKlines($klines, $context);
                 return $klines;
             }
         } catch (ServerExceptionInterface $e) {
@@ -93,8 +104,26 @@ final class BitmartKlineProvider implements KlineProviderInterface
         Timeframe $timeframe,
         \DateTimeImmutable $start,
         \DateTimeImmutable $end,
-        int $limit = 500
+        int $limit = 500,
+        ?ExchangeContext $context = null,
     ): array {
+        $context = ExchangeContext::resolve($context);
+
+        if (!$context->isLegacyDefault()) {
+            $entities = $this->klineRepository->findBySymbolTimeframeAndDateRange(
+                $symbol,
+                $timeframe,
+                $start,
+                $end,
+                $context,
+            );
+
+            return array_map(
+                fn(Kline $kline): ContractKlineDto => $this->mapEntityToDto($kline),
+                array_slice($entities, 0, $limit),
+            );
+        }
+
         try {
             $step = $this->convertTimeframeToStep($timeframe);
             $startTs = $start->getTimestamp();
@@ -117,10 +146,14 @@ final class BitmartKlineProvider implements KlineProviderInterface
         }
     }
 
-    public function getLastKline(string $symbol, Timeframe $timeframe): ?ContractKlineDto
+    public function getLastKline(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?ContractKlineDto
     {
         try {
-            $kline = $this->klineRepository->findLastBySymbolAndTimeframe($symbol, $timeframe);
+            $kline = $this->klineRepository->findLastBySymbolAndTimeframe($symbol, $timeframe, $context);
             if (!$kline) {
                 return null;
             }
@@ -136,10 +169,10 @@ final class BitmartKlineProvider implements KlineProviderInterface
         }
     }
 
-    public function saveKline(ContractKlineDto $kline): void
+    public function saveKline(ContractKlineDto $kline, ?ExchangeContext $context = null): void
     {
         try {
-            $this->klineRepository->upsertKlines([$kline]);
+            $this->klineRepository->upsertKlines([$kline], $context);
         } catch (\Exception $e) {
             $this->logger->error("Erreur lors de la sauvegarde d'une kline", [
                 'symbol' => $kline->symbol,
@@ -150,10 +183,15 @@ final class BitmartKlineProvider implements KlineProviderInterface
         }
     }
 
-    public function saveKlines(array $klines, string $symbol, Timeframe $timeframe): void
+    public function saveKlines(
+        array $klines,
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): void
     {
         try {
-            $this->klineRepository->upsertKlines($klines);
+            $this->klineRepository->upsertKlines($klines, $context);
         } catch (\Exception $e) {
             $this->logger->error("Erreur lors de la sauvegarde des klines", [
                 'count' => count($klines),
@@ -291,13 +329,17 @@ final class BitmartKlineProvider implements KlineProviderInterface
     }
 
 
-    public function hasGaps(string $symbol, Timeframe $timeframe): bool
+    public function hasGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): bool
     {
         try {
             $endTime = new \DateTimeImmutable();
             $startTime = $endTime->sub(new \DateInterval('P7D')); // 7 jours en arrière
 
-            $gaps = $this->klineRepository->getMissingKlineChunks($symbol, $timeframe->value, $startTime, $endTime, 1);
+            $gaps = $this->klineRepository->getMissingKlineChunks($symbol, $timeframe->value, $startTime, $endTime, 1, $context);
             return !empty($gaps);
         } catch (\Exception $e) {
             $this->logger->error("Erreur lors de la vérification des gaps", [
@@ -309,13 +351,17 @@ final class BitmartKlineProvider implements KlineProviderInterface
         }
     }
 
-    public function getGaps(string $symbol, Timeframe $timeframe): array
+    public function getGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): array
     {
         try {
             $endTime = new \DateTimeImmutable();
             $startTime = $endTime->sub(new \DateInterval('P7D')); // 7 jours en arrière
 
-            return $this->klineRepository->getMissingKlineChunks($symbol, $timeframe->value, $startTime, $endTime, 100);
+            return $this->klineRepository->getMissingKlineChunks($symbol, $timeframe->value, $startTime, $endTime, 100, $context);
         } catch (\Exception $e) {
             $this->logger->error("Erreur lors de la récupération des gaps", [
                 'symbol' => $symbol,

--- a/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
@@ -6,9 +6,11 @@ namespace App\Provider\Bitmart;
 
 use App\Common\Enum\OrderSide;
 use App\Common\Enum\OrderType;
+use App\Contract\Provider\ContextualOrderProviderInterface;
 use App\Contract\Provider\Dto\OrderDto;
 use App\Contract\Provider\Dto\SymbolBidAskDto;
 use App\Contract\Provider\OrderProviderInterface;
+use App\Provider\Context\ExchangeContext;
 use App\Provider\Bitmart\Http\BitmartHttpClientPrivate;
 use App\Provider\Bitmart\Http\BitmartHttpClientPublic;
 use App\Provider\Repository\ContractRepository;
@@ -17,6 +19,7 @@ use App\Service\OrderIntentManager;
 use App\Provider\OrderWatcherPublisher;
 use App\Entity\OrderIntent;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -28,7 +31,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
         OrderProviderInterface::class => '@app.provider.bitmart.order'
     ]
 )]
-final class BitmartOrderProvider implements OrderProviderInterface
+#[AsAlias(id: OrderProviderInterface::class)]
+final class BitmartOrderProvider implements ContextualOrderProviderInterface
 {
     private const RETRY_ATTEMPTS = 3;
     private const RETRY_SLEEP_US = 250_000; // 250ms
@@ -57,6 +61,8 @@ final class BitmartOrderProvider implements OrderProviderInterface
     ): ?OrderDto {
         $intent = null;
         try {
+            $context = ExchangeContext::fromArray($options);
+
             // Bitmart Futures V2 expects:
             //  - side: numeric (1=open_long, 4=open_short) for entry orders
             //  - size: stringified contract size quantity
@@ -115,10 +121,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
 
             $this->intentManager->markReadyToSend($intent);
 
-            $orderPayload = $payload;
-            if (isset($orderPayload['leverage'])) {
-                unset($orderPayload['leverage']);
-            }
+            $orderPayload = $this->toExchangeOrderPayload($payload);
 
             $response = $this->bitmartClient->submitOrder($orderPayload);
 
@@ -139,7 +142,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 // Synchroniser la réponse de soumission si disponible
                 if ($this->syncService && isset($response['data'])) {
                     try {
-                        $this->syncService->syncOrderFromApi($response['data']);
+                        $this->syncService->syncOrderFromApi($this->withContextData($response['data'], $context));
                     } catch (\Throwable $e) {
                         // Log mais ne pas bloquer le flux
                         $this->logger->warning('[BitmartOrderProvider] Failed to sync order on submit', [
@@ -152,7 +155,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 // Short retry loop for eventual consistency on order-detail
                 $orderDto = null;
                 for ($i = 0; $i < 3; $i++) {
-                    $orderDto = $this->getOrder($symbol, $orderId);
+                    $orderDto = $this->getOrder($symbol, $orderId, $context);
                     if ($orderDto !== null) {
                         break;
                     }
@@ -185,6 +188,8 @@ final class BitmartOrderProvider implements OrderProviderInterface
                     'metadata' => [
                         'provider' => 'bitmart',
                         'submit_only' => true,
+                        'exchange' => $context->exchange->value,
+                        'market_type' => $context->marketType->value,
                     ],
                 ]);
                 
@@ -226,12 +231,12 @@ final class BitmartOrderProvider implements OrderProviderInterface
         }
     }
 
-    public function cancelOrder(string $symbol, string $orderId): bool
+    public function cancelOrder(string $symbol, string $orderId, ?ExchangeContext $context = null): bool
     {
         // Trouver l'OrderIntent associé si disponible
         $intent = null;
         if ($this->intentManager) {
-            $intent = $this->intentManager->findIntent(orderId: $orderId);
+            $intent = $this->intentManager->findIntent(orderId: $orderId, context: $context);
         }
 
         $lastError = null;
@@ -346,7 +351,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
         return count($errors) > 0 ? $errors : null;
     }
 
-    public function getOrder(string $symbol, string $orderId): ?OrderDto
+    public function getOrder(string $symbol, string $orderId, ?ExchangeContext $context = null): ?OrderDto
     {
         $lastError = null;
         for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
@@ -357,9 +362,10 @@ final class BitmartOrderProvider implements OrderProviderInterface
                         return null;
                     }
                     // Synchroniser l'ordre dans la base de données
+                    $orderData = $this->withContextData($response['data'], $context);
                     if ($this->syncService) {
                         try {
-                            $this->syncService->syncOrderFromApi($response['data']);
+                            $this->syncService->syncOrderFromApi($orderData);
                         } catch (\Throwable $e) {
                             // Log mais ne pas bloquer le flux
                             $this->logger->warning('[BitmartOrderProvider] Failed to sync order detail', [
@@ -368,7 +374,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
                             ]);
                         }
                     }
-                    return OrderDto::fromArray($response['data']);
+                    return OrderDto::fromArray($orderData);
                 }
                 $lastError = new \RuntimeException('Invalid order detail response structure.');
             } catch (\Throwable $e) {
@@ -389,7 +395,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
         return null;
     }
 
-    public function getOpenOrders(?string $symbol = null): array
+    public function getOpenOrders(?string $symbol = null, ?ExchangeContext $context = null): array
     {
         $lastError = null;
         for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
@@ -426,7 +432,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
                     if ($this->syncService) {
                         foreach ($orders as $orderData) {
                             try {
-                                $this->syncService->syncOrderFromApi($orderData);
+                                $this->syncService->syncOrderFromApi($this->withContextData($orderData, $context));
                             } catch (\Throwable $e) {
                                 // Log mais ne pas bloquer le flux
                                 $this->logger->warning('[BitmartOrderProvider] Failed to sync open order', [
@@ -436,7 +442,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
                             }
                         }
                     }
-                    return array_map(fn($order) => OrderDto::fromArray($order), $orders);
+                    return array_map(fn($order) => OrderDto::fromArray($this->withContextData($order, $context)), $orders);
                 }
 
                 // Si code 30000 ou data vide, c'est normal (pas d'ordres)
@@ -537,7 +543,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
         return [];
     }
 
-    public function getOrderHistory(string $symbol, int $limit = 100): array
+    public function getOrderHistory(string $symbol, int $limit = 100, ?ExchangeContext $context = null): array
     {
         $lastError = null;
         for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
@@ -580,7 +586,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
                     if ($this->syncService) {
                         foreach ($orders as $orderData) {
                             try {
-                                $this->syncService->syncOrderFromApi($orderData);
+                                $this->syncService->syncOrderFromApi($this->withContextData($orderData, $context));
                             } catch (\Throwable $e) {
                                 // Log mais ne pas bloquer le flux
                                 $this->logger->warning('[BitmartOrderProvider] Failed to sync history order', [
@@ -590,7 +596,7 @@ final class BitmartOrderProvider implements OrderProviderInterface
                             }
                         }
                     }
-                    return array_map(fn($order) => OrderDto::fromArray($order), $orders);
+                    return array_map(fn($order) => OrderDto::fromArray($this->withContextData($order, $context)), $orders);
                 }
 
                 // Si code 30000 ou data vide, c'est normal (pas d'historique d'ordres)
@@ -928,6 +934,8 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 'filled_notional' => $averagePrice !== null
                     ? $averagePrice * $filledQuantity
                     : null,
+                'exchange' => $payload['exchange'] ?? $intent?->getExchange(),
+                'market_type' => $payload['market_type'] ?? $payload['marketType'] ?? $intent?->getMarketType(),
             ];
 
             // Nettoyer les valeurs null pour les champs optionnels
@@ -941,5 +949,34 @@ final class BitmartOrderProvider implements OrderProviderInterface
                 'error' => $e->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    private function toExchangeOrderPayload(array $payload): array
+    {
+        unset(
+            $payload['leverage'],
+            $payload['exchange'],
+            $payload['market_type'],
+            $payload['marketType'],
+        );
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @return array<string,mixed>
+     */
+    private function withContextData(array $data, ?ExchangeContext $context): array
+    {
+        $context ??= ExchangeContext::fromArray($data);
+        $data['exchange'] ??= $context->exchange->value;
+        $data['market_type'] ??= $context->marketType->value;
+
+        return $data;
     }
 }

--- a/trading-app/src/Provider/Context/ExchangeContext.php
+++ b/trading-app/src/Provider/Context/ExchangeContext.php
@@ -23,6 +23,26 @@ final class ExchangeContext
         return new self($exchange, $marketType);
     }
 
+    public static function legacyDefault(): self
+    {
+        return new self(Exchange::BITMART, MarketType::PERPETUAL);
+    }
+
+    public static function resolve(?self $context): self
+    {
+        return $context ?? self::legacyDefault();
+    }
+
+    public static function exchangeValue(?self $context): string
+    {
+        return self::resolve($context)->exchange->value;
+    }
+
+    public static function marketTypeValue(?self $context): string
+    {
+        return self::resolve($context)->marketType->value;
+    }
+
     public function equals(self $other): bool
     {
         return $this->exchange === $other->exchange && $this->marketType === $other->marketType;
@@ -38,4 +58,3 @@ final class ExchangeContext
         return $this->key();
     }
 }
-

--- a/trading-app/src/Provider/Context/ExchangeContext.php
+++ b/trading-app/src/Provider/Context/ExchangeContext.php
@@ -28,6 +28,29 @@ final class ExchangeContext
         return new self(Exchange::BITMART, MarketType::PERPETUAL);
     }
 
+    public static function fromValues(mixed $exchange = null, mixed $marketType = null): self
+    {
+        try {
+            return new self(
+                Exchange::from(self::normalize($exchange, Exchange::BITMART->value)),
+                MarketType::from(self::normalize($marketType, MarketType::PERPETUAL->value)),
+            );
+        } catch (\ValueError) {
+            return self::legacyDefault();
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return self::fromValues(
+            $data['exchange'] ?? null,
+            $data['market_type'] ?? $data['marketType'] ?? null,
+        );
+    }
+
     public static function resolve(?self $context): self
     {
         return $context ?? self::legacyDefault();
@@ -53,8 +76,26 @@ final class ExchangeContext
         return sprintf('%s::%s', $this->exchange->value, $this->marketType->value);
     }
 
+    public function isLegacyDefault(): bool
+    {
+        return $this->equals(self::legacyDefault());
+    }
+
     public function __toString(): string
     {
         return $this->key();
+    }
+
+    private static function normalize(mixed $value, string $fallback): string
+    {
+        if ($value instanceof Exchange || $value instanceof MarketType) {
+            return $value->value;
+        }
+
+        if (!\is_string($value) || $value === '') {
+            return $fallback;
+        }
+
+        return strtolower($value);
     }
 }

--- a/trading-app/src/Provider/ContextualKlineProvider.php
+++ b/trading-app/src/Provider/ContextualKlineProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider;
+
+use App\Common\Enum\Timeframe;
+use App\Contract\Provider\Dto\KlineDto;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Provider\Context\ExchangeContext;
+
+final readonly class ContextualKlineProvider implements KlineProviderInterface
+{
+    public function __construct(
+        private KlineProviderInterface $inner,
+        private ExchangeContext $context,
+    ) {
+    }
+
+    public function getKlines(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 490,
+        ?ExchangeContext $context = null,
+    ): array {
+        return $this->inner->getKlines($symbol, $timeframe, $limit, $context ?? $this->context);
+    }
+
+    public function getKlinesInWindow(
+        string $symbol,
+        Timeframe $timeframe,
+        \DateTimeImmutable $start,
+        \DateTimeImmutable $end,
+        int $limit = 500,
+        ?ExchangeContext $context = null,
+    ): array {
+        return $this->inner->getKlinesInWindow($symbol, $timeframe, $start, $end, $limit, $context ?? $this->context);
+    }
+
+    public function getLastKline(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?KlineDto {
+        return $this->inner->getLastKline($symbol, $timeframe, $context ?? $this->context);
+    }
+
+    public function saveKline(KlineDto $kline, ?ExchangeContext $context = null): void
+    {
+        $this->inner->saveKline($kline, $context ?? $this->context);
+    }
+
+    public function saveKlines(
+        array $klines,
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): void {
+        $this->inner->saveKlines($klines, $symbol, $timeframe, $context ?? $this->context);
+    }
+
+    public function hasGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): bool {
+        return $this->inner->hasGaps($symbol, $timeframe, $context ?? $this->context);
+    }
+
+    public function getGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): array {
+        return $this->inner->getGaps($symbol, $timeframe, $context ?? $this->context);
+    }
+}

--- a/trading-app/src/Provider/ContextualOrderProvider.php
+++ b/trading-app/src/Provider/ContextualOrderProvider.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\ContextualOrderProviderInterface;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Provider\Context\ExchangeContext;
+
+final readonly class ContextualOrderProvider implements OrderProviderInterface
+{
+    public function __construct(
+        private OrderProviderInterface $inner,
+        private ExchangeContext $context,
+    ) {
+    }
+
+    public function placeOrder(
+        string $symbol,
+        OrderSide $side,
+        OrderType $type,
+        float $quantity,
+        ?float $price = null,
+        ?float $stopPrice = null,
+        array $options = [],
+    ): ?OrderDto {
+        return $this->inner->placeOrder(
+            symbol: $symbol,
+            side: $side,
+            type: $type,
+            quantity: $quantity,
+            price: $price,
+            stopPrice: $stopPrice,
+            options: $this->withContextOptions($options),
+        );
+    }
+
+    public function cancelOrder(string $symbol, string $orderId): bool
+    {
+        if ($this->inner instanceof ContextualOrderProviderInterface) {
+            return $this->inner->cancelOrder($symbol, $orderId, $this->context);
+        }
+
+        return $this->inner->cancelOrder($symbol, $orderId);
+    }
+
+    public function getOrder(string $symbol, string $orderId): ?OrderDto
+    {
+        if ($this->inner instanceof ContextualOrderProviderInterface) {
+            return $this->inner->getOrder($symbol, $orderId, $this->context);
+        }
+
+        return $this->inner->getOrder($symbol, $orderId);
+    }
+
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        if ($this->inner instanceof ContextualOrderProviderInterface) {
+            return $this->inner->getOpenOrders($symbol, $this->context);
+        }
+
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function getOrderHistory(string $symbol, int $limit = 100): array
+    {
+        if ($this->inner instanceof ContextualOrderProviderInterface) {
+            return $this->inner->getOrderHistory($symbol, $limit, $this->context);
+        }
+
+        return $this->inner->getOrderHistory($symbol, $limit);
+    }
+
+    public function cancelAllOrders(string $symbol): bool
+    {
+        return $this->inner->cancelAllOrders($symbol);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function submitLeverage(string $symbol, int $leverage, string $openType = 'isolated'): bool
+    {
+        return $this->inner->submitLeverage($symbol, $leverage, $openType);
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     * @return array<string,mixed>
+     */
+    private function withContextOptions(array $options): array
+    {
+        $options['exchange'] ??= $this->context->exchange->value;
+        $options['market_type'] ??= $this->context->marketType->value;
+
+        return $options;
+    }
+}

--- a/trading-app/src/Provider/ContextualOrderProvider.php
+++ b/trading-app/src/Provider/ContextualOrderProvider.php
@@ -9,15 +9,21 @@ use App\Common\Enum\OrderType;
 use App\Contract\Provider\ContextualOrderProviderInterface;
 use App\Contract\Provider\Dto\OrderDto;
 use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Contract\Provider\OrderProviderDecoratorInterface;
 use App\Contract\Provider\OrderProviderInterface;
 use App\Provider\Context\ExchangeContext;
 
-final readonly class ContextualOrderProvider implements OrderProviderInterface
+final readonly class ContextualOrderProvider implements OrderProviderDecoratorInterface
 {
     public function __construct(
         private OrderProviderInterface $inner,
         private ExchangeContext $context,
     ) {
+    }
+
+    public function innerOrderProvider(): OrderProviderInterface
+    {
+        return $this->inner;
     }
 
     public function placeOrder(

--- a/trading-app/src/Provider/Entity/Contract.php
+++ b/trading-app/src/Provider/Entity/Contract.php
@@ -4,19 +4,28 @@ declare(strict_types=1);
 
 namespace App\Provider\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Provider\Repository\ContractRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: ContractRepository::class)]
 #[ORM\Table(name: 'contracts')]
-#[ORM\UniqueConstraint(name: 'ux_contracts_symbol', columns: ['symbol'])]
+#[ORM\UniqueConstraint(name: 'ux_contracts_exchange_market_symbol', columns: ['exchange', 'market_type', 'symbol'])]
+#[ORM\Index(name: 'idx_contracts_exchange_market_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 class Contract
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -140,6 +149,28 @@ class Contract
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): static
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): static
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+        return $this;
     }
 
     public function getSymbol(): string

--- a/trading-app/src/Provider/Entity/Kline.php
+++ b/trading-app/src/Provider/Entity/Kline.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Provider\Entity;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Provider\Repository\KlineRepository;
 use Brick\Math\BigDecimal;
 use Doctrine\DBAL\Types\Types;
@@ -11,15 +13,21 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: KlineRepository::class)]
 #[ORM\Table(name: 'klines')]
-#[ORM\Index(name: 'idx_klines_symbol_tf', columns: ['symbol', 'timeframe'])]
+#[ORM\Index(name: 'idx_klines_symbol_tf', columns: ['exchange', 'market_type', 'symbol', 'timeframe'])]
 #[ORM\Index(name: 'idx_klines_open_time', columns: ['open_time'])]
-#[ORM\UniqueConstraint(name: 'ux_klines_symbol_tf_open', columns: ['symbol', 'timeframe', 'open_time'])]
+#[ORM\UniqueConstraint(name: 'ux_klines_exchange_market_symbol_tf_open', columns: ['exchange', 'market_type', 'symbol', 'timeframe', 'open_time'])]
 class Kline implements \JsonSerializable
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: Types::BIGINT)]
     private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
 
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
@@ -63,6 +71,28 @@ class Kline implements \JsonSerializable
     public function getId(): ?int
     {
         return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): static
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+        return $this;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): static
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+        return $this;
     }
 
     public function getSymbol(): string
@@ -260,6 +290,8 @@ class Kline implements \JsonSerializable
     public function jsonSerialize(): mixed
     {
         return [
+            'exchange' => $this->exchange,
+            'marketType' => $this->marketType,
             'timeframe' => $this->timeframe->value,
             'openTime' => $this->openTime->format(DATE_RFC3339),
             'openPrice' => $this->openPrice,

--- a/trading-app/src/Provider/MainProvider.php
+++ b/trading-app/src/Provider/MainProvider.php
@@ -48,7 +48,9 @@ final readonly class MainProvider implements MainProviderInterface
 
     public function getOrderProvider(): OrderProviderInterface
     {
-        return $this->bundle()->order();
+        $bundle = $this->bundle();
+
+        return new ContextualOrderProvider($bundle->order(), $bundle->context());
     }
 
     public function getAccountProvider(): AccountProviderInterface

--- a/trading-app/src/Provider/MainProvider.php
+++ b/trading-app/src/Provider/MainProvider.php
@@ -36,7 +36,9 @@ final readonly class MainProvider implements MainProviderInterface
     }
     public function getKlineProvider(): KlineProviderInterface
     {
-        return $this->bundle()->kline();
+        $bundle = $this->bundle();
+
+        return new ContextualKlineProvider($bundle->kline(), $bundle->context());
     }
 
     public function getContractProvider(): ContractProviderInterface

--- a/trading-app/src/Provider/Repository/ContractRepository.php
+++ b/trading-app/src/Provider/Repository/ContractRepository.php
@@ -6,6 +6,7 @@ namespace App\Provider\Repository;
 
 use App\Config\MtfContractsConfig;
 use App\Config\MtfContractsConfigProvider;
+use App\Provider\Context\ExchangeContext;
 use App\Provider\Entity\Contract;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Connection;
@@ -34,9 +35,9 @@ class ContractRepository extends ServiceEntityRepository
      * 
      * @param string|null $profile Profil de configuration à utiliser (ex: 'scalper', 'regular'). Si null, utilise le fallback.
      */
-    public function findActiveContracts(?string $profile = null): array
+    public function findActiveContracts(?string $profile = null, ?ExchangeContext $context = null): array
     {
-        $symbols = $this->findSymbolsMixedLiquidity($profile);
+        $symbols = $this->findSymbolsMixedLiquidity($profile, $context);
         if ($symbols === []) {
             return [];
         }
@@ -45,6 +46,10 @@ class ContractRepository extends ServiceEntityRepository
         // qui ne sont pas reconnues par Doctrine DQL
         $qb = $this->createQueryBuilder('c')
             ->where('c.symbol IN (:symbols)')
+            ->andWhere('c.exchange = :exchange')
+            ->andWhere('c.marketType = :marketType')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbols', $symbols);
 
         $entities = $qb->getQuery()->getResult();
@@ -67,25 +72,37 @@ class ContractRepository extends ServiceEntityRepository
     /**
      * Récupère un contrat par son symbole
      */
-    public function findBySymbol(string $symbol): ?Contract
+    public function findBySymbol(string $symbol, ?ExchangeContext $context = null): ?Contract
     {
-        return $this->findOneBy(['symbol' => $symbol]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'symbol' => strtoupper($symbol),
+        ]);
     }
 
     /**
      * Récupère les contrats par devise de quote
      */
-    public function findByQuoteCurrency(string $quoteCurrency): array
+    public function findByQuoteCurrency(string $quoteCurrency, ?ExchangeContext $context = null): array
     {
-        return $this->findBy(['quoteCurrency' => $quoteCurrency]);
+        return $this->findBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'quoteCurrency' => $quoteCurrency,
+        ]);
     }
 
     /**
      * Récupère les contrats par statut
      */
-    public function findByStatus(string $status): array
+    public function findByStatus(string $status, ?ExchangeContext $context = null): array
     {
-        return $this->findBy(['status' => $status]);
+        return $this->findBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'status' => $status,
+        ]);
     }
 
     /**
@@ -93,18 +110,22 @@ class ContractRepository extends ServiceEntityRepository
      * 
      * @param string|null $profile Profil de configuration à utiliser (ex: 'scalper', 'regular'). Si null, utilise le fallback.
      */
-    public function countActiveContracts(?string $profile = null): int
+    public function countActiveContracts(?string $profile = null, ?ExchangeContext $context = null): int
     {
-        return count($this->findSymbolsMixedLiquidity($profile));
+        return count($this->findSymbolsMixedLiquidity($profile, $context));
     }
 
 
     /**
      * Récupère les statistiques des contrats
      */
-    public function getContractStats(): array
+    public function getContractStats(?ExchangeContext $context = null): array
     {
-        $qb = $this->createQueryBuilder('c');
+        $qb = $this->createQueryBuilder('c')
+            ->where('c.exchange = :exchange')
+            ->andWhere('c.marketType = :marketType')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context));
 
         $stats = $qb
             ->select([
@@ -126,19 +147,29 @@ class ContractRepository extends ServiceEntityRepository
     /**
      * UPSERT un contrat (insert ou update)
      */
-    public function upsertContract(array $contractData): Contract
+    public function upsertContract(array $contractData, ?ExchangeContext $context = null): Contract
     {
         $symbol = $contractData['symbol'] ?? '';
         if (!$symbol) {
             throw new \InvalidArgumentException('Symbol is required');
         }
 
-        $contract = $this->findBySymbol($symbol);
+        $exchange = strtolower((string) ($contractData['exchange'] ?? ExchangeContext::exchangeValue($context)));
+        $marketType = strtolower((string) ($contractData['market_type'] ?? $contractData['marketType'] ?? ExchangeContext::marketTypeValue($context)));
+
+        $contract = $this->findOneBy([
+            'exchange' => $exchange,
+            'marketType' => $marketType,
+            'symbol' => strtoupper((string) $symbol),
+        ]);
 
         if (!$contract) {
             $contract = new \App\Provider\Entity\Contract();
-            $contract->setSymbol($symbol);
+            $contract->setSymbol(strtoupper((string) $symbol));
         }
+
+        $contract->setExchange($exchange);
+        $contract->setMarketType($marketType);
 
         // Mettre à jour les données
         $contract->setName($contractData['name'] ?? null);
@@ -288,7 +319,7 @@ class ContractRepository extends ServiceEntityRepository
     /**
      * UPSERT plusieurs contrats en lot
      */
-    public function upsertContracts(array $contractsData): int
+    public function upsertContracts(array $contractsData, ?ExchangeContext $context = null): int
     {
         $upsertedCount = 0;
         $batchSize = 50;
@@ -304,7 +335,7 @@ class ContractRepository extends ServiceEntityRepository
                         $contractData = $this->normalizeContractDataArray($contractData);
                     }
 
-                    $this->upsertContract($contractData);
+                    $this->upsertContract($contractData, $context);
                     $upsertedCount++;
                 } catch (\Exception $e) {
                     // Log l'erreur mais continue avec les autres contrats
@@ -331,11 +362,16 @@ class ContractRepository extends ServiceEntityRepository
      * @param string|null $profile Profil de configuration à utiliser (ex: 'scalper', 'regular'). Si null, utilise le fallback.
      * @return string[]
      */
-    public function allActiveSymbolNames(array $symbols = [], bool $ignoreLimits = false, ?string $profile = null): array
+    public function allActiveSymbolNames(
+        array $symbols = [],
+        bool $ignoreLimits = false,
+        ?string $profile = null,
+        ?ExchangeContext $context = null,
+    ): array
     {
         $all = $ignoreLimits
-            ? $this->findAllActiveSymbolsWithoutLimits($profile)
-            : $this->findSymbolsMixedLiquidity($profile);           // liste ordonnée (TOP + MID)
+            ? $this->findAllActiveSymbolsWithoutLimits($profile, $context)
+            : $this->findSymbolsMixedLiquidity($profile, $context);           // liste ordonnée (TOP + MID)
         if ($symbols === []) {
             return $all;
         }
@@ -351,7 +387,7 @@ class ContractRepository extends ServiceEntityRepository
      * @param string|null $profile Profil de configuration à utiliser (ex: 'scalper', 'regular'). Si null, utilise le fallback.
      * @return string[]
      */
-    public function findAllActiveSymbolsWithoutLimits(?string $profile = null): array
+    public function findAllActiveSymbolsWithoutLimits(?string $profile = null, ?ExchangeContext $context = null): array
     {
         $config = $this->configProvider->getConfigForProfile($profile);
         
@@ -383,6 +419,8 @@ class ContractRepository extends ServiceEntityRepository
 SELECT c.symbol
 FROM contracts c
 WHERE c.status = :status
+  AND c.exchange = :exchange
+  AND c.market_type = :marketType
   AND c.quote_currency = :quoteCurrency
   AND {$turnoverExpr} >= :minTurnover
   AND (
@@ -409,6 +447,8 @@ ORDER BY {$turnoverExpr} DESC
 
         $stmt = $this->conn->prepare($sql);
         $stmt->bindValue('status', $status);
+        $stmt->bindValue('exchange', ExchangeContext::exchangeValue($context));
+        $stmt->bindValue('marketType', ExchangeContext::marketTypeValue($context));
         $stmt->bindValue('quoteCurrency', $quoteCurrency);
         $stmt->bindValue('minTurnover', $minTurnover);
         $stmt->bindValue('requireNotExpired', $requireNotExpired, ParameterType::BOOLEAN);
@@ -423,9 +463,13 @@ ORDER BY {$turnoverExpr} DESC
 
         return array_values(array_unique($symbols));
     }
-    public function findWithFilters(?string $status = null, ?string $symbol = null): array
+    public function findWithFilters(?string $status = null, ?string $symbol = null, ?ExchangeContext $context = null): array
     {
         $qb = $this->createQueryBuilder('c')
+            ->where('c.exchange = :exchange')
+            ->andWhere('c.marketType = :marketType')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->orderBy('c.symbol', 'ASC');
 
         if ($status) {
@@ -447,7 +491,7 @@ ORDER BY {$turnoverExpr} DESC
      * @param string|null $profile Profil de configuration à utiliser (ex: 'scalper', 'regular'). Si null, utilise le fallback.
      * @return string[]
      */
-    public function findSymbolsMixedLiquidity(?string $profile = null): array
+    public function findSymbolsMixedLiquidity(?string $profile = null, ?ExchangeContext $context = null): array
     {
         $config = $this->configProvider->getConfigForProfile($profile);
         
@@ -504,6 +548,8 @@ WITH base AS (
   SELECT c.symbol, {$turnoverExpr} AS t24
   FROM contracts c
   WHERE c.status = :status
+    AND c.exchange = :exchange
+    AND c.market_type = :marketType
     AND c.quote_currency = :quoteCurrency
     AND {$turnoverExpr} >= :minTurnover
     AND (
@@ -563,6 +609,8 @@ SELECT symbol FROM (
 
         // --- Bind communs ---
         $stmt->bindValue('status',         $status);
+        $stmt->bindValue('exchange',       ExchangeContext::exchangeValue($context));
+        $stmt->bindValue('marketType',     ExchangeContext::marketTypeValue($context));
         $stmt->bindValue('quoteCurrency',  $quoteCurrency);
         $stmt->bindValue('minTurnover',    $minTurnover);
         $stmt->bindValue('requireNotExpired', $requireNotExpired, ParameterType::BOOLEAN);

--- a/trading-app/src/Provider/Repository/KlineRepository.php
+++ b/trading-app/src/Provider/Repository/KlineRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Provider\Repository;
 
 use App\Common\Enum\Timeframe;
+use App\Provider\Context\ExchangeContext;
 use App\Provider\Entity\Kline;
 use App\Provider\Bitmart\Dto\KlineDto;
 use App\Provider\Bitmart\Dto\ListKlinesDto;
@@ -49,23 +50,60 @@ class KlineRepository extends ServiceEntityRepository
         string $timeframe,
         \DateTimeImmutable $startUtc,
         \DateTimeImmutable $endUtc,
-        int $maxPerReq = 500
+        int $maxPerReq = 500,
+        ?ExchangeContext $context = null,
     ): array {
         $conn = $this->getConnection();
+        $step = Timeframe::from($timeframe)->getStepInMinutes();
 
         try {
-            // Appel direct de la fonction PostgreSQL avec les paramètres
             $rows = $conn->fetchAllAssociative(
-                'SELECT symbol, step, "from", "to"
-                 FROM get_missing_kline_chunks(?, ?, ?, ?, ?)
-                 ORDER BY "from", "to"',
+                <<<SQL
+WITH expected AS (
+    SELECT generate_series(
+        CAST(:start_utc AS timestamptz),
+        CAST(:end_utc AS timestamptz),
+        (:step_minutes || ' minutes')::interval
+    ) AS open_time
+),
+missing AS (
+    SELECT
+        e.open_time,
+        ROW_NUMBER() OVER (ORDER BY e.open_time) AS rn
+    FROM expected e
+    LEFT JOIN klines k
+        ON k.exchange = :exchange
+       AND k.market_type = :market_type
+       AND k.symbol = :symbol
+       AND k.timeframe = :timeframe
+       AND k.open_time = e.open_time
+    WHERE k.id IS NULL
+),
+chunked AS (
+    SELECT
+        open_time,
+        FLOOR((rn - 1) / :max_per_req) AS chunk_id
+    FROM missing
+)
+SELECT
+    :symbol AS symbol,
+    :step_minutes AS step,
+    EXTRACT(EPOCH FROM MIN(open_time))::bigint AS "from",
+    EXTRACT(EPOCH FROM MAX(open_time))::bigint AS "to"
+FROM chunked
+GROUP BY chunk_id
+ORDER BY "from", "to"
+SQL,
                 [
-                    $symbol,
-                    $timeframe,
-                    $startUtc->format('Y-m-d H:i:sP'),
-                    $endUtc->format('Y-m-d H:i:sP'),
-                    $maxPerReq
-                ]
+                    'exchange' => ExchangeContext::exchangeValue($context),
+                    'market_type' => ExchangeContext::marketTypeValue($context),
+                    'symbol' => strtoupper($symbol),
+                    'timeframe' => $timeframe,
+                    'start_utc' => $startUtc->format('Y-m-d H:i:sP'),
+                    'end_utc' => $endUtc->format('Y-m-d H:i:sP'),
+                    'step_minutes' => $step,
+                    'max_per_req' => max(1, $maxPerReq),
+                ],
             );
 
             // Normalisation typée
@@ -92,11 +130,20 @@ class KlineRepository extends ServiceEntityRepository
      *
      * @return Kline[]
      */
-    public function getKlines(string $symbol, Timeframe $timeframe, int $limit = 1000): array
+    public function getKlines(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 1000,
+        ?ExchangeContext $context = null,
+    ): array
     {
         return $this->createQueryBuilder('k')
-            ->where('k.symbol = :symbol')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->andWhere('k.symbol = :symbol')
             ->andWhere('k.timeframe = :timeframe')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->orderBy('k.openTime', 'DESC')
@@ -108,19 +155,32 @@ class KlineRepository extends ServiceEntityRepository
     /**
      * Récupère les klines pour un symbole et timeframe
      */
-    public function findBySymbolAndTimeframe(string $symbol, Timeframe $timeframe, int $limit = 1000): array
+    public function findBySymbolAndTimeframe(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 1000,
+        ?ExchangeContext $context = null,
+    ): array
     {
-        return $this->getKlines($symbol, $timeframe, $limit);
+        return $this->getKlines($symbol, $timeframe, $limit, $context);
     }
 
     /**
      * Récupère la dernière kline pour un symbole et timeframe
      */
-    public function findLastBySymbolAndTimeframe(string $symbol, Timeframe $timeframe): ?Kline
+    public function findLastBySymbolAndTimeframe(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?Kline
     {
         return $this->createQueryBuilder('k')
-            ->where('k.symbol = :symbol')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->andWhere('k.symbol = :symbol')
             ->andWhere('k.timeframe = :timeframe')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->orderBy('k.openTime', 'DESC')
@@ -136,13 +196,18 @@ class KlineRepository extends ServiceEntityRepository
         string $symbol,
         Timeframe $timeframe,
         \DateTimeImmutable $startDate,
-        \DateTimeImmutable $endDate
+        \DateTimeImmutable $endDate,
+        ?ExchangeContext $context = null,
     ): array {
         return $this->createQueryBuilder('k')
-            ->where('k.symbol = :symbol')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->andWhere('k.symbol = :symbol')
             ->andWhere('k.timeframe = :timeframe')
             ->andWhere('k.openTime >= :startDate')
             ->andWhere('k.openTime <= :endDate')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->setParameter('startDate', $startDate)
@@ -155,13 +220,17 @@ class KlineRepository extends ServiceEntityRepository
     /**
      * Vérifie s'il y a des gaps dans les données
      */
-    public function hasGaps(string $symbol, Timeframe $timeframe): bool
+    public function hasGaps(string $symbol, Timeframe $timeframe, ?ExchangeContext $context = null): bool
     {
         $qb = $this->createQueryBuilder('k');
 
         $result = $qb->select('COUNT(k.id) as count')
-            ->where('k.symbol = :symbol')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->andWhere('k.symbol = :symbol')
             ->andWhere('k.timeframe = :timeframe')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->getQuery()
@@ -184,9 +253,16 @@ class KlineRepository extends ServiceEntityRepository
     /**
      * Sauvegarde ou met à jour une kline
      */
-    public function upsert(Kline $kline): void
+    public function upsert(Kline $kline, ?ExchangeContext $context = null): void
     {
+        if ($context !== null) {
+            $kline->setExchange($context->exchange);
+            $kline->setMarketType($context->marketType);
+        }
+
         $existing = $this->findOneBy([
+            'exchange' => $kline->getExchange(),
+            'marketType' => $kline->getMarketType(),
             'symbol' => $kline->getSymbol(),
             'timeframe' => $kline->getTimeframe(),
             'openTime' => $kline->getOpenTime()
@@ -217,7 +293,12 @@ class KlineRepository extends ServiceEntityRepository
      * Sauvegarde plusieurs klines (DTOs) en lot.
      * @param KlineDto[] $klineDtos
      */
-    public function saveKlines(ListKlinesDto $listKlinesDto, string $symbol, Timeframe $timeframe): void
+    public function saveKlines(
+        ListKlinesDto $listKlinesDto,
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): void
     {
         $em = $this->getEntityManager();
         $batchSize = 100;
@@ -225,6 +306,8 @@ class KlineRepository extends ServiceEntityRepository
 
         foreach ($listKlinesDto as $klineDto) {
             $kline = new \App\Provider\Entity\Kline();
+            $kline->setExchange(ExchangeContext::exchangeValue($context));
+            $kline->setMarketType(ExchangeContext::marketTypeValue($context));
             $kline->setSymbol($symbol);
             $kline->setTimeframe($timeframe);
             $kline->setOpenTime($klineDto->openTime);
@@ -253,11 +336,20 @@ class KlineRepository extends ServiceEntityRepository
     /**
      * Récupère les klines les plus récentes pour le calcul des indicateurs
      */
-    public function findRecentForIndicators(string $symbol, Timeframe $timeframe, int $requiredPeriods = 200): array
+    public function findRecentForIndicators(
+        string $symbol,
+        Timeframe $timeframe,
+        int $requiredPeriods = 200,
+        ?ExchangeContext $context = null,
+    ): array
     {
         return $this->createQueryBuilder('k')
-            ->where('k.symbol = :symbol')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->andWhere('k.symbol = :symbol')
             ->andWhere('k.timeframe = :timeframe')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->orderBy('k.openTime', 'DESC')
@@ -266,9 +358,19 @@ class KlineRepository extends ServiceEntityRepository
             ->getResult();
     }
 
-    public function findWithFilters(?string $symbol = null, ?string $timeframe = null, ?string $dateFrom = null, ?string $dateTo = null): array
+    public function findWithFilters(
+        ?string $symbol = null,
+        ?string $timeframe = null,
+        ?string $dateFrom = null,
+        ?string $dateTo = null,
+        ?ExchangeContext $context = null,
+    ): array
     {
         $qb = $this->createQueryBuilder('k')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->orderBy('k.openTime', 'DESC')
             ->setMaxResults(1000); // Limiter pour les performances
 
@@ -297,22 +399,30 @@ class KlineRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function countKlines(string $symbol, Timeframe $timeframe)
+    public function countKlines(string $symbol, Timeframe $timeframe, ?ExchangeContext $context = null)
     {
         return $this->createQueryBuilder('k')
             ->select('COUNT(k.id)')
-            ->where('k.symbol = :symbol')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->andWhere('k.symbol = :symbol')
             ->andWhere('k.timeframe = :timeframe')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->getQuery()
             ->getSingleScalarResult();
     }
 
-    public function getKlinesStats()
+    public function getKlinesStats(?ExchangeContext $context = null)
     {
         return $this->createQueryBuilder('k')
             ->select('k.symbol, k.timeframe, COUNT(k.id) as count, MAX(k.openTime) as earliest, MIN(k.openTime) as latest')
+            ->where('k.exchange = :exchange')
+            ->andWhere('k.marketType = :marketType')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->groupBy('k.symbol, k.timeframe')
             ->orderBy('k.symbol, k.timeframe')
             ->getQuery()
@@ -324,7 +434,7 @@ class KlineRepository extends ServiceEntityRepository
      *
      * @param \App\Contract\Provider\Dto\KlineDto[] $klines
      */
-    public function upsertKlines(array $klines): int
+    public function upsertKlines(array $klines, ?ExchangeContext $context = null): int
     {
         if (empty($klines)) {
             return 0;
@@ -332,6 +442,8 @@ class KlineRepository extends ServiceEntityRepository
 
         $this->logger->info('Starting klines upsert', [
             'count' => \count($klines),
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'market_type' => ExchangeContext::marketTypeValue($context),
             'symbol' => $klines[0]->symbol ?? 'unknown',
             'timeframe' => $klines[0]->timeframe->value ?? 'unknown',
         ]);
@@ -349,12 +461,14 @@ class KlineRepository extends ServiceEntityRepository
                     continue;
                 }
 
-                $placeholders[] = "(nextval('klines_id_seq'),?,?,?,?,?,?,?,?,?,?,?)";
+                $placeholders[] = "(nextval('klines_id_seq'),?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
                 $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
                 $openTime = $klineDto->openTime->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:sP');
                 $nowStr = $now->format('Y-m-d H:i:sP');
 
+                $params[] = ExchangeContext::exchangeValue($context);
+                $params[] = ExchangeContext::marketTypeValue($context);
                 $params[] = $klineDto->symbol;
                 $params[] = $klineDto->timeframe->value;
                 $params[] = $openTime;
@@ -375,6 +489,8 @@ class KlineRepository extends ServiceEntityRepository
             $sql = '
                 INSERT INTO klines (
                     id,
+                    exchange,
+                    market_type,
                     symbol,
                     timeframe,
                     open_time,
@@ -387,7 +503,7 @@ class KlineRepository extends ServiceEntityRepository
                     inserted_at,
                     updated_at
                 ) VALUES ' . \implode(',', $placeholders) . '
-                ON CONFLICT (symbol, timeframe, open_time) DO UPDATE SET
+                ON CONFLICT (exchange, market_type, symbol, timeframe, open_time) DO UPDATE SET
                     open_price = EXCLUDED.open_price,
                     high_price = EXCLUDED.high_price,
                     low_price  = EXCLUDED.low_price,
@@ -412,6 +528,8 @@ class KlineRepository extends ServiceEntityRepository
         $this->logger->info('Klines upsert completed', [
             'total_upserted' => $totalUpserted,
             'total_input' => \count($klines),
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'market_type' => ExchangeContext::marketTypeValue($context),
         ]);
 
         return $totalUpserted;
@@ -434,7 +552,12 @@ class KlineRepository extends ServiceEntityRepository
      *                 'dry_run' => true
      *               ]
      */
-    public function cleanupOldKlines(?string $symbol, int $keepLimit, bool $dryRun): array
+    public function cleanupOldKlines(
+        ?string $symbol,
+        int $keepLimit,
+        bool $dryRun,
+        ?ExchangeContext $context = null,
+    ): array
     {
         $conn = $this->getConnection();
         $stats = [
@@ -448,7 +571,7 @@ class KlineRepository extends ServiceEntityRepository
             $timeframes = array_map(fn($tf) => $tf->value, Timeframe::cases());
 
             foreach ($timeframes as $tf) {
-                $tfStats = $this->cleanupForTimeframe($symbol, $tf, $keepLimit, $dryRun, $conn);
+                $tfStats = $this->cleanupForTimeframe($symbol, $tf, $keepLimit, $dryRun, $conn, $context);
                 
                 if ($tfStats['total'] > 0) {
                     $stats['timeframes'][$tf] = $tfStats;
@@ -458,6 +581,8 @@ class KlineRepository extends ServiceEntityRepository
 
             $this->logger->info('[Cleanup] Klines cleanup completed', [
                 'dry_run' => $dryRun,
+                'exchange' => ExchangeContext::exchangeValue($context),
+                'market_type' => ExchangeContext::marketTypeValue($context),
                 'symbol' => $symbol ?? 'ALL',
                 'keep_limit' => $keepLimit,
                 'total_to_delete' => $stats['total_to_delete'],
@@ -477,11 +602,28 @@ class KlineRepository extends ServiceEntityRepository
     /**
      * Nettoie les klines pour un timeframe spécifique
      */
-    private function cleanupForTimeframe(?string $symbol, string $timeframe, int $keepLimit, bool $dryRun, Connection $conn): array
+    private function cleanupForTimeframe(
+        ?string $symbol,
+        string $timeframe,
+        int $keepLimit,
+        bool $dryRun,
+        Connection $conn,
+        ?ExchangeContext $context = null,
+    ): array
     {
         $symbolFilter = $symbol ? 'AND symbol = :symbol' : '';
-        $params = ['timeframe' => $timeframe, 'keep_limit' => $keepLimit];
-        $types = ['timeframe' => \Doctrine\DBAL\ParameterType::STRING, 'keep_limit' => \Doctrine\DBAL\ParameterType::INTEGER];
+        $params = [
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'market_type' => ExchangeContext::marketTypeValue($context),
+            'timeframe' => $timeframe,
+            'keep_limit' => $keepLimit,
+        ];
+        $types = [
+            'exchange' => \Doctrine\DBAL\ParameterType::STRING,
+            'market_type' => \Doctrine\DBAL\ParameterType::STRING,
+            'timeframe' => \Doctrine\DBAL\ParameterType::STRING,
+            'keep_limit' => \Doctrine\DBAL\ParameterType::INTEGER,
+        ];
 
         if ($symbol) {
             $params['symbol'] = $symbol;
@@ -498,7 +640,9 @@ WITH ranked AS (
     open_time,
     ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY open_time DESC) AS rn
   FROM klines
-  WHERE timeframe = :timeframe
+  WHERE exchange = :exchange
+    AND market_type = :market_type
+    AND timeframe = :timeframe
     {$symbolFilter}
 )
 SELECT 
@@ -547,7 +691,9 @@ WHERE id IN (
       id,
       ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY open_time DESC) AS rn
     FROM klines
-    WHERE timeframe = :timeframe
+    WHERE exchange = :exchange
+      AND market_type = :market_type
+      AND timeframe = :timeframe
       {$symbolFilter}
   ) ranked
   WHERE rn > :keep_limit

--- a/trading-app/src/Provider/Repository/KlineRepository.php
+++ b/trading-app/src/Provider/Repository/KlineRepository.php
@@ -59,17 +59,46 @@ class KlineRepository extends ServiceEntityRepository
         try {
             $rows = $conn->fetchAllAssociative(
                 <<<SQL
-WITH expected AS (
-    SELECT generate_series(
-        CAST(:start_utc AS timestamptz),
-        CAST(:end_utc AS timestamptz),
-        (:step_minutes || ' minutes')::interval
-    ) AS open_time
+WITH input AS (
+    SELECT
+        CAST(:start_utc AS timestamptz) AS start_utc,
+        CAST(:end_utc AS timestamptz) AS end_utc,
+        (:step_minutes || ' minutes')::interval AS step_interval
+),
+bounds AS (
+    SELECT
+        CASE :timeframe
+            WHEN '1m' THEN date_trunc('minute', start_utc)
+            WHEN '5m' THEN date_trunc('hour', start_utc)
+                + make_interval(mins => (floor(extract(minute from start_utc)::numeric / 5) * 5)::int)
+            WHEN '15m' THEN date_trunc('hour', start_utc)
+                + make_interval(mins => (floor(extract(minute from start_utc)::numeric / 15) * 15)::int)
+            WHEN '1h' THEN date_trunc('hour', start_utc)
+            WHEN '4h' THEN date_trunc('day', start_utc)
+                + make_interval(hours => (floor(extract(hour from start_utc)::numeric / 4) * 4)::int)
+            WHEN '1d' THEN date_trunc('day', start_utc)
+        END AS start_at,
+        CASE :timeframe
+            WHEN '1m' THEN date_trunc('minute', end_utc)
+            WHEN '5m' THEN date_trunc('hour', end_utc)
+                + make_interval(mins => (floor(extract(minute from end_utc)::numeric / 5) * 5)::int)
+            WHEN '15m' THEN date_trunc('hour', end_utc)
+                + make_interval(mins => (floor(extract(minute from end_utc)::numeric / 15) * 15)::int)
+            WHEN '1h' THEN date_trunc('hour', end_utc)
+            WHEN '4h' THEN date_trunc('day', end_utc)
+                + make_interval(hours => (floor(extract(hour from end_utc)::numeric / 4) * 4)::int)
+            WHEN '1d' THEN date_trunc('day', end_utc)
+        END AS end_at,
+        step_interval
+    FROM input
+),
+expected AS (
+    SELECT generate_series(start_at, end_at, step_interval) AS open_time, step_interval
+    FROM bounds
+    WHERE end_at >= start_at
 ),
 missing AS (
-    SELECT
-        e.open_time,
-        ROW_NUMBER() OVER (ORDER BY e.open_time) AS rn
+    SELECT e.open_time, e.step_interval
     FROM expected e
     LEFT JOIN klines k
         ON k.exchange = :exchange
@@ -79,11 +108,18 @@ missing AS (
        AND k.open_time = e.open_time
     WHERE k.id IS NULL
 ),
+contiguous AS (
+    SELECT
+        open_time,
+        open_time - ((ROW_NUMBER() OVER (ORDER BY open_time))::int * step_interval) AS run_key
+    FROM missing
+),
 chunked AS (
     SELECT
         open_time,
-        FLOOR((rn - 1) / :max_per_req) AS chunk_id
-    FROM missing
+        run_key,
+        FLOOR(((ROW_NUMBER() OVER (PARTITION BY run_key ORDER BY open_time) - 1)::numeric) / :max_per_req) AS chunk_id
+    FROM contiguous
 )
 SELECT
     :symbol AS symbol,
@@ -91,7 +127,7 @@ SELECT
     EXTRACT(EPOCH FROM MIN(open_time))::bigint AS "from",
     EXTRACT(EPOCH FROM MAX(open_time))::bigint AS "to"
 FROM chunked
-GROUP BY chunk_id
+GROUP BY run_key, chunk_id
 ORDER BY "from", "to"
 SQL,
                 [

--- a/trading-app/src/Provider/Repository/KlineRepository.php
+++ b/trading-app/src/Provider/Repository/KlineRepository.php
@@ -39,7 +39,7 @@ class KlineRepository extends ServiceEntityRepository
      * Chaque ligne = un "chunk" (symbol, step en minutes, from/to en secondes epoch)
      *
      * @param string $symbol        ex: 'BTCUSDT'
-     * @param string $timeframe     ex: '1m','5m','15m','1h','4h','1d'
+     * @param string $timeframe     ex: '1m','5m','15m','30m','1h','4h','1d'
      * @param \DateTimeImmutable $startUtc
      * @param \DateTimeImmutable $endUtc
      * @param int $maxPerReq        (par défaut 500)
@@ -73,6 +73,8 @@ bounds AS (
                 + make_interval(mins => (floor(extract(minute from start_utc)::numeric / 5) * 5)::int)
             WHEN '15m' THEN date_trunc('hour', start_utc)
                 + make_interval(mins => (floor(extract(minute from start_utc)::numeric / 15) * 15)::int)
+            WHEN '30m' THEN date_trunc('hour', start_utc)
+                + make_interval(mins => (floor(extract(minute from start_utc)::numeric / 30) * 30)::int)
             WHEN '1h' THEN date_trunc('hour', start_utc)
             WHEN '4h' THEN date_trunc('day', start_utc)
                 + make_interval(hours => (floor(extract(hour from start_utc)::numeric / 4) * 4)::int)
@@ -84,6 +86,8 @@ bounds AS (
                 + make_interval(mins => (floor(extract(minute from end_utc)::numeric / 5) * 5)::int)
             WHEN '15m' THEN date_trunc('hour', end_utc)
                 + make_interval(mins => (floor(extract(minute from end_utc)::numeric / 15) * 15)::int)
+            WHEN '30m' THEN date_trunc('hour', end_utc)
+                + make_interval(mins => (floor(extract(minute from end_utc)::numeric / 30) * 30)::int)
             WHEN '1h' THEN date_trunc('hour', end_utc)
             WHEN '4h' THEN date_trunc('day', end_utc)
                 + make_interval(hours => (floor(extract(hour from end_utc)::numeric / 4) * 4)::int)

--- a/trading-app/src/Repository/FuturesOrderRepository.php
+++ b/trading-app/src/Repository/FuturesOrderRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\FuturesOrder;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -18,14 +19,22 @@ final class FuturesOrderRepository extends ServiceEntityRepository
         parent::__construct($registry, FuturesOrder::class);
     }
 
-    public function findOneByOrderId(string $orderId): ?FuturesOrder
+    public function findOneByOrderId(string $orderId, ?ExchangeContext $context = null): ?FuturesOrder
     {
-        return $this->findOneBy(['orderId' => $orderId]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'orderId' => $orderId,
+        ]);
     }
 
-    public function findOneByClientOrderId(string $clientOrderId): ?FuturesOrder
+    public function findOneByClientOrderId(string $clientOrderId, ?ExchangeContext $context = null): ?FuturesOrder
     {
-        return $this->findOneBy(['clientOrderId' => $clientOrderId]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'clientOrderId' => $clientOrderId,
+        ]);
     }
 
     /**
@@ -34,10 +43,15 @@ final class FuturesOrderRepository extends ServiceEntityRepository
     public function findRecentBySymbol(
         string $symbol,
         int $limit = 200,
-        ?\DateTimeImmutable $since = null
+        ?\DateTimeImmutable $since = null,
+        ?ExchangeContext $context = null,
     ): array {
         $qb = $this->createQueryBuilder('o')
+            ->andWhere('o.exchange = :exchange')
+            ->andWhere('o.marketType = :marketType')
             ->andWhere('o.symbol = :symbol')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
             ->orderBy('o.createdAt', 'DESC')
             ->setMaxResults($limit);

--- a/trading-app/src/Repository/FuturesOrderTradeRepository.php
+++ b/trading-app/src/Repository/FuturesOrderTradeRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\FuturesOrderTrade;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -18,18 +19,26 @@ final class FuturesOrderTradeRepository extends ServiceEntityRepository
         parent::__construct($registry, FuturesOrderTrade::class);
     }
 
-    public function findOneByTradeId(string $tradeId): ?FuturesOrderTrade
+    public function findOneByTradeId(string $tradeId, ?ExchangeContext $context = null): ?FuturesOrderTrade
     {
-        return $this->findOneBy(['tradeId' => $tradeId]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'tradeId' => $tradeId,
+        ]);
     }
 
     /**
      * @return FuturesOrderTrade[]
      */
-    public function findByOrderId(string $orderId, int $limit = 100): array
+    public function findByOrderId(string $orderId, int $limit = 100, ?ExchangeContext $context = null): array
     {
         return $this->createQueryBuilder('fot')
-            ->where('fot.orderId = :orderId')
+            ->where('fot.exchange = :exchange')
+            ->andWhere('fot.marketType = :marketType')
+            ->andWhere('fot.orderId = :orderId')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('orderId', $orderId)
             ->orderBy('fot.tradeTime', 'DESC')
             ->setMaxResults($limit)
@@ -40,9 +49,13 @@ final class FuturesOrderTradeRepository extends ServiceEntityRepository
     /**
      * @return FuturesOrderTrade[]
      */
-    public function findBySymbol(?string $symbol = null, int $limit = 100): array
+    public function findBySymbol(?string $symbol = null, int $limit = 100, ?ExchangeContext $context = null): array
     {
         $qb = $this->createQueryBuilder('fot')
+            ->where('fot.exchange = :exchange')
+            ->andWhere('fot.marketType = :marketType')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->orderBy('fot.tradeTime', 'DESC')
             ->setMaxResults($limit);
 
@@ -65,10 +78,15 @@ final class FuturesOrderTradeRepository extends ServiceEntityRepository
     public function findRecentBySymbol(
         string $symbol,
         int $limit = 200,
-        ?\DateTimeImmutable $since = null
+        ?\DateTimeImmutable $since = null,
+        ?ExchangeContext $context = null,
     ): array {
         $qb = $this->createQueryBuilder('t')
+            ->andWhere('t.exchange = :exchange')
+            ->andWhere('t.marketType = :marketType')
             ->andWhere('t.symbol = :symbol')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
             ->orderBy('t.createdAt', 'DESC')
             ->setMaxResults($limit);
@@ -82,4 +100,3 @@ final class FuturesOrderTradeRepository extends ServiceEntityRepository
     }
 
 }
-

--- a/trading-app/src/Repository/FuturesPlanOrderRepository.php
+++ b/trading-app/src/Repository/FuturesPlanOrderRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\FuturesPlanOrder;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -18,22 +19,34 @@ final class FuturesPlanOrderRepository extends ServiceEntityRepository
         parent::__construct($registry, FuturesPlanOrder::class);
     }
 
-    public function findOneByOrderId(string $orderId): ?FuturesPlanOrder
+    public function findOneByOrderId(string $orderId, ?ExchangeContext $context = null): ?FuturesPlanOrder
     {
-        return $this->findOneBy(['orderId' => $orderId]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'orderId' => $orderId,
+        ]);
     }
 
-    public function findOneByClientOrderId(string $clientOrderId): ?FuturesPlanOrder
+    public function findOneByClientOrderId(string $clientOrderId, ?ExchangeContext $context = null): ?FuturesPlanOrder
     {
-        return $this->findOneBy(['clientOrderId' => $clientOrderId]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'clientOrderId' => $clientOrderId,
+        ]);
     }
 
     /**
      * @return FuturesPlanOrder[]
      */
-    public function findBySymbol(?string $symbol = null, int $limit = 100): array
+    public function findBySymbol(?string $symbol = null, int $limit = 100, ?ExchangeContext $context = null): array
     {
         $qb = $this->createQueryBuilder('fpo')
+            ->where('fpo.exchange = :exchange')
+            ->andWhere('fpo.marketType = :marketType')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->orderBy('fpo.createdTime', 'DESC')
             ->setMaxResults($limit);
 
@@ -48,10 +61,19 @@ final class FuturesPlanOrderRepository extends ServiceEntityRepository
     /**
      * @return FuturesPlanOrder[]
      */
-    public function findByStatus(string $status, ?string $symbol = null, int $limit = 100): array
+    public function findByStatus(
+        string $status,
+        ?string $symbol = null,
+        int $limit = 100,
+        ?ExchangeContext $context = null,
+    ): array
     {
         $qb = $this->createQueryBuilder('fpo')
-            ->where('fpo.status = :status')
+            ->where('fpo.exchange = :exchange')
+            ->andWhere('fpo.marketType = :marketType')
+            ->andWhere('fpo.status = :status')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('status', strtolower($status))
             ->orderBy('fpo.createdTime', 'DESC')
             ->setMaxResults($limit);
@@ -70,4 +92,3 @@ final class FuturesPlanOrderRepository extends ServiceEntityRepository
         $this->getEntityManager()->flush();
     }
 }
-

--- a/trading-app/src/Repository/FuturesTransactionRepository.php
+++ b/trading-app/src/Repository/FuturesTransactionRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\FuturesTransaction;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -24,10 +25,15 @@ final class FuturesTransactionRepository extends ServiceEntityRepository
     public function findRecentBySymbol(
         string $symbol,
         int $limit = 200,
-        ?\DateTimeImmutable $since = null
+        ?\DateTimeImmutable $since = null,
+        ?ExchangeContext $context = null,
     ): array {
         $qb = $this->createQueryBuilder('t')
+            ->andWhere('t.exchange = :exchange')
+            ->andWhere('t.marketType = :marketType')
             ->andWhere('t.symbol = :symbol')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
             ->orderBy('t.happenedAt', 'DESC')
             ->setMaxResults($limit);
@@ -43,11 +49,19 @@ final class FuturesTransactionRepository extends ServiceEntityRepository
     /**
      * @return FuturesTransaction[]
      */
-    public function findBySymbolSince(string $symbol, \DateTimeImmutable $since): array
+    public function findBySymbolSince(
+        string $symbol,
+        \DateTimeImmutable $since,
+        ?ExchangeContext $context = null,
+    ): array
     {
         return $this->createQueryBuilder('t')
+            ->andWhere('t.exchange = :exchange')
+            ->andWhere('t.marketType = :marketType')
             ->andWhere('t.symbol = :symbol')
             ->andWhere('t.happenedAt >= :since')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
             ->setParameter('since', $since)
             ->orderBy('t.happenedAt', 'ASC')

--- a/trading-app/src/Repository/IndicatorSnapshotRepository.php
+++ b/trading-app/src/Repository/IndicatorSnapshotRepository.php
@@ -6,6 +6,7 @@ namespace App\Repository;
 
 use App\Common\Enum\Timeframe;
 use App\Entity\IndicatorSnapshot;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
@@ -27,11 +28,19 @@ class IndicatorSnapshotRepository extends ServiceEntityRepository
     /**
      * Récupère le dernier snapshot d'indicateurs
      */
-    public function findLastBySymbolAndTimeframe(string $symbol, Timeframe $timeframe): ?IndicatorSnapshot
+    public function findLastBySymbolAndTimeframe(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?IndicatorSnapshot
     {
         return $this->createQueryBuilder('i')
-            ->where('i.symbol = :symbol')
+            ->where('i.exchange = :exchange')
+            ->andWhere('i.marketType = :marketType')
+            ->andWhere('i.symbol = :symbol')
             ->andWhere('i.timeframe = :timeframe')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->orderBy('i.klineTime', 'DESC')
@@ -47,13 +56,18 @@ class IndicatorSnapshotRepository extends ServiceEntityRepository
         string $symbol,
         Timeframe $timeframe,
         \DateTimeImmutable $startDate,
-        \DateTimeImmutable $endDate
+        \DateTimeImmutable $endDate,
+        ?ExchangeContext $context = null,
     ): array {
         return $this->createQueryBuilder('i')
-            ->where('i.symbol = :symbol')
+            ->where('i.exchange = :exchange')
+            ->andWhere('i.marketType = :marketType')
+            ->andWhere('i.symbol = :symbol')
             ->andWhere('i.timeframe = :timeframe')
             ->andWhere('i.klineTime >= :startDate')
             ->andWhere('i.klineTime <= :endDate')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->setParameter('startDate', $startDate)
@@ -66,11 +80,20 @@ class IndicatorSnapshotRepository extends ServiceEntityRepository
     /**
      * Récupère les snapshots récents pour le calcul des indicateurs
      */
-    public function findRecentForIndicators(string $symbol, Timeframe $timeframe, int $limit = 100): array
+    public function findRecentForIndicators(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 100,
+        ?ExchangeContext $context = null,
+    ): array
     {
         return $this->createQueryBuilder('i')
-            ->where('i.symbol = :symbol')
+            ->where('i.exchange = :exchange')
+            ->andWhere('i.marketType = :marketType')
+            ->andWhere('i.symbol = :symbol')
             ->andWhere('i.timeframe = :timeframe')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', $symbol)
             ->setParameter('timeframe', $timeframe)
             ->orderBy('i.klineTime', 'DESC')
@@ -82,9 +105,16 @@ class IndicatorSnapshotRepository extends ServiceEntityRepository
     /**
      * Sauvegarde ou met à jour un snapshot d'indicateurs
      */
-    public function upsert(IndicatorSnapshot $snapshot): void
+    public function upsert(IndicatorSnapshot $snapshot, ?ExchangeContext $context = null): void
     {
+        if ($context !== null) {
+            $snapshot->setExchange($context->exchange);
+            $snapshot->setMarketType($context->marketType);
+        }
+
         $existing = $this->findOneBy([
+            'exchange' => $snapshot->getExchange(),
+            'marketType' => $snapshot->getMarketType(),
             'symbol' => $snapshot->getSymbol(),
             'timeframe' => $snapshot->getTimeframe(),
             'klineTime' => $snapshot->getKlineTime()
@@ -98,6 +128,8 @@ class IndicatorSnapshotRepository extends ServiceEntityRepository
             $existing->setUpdatedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
             $this->logger->debug('[IndicatorSnapshotRepository] Snapshot updated', [
                 'symbol' => $existing->getSymbol(),
+                'exchange' => $existing->getExchange(),
+                'market_type' => $existing->getMarketType(),
                 'timeframe' => $existing->getTimeframe()->value,
                 'kline_time' => $existing->getKlineTime()->format('Y-m-d H:i:s'),
                 'run_id' => $existing->getRunId(),
@@ -107,6 +139,8 @@ class IndicatorSnapshotRepository extends ServiceEntityRepository
             $this->getEntityManager()->persist($snapshot);
             $this->logger->debug('[IndicatorSnapshotRepository] Snapshot inserted', [
                 'symbol' => $snapshot->getSymbol(),
+                'exchange' => $snapshot->getExchange(),
+                'market_type' => $snapshot->getMarketType(),
                 'timeframe' => $snapshot->getTimeframe()->value,
                 'kline_time' => $snapshot->getKlineTime()->format('Y-m-d H:i:s'),
                 'run_id' => $snapshot->getRunId(),
@@ -115,5 +149,4 @@ class IndicatorSnapshotRepository extends ServiceEntityRepository
         }
     }
 }
-
 

--- a/trading-app/src/Repository/MtfStateRepository.php
+++ b/trading-app/src/Repository/MtfStateRepository.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\MtfState;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -18,12 +20,19 @@ class MtfStateRepository extends ServiceEntityRepository
         parent::__construct($registry, MtfState::class);
     }
 
-    public function getOrCreateForSymbol(string $symbol): MtfState
+    public function getOrCreateForSymbol(string $symbol, ?ExchangeContext $context = null): MtfState
     {
-        $state = $this->findOneBy(['symbol' => $symbol]);
+        $context = ExchangeContext::resolve($context);
+        $state = $this->findOneBy([
+            'exchange' => $context->exchange->value,
+            'marketType' => $context->marketType->value,
+            'symbol' => strtoupper($symbol),
+        ]);
         if (!$state) {
             $state = new MtfState();
             $state->setSymbol($symbol);
+            $state->setExchange($context->exchange);
+            $state->setMarketType($context->marketType);
             $em = $this->getEntityManager();
             // Eviter les erreurs en cascade si l'EntityManager est fermé
             $isOpen = true;
@@ -47,41 +56,41 @@ class MtfStateRepository extends ServiceEntityRepository
         return $state;
     }
 
-    public function update4hValidation(string $symbol, \DateTimeImmutable $klineTime, ?string $side): void
+    public function update4hValidation(string $symbol, \DateTimeImmutable $klineTime, ?string $side, ?ExchangeContext $context = null): void
     {
-        $state = $this->getOrCreateForSymbol($symbol);
+        $state = $this->getOrCreateForSymbol($symbol, $context);
         $state->setK4hTime($klineTime);
         $state->set4hSide($side);
         $this->getEntityManager()->flush();
     }
 
-    public function update1hValidation(string $symbol, \DateTimeImmutable $klineTime, ?string $side): void
+    public function update1hValidation(string $symbol, \DateTimeImmutable $klineTime, ?string $side, ?ExchangeContext $context = null): void
     {
-        $state = $this->getOrCreateForSymbol($symbol);
+        $state = $this->getOrCreateForSymbol($symbol, $context);
         $state->setK1hTime($klineTime);
         $state->set1hSide($side);
         $this->getEntityManager()->flush();
     }
 
-    public function update15mValidation(string $symbol, \DateTimeImmutable $klineTime, ?string $side): void
+    public function update15mValidation(string $symbol, \DateTimeImmutable $klineTime, ?string $side, ?ExchangeContext $context = null): void
     {
-        $state = $this->getOrCreateForSymbol($symbol);
+        $state = $this->getOrCreateForSymbol($symbol, $context);
         $state->setK15mTime($klineTime);
         $state->set15mSide($side);
         $this->getEntityManager()->flush();
     }
 
-    public function updateExecutionSides(string $symbol, ?string $side5m, ?string $side1m): void
+    public function updateExecutionSides(string $symbol, ?string $side5m, ?string $side1m, ?ExchangeContext $context = null): void
     {
-        $state = $this->getOrCreateForSymbol($symbol);
+        $state = $this->getOrCreateForSymbol($symbol, $context);
         $state->set5mSide($side5m);
         $state->set1mSide($side1m);
         $this->getEntityManager()->flush();
     }
 
-    public function isSymbolReadyForExecution(string $symbol): bool
+    public function isSymbolReadyForExecution(string $symbol, ?ExchangeContext $context = null): bool
     {
-        $state = $this->findOneBy(['symbol' => $symbol]);
+        $state = $this->findOneBy($this->criteria($symbol, $context));
         if (!$state) {
             return false;
         }
@@ -89,19 +98,23 @@ class MtfStateRepository extends ServiceEntityRepository
         return $state->areParentTimeframesValidated() && $state->hasConsistentSides();
     }
 
-    public function getSymbolsReadyForExecution(): array
+    public function getSymbolsReadyForExecution(?ExchangeContext $context = null): array
     {
-        return $this->createQueryBuilder('s')
-            ->where('s.k4hTime IS NOT NULL')
+        $qb = $this->scope($this->createQueryBuilder('s'), $context);
+
+        return $qb
+            ->andWhere('s.k4hTime IS NOT NULL')
             ->andWhere('s.k1hTime IS NOT NULL')
             ->andWhere('s.k15mTime IS NOT NULL')
             ->getQuery()
             ->getResult();
     }
 
-    public function getSymbolsWithInconsistentSides(): array
+    public function getSymbolsWithInconsistentSides(?ExchangeContext $context = null): array
     {
-        $states = $this->findAll();
+        $states = $this->scope($this->createQueryBuilder('s'), $context)
+            ->getQuery()
+            ->getResult();
         $inconsistent = [];
 
         foreach ($states as $state) {
@@ -113,9 +126,9 @@ class MtfStateRepository extends ServiceEntityRepository
         return $inconsistent;
     }
 
-    public function resetSymbolState(string $symbol): void
+    public function resetSymbolState(string $symbol, ?ExchangeContext $context = null): void
     {
-        $state = $this->findOneBy(['symbol' => $symbol]);
+        $state = $this->findOneBy($this->criteria($symbol, $context));
         if ($state) {
             $state->setK4hTime(null);
             $state->setK1hTime(null);
@@ -125,16 +138,16 @@ class MtfStateRepository extends ServiceEntityRepository
         }
     }
 
-    public function getSymbolsWithValidatedTimeframes(): array
+    public function getSymbolsWithValidatedTimeframes(?ExchangeContext $context = null): array
     {
-        return $this->createQueryBuilder('s')
-            ->where('s.k4hTime IS NOT NULL OR s.k1hTime IS NOT NULL OR s.k15mTime IS NOT NULL')
+        return $this->scope($this->createQueryBuilder('s'), $context)
+            ->andWhere('s.k4hTime IS NOT NULL OR s.k1hTime IS NOT NULL OR s.k15mTime IS NOT NULL')
             ->orderBy('s.symbol')
             ->getQuery()
             ->getResult();
     }
 
-    public function getSymbolsByTimeframeValidation(string $timeframe): array
+    public function getSymbolsByTimeframeValidation(string $timeframe, ?ExchangeContext $context = null): array
     {
         $field = match ($timeframe) {
             '4h' => 'k4hTime',
@@ -143,8 +156,8 @@ class MtfStateRepository extends ServiceEntityRepository
             default => throw new \InvalidArgumentException("Invalid timeframe: {$timeframe}")
         };
 
-        return $this->createQueryBuilder('s')
-            ->where("s.{$field} IS NOT NULL")
+        return $this->scope($this->createQueryBuilder('s'), $context)
+            ->andWhere("s.{$field} IS NOT NULL")
             ->orderBy('s.symbol')
             ->getQuery()
             ->getResult();
@@ -156,26 +169,26 @@ class MtfStateRepository extends ServiceEntityRepository
      * @param string $startFromTimeframe '4h' ou '1h'
      * @return MtfState[]
      */
-    public function getStatesForDashboard(string $startFromTimeframe = '4h'): array
+    public function getStatesForDashboard(string $startFromTimeframe = '4h', ?ExchangeContext $context = null): array
     {
-        $qb = $this->createQueryBuilder('s');
+        $qb = $this->scope($this->createQueryBuilder('s'), $context);
 
         if ($startFromTimeframe === '1h') {
             // Pour 1h, on récupère tous les états qui ont au moins k1hTime
-            $qb->where('s.k1hTime IS NOT NULL')
+            $qb->andWhere('s.k1hTime IS NOT NULL')
                ->orderBy('s.symbol', 'ASC');
         } else {
             // Pour 4h, on récupère tous les états qui ont au moins k4hTime
-            $qb->where('s.k4hTime IS NOT NULL')
+            $qb->andWhere('s.k4hTime IS NOT NULL')
                ->orderBy('s.symbol', 'ASC');
         }
 
         return $qb->getQuery()->getResult();
     }
 
-    public function getSummary(string $startFromTimeframe = '4h'): array
+    public function getSummary(string $startFromTimeframe = '4h', ?ExchangeContext $context = null): array
     {
-        $qb   = $this->createQueryBuilder('s');
+        $qb   = $this->scope($this->createQueryBuilder('s'), $context);
         $expr = $qb->expr();
 
         if ($startFromTimeframe === '1h') {
@@ -240,7 +253,7 @@ DQL;
 
             $qb
                 ->addSelect($caseRuleRank . ' AS HIDDEN ruleRank')
-                ->where($expr->orX($rule1, $rule2, $rule3, $rule4))
+                ->andWhere($expr->orX($rule1, $rule2, $rule3, $rule4))
                 ->orderBy('ruleRank', 'ASC')
                 ->addOrderBy('s.k1hTime', 'DESC');
         } else {
@@ -251,6 +264,29 @@ DQL;
         return $qb->getQuery()->getResult();
     }
 
+    /**
+     * @return array{exchange:string,marketType:string,symbol:string}
+     */
+    private function criteria(string $symbol, ?ExchangeContext $context = null): array
+    {
+        $context = ExchangeContext::resolve($context);
+
+        return [
+            'exchange' => $context->exchange->value,
+            'marketType' => $context->marketType->value,
+            'symbol' => strtoupper($symbol),
+        ];
+    }
+
+    private function scope(QueryBuilder $qb, ?ExchangeContext $context = null): QueryBuilder
+    {
+        $context = ExchangeContext::resolve($context);
+
+        return $qb
+            ->andWhere('s.exchange = :exchange')
+            ->andWhere('s.marketType = :marketType')
+            ->setParameter('exchange', $context->exchange->value)
+            ->setParameter('marketType', $context->marketType->value);
+    }
+
 }
-
-

--- a/trading-app/src/Repository/OrderIntentRepository.php
+++ b/trading-app/src/Repository/OrderIntentRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\OrderIntent;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -18,23 +19,40 @@ final class OrderIntentRepository extends ServiceEntityRepository
         parent::__construct($registry, OrderIntent::class);
     }
 
-    public function findOneByClientOrderId(string $clientOrderId): ?OrderIntent
+    public function findOneByClientOrderId(string $clientOrderId, ?ExchangeContext $context = null): ?OrderIntent
     {
-        return $this->findOneBy(['clientOrderId' => $clientOrderId]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'clientOrderId' => $clientOrderId,
+        ]);
     }
 
-    public function findOneByOrderId(string $orderId): ?OrderIntent
+    public function findOneByOrderId(string $orderId, ?ExchangeContext $context = null): ?OrderIntent
     {
-        return $this->findOneBy(['orderId' => $orderId]);
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'orderId' => $orderId,
+        ]);
     }
 
     /**
      * @return OrderIntent[]
      */
-    public function findByStatus(string $status, ?string $symbol = null, int $limit = 100): array
+    public function findByStatus(
+        string $status,
+        ?string $symbol = null,
+        int $limit = 100,
+        ?ExchangeContext $context = null,
+    ): array
     {
         $qb = $this->createQueryBuilder('oi')
-            ->where('oi.status = :status')
+            ->where('oi.exchange = :exchange')
+            ->andWhere('oi.marketType = :marketType')
+            ->andWhere('oi.status = :status')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('status', $status)
             ->orderBy('oi.createdAt', 'DESC')
             ->setMaxResults($limit);
@@ -50,9 +68,9 @@ final class OrderIntentRepository extends ServiceEntityRepository
     /**
      * @return OrderIntent[]
      */
-    public function findReadyToSend(?string $symbol = null, int $limit = 50): array
+    public function findReadyToSend(?string $symbol = null, int $limit = 50, ?ExchangeContext $context = null): array
     {
-        return $this->findByStatus(OrderIntent::STATUS_READY_TO_SEND, $symbol, $limit);
+        return $this->findByStatus(OrderIntent::STATUS_READY_TO_SEND, $symbol, $limit, $context);
     }
 
     public function save(OrderIntent $intent): void
@@ -68,14 +86,22 @@ final class OrderIntentRepository extends ServiceEntityRepository
      *
      * @return string[]
      */
-    public function findDistinctSymbolsSince(\DateTimeImmutable $since, int $max = 50): array
+    public function findDistinctSymbolsSince(
+        \DateTimeImmutable $since,
+        int $max = 50,
+        ?ExchangeContext $context = null,
+    ): array
     {
         // Utilise un GROUP BY pour satisfaire PostgreSQL (ORDER BY sur une colonne agrégée)
         $qb = $this->createQueryBuilder('oi')
             ->select('oi.symbol AS symbol, MAX(oi.createdAt) AS lastCreatedAt')
-            ->where('oi.createdAt >= :since')
+            ->where('oi.exchange = :exchange')
+            ->andWhere('oi.marketType = :marketType')
+            ->andWhere('oi.createdAt >= :since')
             // On ne retient que les intents réellement envoyés ou finalisés côté exchange
             ->andWhere('oi.status IN (:statuses)')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('since', $since)
             ->setParameter('statuses', [
                 OrderIntent::STATUS_SENT,

--- a/trading-app/src/Repository/PositionRepository.php
+++ b/trading-app/src/Repository/PositionRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Position;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -18,9 +19,11 @@ class PositionRepository extends ServiceEntityRepository
         parent::__construct($registry, Position::class);
     }
 
-    public function findOneBySymbolSide(string $symbol, string $side): ?Position
+    public function findOneBySymbolSide(string $symbol, string $side, ?ExchangeContext $context = null): ?Position
     {
         return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
             'symbol' => strtoupper($symbol),
             'side' => strtoupper($side),
         ]);
@@ -37,21 +40,29 @@ class PositionRepository extends ServiceEntityRepository
      * Récupère toutes les positions ouvertes
      * @return Position[]
      */
-    public function findAllOpen(): array
+    public function findAllOpen(?ExchangeContext $context = null): array
     {
-        return $this->findBy(['status' => 'OPEN']);
+        return $this->findBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'status' => 'OPEN',
+        ]);
     }
 
     /**
      * Récupère les symboles uniques des positions ouvertes
      * @return string[]
      */
-    public function findOpenSymbols(): array
+    public function findOpenSymbols(?ExchangeContext $context = null): array
     {
         $qb = $this->createQueryBuilder('p');
         $results = $qb
             ->select('DISTINCT p.symbol')
-            ->where('p.status = :status')
+            ->where('p.exchange = :exchange')
+            ->andWhere('p.marketType = :marketType')
+            ->andWhere('p.status = :status')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('status', 'OPEN')
             ->getQuery()
             ->getResult();
@@ -71,10 +82,14 @@ class PositionRepository extends ServiceEntityRepository
      *
      * @return Position[]
      */
-    public function findHistoryBySymbol(string $symbol, ?int $limit = null): array
+    public function findHistoryBySymbol(string $symbol, ?int $limit = null, ?ExchangeContext $context = null): array
     {
         $qb = $this->createQueryBuilder('p')
+            ->andWhere('p.exchange = :exchange')
+            ->andWhere('p.marketType = :marketType')
             ->andWhere('p.symbol = :symbol')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
             ->orderBy('p.insertedAt', 'DESC');
 
@@ -85,5 +100,4 @@ class PositionRepository extends ServiceEntityRepository
         return $qb->getQuery()->getResult();
     }
 }
-
 

--- a/trading-app/src/Repository/TradeLifecycleEventRepository.php
+++ b/trading-app/src/Repository/TradeLifecycleEventRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\TradeLifecycleEvent;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -22,11 +23,16 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
      * @param array<string, mixed> $criteria
      * @return TradeLifecycleEvent[]
      */
-    public function findRecentBy(array $criteria, int $limit = 50): array
+    public function findRecentBy(array $criteria, int $limit = 50, ?ExchangeContext $context = null): array
     {
         $qb = $this->createQueryBuilder('event')
             ->orderBy('event.happenedAt', 'DESC')
             ->setMaxResults($limit);
+
+        $criteria += [
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+        ];
 
         foreach ($criteria as $field => $value) {
             $param = ':' . $field;
@@ -43,7 +49,7 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
      * @param string[] $symbols
      * @return array<string, array{has_trade: bool, side: ?string, position_status: ?string, last_event: ?string, last_event_at: ?\DateTimeImmutable}>
      */
-    public function getActiveOrRecentBySymbols(array $symbols): array
+    public function getActiveOrRecentBySymbols(array $symbols, ?ExchangeContext $context = null): array
     {
         if (empty($symbols)) {
             return [];
@@ -52,8 +58,12 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
         // Récupérer les derniers événements pour chaque symbole
         // On considère qu'un trade est actif s'il y a des événements récents (position_opened, order_placed, etc.)
         $qb = $this->createQueryBuilder('event')
-            ->where('event.symbol IN (:symbols)')
+            ->where('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
+            ->andWhere('event.symbol IN (:symbols)')
             ->andWhere('event.eventType IN (:activeTypes)')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbols', $symbols)
             ->setParameter('activeTypes', ['position_opened', 'order_placed', 'order_filled', 'position_closed'])
             ->orderBy('event.happenedAt', 'DESC');

--- a/trading-app/src/Repository/TradeZoneEventRepository.php
+++ b/trading-app/src/Repository/TradeZoneEventRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\TradeZoneEvent;
+use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -30,10 +31,14 @@ final class TradeZoneEventRepository extends ServiceEntityRepository
     /**
      * @return TradeZoneEvent[]
      */
-    public function findRecentForSymbol(string $symbol, int $limit = 100): array
+    public function findRecentForSymbol(string $symbol, int $limit = 100, ?ExchangeContext $context = null): array
     {
         return $this->createQueryBuilder('event')
+            ->andWhere('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
             ->andWhere('event.symbol = :symbol')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
             ->orderBy('event.happenedAt', 'DESC')
             ->setMaxResults($limit)
@@ -44,14 +49,23 @@ final class TradeZoneEventRepository extends ServiceEntityRepository
     /**
      * @return array<int, array{zoneDevPct: float, zoneMaxDevPct: float, happenedAt: \DateTimeImmutable}>
      */
-    public function getDeviationSeries(string $symbol, \DateTimeImmutable $since, int $limit = 500): array
+    public function getDeviationSeries(
+        string $symbol,
+        \DateTimeImmutable $since,
+        int $limit = 500,
+        ?ExchangeContext $context = null,
+    ): array
     {
         $qb = $this->createQueryBuilder('event')
             ->select('event.zoneDevPct AS zoneDevPct', 'event.zoneMaxDevPct AS zoneMaxDevPct', 'event.happenedAt AS happenedAt')
+            ->andWhere('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
             ->andWhere('event.symbol = :symbol')
             ->andWhere('event.happenedAt >= :since')
             ->orderBy('event.happenedAt', 'DESC')
             ->setMaxResults($limit)
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
             ->setParameter('since', $since);
 
@@ -64,14 +78,18 @@ final class TradeZoneEventRepository extends ServiceEntityRepository
     /**
      * @return array<int, array{symbol: string, avgDevPct: float, avgMaxDevPct: float, events: int}>
      */
-    public function getAggregatedStats(\DateTimeImmutable $since): array
+    public function getAggregatedStats(\DateTimeImmutable $since, ?ExchangeContext $context = null): array
     {
         $rows = $this->createQueryBuilder('event')
             ->select('event.symbol AS symbol')
             ->addSelect('AVG(event.zoneDevPct) AS avgDevPct')
             ->addSelect('AVG(event.zoneMaxDevPct) AS avgMaxDevPct')
             ->addSelect('COUNT(event.id) AS events')
+            ->andWhere('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
             ->andWhere('event.happenedAt >= :since')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->groupBy('event.symbol')
             ->setParameter('since', $since)
             ->getQuery()
@@ -93,7 +111,7 @@ final class TradeZoneEventRepository extends ServiceEntityRepository
      * @param string[] $symbols
      * @return array<string, array{reason: string, happened_at: \DateTimeImmutable}>
      */
-    public function getLastReasonBySymbols(array $symbols): array
+    public function getLastReasonBySymbols(array $symbols, ?ExchangeContext $context = null): array
     {
         if (empty($symbols)) {
             return [];
@@ -103,11 +121,17 @@ final class TradeZoneEventRepository extends ServiceEntityRepository
         // On utilise une sous-requête pour obtenir le dernier événement par symbole
         $subQb = $this->createQueryBuilder('event2')
             ->select('MAX(event2.happenedAt)')
-            ->where('event2.symbol = event.symbol');
+            ->where('event2.exchange = event.exchange')
+            ->andWhere('event2.marketType = event.marketType')
+            ->andWhere('event2.symbol = event.symbol');
 
         $qb = $this->createQueryBuilder('event')
-            ->where('event.symbol IN (:symbols)')
+            ->where('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
+            ->andWhere('event.symbol IN (:symbols)')
             ->andWhere('event.happenedAt = (' . $subQb->getDQL() . ')')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbols', $symbols)
             ->orderBy('event.symbol', 'ASC');
 

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Entity\OrderIntent;
 use App\Entity\OrderProtection;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\OrderIntentRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
@@ -32,6 +33,8 @@ final class OrderIntentManager
     ): OrderIntent {
         $intent = new OrderIntent();
 
+        $intent->setExchange((string)($orderParams['exchange'] ?? ExchangeContext::exchangeValue(null)));
+        $intent->setMarketType((string)($orderParams['market_type'] ?? $orderParams['marketType'] ?? ExchangeContext::marketTypeValue(null)));
         $intent->setSymbol($orderParams['symbol'] ?? '');
         $intent->setSide((int)($orderParams['side'] ?? 1));
         $intent->setType($orderParams['type'] ?? OrderIntent::TYPE_LIMIT);
@@ -67,6 +70,8 @@ final class OrderIntentManager
         // Ajouter les protections TP/SL si présentes
         if (isset($orderParams['preset_take_profit_price'])) {
             $tp = new OrderProtection();
+            $tp->setExchange($intent->getExchange());
+            $tp->setMarketType($intent->getMarketType());
             $tp->setType(OrderProtection::TYPE_TAKE_PROFIT);
             $tp->setPrice((string)$orderParams['preset_take_profit_price']);
             $tp->setPriceType($orderParams['preset_take_profit_price_type'] ?? 1);
@@ -75,6 +80,8 @@ final class OrderIntentManager
 
         if (isset($orderParams['preset_stop_loss_price'])) {
             $sl = new OrderProtection();
+            $sl->setExchange($intent->getExchange());
+            $sl->setMarketType($intent->getMarketType());
             $sl->setType(OrderProtection::TYPE_STOP_LOSS);
             $sl->setPrice((string)$orderParams['preset_stop_loss_price']);
             $sl->setPriceType($orderParams['preset_stop_loss_price_type'] ?? 1);
@@ -86,6 +93,8 @@ final class OrderIntentManager
 
         $this->logger->debug('[OrderIntentManager] Created intent', [
             'client_order_id' => $clientOrderId,
+            'exchange' => $intent->getExchange(),
+            'market_type' => $intent->getMarketType(),
             'symbol' => $intent->getSymbol(),
             'status' => $intent->getStatus(),
         ]);
@@ -201,4 +210,3 @@ final class OrderIntentManager
         return sprintf('INTENT_%s_%d_%s', $symbol, $timestamp, $random);
     }
 }
-

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -187,14 +187,18 @@ final class OrderIntentManager
     /**
      * Trouve un OrderIntent par client_order_id ou order_id
      */
-    public function findIntent(?string $clientOrderId = null, ?string $orderId = null): ?OrderIntent
+    public function findIntent(
+        ?string $clientOrderId = null,
+        ?string $orderId = null,
+        ?ExchangeContext $context = null,
+    ): ?OrderIntent
     {
         if ($clientOrderId !== null) {
-            return $this->orderIntentRepository->findOneByClientOrderId($clientOrderId);
+            return $this->orderIntentRepository->findOneByClientOrderId($clientOrderId, $context);
         }
 
         if ($orderId !== null) {
-            return $this->orderIntentRepository->findOneByOrderId($orderId);
+            return $this->orderIntentRepository->findOneByOrderId($orderId, $context);
         }
 
         return null;

--- a/trading-app/src/TradeEntry/Builder/TradeEntryRequestBuilder.php
+++ b/trading-app/src/TradeEntry/Builder/TradeEntryRequestBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\TradeEntry\Builder;
 
 use App\Config\{TradeEntryConfig, TradeEntryConfigProvider, TradeEntryModeContext, ZoneDeviationOverrideStore};
+use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Dto\TradeEntryRequest;
 use App\TradeEntry\Types\Side;
 use Psr\Log\LoggerInterface;
@@ -42,7 +43,8 @@ final class TradeEntryRequestBuilder
         ?float $price = null,
         ?float $atr = null,
         ?string $mode = null,
-        ?array $metrics = null
+        ?array $metrics = null,
+        ?ExchangeContext $exchangeContext = null,
     ): ?TradeEntryRequest {
         $side = strtoupper((string)$signalSide);
         if (!in_array($side, ['LONG', 'SHORT'], true)) {
@@ -244,6 +246,7 @@ final class TradeEntryRequestBuilder
             tpMaxExtraR: $tpMaxExtraR,
             leverageMultiplier: 1.0,
             leverageExchangeCap: $leverageExchangeCap,
+            exchangeContext: $exchangeContext,
         );
     }
 

--- a/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TpSlTwoTargetsRequest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\Dto;
 
+use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Types\Side;
 
 final class TpSlTwoTargetsRequest
@@ -23,5 +24,6 @@ final class TpSlTwoTargetsRequest
         public readonly ?bool $pullbackClear = null,
         public readonly ?bool $lateEntry = null,
         public readonly ?bool $dryRun = false,
+        public readonly ?ExchangeContext $exchangeContext = null,
     ) {}
 }

--- a/trading-app/src/TradeEntry/Dto/TradeEntryRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TradeEntryRequest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\Dto;
 
+use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Types\Side;
 
 final class TradeEntryRequest
@@ -37,5 +38,6 @@ final class TradeEntryRequest
         public readonly ?float $tpMaxExtraR = null,
         public readonly float $leverageMultiplier = 1.0,
         public readonly ?float $leverageExchangeCap = null,
+        public readonly ?ExchangeContext $exchangeContext = null,
     ) {}
 }

--- a/trading-app/src/TradeEntry/Dto/ZoneSkipEventDto.php
+++ b/trading-app/src/TradeEntry/Dto/ZoneSkipEventDto.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\Dto;
 
+use App\Provider\Context\ExchangeContext;
+
 final class ZoneSkipEventDto
 {
     public const REASON = 'skipped_out_of_zone';
@@ -32,5 +34,6 @@ final class ZoneSkipEventDto
         public readonly ?float $proposedZoneMaxPct = null,
         public readonly ?string $category = null,
         public readonly string $reason = self::REASON,
+        public readonly ?ExchangeContext $exchangeContext = null,
     ) {}
 }

--- a/trading-app/src/TradeEntry/EntryZone/EntryZoneCalculator.php
+++ b/trading-app/src/TradeEntry/EntryZone/EntryZoneCalculator.php
@@ -8,6 +8,7 @@ use App\TradeEntry\Types\Side;
 use App\Contract\Indicator\IndicatorProviderInterface;
 use App\TradeEntry\Pricing\TickQuantizer;
 use App\Config\{TradeEntryConfig, TradeEntryConfigProvider, TradeEntryModeContext};
+use App\Provider\Context\ExchangeContext;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -32,7 +33,14 @@ final class EntryZoneCalculator
         #[Autowire(service: 'monolog.logger.positions')] private readonly ?LoggerInterface $positionsLogger = null,
     ) {}
 
-    public function compute(string $symbol, ?Side $side = null, ?int $pricePrecision = null, ?string $decisionKey = null, ?string $mode = null): EntryZone
+    public function compute(
+        string $symbol,
+        ?Side $side = null,
+        ?int $pricePrecision = null,
+        ?string $decisionKey = null,
+        ?string $mode = null,
+        ?ExchangeContext $context = null,
+    ): EntryZone
     {
         // Lecture config selon le mode (même mécanisme que validations.{mode}.yaml)
         $config = $this->getConfigForMode($mode);
@@ -100,8 +108,8 @@ final class EntryZoneCalculator
         }
 
         // 1) Récupère ATR et liste pivot (vwap/sma...)
-        $atr = $this->indicators->getAtr(symbol: $symbol, tf: $atrTf);
-        $list = $this->indicators->getListPivot(symbol: $symbol, tf: $pivotTf);
+        $atr = $this->indicators->getAtr(symbol: $symbol, tf: $atrTf, context: $context);
+        $list = $this->indicators->getListPivot(symbol: $symbol, tf: $pivotTf, context: $context);
 
         $ind = $list?->toArray() ?? [];
         $pivot = null;

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -255,7 +255,7 @@ final class ExecutionBox
                     // Utiliser la fenêtre locale forcée si définie, sinon fallback sur 60s
                     $watchSec = $watchWindowSec ?? ($cancelAfterTimeout ?? 60);
                     if ($watchSec <= 0) { $watchSec = 60; }
-                    $contextSnapshot = $contextBuilder?->toArray();
+                    $contextSnapshot = $this->watchLifecycleContext($contextBuilder, $plan->exchangeContext);
                     $this->bus->dispatch(
                         new LimitFillWatchMessage(
                             symbol: $plan->symbol,
@@ -938,6 +938,23 @@ final class ExecutionBox
         }
 
         return $provider;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function watchLifecycleContext(
+        ?LifecycleContextBuilder $contextBuilder,
+        ?ExchangeContext $context,
+    ): ?array {
+        $snapshot = $contextBuilder?->toArray() ?? [];
+
+        if ($context !== null) {
+            $snapshot['exchange'] ??= $context->exchange->value;
+            $snapshot['market_type'] ??= $context->marketType->value;
+        }
+
+        return $snapshot !== [] ? $snapshot : null;
     }
 
     private function applyMakerTakerSwitch(

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -6,7 +6,10 @@ namespace App\TradeEntry\Execution;
 use App\Common\Enum\OrderSide;
 use App\Common\Enum\OrderType;
 use App\Contract\Provider\MainProviderInterface;
+use App\Contract\Provider\OrderProviderDecoratorInterface;
+use App\Contract\Provider\OrderProviderInterface;
 use App\Provider\Context\ExchangeContext;
+use App\Provider\Bitmart\BitmartOrderProvider;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
 use App\TradeEntry\Message\LimitFillWatchMessage;
 use App\TradeEntry\Pricing\TickQuantizer;
@@ -880,8 +883,9 @@ final class ExecutionBox
     ): void
     {
         $orderProvider = $this->providersFor($context)->getOrderProvider();
+        $bitmartProvider = $this->unwrapOrderProvider($orderProvider);
         // Vérifier si le provider supporte getPlanOrders (spécifique BitMart)
-        if (!$orderProvider instanceof \App\Provider\Bitmart\BitmartOrderProvider) {
+        if (!$bitmartProvider instanceof BitmartOrderProvider) {
             $this->positionsLogger->debug('execution.market_order.verify_skip', [
                 'symbol' => $symbol,
                 'reason' => 'getPlanOrders_not_available',
@@ -891,7 +895,7 @@ final class ExecutionBox
         }
 
         try {
-            $planOrders = $orderProvider->getPlanOrders($symbol);
+            $planOrders = $bitmartProvider->getPlanOrders($symbol);
             $submittedIds = array_column($submitted, 'order_id');
             $foundIds = [];
 
@@ -925,6 +929,15 @@ final class ExecutionBox
                 'decision_key' => $decisionKey,
             ]);
         }
+    }
+
+    private function unwrapOrderProvider(OrderProviderInterface $provider): OrderProviderInterface
+    {
+        while ($provider instanceof OrderProviderDecoratorInterface) {
+            $provider = $provider->innerOrderProvider();
+        }
+
+        return $provider;
     }
 
     private function applyMakerTakerSwitch(

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -6,6 +6,7 @@ namespace App\TradeEntry\Execution;
 use App\Common\Enum\OrderSide;
 use App\Common\Enum\OrderType;
 use App\Contract\Provider\MainProviderInterface;
+use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
 use App\TradeEntry\Message\LimitFillWatchMessage;
 use App\TradeEntry\Pricing\TickQuantizer;
@@ -117,7 +118,8 @@ final class ExecutionBox
             'open_type' => $plan->openType,
             'decision_key' => $decisionKey,
         ]);
-        $leverageResult = $this->providers->getOrderProvider()->submitLeverage($plan->symbol, $plan->leverage, $plan->openType);
+        $providers = $this->providersFor($plan->exchangeContext);
+        $leverageResult = $providers->getOrderProvider()->submitLeverage($plan->symbol, $plan->leverage, $plan->openType);
         $this->positionsLogger->debug('execution.leverage_response', [
             'symbol' => $plan->symbol,
             'result' => $leverageResult,
@@ -214,7 +216,7 @@ final class ExecutionBox
         $this->positionsLogger->debug('execution.order_submit', $attemptPayload);
         // Single-channel logging only
 
-        $orderResult = $this->providers->getOrderProvider()->placeOrder(
+        $orderResult = $providers->getOrderProvider()->placeOrder(
             symbol: $orderPayload['symbol'],
             side: $side,
             type: $enforcedOrderType,
@@ -594,7 +596,8 @@ final class ExecutionBox
             'decision_key' => $decisionKey,
         ]);
 
-        $orderResult = $this->providers->getOrderProvider()->placeOrder(
+        $providers = $this->providersFor($plan->exchangeContext);
+        $orderResult = $providers->getOrderProvider()->placeOrder(
             symbol: $plan->symbol,
             side: $side,
             type: OrderType::MARKET,
@@ -627,7 +630,7 @@ final class ExecutionBox
         ]);
 
         // 2) Attendre l'exécution (3s WS strict, 10s total avec REST fallback)
-        $filled = $this->waitForMarketOrderFill($orderId, $clientOrderId, $plan->symbol, $decisionKey);
+        $filled = $this->waitForMarketOrderFill($orderId, $clientOrderId, $plan->symbol, $decisionKey, $plan->exchangeContext);
         if (!$filled) {
             $this->positionsLogger->error('execution.market_order.fill_timeout', [
                 'symbol' => $plan->symbol,
@@ -644,7 +647,7 @@ final class ExecutionBox
         }
 
         // 3) Récupérer le prix d'entrée exact depuis la position
-        $entryPrice = $this->getPositionEntryPrice($plan->symbol, $plan->side, $decisionKey);
+        $entryPrice = $this->getPositionEntryPrice($plan->symbol, $plan->side, $decisionKey, $plan->exchangeContext);
         if ($entryPrice === null) {
             $this->positionsLogger->error('execution.market_order.entry_price_not_found', [
                 'symbol' => $plan->symbol,
@@ -695,6 +698,7 @@ final class ExecutionBox
             pullbackClear: null,
             lateEntry: null,
             dryRun: false,
+            exchangeContext: $plan->exchangeContext,
         );
 
         $tpSlResult = null;
@@ -710,7 +714,7 @@ final class ExecutionBox
             ]);
 
             // 5) Vérifier les plans TP/SL
-            $this->verifyPlanOrders($plan->symbol, $tpSlResult['submitted'], $decisionKey);
+            $this->verifyPlanOrders($plan->symbol, $tpSlResult['submitted'], $decisionKey, $plan->exchangeContext);
 
             // 6) Désarmer le dead-man switch symbolique (cancel-all-after) une fois la position ouverte et TP/SL soumis.
            /* $orderProvider = $this->providers->getOrderProvider();
@@ -755,8 +759,15 @@ final class ExecutionBox
     /**
      * Attend l'exécution d'un ordre market (3s WS strict, 10s total avec REST fallback).
      */
-    private function waitForMarketOrderFill(string $orderId, string $clientOrderId, string $symbol, ?string $decisionKey): bool
+    private function waitForMarketOrderFill(
+        string $orderId,
+        string $clientOrderId,
+        string $symbol,
+        ?string $decisionKey,
+        ?ExchangeContext $context = null,
+    ): bool
     {
+        $providers = $this->providersFor($context);
         $startTime = time();
         $wsDeadline = $startTime + self::MARKET_FILL_TIMEOUT_WS_STRICT;
         $totalDeadline = $startTime + self::MARKET_FILL_TIMEOUT_TOTAL;
@@ -775,7 +786,7 @@ final class ExecutionBox
         $maxPollInterval = 1.0; // 1s max
 
         while (time() < $totalDeadline) {
-            $order = $this->providers->getOrderProvider()->getOrder($symbol, $orderId);
+            $order = $providers->getOrderProvider()->getOrder($symbol, $orderId);
             if ($order !== null) {
                 $status = $order->status;
                 if ($status === OrderStatus::FILLED || $status === OrderStatus::PARTIALLY_FILLED) {
@@ -812,9 +823,14 @@ final class ExecutionBox
     /**
      * Récupère le prix d'entrée exact depuis la position.
      */
-    private function getPositionEntryPrice(string $symbol, \App\TradeEntry\Types\Side $side, ?string $decisionKey): ?float
+    private function getPositionEntryPrice(
+        string $symbol,
+        \App\TradeEntry\Types\Side $side,
+        ?string $decisionKey,
+        ?ExchangeContext $context = null,
+    ): ?float
     {
-        $accountProvider = $this->providers->getAccountProvider();
+        $accountProvider = $this->providersFor($context)->getAccountProvider();
         if ($accountProvider === null) {
             return null;
         }
@@ -856,9 +872,14 @@ final class ExecutionBox
     /**
      * Vérifie que les plans TP/SL sont bien actifs.
      */
-    private function verifyPlanOrders(string $symbol, array $submitted, ?string $decisionKey): void
+    private function verifyPlanOrders(
+        string $symbol,
+        array $submitted,
+        ?string $decisionKey,
+        ?ExchangeContext $context = null,
+    ): void
     {
-        $orderProvider = $this->providers->getOrderProvider();
+        $orderProvider = $this->providersFor($context)->getOrderProvider();
         // Vérifier si le provider supporte getPlanOrders (spécifique BitMart)
         if (!$orderProvider instanceof \App\Provider\Bitmart\BitmartOrderProvider) {
             $this->positionsLogger->debug('execution.market_order.verify_skip', [
@@ -965,13 +986,14 @@ final class ExecutionBox
         EntryZone $zone,
         string $symbol,
         float $currentPrice,
-        int $ttlRemainingSec
+        int $ttlRemainingSec,
+        ?ExchangeContext $context = null,
     ): ?array {
         if (!$cfg->enabled || $ttlRemainingSec > $cfg->ttlThresholdSec) {
             return null;
         }
 
-        $orderBook = $this->providers->getOrderProvider()->getOrderBookTop($symbol);
+        $orderBook = $this->providersFor($context)->getOrderProvider()->getOrderBookTop($symbol);
         $spreadBps = SpreadHelper::calculateSpreadBps($orderBook);
 
         if ($spreadBps > $cfg->maxSpreadBps) {
@@ -999,5 +1021,10 @@ final class ExecutionBox
             'order_type' => $cfg->takerOrderType,
             'reason' => 'end_of_zone_fallback',
         ];
+    }
+
+    private function providersFor(?ExchangeContext $context = null): MainProviderInterface
+    {
+        return $this->providers->forContext($context);
     }
 }

--- a/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
@@ -6,8 +6,12 @@ namespace App\TradeEntry\MessageHandler;
 use App\Common\Enum\OrderStatus;
 use App\Contract\Provider\Dto\OrderDto;
 use App\Contract\Provider\MainProviderInterface;
+use App\Contract\Provider\OrderProviderDecoratorInterface;
+use App\Contract\Provider\OrderProviderInterface;
 use App\Logging\TradeLifecycleLogger;
 use App\Logging\TradeLifecycleReason;
+use App\Provider\Bitmart\BitmartOrderProvider;
+use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Message\LimitFillWatchMessage;
 use Brick\Math\RoundingMode;
 use Psr\Log\LoggerInterface;
@@ -33,7 +37,10 @@ final class LimitFillWatchMessageHandler
 
     public function __invoke(LimitFillWatchMessage $message): void
     {
-        $orderProvider = $this->provider->getOrderProvider();
+        $context = $message->lifecycleContext !== null
+            ? ExchangeContext::fromArray($message->lifecycleContext)
+            : null;
+        $orderProvider = $this->provider->forContext($context)->getOrderProvider();
 
         try {
             $order = $orderProvider->getOrder($message->symbol, $message->exchangeOrderId);
@@ -54,9 +61,10 @@ final class LimitFillWatchMessageHandler
 
             if ($status === OrderStatus::FILLED || $status === OrderStatus::PARTIALLY_FILLED) {
                 // Position ouverte: désarmer le dead-man switch pour ce symbole
-                if ($orderProvider instanceof \App\Provider\Bitmart\BitmartOrderProvider) {
+                $bitmartProvider = $this->unwrapOrderProvider($orderProvider);
+                if ($bitmartProvider instanceof BitmartOrderProvider) {
                     try {
-                        $orderProvider->cancelAllAfter($message->symbol, 0);
+                        $bitmartProvider->cancelAllAfter($message->symbol, 0);
                         $this->positionsLogger->info('limit_watch.deadman_disarmed', [
                             'symbol' => $message->symbol,
                             'exchange_order_id' => $message->exchangeOrderId,
@@ -154,6 +162,15 @@ final class LimitFillWatchMessageHandler
         }
 
         $this->rescheduleWatch($message, $message->cancelIssued, $maxTriesBeforeCancel, $maxAllowedTries);
+    }
+
+    private function unwrapOrderProvider(OrderProviderInterface $provider): OrderProviderInterface
+    {
+        while ($provider instanceof OrderProviderDecoratorInterface) {
+            $provider = $provider->innerOrderProvider();
+        }
+
+        return $provider;
     }
 
     private function logOrderExpiredLifecycle(

--- a/trading-app/src/TradeEntry/OrderPlan/OrderPlanBuilder.php
+++ b/trading-app/src/TradeEntry/OrderPlan/OrderPlanBuilder.php
@@ -553,7 +553,12 @@ final class OrderPlanBuilder
 
         $pivotLevels = \is_array($pre->pivotLevels) && !empty($pre->pivotLevels) ? $pre->pivotLevels : null;
         if ($pivotLevels === null) {
-            $list15 = $this->indicatorProvider->getListPivot(key: 'pivot', symbol: $req->symbol, tf: '15m');
+            $list15 = $this->indicatorProvider->getListPivot(
+                key: 'pivot',
+                symbol: $req->symbol,
+                tf: '15m',
+                context: $req->exchangeContext,
+            );
             if ($list15 !== null) {
                 $indicators = $list15->indicators;
                 if (\is_array($indicators['pivot_levels'] ?? null) && !empty($indicators['pivot_levels'])) {
@@ -608,7 +613,7 @@ final class OrderPlanBuilder
         // --- Levier dynamique ---
         $stopPct = abs($stop - $entry) / max($entry, 1e-9);
 
-        $atr15m = $this->indicatorProvider->getAtr(symbol: $req->symbol, tf: '15m');
+        $atr15m = $this->indicatorProvider->getAtr(symbol: $req->symbol, tf: '15m', context: $req->exchangeContext);
         $leverage = $this->leverageService->computeLeverage(
             $req->symbol,
             $entry,
@@ -781,6 +786,7 @@ final class OrderPlanBuilder
             stopRisk: $stopRisk,
             stopPivot: $stopPivot,
             stopFinalSource: $stopFinalSource,
+            exchangeContext: $req->exchangeContext,
         );
 
         $this->positionsLogger->info('order_plan.model_ready', [

--- a/trading-app/src/TradeEntry/OrderPlan/OrderPlanModel.php
+++ b/trading-app/src/TradeEntry/OrderPlan/OrderPlanModel.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\OrderPlan;
 
+use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Types\Side;
 
 final class OrderPlanModel
@@ -29,6 +30,7 @@ final class OrderPlanModel
         public readonly ?float $stopRisk = null,
         public readonly ?float $stopPivot = null,
         public readonly ?string $stopFinalSource = null,
+        public readonly ?ExchangeContext $exchangeContext = null,
     ) {}
 
     public function copyWith(
@@ -60,6 +62,7 @@ final class OrderPlanModel
             $this->stopRisk,
             $this->stopPivot,
             $this->stopFinalSource,
+            $this->exchangeContext,
         );
     }
 }

--- a/trading-app/src/TradeEntry/Policy/PreTradeChecks.php
+++ b/trading-app/src/TradeEntry/Policy/PreTradeChecks.php
@@ -6,6 +6,7 @@ namespace App\TradeEntry\Policy;
 use App\Common\Enum\Timeframe;
 use App\Contract\Indicator\IndicatorProviderInterface;
 use App\Contract\Provider\MainProviderInterface;
+use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Dto\{PreflightReport, TradeEntryRequest};
 use App\TradeEntry\Service\MarketStructureSampler;
 use App\TradeEntry\Pricing\TickQuantizer;
@@ -30,24 +31,26 @@ final readonly class PreTradeChecks
     public function run(TradeEntryRequest $req): PreflightReport
     {
         $symbol = $req->symbol;
+        $context = ExchangeContext::resolve($req->exchangeContext);
+        $providers = $this->providers->forContext($context);
 
         $this->positionsLogger->debug('pretrade.fetch_contract', [
             'symbol' => $symbol,
             'reason' => 'load_contract_specifications',
         ]);
-        $specs = $this->providers->getContractProvider()->getContractDetails($symbol);
+        $specs = $providers->getContractProvider()->getContractDetails($symbol);
 
         $this->positionsLogger->debug('pretrade.fetch_order_book', [
             'symbol' => $symbol,
             'reason' => 'load_order_book_snapshot',
         ]);
-        $orderBook = $this->providers->getOrderProvider()->getOrderBookTop($symbol)->toArray();
+        $orderBook = $providers->getOrderProvider()->getOrderBookTop($symbol)->toArray();
 
         $this->positionsLogger->debug('pretrade.fetch_balance', [
             'symbol' => $symbol,
             'reason' => 'load_available_balance',
         ]);
-        $available = $this->providers->getAccountProvider()->getAccountBalance() ?? 0.0;
+        $available = $providers->getAccountProvider()->getAccountBalance() ?? 0.0;
 
         $bestBid = $orderBook['bid'];
         $bestAsk = $orderBook['ask'];
@@ -102,7 +105,7 @@ final readonly class PreTradeChecks
             $markPrice = $lastPrice;
         }
 
-        $pivotLevels = $this->fetchPivotLevels($symbol);
+        $pivotLevels = $this->fetchPivotLevels($symbol, $context);
 
         $marketSnapshot = $this->marketStructureSampler->sample($symbol, $specs->contractSize->toFloat(), $mid);
 
@@ -230,10 +233,14 @@ final readonly class PreTradeChecks
     /**
      * @return array<string,float>|null
      */
-    private function fetchPivotLevels(string $symbol): ?array
+    private function fetchPivotLevels(string $symbol, ?ExchangeContext $context = null): ?array
     {
         try {
-            $dto = $this->indicatorProvider->getListPivot(symbol: $symbol, tf: Timeframe::TF_1D->value);
+            $dto = $this->indicatorProvider->getListPivot(
+                symbol: $symbol,
+                tf: Timeframe::TF_1D->value,
+                context: $context,
+            );
             if (!$dto instanceof \App\Contract\Indicator\Dto\ListIndicatorDto) {
                 return null;
             }

--- a/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
+++ b/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
@@ -6,6 +6,7 @@ namespace App\TradeEntry\Service;
 use App\Config\{IndicatorConfig, SignalConfig, TradeEntryConfig, TradeEntryConfigProvider, TradeEntryModeContext};
 use App\Contract\Provider\MainProviderInterface;
 use App\Entity\Position;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\PositionRepository;
 use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
 use App\TradeEntry\Policy\PreTradeChecks;
@@ -50,11 +51,14 @@ final class TpSlTwoTargetsService
     public function __invoke(TpSlTwoTargetsRequest $req, ?string $decisionKey = null, ?string $mode = null): array
     {
         $symbol = strtoupper($req->symbol);
+        $exchangeContext = ExchangeContext::resolve($req->exchangeContext);
+        $providers = $this->providers->forContext($exchangeContext);
 
         // 1) Prétraitement/exchange state
         $dummy = new \App\TradeEntry\Dto\TradeEntryRequest(
             symbol: $symbol,
             side: $req->side,
+            exchangeContext: $exchangeContext,
         );
         $pre = $this->pretrade->run($dummy);
 
@@ -69,7 +73,7 @@ final class TpSlTwoTargetsService
 
         if ($entryPrice === null || $size === null) {
             // Essayer d'abord depuis l'exchange (AccountProvider)
-            $accountProvider = $this->providers->getAccountProvider();
+            $accountProvider = $providers->getAccountProvider();
             if ($accountProvider !== null) {
                 try {
                     $openPositions = $accountProvider->getOpenPositions($symbol);
@@ -104,7 +108,7 @@ final class TpSlTwoTargetsService
 
             // Fallback sur la base de données locale si toujours pas trouvé
             if ($entryPrice === null || $size === null) {
-                $pos = $this->resolvePosition($symbol, $req->side);
+                $pos = $this->resolvePosition($symbol, $req->side, $exchangeContext);
                 if ($pos instanceof Position) {
                     if ($entryPrice === null) {
                         $entryPrice = (float)($pos->getAvgEntryPrice() ?? 0.0);
@@ -499,7 +503,7 @@ final class TpSlTwoTargetsService
 
         // 4) Annulations (SL si différent, TP existants)
         $cancelled = [];
-        $orderProvider = $this->providers->getOrderProvider();
+        $orderProvider = $providers->getOrderProvider();
         $isDryRun = $req->dryRun ?? false;
 
         if ($isDryRun) {
@@ -613,7 +617,7 @@ final class TpSlTwoTargetsService
             if ($this->indicatorProvider !== null) {
                 try {
                     $tf = $this->resolveAtrTimeframe();
-                    $atrAbs = $this->indicatorProvider->getAtr(symbol: $symbol, tf: $tf);
+                    $atrAbs = $this->indicatorProvider->getAtr(symbol: $symbol, tf: $tf, context: $exchangeContext);
                 } catch (\Throwable) {
                     $atrAbs = null;
                 }
@@ -812,10 +816,10 @@ final class TpSlTwoTargetsService
         ];
     }
 
-    private function resolvePosition(string $symbol, EntrySide $side): ?Position
+    private function resolvePosition(string $symbol, EntrySide $side, ?ExchangeContext $context = null): ?Position
     {
         // Position entity side is LONG|SHORT
-        $pos = $this->positions->findOneBySymbolSide($symbol, $side === EntrySide::Long ? 'LONG' : 'SHORT');
+        $pos = $this->positions->findOneBySymbolSide($symbol, $side === EntrySide::Long ? 'LONG' : 'SHORT', $context);
         return $pos;
     }
 

--- a/trading-app/src/TradeEntry/Service/TradeEntryService.php
+++ b/trading-app/src/TradeEntry/Service/TradeEntryService.php
@@ -19,6 +19,7 @@ use App\TradeEntry\Types\Side;
 use App\Logging\Dto\LifecycleContextBuilder;
 use App\Repository\IndicatorSnapshotRepository;
 use App\Common\Enum\Timeframe;
+use App\Provider\Context\ExchangeContext;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -221,7 +222,8 @@ final class TradeEntryService
                     $zone,
                     $request->symbol,
                     $currentPrice,
-                    $ttlRemaining
+                    $ttlRemaining,
+                    $request->exchangeContext,
                 );
 
                 if (is_array($fallbackDecision)) {
@@ -502,6 +504,8 @@ final class TradeEntryService
                 timeframe: $request->executionTf,
                 configProfile: $mode,
                 extra: $payload,
+                exchange: ExchangeContext::exchangeValue($request->exchangeContext),
+                marketType: ExchangeContext::marketTypeValue($request->exchangeContext),
             );
         } catch (\Throwable $e) {
             $this->positionsLogger->warning('trade_lifecycle.skip_log_failed', [
@@ -599,6 +603,7 @@ final class TradeEntryService
             mtfContext: $mtfContext,
             mtfLevel: $mtfLevel,
             reason: $reason,
+            exchangeContext: $request->exchangeContext,
         );
     }
 
@@ -679,7 +684,8 @@ final class TradeEntryService
                     $tfEnum = Timeframe::from($request->executionTf);
                     $snapshot = $this->indicatorSnapshotRepository->findLastBySymbolAndTimeframe(
                         strtoupper($plan->symbol),
-                        $tfEnum
+                        $tfEnum,
+                        $request->exchangeContext,
                     );
                     if ($snapshot !== null) {
                         $entryPrice = $plan->entry;
@@ -716,11 +722,12 @@ final class TradeEntryService
                 qty: (string) $plan->size,
                 price: $price,
                 runId: $runId,
-                exchange: null,
+                exchange: ExchangeContext::exchangeValue($request->exchangeContext),
                 accountId: null,
                 extra: $extra,
                 timeframe: $request->executionTf,
                 configProfile: $mode,
+                marketType: ExchangeContext::marketTypeValue($request->exchangeContext),
             );
         } catch (\Throwable $e) {
             $this->positionsLogger->warning('trade_lifecycle.submit_log_failed', [

--- a/trading-app/src/TradeEntry/Service/ZoneSkipPersistenceService.php
+++ b/trading-app/src/TradeEntry/Service/ZoneSkipPersistenceService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\TradeEntry\Service;
 
 use App\Entity\TradeZoneEvent;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\TradeZoneEventRepository;
 use App\TradeEntry\Dto\ZoneSkipEventDto;
 
@@ -29,8 +30,11 @@ final class ZoneSkipPersistenceService
             zoneMaxDevPct: $dto->zoneMaxDevPct,
             happenedAt: $dto->happenedAt,
         );
+        $context = ExchangeContext::resolve($dto->exchangeContext);
 
         $event
+            ->setExchange($context->exchange)
+            ->setMarketType($context->marketType)
             ->setDecisionKey($dto->decisionKey)
             ->setTimeframe($dto->timeframe)
             ->setConfigProfile($dto->configProfile)

--- a/trading-app/src/TradeEntry/Workflow/BuildOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/BuildOrderPlan.php
@@ -35,7 +35,13 @@ final class BuildOrderPlan
         ]);
 
         // Compute entry zone first, then create the plan with zone so builder can clamp entry if needed
-        $zone = $this->zones->compute($req->symbol, $req->side, $pre->pricePrecision, $decisionKey);
+        $zone = $this->zones->compute(
+            symbol: $req->symbol,
+            side: $req->side,
+            pricePrecision: $pre->pricePrecision,
+            decisionKey: $decisionKey,
+            context: $req->exchangeContext,
+        );
         $plan = $this->box->create($req, $pre, $decisionKey, $zone);
         $candidate = $plan->entry > 0.0 ? $plan->entry : ($req->side === Side::Long ? $pre->bestAsk : $pre->bestBid);
 

--- a/trading-app/src/Trading/Dto/OrderDto.php
+++ b/trading-app/src/Trading/Dto/OrderDto.php
@@ -8,6 +8,7 @@ use App\Common\Enum\OrderSide;
 use App\Common\Enum\OrderStatus;
 use App\Common\Enum\OrderType;
 use App\Contract\Provider\Dto\OrderDto as ProviderOrderDto;
+use App\Provider\Context\ExchangeContext;
 use Brick\Math\BigDecimal;
 
 /**
@@ -34,8 +35,10 @@ final class OrderDto
     /**
      * Mappe depuis un ProviderOrderDto
      */
-    public static function fromProviderDto(ProviderOrderDto $providerDto): self
+    public static function fromProviderDto(ProviderOrderDto $providerDto, ?ExchangeContext $context = null): self
     {
+        $context = ExchangeContext::resolve($context);
+
         return new self(
             orderId: $providerDto->orderId,
             clientOrderId: $providerDto->metadata['client_order_id'] ?? null,
@@ -49,9 +52,11 @@ final class OrderDto
             avgFilledPrice: $providerDto->averagePrice,
             createdAt: $providerDto->createdAt,
             updatedAt: $providerDto->updatedAt,
-            raw: $providerDto->metadata
+            raw: array_replace($providerDto->metadata, [
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+            ])
         );
     }
 }
-
 

--- a/trading-app/src/Trading/Dto/PositionDto.php
+++ b/trading-app/src/Trading/Dto/PositionDto.php
@@ -6,6 +6,7 @@ namespace App\Trading\Dto;
 
 use App\Common\Enum\PositionSide;
 use App\Contract\Provider\Dto\PositionDto as ProviderPositionDto;
+use App\Provider\Context\ExchangeContext;
 use Brick\Math\BigDecimal;
 
 /**
@@ -28,8 +29,10 @@ final class PositionDto
     /**
      * Mappe depuis un ProviderPositionDto
      */
-    public static function fromProviderDto(ProviderPositionDto $providerDto): self
+    public static function fromProviderDto(ProviderPositionDto $providerDto, ?ExchangeContext $context = null): self
     {
+        $context = ExchangeContext::resolve($context);
+
         return new self(
             symbol: $providerDto->symbol,
             side: $providerDto->side,
@@ -39,9 +42,11 @@ final class PositionDto
             unrealizedPnl: $providerDto->unrealizedPnl,
             leverage: $providerDto->leverage,
             openedAt: $providerDto->openedAt,
-            raw: $providerDto->metadata
+            raw: array_replace($providerDto->metadata, [
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+            ])
         );
     }
 }
-
 

--- a/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
+++ b/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
@@ -7,6 +7,7 @@ namespace App\Trading\Listener;
 use App\Common\Enum\Timeframe;
 use App\Contract\Provider\MainProviderInterface;
 use App\Logging\TradeLifecycleLogger;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\TradeLifecycleEventRepository;
 use App\Trading\Event\OrderStateChangedEvent;
 use App\Trading\Event\PositionClosedEvent;
@@ -28,6 +29,7 @@ final class TradeLifecycleLoggerListener
     public function onPositionOpened(PositionOpenedEvent $event): void
     {
         $position = $event->position;
+        $marketType = $this->marketTypeFromExtra($event->extra);
 
         $positionId = $position->raw['position_id']
             ?? $position->raw['positionId']
@@ -46,6 +48,7 @@ final class TradeLifecycleLoggerListener
                 'source' => 'trading_state_sync',
                 'raw'    => $position->raw,
             ], $event->extra),
+            marketType: $marketType,
         );
     }
 
@@ -55,6 +58,7 @@ final class TradeLifecycleLoggerListener
     public function onPositionClosed(PositionClosedEvent $event): void
     {
         $history = $event->positionHistory;
+        $marketType = $this->marketTypeFromExtra($event->extra);
 
         $positionId = $history->raw['position_id']
             ?? $history->raw['positionId']
@@ -88,6 +92,12 @@ final class TradeLifecycleLoggerListener
             if ($event->runId !== null) {
                 $criteria['runId'] = $event->runId;
             }
+            if ($event->exchange !== null) {
+                $criteria['exchange'] = $event->exchange;
+            }
+            if ($marketType !== null) {
+                $criteria['marketType'] = $marketType;
+            }
             $recent = $this->tradeLifecycleRepository->findRecentBy($criteria, 10);
             foreach ($recent as $lifecycleEvent) {
                 $extra = $lifecycleEvent->getExtra();
@@ -113,7 +123,9 @@ final class TradeLifecycleLoggerListener
 
         if ($this->mainProvider !== null) {
             try {
-                $klineProvider = $this->mainProvider->getKlineProvider();
+                $klineProvider = $this->mainProvider
+                    ->forContext(ExchangeContext::fromValues($event->exchange, $marketType))
+                    ->getKlineProvider();
                 $klines = $klineProvider->getKlinesInWindow(
                     $history->symbol,
                     Timeframe::TF_1M,
@@ -190,6 +202,7 @@ final class TradeLifecycleLoggerListener
                 'fees' => $history->fees?->__toString(),
                 'raw'  => $history->raw,
             ], $event->extra),
+            marketType: $marketType,
         );
     }
 
@@ -199,6 +212,7 @@ final class TradeLifecycleLoggerListener
     public function onOrderStateChanged(OrderStateChangedEvent $event): void
     {
         $order = $event->order;
+        $marketType = $this->marketTypeFromExtra($event->extra);
 
         // Détection simple "expired" : ordre qui passe d'OPEN -> CLOSED/CANCELED sans aucun fill
         $isClosedState = \in_array(strtoupper($event->newStatus), ['CANCELED', 'CLOSED', 'REJECTED', 'CANCELLED'], true);
@@ -219,6 +233,7 @@ final class TradeLifecycleLoggerListener
                 runId: $event->runId,
                 exchange: $event->exchange,
                 accountId: $event->accountId,
+                marketType: $marketType,
                 extra: array_merge([
                     'previous_status' => $event->previousStatus,
                     'new_status'      => $event->newStatus,
@@ -245,5 +260,15 @@ final class TradeLifecycleLoggerListener
             configVersion: $event->configVersion,
             extra: $event->extra,
         );
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    private function marketTypeFromExtra(array $extra): ?string
+    {
+        $marketType = $extra['market_type'] ?? $extra['marketType'] ?? null;
+
+        return \is_string($marketType) && $marketType !== '' ? $marketType : null;
     }
 }

--- a/trading-app/src/Trading/Storage/FuturesOrderOrderStateRepository.php
+++ b/trading-app/src/Trading/Storage/FuturesOrderOrderStateRepository.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Trading\Storage;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Entity\FuturesOrder;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\FuturesOrderRepository;
 use App\Trading\Dto\OrderDto;
 use Brick\Math\BigDecimal;
@@ -38,7 +41,11 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
         $openStatuses = ['pending', 'partially_filled', 'new', 'sent'];
 
         $qb = $this->repository->createQueryBuilder('o')
-            ->where('o.status IN (:statuses)')
+            ->where('o.exchange = :exchange')
+            ->andWhere('o.marketType = :marketType')
+            ->andWhere('o.status IN (:statuses)')
+            ->setParameter('exchange', ExchangeContext::exchangeValue(null))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue(null))
             ->setParameter('statuses', $openStatuses);
 
         if ($symbols !== null && $symbols !== []) {
@@ -61,13 +68,14 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
     {
         /** @var FuturesOrder|null $entity */
         $entity = null;
+        $context = $this->resolveContext($order->raw);
 
         if ($order->clientOrderId !== null) {
-            $entity = $this->repository->findOneByClientOrderId($order->clientOrderId);
+            $entity = $this->repository->findOneByClientOrderId($order->clientOrderId, $context);
         }
 
         if ($entity === null && $order->orderId !== '') {
-            $entity = $this->repository->findOneByOrderId($order->orderId);
+            $entity = $this->repository->findOneByOrderId($order->orderId, $context);
         }
 
         if ($entity === null) {
@@ -147,6 +155,8 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
 
     private function mapDtoToEntity(OrderDto $dto, FuturesOrder $entity): void
     {
+        $entity->setExchange((string)($dto->raw['exchange'] ?? ExchangeContext::exchangeValue(null)));
+        $entity->setMarketType((string)($dto->raw['market_type'] ?? $dto->raw['marketType'] ?? ExchangeContext::marketTypeValue(null)));
         $entity->setSymbol($dto->symbol);
         $entity->setClientOrderId($dto->clientOrderId);
         $entity->setSide($this->mapOrderSideToNumericSide($dto->side));
@@ -170,6 +180,21 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
         }
 
         $entity->setRawData($dto->raw);
+    }
+
+    /**
+     * @param array<string,mixed> $raw
+     */
+    private function resolveContext(array $raw): ExchangeContext
+    {
+        try {
+            return new ExchangeContext(
+                Exchange::from(strtolower((string)($raw['exchange'] ?? ExchangeContext::exchangeValue(null)))),
+                MarketType::from(strtolower((string)($raw['market_type'] ?? $raw['marketType'] ?? ExchangeContext::marketTypeValue(null)))),
+            );
+        } catch (\ValueError) {
+            return ExchangeContext::legacyDefault();
+        }
     }
 
     /**

--- a/trading-app/src/Trading/Storage/FuturesOrderOrderStateRepository.php
+++ b/trading-app/src/Trading/Storage/FuturesOrderOrderStateRepository.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Trading\Storage;
 
-use App\Common\Enum\Exchange;
-use App\Common\Enum\MarketType;
 use App\Entity\FuturesOrder;
 use App\Provider\Context\ExchangeContext;
 use App\Repository\FuturesOrderRepository;
@@ -20,10 +18,14 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
         private readonly EntityManagerInterface $em,
     ) {}
 
-    public function findLocalOrder(string $symbol, string $orderId): ?OrderDto
+    public function findLocalOrder(
+        string $symbol,
+        string $orderId,
+        ?ExchangeContext $context = null,
+    ): ?OrderDto
     {
         /** @var FuturesOrder|null $entity */
-        $entity = $this->repository->findOneByOrderId($orderId);
+        $entity = $this->repository->findOneByOrderId($orderId, $context);
         if ($entity === null || strtoupper($entity->getSymbol()) !== strtoupper($symbol)) {
             return null;
         }
@@ -35,8 +37,12 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
      * @param string[]|null $symbols
      * @return OrderDto[]
      */
-    public function findLocalOpenOrders(?array $symbols = null): array
+    public function findLocalOpenOrders(
+        ?array $symbols = null,
+        ?ExchangeContext $context = null,
+    ): array
     {
+        $context = ExchangeContext::resolve($context);
         // Statuts considérés comme "ouverts" : pending, partially_filled
         $openStatuses = ['pending', 'partially_filled', 'new', 'sent'];
 
@@ -44,8 +50,8 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
             ->where('o.exchange = :exchange')
             ->andWhere('o.marketType = :marketType')
             ->andWhere('o.status IN (:statuses)')
-            ->setParameter('exchange', ExchangeContext::exchangeValue(null))
-            ->setParameter('marketType', ExchangeContext::marketTypeValue(null))
+            ->setParameter('exchange', $context->exchange->value)
+            ->setParameter('marketType', $context->marketType->value)
             ->setParameter('statuses', $openStatuses);
 
         if ($symbols !== null && $symbols !== []) {
@@ -149,14 +155,18 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
             avgFilledPrice: $avgFilledPrice,
             createdAt: $createdAt ?? new \DateTimeImmutable('now'),
             updatedAt: $updatedAt,
-            raw: $entity->getRawData()
+            raw: array_replace($entity->getRawData(), [
+                'exchange' => $entity->getExchange(),
+                'market_type' => $entity->getMarketType(),
+            ])
         );
     }
 
     private function mapDtoToEntity(OrderDto $dto, FuturesOrder $entity): void
     {
-        $entity->setExchange((string)($dto->raw['exchange'] ?? ExchangeContext::exchangeValue(null)));
-        $entity->setMarketType((string)($dto->raw['market_type'] ?? $dto->raw['marketType'] ?? ExchangeContext::marketTypeValue(null)));
+        $context = $this->resolveContext($dto->raw);
+        $entity->setExchange($context->exchange);
+        $entity->setMarketType($context->marketType);
         $entity->setSymbol($dto->symbol);
         $entity->setClientOrderId($dto->clientOrderId);
         $entity->setSide($this->mapOrderSideToNumericSide($dto->side));
@@ -187,14 +197,7 @@ final class FuturesOrderOrderStateRepository implements OrderStateRepositoryInte
      */
     private function resolveContext(array $raw): ExchangeContext
     {
-        try {
-            return new ExchangeContext(
-                Exchange::from(strtolower((string)($raw['exchange'] ?? ExchangeContext::exchangeValue(null)))),
-                MarketType::from(strtolower((string)($raw['market_type'] ?? $raw['marketType'] ?? ExchangeContext::marketTypeValue(null)))),
-            );
-        } catch (\ValueError) {
-            return ExchangeContext::legacyDefault();
-        }
+        return ExchangeContext::fromArray($raw);
     }
 
     /**

--- a/trading-app/src/Trading/Storage/OrderStateRepositoryInterface.php
+++ b/trading-app/src/Trading/Storage/OrderStateRepositoryInterface.php
@@ -4,19 +4,26 @@ declare(strict_types=1);
 
 namespace App\Trading\Storage;
 
+use App\Provider\Context\ExchangeContext;
 use App\Trading\Dto\OrderDto;
 
 interface OrderStateRepositoryInterface
 {
-    public function findLocalOrder(string $symbol, string $orderId): ?OrderDto;
+    public function findLocalOrder(
+        string $symbol,
+        string $orderId,
+        ?ExchangeContext $context = null,
+    ): ?OrderDto;
 
     /**
      * @param string[]|null $symbols
      * @return OrderDto[]
      */
-    public function findLocalOpenOrders(?array $symbols = null): array;
+    public function findLocalOpenOrders(
+        ?array $symbols = null,
+        ?ExchangeContext $context = null,
+    ): array;
 
     public function saveOrder(OrderDto $order): void;
 }
-
 

--- a/trading-app/src/Trading/Storage/PositionPositionStateRepository.php
+++ b/trading-app/src/Trading/Storage/PositionPositionStateRepository.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Trading\Storage;
 
-use App\Common\Enum\Exchange;
-use App\Common\Enum\MarketType;
 use App\Entity\Position;
 use App\Provider\Context\ExchangeContext;
 use App\Repository\PositionRepository;
@@ -21,10 +19,14 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
         private readonly EntityManagerInterface $em,
     ) {}
 
-    public function findLocalOpenPosition(string $symbol, string $side): ?PositionDto
+    public function findLocalOpenPosition(
+        string $symbol,
+        string $side,
+        ?ExchangeContext $context = null,
+    ): ?PositionDto
     {
         /** @var Position|null $entity */
-        $entity = $this->repository->findOneBySymbolSide($symbol, $side);
+        $entity = $this->repository->findOneBySymbolSide($symbol, $side, $context);
         if ($entity === null || $entity->getStatus() !== 'OPEN') {
             return null;
         }
@@ -36,14 +38,18 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
      * @param string[]|null $symbols
      * @return PositionDto[]
      */
-    public function findLocalOpenPositions(?array $symbols = null): array
+    public function findLocalOpenPositions(
+        ?array $symbols = null,
+        ?ExchangeContext $context = null,
+    ): array
     {
+        $context = ExchangeContext::resolve($context);
         $qb = $this->repository->createQueryBuilder('p')
             ->where('p.exchange = :exchange')
             ->andWhere('p.marketType = :marketType')
             ->andWhere('p.status = :status')
-            ->setParameter('exchange', ExchangeContext::exchangeValue(null))
-            ->setParameter('marketType', ExchangeContext::marketTypeValue(null))
+            ->setParameter('exchange', $context->exchange->value)
+            ->setParameter('marketType', $context->marketType->value)
             ->setParameter('status', 'OPEN');
 
         if ($symbols !== null && $symbols !== []) {
@@ -109,14 +115,16 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
     public function findLocalClosedPositions(
         ?array $symbols = null,
         ?\DateTimeInterface $from = null,
-        ?\DateTimeInterface $to = null
+        ?\DateTimeInterface $to = null,
+        ?ExchangeContext $context = null,
     ): array {
+        $context = ExchangeContext::resolve($context);
         $qb = $this->repository->createQueryBuilder('p')
             ->where('p.exchange = :exchange')
             ->andWhere('p.marketType = :marketType')
             ->andWhere('p.status = :status')
-            ->setParameter('exchange', ExchangeContext::exchangeValue(null))
-            ->setParameter('marketType', ExchangeContext::marketTypeValue(null))
+            ->setParameter('exchange', $context->exchange->value)
+            ->setParameter('marketType', $context->marketType->value)
             ->setParameter('status', 'CLOSED')
             ->orderBy('p.updatedAt', 'DESC');
 
@@ -174,14 +182,18 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
             unrealizedPnl: BigDecimal::of($entity->getUnrealizedPnl() ?? '0'),
             leverage: $leverage,
             openedAt: $entity->getInsertedAt(),
-            raw: $payload
+            raw: array_replace($payload, [
+                'exchange' => $entity->getExchange(),
+                'market_type' => $entity->getMarketType(),
+            ])
         );
     }
 
     private function mapDtoToOpenEntity(PositionDto $dto, Position $entity): void
     {
-        $entity->setExchange((string)($dto->raw['exchange'] ?? ExchangeContext::exchangeValue(null)));
-        $entity->setMarketType((string)($dto->raw['market_type'] ?? $dto->raw['marketType'] ?? ExchangeContext::marketTypeValue(null)));
+        $context = $this->resolveContext($dto->raw);
+        $entity->setExchange($context->exchange);
+        $entity->setMarketType($context->marketType);
         $entity->setStatus('OPEN');
         $entity->setSize($dto->size->__toString());
         $entity->setAvgEntryPrice($dto->entryPrice->__toString());
@@ -198,14 +210,7 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
      */
     private function resolveContext(array $raw): ExchangeContext
     {
-        try {
-            return new ExchangeContext(
-                Exchange::from(strtolower((string)($raw['exchange'] ?? ExchangeContext::exchangeValue(null)))),
-                MarketType::from(strtolower((string)($raw['market_type'] ?? $raw['marketType'] ?? ExchangeContext::marketTypeValue(null)))),
-            );
-        } catch (\ValueError) {
-            return ExchangeContext::legacyDefault();
-        }
+        return ExchangeContext::fromArray($raw);
     }
 
     private function mapEntityToHistoryDto(Position $entity): ?PositionHistoryEntryDto
@@ -245,7 +250,10 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
             fees: $fees,
             openedAt: $entity->getInsertedAt(),
             closedAt: $closedAt,
-            raw: $payload['raw_history'] ?? $payload
+            raw: array_replace($payload['raw_history'] ?? $payload, [
+                'exchange' => $entity->getExchange(),
+                'market_type' => $entity->getMarketType(),
+            ])
         );
     }
 }

--- a/trading-app/src/Trading/Storage/PositionPositionStateRepository.php
+++ b/trading-app/src/Trading/Storage/PositionPositionStateRepository.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Trading\Storage;
 
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
 use App\Entity\Position;
+use App\Provider\Context\ExchangeContext;
 use App\Repository\PositionRepository;
 use App\Trading\Dto\PositionDto;
 use App\Trading\Dto\PositionHistoryEntryDto;
@@ -36,7 +39,11 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
     public function findLocalOpenPositions(?array $symbols = null): array
     {
         $qb = $this->repository->createQueryBuilder('p')
-            ->where('p.status = :status')
+            ->where('p.exchange = :exchange')
+            ->andWhere('p.marketType = :marketType')
+            ->andWhere('p.status = :status')
+            ->setParameter('exchange', ExchangeContext::exchangeValue(null))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue(null))
             ->setParameter('status', 'OPEN');
 
         if ($symbols !== null && $symbols !== []) {
@@ -58,10 +65,11 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
     public function saveOpenPosition(PositionDto $position): void
     {
         /** @var Position|null $entity */
-        $entity = $this->repository->findOneBySymbolSide($position->symbol, $position->side->value);
+        $context = $this->resolveContext($position->raw);
+        $entity = $this->repository->findOneBySymbolSide($position->symbol, $position->side->value, $context);
 
         if ($entity === null) {
-            $entity = new Position($position->symbol, $position->side->value);
+            $entity = new Position($position->symbol, $position->side->value, $context->exchange, $context->marketType);
         }
 
         $this->mapDtoToOpenEntity($position, $entity);
@@ -72,10 +80,11 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
     public function saveClosedPosition(PositionHistoryEntryDto $history): void
     {
         /** @var Position|null $entity */
-        $entity = $this->repository->findOneBySymbolSide($history->symbol, $history->side->value);
+        $context = $this->resolveContext($history->raw);
+        $entity = $this->repository->findOneBySymbolSide($history->symbol, $history->side->value, $context);
 
         if ($entity === null) {
-            $entity = new Position($history->symbol, $history->side->value);
+            $entity = new Position($history->symbol, $history->side->value, $context->exchange, $context->marketType);
         }
 
         $entity->setStatus('CLOSED');
@@ -103,7 +112,11 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
         ?\DateTimeInterface $to = null
     ): array {
         $qb = $this->repository->createQueryBuilder('p')
-            ->where('p.status = :status')
+            ->where('p.exchange = :exchange')
+            ->andWhere('p.marketType = :marketType')
+            ->andWhere('p.status = :status')
+            ->setParameter('exchange', ExchangeContext::exchangeValue(null))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue(null))
             ->setParameter('status', 'CLOSED')
             ->orderBy('p.updatedAt', 'DESC');
 
@@ -167,6 +180,8 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
 
     private function mapDtoToOpenEntity(PositionDto $dto, Position $entity): void
     {
+        $entity->setExchange((string)($dto->raw['exchange'] ?? ExchangeContext::exchangeValue(null)));
+        $entity->setMarketType((string)($dto->raw['market_type'] ?? $dto->raw['marketType'] ?? ExchangeContext::marketTypeValue(null)));
         $entity->setStatus('OPEN');
         $entity->setSize($dto->size->__toString());
         $entity->setAvgEntryPrice($dto->entryPrice->__toString());
@@ -176,6 +191,21 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
             'mark_price' => $dto->markPrice->__toString(),
             'raw_snapshot' => $dto->raw,
         ]);
+    }
+
+    /**
+     * @param array<string,mixed> $raw
+     */
+    private function resolveContext(array $raw): ExchangeContext
+    {
+        try {
+            return new ExchangeContext(
+                Exchange::from(strtolower((string)($raw['exchange'] ?? ExchangeContext::exchangeValue(null)))),
+                MarketType::from(strtolower((string)($raw['market_type'] ?? $raw['marketType'] ?? ExchangeContext::marketTypeValue(null)))),
+            );
+        } catch (\ValueError) {
+            return ExchangeContext::legacyDefault();
+        }
     }
 
     private function mapEntityToHistoryDto(Position $entity): ?PositionHistoryEntryDto
@@ -219,4 +249,3 @@ final class PositionPositionStateRepository implements PositionStateRepositoryIn
         );
     }
 }
-

--- a/trading-app/src/Trading/Storage/PositionStateRepositoryInterface.php
+++ b/trading-app/src/Trading/Storage/PositionStateRepositoryInterface.php
@@ -4,18 +4,26 @@ declare(strict_types=1);
 
 namespace App\Trading\Storage;
 
+use App\Provider\Context\ExchangeContext;
 use App\Trading\Dto\PositionDto;
 use App\Trading\Dto\PositionHistoryEntryDto;
 
 interface PositionStateRepositoryInterface
 {
-    public function findLocalOpenPosition(string $symbol, string $side): ?PositionDto;
+    public function findLocalOpenPosition(
+        string $symbol,
+        string $side,
+        ?ExchangeContext $context = null,
+    ): ?PositionDto;
 
     /**
      * @param string[]|null $symbols
      * @return PositionDto[]
      */
-    public function findLocalOpenPositions(?array $symbols = null): array;
+    public function findLocalOpenPositions(
+        ?array $symbols = null,
+        ?ExchangeContext $context = null,
+    ): array;
 
     public function saveOpenPosition(PositionDto $position): void;
 
@@ -28,8 +36,8 @@ interface PositionStateRepositoryInterface
     public function findLocalClosedPositions(
         ?array $symbols = null,
         ?\DateTimeInterface $from = null,
-        ?\DateTimeInterface $to = null
+        ?\DateTimeInterface $to = null,
+        ?ExchangeContext $context = null,
     ): array;
 }
-
 

--- a/trading-app/src/Trading/Sync/TradingStateSyncRunner.php
+++ b/trading-app/src/Trading/Sync/TradingStateSyncRunner.php
@@ -7,6 +7,7 @@ namespace App\Trading\Sync;
 use App\Contract\Provider\AccountProviderInterface;
 use App\Contract\Provider\MainProviderInterface;
 use App\Contract\Provider\OrderProviderInterface;
+use App\Provider\Context\ExchangeContext;
 use App\Trading\Dto\OrderDto as TradingOrderDto;
 use App\Trading\Dto\PositionDto as TradingPositionDto;
 use App\Trading\Dto\PositionHistoryEntryDto;
@@ -20,35 +21,13 @@ use Psr\Log\LoggerInterface;
 
 final class TradingStateSyncRunner
 {
-    private ?AccountProviderInterface $accountProvider = null;
-    private ?OrderProviderInterface $orderProvider = null;
-
     public function __construct(
         private readonly ?MainProviderInterface $mainProvider,
         private readonly PositionStateRepositoryInterface $positionStateRepository,
         private readonly OrderStateRepositoryInterface $orderStateRepository,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
         private readonly ?LoggerInterface $logger = null,
-    ) {
-        // Récupérer les providers depuis MainProvider si disponible
-        if ($this->mainProvider !== null) {
-            try {
-                $this->accountProvider = $this->mainProvider->getAccountProvider();
-            } catch (\Throwable $e) {
-                $this->logger?->warning('[TradingStateSync] AccountProvider not available', [
-                    'error' => $e->getMessage(),
-                ]);
-            }
-
-            try {
-                $this->orderProvider = $this->mainProvider->getOrderProvider();
-            } catch (\Throwable $e) {
-                $this->logger?->warning('[TradingStateSync] OrderProvider not available', [
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
-    }
+    ) {}
 
     /**
      * Synchronise les positions et ordres depuis l'exchange vers la BDD
@@ -56,22 +35,28 @@ final class TradingStateSyncRunner
      * @param string $context Contexte de la synchronisation (pour logging)
      * @param string[]|null $symbols Symboles à synchroniser (null = tous)
      */
-    public function syncAndDispatch(string $context, ?array $symbols = null): void
+    public function syncAndDispatch(string $context, ?array $symbols = null, ?ExchangeContext $exchangeContext = null): void
     {
+        $exchangeContext = ExchangeContext::resolve($exchangeContext);
+        $accountProvider = $this->resolveAccountProvider($exchangeContext);
+        $orderProvider = $this->resolveOrderProvider($exchangeContext);
+
         $this->logger?->info('[TradingStateSync] Starting sync', [
             'context' => $context,
             'symbols' => $symbols,
+            'exchange' => $exchangeContext->exchange->value,
+            'market_type' => $exchangeContext->marketType->value,
         ]);
 
         try {
             // 1. Synchroniser les positions ouvertes
-            if ($this->accountProvider !== null) {
-                $this->syncPositions($symbols);
+            if ($accountProvider !== null) {
+                $this->syncPositions($symbols, $exchangeContext, $accountProvider);
             }
 
             // 2. Synchroniser les ordres ouverts
-            if ($this->orderProvider !== null) {
-                $this->syncOrders($symbols);
+            if ($orderProvider !== null) {
+                $this->syncOrders($symbols, $exchangeContext, $orderProvider);
             }
 
             $this->logger?->info('[TradingStateSync] Sync completed', [
@@ -92,15 +77,15 @@ final class TradingStateSyncRunner
      * 
      * @param string[]|null $symbols
      */
-    private function syncPositions(?array $symbols = null): void
+    private function syncPositions(
+        ?array $symbols,
+        ExchangeContext $context,
+        AccountProviderInterface $accountProvider,
+    ): void
     {
-        if ($this->accountProvider === null) {
-            return;
-        }
-
         try {
             // Récupérer les positions ouvertes depuis l'exchange
-            $openPositions = $this->accountProvider->getOpenPositions();
+            $openPositions = $accountProvider->getOpenPositions();
 
             // Filtrer par symboles si spécifié
             if ($symbols !== null && $symbols !== []) {
@@ -115,7 +100,7 @@ final class TradingStateSyncRunner
             ]);
 
             // Récupérer les positions actuellement en BDD pour détecter les nouvelles/fermetures
-            $localOpenPositions = $this->positionStateRepository->findLocalOpenPositions($symbols);
+            $localOpenPositions = $this->positionStateRepository->findLocalOpenPositions($symbols, $context);
             $localPositionsMap = [];
             foreach ($localOpenPositions as $localPos) {
                 $key = strtoupper($localPos->symbol) . '_' . strtoupper($localPos->side->value);
@@ -128,7 +113,7 @@ final class TradingStateSyncRunner
             // Sauvegarder les positions ouvertes depuis l'exchange
             foreach ($openPositions as $providerPosition) {
                 try {
-                    $tradingPosition = TradingPositionDto::fromProviderDto($providerPosition);
+                    $tradingPosition = TradingPositionDto::fromProviderDto($providerPosition, $context);
                     $key = strtoupper($tradingPosition->symbol) . '_' . strtoupper($tradingPosition->side->value);
                     
                     // Vérifier si c'est une nouvelle position (pas présente en BDD)
@@ -142,9 +127,9 @@ final class TradingStateSyncRunner
                         $this->eventDispatcher->dispatch(new PositionOpenedEvent(
                             position: $tradingPosition,
                             runId: null,
-                            exchange: null,
+                            exchange: $context->exchange->value,
                             accountId: null,
-                            extra: []
+                            extra: ['market_type' => $context->marketType->value]
                         ));
                     }
                 } catch (\Throwable $e) {
@@ -167,12 +152,12 @@ final class TradingStateSyncRunner
                 }
 
                 if (!$found) {
-                    // Position fermée : récupérer les données réelles depuis l'API BitMart
+                    // Position fermée : récupérer les données réelles depuis le provider courant
                     try {
                         // 1. Récupérer les trades (fills) pour ce symbole
                         // 2. Récupérer le transaction history avec flow_type=2 (realized PnL)
                         // 3. Optionnellement récupérer l'order history pour les métadonnées
-                        $history = $this->createHistoryFromApiData($localPos);
+                        $history = $this->createHistoryFromApiData($localPos, $accountProvider, $context);
                         
                         if ($history !== null) {
                             $this->positionStateRepository->saveClosedPosition($history);
@@ -187,10 +172,10 @@ final class TradingStateSyncRunner
                                 $this->eventDispatcher->dispatch(new PositionClosedEvent(
                                     positionHistory: $history,
                                     runId: null,
-                                    exchange: null,
+                                    exchange: $context->exchange->value,
                                     accountId: null,
                                     reasonCode: $reasonCode,
-                                    extra: []
+                                    extra: ['market_type' => $context->marketType->value]
                                 ));
                             }
                         }
@@ -216,15 +201,15 @@ final class TradingStateSyncRunner
      * 
      * @param string[]|null $symbols
      */
-    private function syncOrders(?array $symbols = null): void
+    private function syncOrders(
+        ?array $symbols,
+        ExchangeContext $context,
+        OrderProviderInterface $orderProvider,
+    ): void
     {
-        if ($this->orderProvider === null) {
-            return;
-        }
-
         try {
             // Récupérer les ordres ouverts depuis l'exchange
-            $openOrders = $this->orderProvider->getOpenOrders();
+            $openOrders = $orderProvider->getOpenOrders();
 
             // Filtrer par symboles si spécifié
             if ($symbols !== null && $symbols !== []) {
@@ -239,7 +224,7 @@ final class TradingStateSyncRunner
             ]);
 
             // Récupérer les ordres locaux pour détecter les changements de statut
-            $localOpenOrders = $this->orderStateRepository->findLocalOpenOrders($symbols);
+            $localOpenOrders = $this->orderStateRepository->findLocalOpenOrders($symbols, $context);
             $localOrdersMap = [];
             foreach ($localOpenOrders as $localOrder) {
                 $localOrdersMap[$localOrder->orderId] = $localOrder;
@@ -248,7 +233,7 @@ final class TradingStateSyncRunner
             // Sauvegarder les ordres ouverts et détecter les changements de statut
             foreach ($openOrders as $providerOrder) {
                 try {
-                    $tradingOrder = TradingOrderDto::fromProviderDto($providerOrder);
+                    $tradingOrder = TradingOrderDto::fromProviderDto($providerOrder, $context);
                     $previousOrder = $localOrdersMap[$tradingOrder->orderId] ?? null;
                     
                     // Sauvegarder l'ordre
@@ -265,9 +250,9 @@ final class TradingStateSyncRunner
                                 previousStatus: $previousStatus,
                                 newStatus: $newStatus,
                                 runId: null,
-                                exchange: null,
+                                exchange: $context->exchange->value,
                                 accountId: null,
-                                extra: []
+                                extra: ['market_type' => $context->marketType->value]
                             ));
                         }
                     }
@@ -288,27 +273,25 @@ final class TradingStateSyncRunner
     }
 
     /**
-     * Crée un PositionHistoryEntryDto depuis les données API BitMart
-     * Utilise GET /contract/private/trades et GET /contract/private/transaction-history
+     * Crée un PositionHistoryEntryDto depuis les données API du provider courant.
      */
-    private function createHistoryFromApiData(TradingPositionDto $localPos): ?PositionHistoryEntryDto
+    private function createHistoryFromApiData(
+        TradingPositionDto $localPos,
+        AccountProviderInterface $accountProvider,
+        ExchangeContext $context,
+    ): ?PositionHistoryEntryDto
     {
         try {
-            if ($this->accountProvider === null) {
-                $this->logger?->warning('[TradingStateSync] Cannot create history: AccountProvider not available');
-                return null;
-            }
-
             $symbol = $localPos->symbol;
             
             // 1. Récupérer les trades (fills) pour ce symbole
             // Limiter aux 7 derniers jours pour éviter trop de données
             $endTime = time();
             $startTime = $endTime - (7 * 24 * 60 * 60); // 7 jours
-            $trades = $this->accountProvider->getTrades($symbol, 200, $startTime, $endTime);
+            $trades = $accountProvider->getTrades($symbol, 200, $startTime, $endTime);
             
             // 2. Récupérer le transaction history avec flow_type=2 (realized PnL)
-            $transactions = $this->accountProvider->getTransactionHistory($symbol, 2, 200, $startTime, $endTime);
+            $transactions = $accountProvider->getTransactionHistory($symbol, 2, 200, $startTime, $endTime);
             
             // 3. Calculer les données agrégées depuis les trades
             $totalFilledSize = \Brick\Math\BigDecimal::zero();
@@ -376,6 +359,8 @@ final class TradingStateSyncRunner
                 openedAt: $localPos->openedAt,
                 closedAt: $closedAt,
                 raw: array_merge($localPos->raw, [
+                    'exchange' => $context->exchange->value,
+                    'market_type' => $context->marketType->value,
                     'closed_detected_at' => $closedAt->format('Y-m-d H:i:s'),
                     'source' => 'trading_state_sync_api',
                     'trades_count' => count($trades),
@@ -392,5 +377,42 @@ final class TradingStateSyncRunner
             return null;
         }
     }
-}
 
+    private function resolveAccountProvider(ExchangeContext $context): ?AccountProviderInterface
+    {
+        if ($this->mainProvider === null) {
+            return null;
+        }
+
+        try {
+            return $this->mainProvider->forContext($context)->getAccountProvider();
+        } catch (\Throwable $e) {
+            $this->logger?->warning('[TradingStateSync] AccountProvider not available for context', [
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    private function resolveOrderProvider(ExchangeContext $context): ?OrderProviderInterface
+    {
+        if ($this->mainProvider === null) {
+            return null;
+        }
+
+        try {
+            return $this->mainProvider->forContext($context)->getOrderProvider();
+        } catch (\Throwable $e) {
+            $this->logger?->warning('[TradingStateSync] OrderProvider not available for context', [
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/trading-app/tests/Provider/ContextualKlineProviderTest.php
+++ b/trading-app/tests/Provider/ContextualKlineProviderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Provider;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\Timeframe;
+use App\Contract\Provider\Dto\KlineDto;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\ContextualKlineProvider;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class ContextualKlineProviderTest extends TestCase
+{
+    public function testScopedProviderPassesDefaultContextToInnerProvider(): void
+    {
+        $inner = new class implements KlineProviderInterface {
+            public ?ExchangeContext $lastContext = null;
+
+            public function getKlines(
+                string $symbol,
+                Timeframe $timeframe,
+                int $limit = 490,
+                ?ExchangeContext $context = null,
+            ): array {
+                $this->lastContext = $context;
+                return [];
+            }
+
+            public function getKlinesInWindow(
+                string $symbol,
+                Timeframe $timeframe,
+                \DateTimeImmutable $start,
+                \DateTimeImmutable $end,
+                int $limit = 500,
+                ?ExchangeContext $context = null,
+            ): array {
+                $this->lastContext = $context;
+                return [];
+            }
+
+            public function getLastKline(
+                string $symbol,
+                Timeframe $timeframe,
+                ?ExchangeContext $context = null,
+            ): ?KlineDto {
+                $this->lastContext = $context;
+                return null;
+            }
+
+            public function saveKline(KlineDto $kline, ?ExchangeContext $context = null): void
+            {
+                $this->lastContext = $context;
+            }
+
+            public function saveKlines(
+                array $klines,
+                string $symbol,
+                Timeframe $timeframe,
+                ?ExchangeContext $context = null,
+            ): void {
+                $this->lastContext = $context;
+            }
+
+            public function hasGaps(
+                string $symbol,
+                Timeframe $timeframe,
+                ?ExchangeContext $context = null,
+            ): bool {
+                $this->lastContext = $context;
+                return false;
+            }
+
+            public function getGaps(
+                string $symbol,
+                Timeframe $timeframe,
+                ?ExchangeContext $context = null,
+            ): array {
+                $this->lastContext = $context;
+                return [];
+            }
+        };
+        $binance = new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL);
+        $provider = new ContextualKlineProvider($inner, $binance);
+
+        $provider->getKlines('BTCUSDT', Timeframe::TF_1M);
+        self::assertTrue($inner->lastContext?->equals($binance));
+
+        $provider->getLastKline('BTCUSDT', Timeframe::TF_1M, ExchangeContext::legacyDefault());
+        self::assertTrue($inner->lastContext?->equals(ExchangeContext::legacyDefault()));
+    }
+}

--- a/trading-app/tests/Provider/ContextualOrderProviderTest.php
+++ b/trading-app/tests/Provider/ContextualOrderProviderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Provider;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\ContextualOrderProviderInterface;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\ContextualOrderProvider;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class ContextualOrderProviderTest extends TestCase
+{
+    public function testPlaceOrderInjectsContextIntoOptions(): void
+    {
+        $inner = new class implements ContextualOrderProviderInterface {
+            /** @var array<string,mixed> */
+            public array $lastOptions = [];
+            public ?ExchangeContext $lastContext = null;
+
+            public function placeOrder(
+                string $symbol,
+                OrderSide $side,
+                OrderType $type,
+                float $quantity,
+                ?float $price = null,
+                ?float $stopPrice = null,
+                array $options = []
+            ): ?OrderDto {
+                $this->lastOptions = $options;
+                return null;
+            }
+
+            public function cancelOrder(string $symbol, string $orderId, ?ExchangeContext $context = null): bool
+            {
+                $this->lastContext = $context;
+                return true;
+            }
+
+            public function getOrder(string $symbol, string $orderId, ?ExchangeContext $context = null): ?OrderDto
+            {
+                $this->lastContext = $context;
+                return null;
+            }
+
+            public function getOpenOrders(?string $symbol = null, ?ExchangeContext $context = null): array
+            {
+                $this->lastContext = $context;
+                return [];
+            }
+
+            public function getOrderHistory(string $symbol, int $limit = 100, ?ExchangeContext $context = null): array
+            {
+                $this->lastContext = $context;
+                return [];
+            }
+
+            public function cancelAllOrders(string $symbol): bool
+            {
+                return true;
+            }
+
+            public function getOrderBookTop(string $symbol): SymbolBidAskDto
+            {
+                return new SymbolBidAskDto($symbol, 1.0, 1.1, new \DateTimeImmutable());
+            }
+
+            public function submitLeverage(string $symbol, int $leverage, string $openType = 'isolated'): bool
+            {
+                return true;
+            }
+        };
+        $spot = new ExchangeContext(Exchange::BITMART, MarketType::SPOT);
+        $provider = new ContextualOrderProvider($inner, $spot);
+
+        $provider->placeOrder('BTCUSDT', OrderSide::BUY, OrderType::LIMIT, 1.0, options: ['client_order_id' => 'ctx-test']);
+
+        self::assertSame('bitmart', $inner->lastOptions['exchange']);
+        self::assertSame('spot', $inner->lastOptions['market_type']);
+        self::assertSame('ctx-test', $inner->lastOptions['client_order_id']);
+
+        $provider->getOrder('BTCUSDT', '123');
+        self::assertTrue($inner->lastContext?->equals($spot));
+    }
+}

--- a/trading-app/tests/Provider/ContextualOrderProviderTest.php
+++ b/trading-app/tests/Provider/ContextualOrderProviderTest.php
@@ -81,6 +81,8 @@ final class ContextualOrderProviderTest extends TestCase
         $spot = new ExchangeContext(Exchange::BITMART, MarketType::SPOT);
         $provider = new ContextualOrderProvider($inner, $spot);
 
+        self::assertSame($inner, $provider->innerOrderProvider());
+
         $provider->placeOrder('BTCUSDT', OrderSide::BUY, OrderType::LIMIT, 1.0, options: ['client_order_id' => 'ctx-test']);
 
         self::assertSame('bitmart', $inner->lastOptions['exchange']);

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Repository;
 use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Common\Enum\Timeframe;
+use App\Entity\FuturesOrder;
 use App\Entity\IndicatorSnapshot;
 use App\Entity\OrderIntent;
 use App\Entity\OrderProtection;
@@ -19,6 +20,8 @@ use App\Provider\Repository\KlineRepository;
 use App\Repository\IndicatorSnapshotRepository;
 use App\Repository\OrderIntentRepository;
 use App\Repository\PositionRepository;
+use App\Trading\Storage\FuturesOrderOrderStateRepository;
+use App\Trading\Storage\PositionPositionStateRepository;
 use Brick\Math\BigDecimal;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -44,6 +47,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
             fn (string $class) => $this->em->getClassMetadata($class),
             [
                 Contract::class,
+                FuturesOrder::class,
                 Kline::class,
                 Position::class,
                 OrderIntent::class,
@@ -64,6 +68,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
                 fn (string $class) => $this->em->getClassMetadata($class),
                 [
                     Contract::class,
+                    FuturesOrder::class,
                     Kline::class,
                     Position::class,
                     OrderIntent::class,
@@ -180,6 +185,44 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         self::assertSame('binance', $intentRepository->findOneByClientOrderId('shared-client', $binanceContext)?->getExchange());
     }
 
+    public function testTradingStateReadsCanSelectExplicitExchangeContext(): void
+    {
+        $this->em->persist(
+            (new Position('ETHUSDT', 'LONG'))
+                ->setSize('1')
+                ->setAvgEntryPrice('100')
+                ->setUnrealizedPnl('0')
+        );
+        $this->em->persist(
+            (new Position('ETHUSDT', 'LONG', Exchange::BINANCE, MarketType::PERPETUAL))
+                ->setSize('2')
+                ->setAvgEntryPrice('200')
+                ->setUnrealizedPnl('0')
+                ->mergePayload(['exchange' => 'binance', 'market_type' => 'perpetual'])
+        );
+        $this->em->persist($this->newFuturesOrder('bitmart', 'shared-order', '1'));
+        $this->em->persist($this->newFuturesOrder('binance', 'shared-order', '2'));
+        $this->em->flush();
+
+        $binanceContext = new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL);
+        $positionState = new PositionPositionStateRepository(
+            $this->em->getRepository(Position::class),
+            $this->em,
+        );
+        $orderState = new FuturesOrderOrderStateRepository(
+            $this->em->getRepository(FuturesOrder::class),
+            $this->em,
+        );
+
+        self::assertSame('1', $positionState->findLocalOpenPosition('ETHUSDT', 'LONG')?->size->__toString());
+        self::assertSame('2', $positionState->findLocalOpenPosition('ETHUSDT', 'LONG', $binanceContext)?->size->__toString());
+        self::assertCount(1, $positionState->findLocalOpenPositions(['ETHUSDT'], $binanceContext));
+
+        self::assertSame('1', $orderState->findLocalOrder('ETHUSDT', 'shared-order')?->quantity->__toString());
+        self::assertSame('2', $orderState->findLocalOrder('ETHUSDT', 'shared-order', $binanceContext)?->quantity->__toString());
+        self::assertCount(1, $orderState->findLocalOpenOrders(['ETHUSDT'], $binanceContext));
+    }
+
     private function newKline(string $exchange, string $close, \DateTimeImmutable $openTime): Kline
     {
         return (new Kline())
@@ -225,5 +268,22 @@ final class ExchangeScopedStorageTest extends KernelTestCase
             ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
             ->setQuantization([])
             ->setStatus(OrderIntent::STATUS_DRAFT);
+    }
+
+    private function newFuturesOrder(string $exchange, string $orderId, string $size): FuturesOrder
+    {
+        return (new FuturesOrder())
+            ->setExchange($exchange)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('ETHUSDT')
+            ->setOrderId($orderId)
+            ->setClientOrderId($exchange . '-client')
+            ->setStatus('new')
+            ->setSide(1)
+            ->setType('market')
+            ->setPrice('100')
+            ->setSize((int) $size)
+            ->setFilledSize(0)
+            ->setRawData(['exchange' => $exchange, 'market_type' => 'perpetual']);
     }
 }

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Repository;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\Timeframe;
+use App\Entity\IndicatorSnapshot;
+use App\Entity\OrderIntent;
+use App\Entity\OrderProtection;
+use App\Entity\Position;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Entity\Contract;
+use App\Provider\Entity\Kline;
+use App\Provider\Repository\ContractRepository;
+use App\Provider\Repository\KlineRepository;
+use App\Repository\IndicatorSnapshotRepository;
+use App\Repository\OrderIntentRepository;
+use App\Repository\PositionRepository;
+use Brick\Math\BigDecimal;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversNothing]
+final class ExchangeScopedStorageTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadata = array_map(
+            fn (string $class) => $this->em->getClassMetadata($class),
+            [
+                Contract::class,
+                Kline::class,
+                Position::class,
+                OrderIntent::class,
+                OrderProtection::class,
+                IndicatorSnapshot::class,
+            ],
+        );
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            $metadata = array_map(
+                fn (string $class) => $this->em->getClassMetadata($class),
+                [
+                    Contract::class,
+                    Kline::class,
+                    Position::class,
+                    OrderIntent::class,
+                    OrderProtection::class,
+                    IndicatorSnapshot::class,
+                ],
+            );
+            (new SchemaTool($this->em))->dropSchema($metadata);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testContractRepositoryDefaultsToLegacyContextAndCanSelectAnotherExchange(): void
+    {
+        $bitmart = (new Contract())
+            ->setExchange(Exchange::BITMART)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setName('Bitmart BTC');
+
+        $binance = (new Contract())
+            ->setExchange(Exchange::BINANCE)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setName('Binance BTC');
+
+        $this->em->persist($bitmart);
+        $this->em->persist($binance);
+        $this->em->flush();
+
+        /** @var ContractRepository $repository */
+        $repository = $this->em->getRepository(Contract::class);
+
+        self::assertSame('Bitmart BTC', $repository->findBySymbol('BTCUSDT')?->getName());
+        self::assertSame(
+            'Binance BTC',
+            $repository->findBySymbol(
+                'BTCUSDT',
+                new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL),
+            )?->getName(),
+        );
+    }
+
+    public function testKlineRepositorySeparatesSameSymbolTimeframeAndOpenTime(): void
+    {
+        $openTime = new \DateTimeImmutable('2026-05-31 00:00:00', new \DateTimeZone('UTC'));
+
+        $this->em->persist($this->newKline('bitmart', '100', $openTime));
+        $this->em->persist($this->newKline('binance', '200', $openTime));
+        $this->em->flush();
+
+        /** @var KlineRepository $repository */
+        $repository = $this->em->getRepository(Kline::class);
+
+        self::assertSame('100.000000000000', $repository->getKlines('BTCUSDT', Timeframe::TF_1M, 1)[0]->getClosePrice()->__toString());
+        self::assertSame(
+            '200.000000000000',
+            $repository->getKlines(
+                'BTCUSDT',
+                Timeframe::TF_1M,
+                1,
+                new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL),
+            )[0]->getClosePrice()->__toString(),
+        );
+    }
+
+    public function testIndicatorSnapshotUpsertUsesExchangeAndMarketType(): void
+    {
+        $klineTime = new \DateTimeImmutable('2026-05-31 00:00:00', new \DateTimeZone('UTC'));
+
+        /** @var IndicatorSnapshotRepository $repository */
+        $repository = $this->em->getRepository(IndicatorSnapshot::class);
+
+        $repository->upsert($this->newSnapshot('bitmart', $klineTime, ['rsi' => 51]));
+        $repository->upsert(
+            $this->newSnapshot('binance', $klineTime, ['rsi' => 61]),
+            new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL),
+        );
+        $repository->upsert($this->newSnapshot('bitmart', $klineTime, ['rsi' => 52]));
+
+        self::assertSame(52, $repository->findLastBySymbolAndTimeframe('BTCUSDT', Timeframe::TF_1M)?->getValue('rsi'));
+        self::assertSame(
+            61,
+            $repository->findLastBySymbolAndTimeframe(
+                'BTCUSDT',
+                Timeframe::TF_1M,
+                new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL),
+            )?->getValue('rsi'),
+        );
+    }
+
+    public function testPositionAndOrderIntentRepositoriesFallbackToBitmartOnly(): void
+    {
+        $this->em->persist((new Position('BTCUSDT', 'LONG'))->setSize('1'));
+        $this->em->persist((new Position('BTCUSDT', 'LONG', Exchange::BINANCE, MarketType::PERPETUAL))->setSize('2'));
+
+        $bitmartIntent = $this->newIntent('bitmart', 'shared-client');
+        $binanceIntent = $this->newIntent('binance', 'shared-client');
+        $this->em->persist($bitmartIntent);
+        $this->em->persist($binanceIntent);
+        $this->em->flush();
+
+        /** @var PositionRepository $positionRepository */
+        $positionRepository = $this->em->getRepository(Position::class);
+        /** @var OrderIntentRepository $intentRepository */
+        $intentRepository = $this->em->getRepository(OrderIntent::class);
+        $binanceContext = new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL);
+
+        self::assertSame('1', $positionRepository->findOneBySymbolSide('BTCUSDT', 'LONG')?->getSize());
+        self::assertSame('2', $positionRepository->findOneBySymbolSide('BTCUSDT', 'LONG', $binanceContext)?->getSize());
+        self::assertSame('bitmart', $intentRepository->findOneByClientOrderId('shared-client')?->getExchange());
+        self::assertSame('binance', $intentRepository->findOneByClientOrderId('shared-client', $binanceContext)?->getExchange());
+    }
+
+    private function newKline(string $exchange, string $close, \DateTimeImmutable $openTime): Kline
+    {
+        return (new Kline())
+            ->setExchange($exchange)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setTimeframe(Timeframe::TF_1M)
+            ->setOpenTime($openTime)
+            ->setOpenPrice(BigDecimal::of('100'))
+            ->setHighPrice(BigDecimal::of('210'))
+            ->setLowPrice(BigDecimal::of('90'))
+            ->setClosePrice(BigDecimal::of($close))
+            ->setVolume(BigDecimal::of('1'));
+    }
+
+    /**
+     * @param array<string,mixed> $values
+     */
+    private function newSnapshot(string $exchange, \DateTimeImmutable $klineTime, array $values): IndicatorSnapshot
+    {
+        return (new IndicatorSnapshot())
+            ->setExchange($exchange)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setTimeframe(Timeframe::TF_1M)
+            ->setKlineTime($klineTime)
+            ->setValues($values);
+    }
+
+    private function newIntent(string $exchange, string $clientOrderId): OrderIntent
+    {
+        return (new OrderIntent())
+            ->setExchange($exchange)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setPrice('100')
+            ->setSize(1)
+            ->setClientOrderId($clientOrderId)
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setQuantization([])
+            ->setStatus(OrderIntent::STATUS_DRAFT);
+    }
+}

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -13,6 +13,8 @@ use App\Entity\MtfState;
 use App\Entity\OrderIntent;
 use App\Entity\OrderProtection;
 use App\Entity\Position;
+use App\MtfValidator\Entity\MtfAudit;
+use App\MtfValidator\Repository\MtfAuditRepository;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Entity\Contract;
 use App\Provider\Entity\Kline;
@@ -25,9 +27,11 @@ use App\Repository\PositionRepository;
 use App\Trading\Storage\FuturesOrderOrderStateRepository;
 use App\Trading\Storage\PositionPositionStateRepository;
 use Brick\Math\BigDecimal;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 #[CoversNothing]
@@ -56,6 +60,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
                 OrderProtection::class,
                 IndicatorSnapshot::class,
                 MtfState::class,
+                MtfAudit::class,
             ],
         );
 
@@ -78,6 +83,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
                     OrderProtection::class,
                     IndicatorSnapshot::class,
                     MtfState::class,
+                    MtfAudit::class,
                 ],
             );
             (new SchemaTool($this->em))->dropSchema($metadata);
@@ -247,6 +253,29 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         self::assertSame('short', $repository->getOrCreateForSymbol('BTCUSDT', $binanceContext)->get4hSide());
     }
 
+    public function testLatestValidationFailuresKeepFailedTimeframeAndExchangeScope(): void
+    {
+        if (!$this->em->getConnection()->getDatabasePlatform() instanceof PostgreSQLPlatform) {
+            self::markTestSkipped('MtfAuditRepository uses PostgreSQL-specific SQL.');
+        }
+
+        $openTime = new \DateTimeImmutable('2026-05-31 00:00:00', new \DateTimeZone('UTC'));
+        $this->em->persist($this->newMtfAudit('binance', '1M_VALIDATION_FAILED', $openTime, 'rsi_rejected'));
+        $this->em->flush();
+
+        /** @var MtfAuditRepository $repository */
+        $repository = $this->em->getRepository(MtfAudit::class);
+
+        $rows = $repository->getLatestValidationSuccessesPerSymbol('BTCUSDT', ['1m']);
+
+        self::assertCount(1, $rows);
+        self::assertSame('BTCUSDT', $rows[0]['symbol']);
+        self::assertSame('binance', $rows[0]['exchange']);
+        self::assertSame('perpetual', $rows[0]['market_type']);
+        self::assertSame('failed', $rows[0]['timeframes']['1m']['status']);
+        self::assertSame('rsi_rejected', $rows[0]['timeframes']['1m']['cause']);
+    }
+
     private function newKline(string $exchange, string $close, \DateTimeImmutable $openTime): Kline
     {
         return (new Kline())
@@ -309,5 +338,25 @@ final class ExchangeScopedStorageTest extends KernelTestCase
             ->setSize((int) $size)
             ->setFilledSize(0)
             ->setRawData(['exchange' => $exchange, 'market_type' => 'perpetual']);
+    }
+
+    private function newMtfAudit(
+        string $exchange,
+        string $step,
+        \DateTimeImmutable $candleOpenTs,
+        string $cause,
+    ): MtfAudit {
+        return (new MtfAudit())
+            ->setSymbol('BTCUSDT')
+            ->setRunId(Uuid::uuid4())
+            ->setStep($step)
+            ->setTimeframe(Timeframe::TF_1M)
+            ->setCandleOpenTs($candleOpenTs)
+            ->setCreatedAt($candleOpenTs->modify('+30 seconds'))
+            ->setCause($cause)
+            ->setDetails([
+                'exchange' => $exchange,
+                'market_type' => 'perpetual',
+            ]);
     }
 }

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -9,6 +9,7 @@ use App\Common\Enum\MarketType;
 use App\Common\Enum\Timeframe;
 use App\Entity\FuturesOrder;
 use App\Entity\IndicatorSnapshot;
+use App\Entity\MtfState;
 use App\Entity\OrderIntent;
 use App\Entity\OrderProtection;
 use App\Entity\Position;
@@ -18,6 +19,7 @@ use App\Provider\Entity\Kline;
 use App\Provider\Repository\ContractRepository;
 use App\Provider\Repository\KlineRepository;
 use App\Repository\IndicatorSnapshotRepository;
+use App\Repository\MtfStateRepository;
 use App\Repository\OrderIntentRepository;
 use App\Repository\PositionRepository;
 use App\Trading\Storage\FuturesOrderOrderStateRepository;
@@ -53,6 +55,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
                 OrderIntent::class,
                 OrderProtection::class,
                 IndicatorSnapshot::class,
+                MtfState::class,
             ],
         );
 
@@ -74,6 +77,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
                     OrderIntent::class,
                     OrderProtection::class,
                     IndicatorSnapshot::class,
+                    MtfState::class,
                 ],
             );
             (new SchemaTool($this->em))->dropSchema($metadata);
@@ -221,6 +225,26 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         self::assertSame('1', $orderState->findLocalOrder('ETHUSDT', 'shared-order')?->quantity->__toString());
         self::assertSame('2', $orderState->findLocalOrder('ETHUSDT', 'shared-order', $binanceContext)?->quantity->__toString());
         self::assertCount(1, $orderState->findLocalOpenOrders(['ETHUSDT'], $binanceContext));
+    }
+
+    public function testMtfStateRepositoryScopesStateByExchangeAndMarketType(): void
+    {
+        /** @var MtfStateRepository $repository */
+        $repository = $this->em->getRepository(MtfState::class);
+        $binanceContext = new ExchangeContext(Exchange::BINANCE, MarketType::PERPETUAL);
+
+        $bitmart = $repository->getOrCreateForSymbol('BTCUSDT');
+        $bitmart->set4hSide('long');
+
+        $binance = $repository->getOrCreateForSymbol('BTCUSDT', $binanceContext);
+        $binance->set4hSide('short');
+        $this->em->flush();
+
+        self::assertNotSame($bitmart->getId(), $binance->getId());
+        self::assertSame('bitmart', $repository->getOrCreateForSymbol('BTCUSDT')->getExchange());
+        self::assertSame('long', $repository->getOrCreateForSymbol('BTCUSDT')->get4hSide());
+        self::assertSame('binance', $repository->getOrCreateForSymbol('BTCUSDT', $binanceContext)->getExchange());
+        self::assertSame('short', $repository->getOrCreateForSymbol('BTCUSDT', $binanceContext)->get4hSide());
     }
 
     private function newKline(string $exchange, string $close, \DateTimeImmutable $openTime): Kline


### PR DESCRIPTION
Closes #80

## Summary
- Add exchange and market_type scoping to core storage entities, repositories, and order/position sync paths.
- Propagate exchange context through MTF runner requests, indicator projection messages, order intents, and persistence helpers.
- Add a PostgreSQL migration and update SQL helper routines so legacy Bitmart perpetual data remains the default while Binance/perpetual rows can coexist.
- Add repository integration tests covering context fallback and same-symbol separation across exchanges.

## Local review / validation
- git diff --cached --check
- PHP lint on changed PHP files
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- ./vendor/bin/phpunit tests/Repository/ExchangeScopedStorageTest.php tests/Exchange

## Known existing test noise
- ./vendor/bin/phpunit tests/Contract/MtfValidator/MtfValidatorInterfaceTest.php tests/MtfValidator/Service/Dto/DtoMapperTest.php still reports pre-existing failures/risky metadata outside this PR scope: one interface assertion, one DTO raw-key expectation, and missing coverage metadata.