### PR TITLE
[API-04] Enforce protected exchange execution

### DIFF
--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -14,6 +14,8 @@ use App\Contract\Provider\Dto\OrderDto;
 use App\Contract\Provider\Dto\PositionDto;
 use App\Contract\Provider\Dto\SymbolBidAskDto;
 use App\Contract\Provider\ExchangeProviderRegistryInterface;
+use App\Contract\Provider\OrderProviderDecoratorInterface;
+use App\Contract\Provider\OrderProviderInterface;
 use App\Exchange\Contract\ExchangeAdapterInterface;
 use App\Exchange\Dto\CancelOrderRequest;
 use App\Exchange\Dto\CancelOrderResult;
@@ -112,10 +114,19 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
 
     public function getOpenOrders(?string $symbol = null): array
     {
-        return array_values(array_map(
+        $orders = array_values(array_map(
             fn (OrderDto $order): ExchangeOrderDto => $this->mapOrder($order),
             $this->bundle()->order()->getOpenOrders($symbol),
         ));
+
+        foreach ($this->getPlanOrders($symbol) as $planOrder) {
+            $mapped = $this->mapPlanOrder($planOrder);
+            if ($mapped instanceof ExchangeOrderDto) {
+                $orders[] = $mapped;
+            }
+        }
+
+        return $orders;
     }
 
     public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
@@ -213,6 +224,117 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
     private function bundle(): \App\Provider\Registry\ExchangeProviderBundle
     {
         return $this->providerRegistry->get($this->context);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function getPlanOrders(?string $symbol): array
+    {
+        $orderProvider = $this->unwrapOrderProvider($this->bundle()->order());
+        if (!method_exists($orderProvider, 'getPlanOrders')) {
+            return [];
+        }
+
+        try {
+            /** @var array<int,array<string,mixed>> $planOrders */
+            $planOrders = $orderProvider->getPlanOrders($symbol);
+            return $planOrders;
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    private function unwrapOrderProvider(OrderProviderInterface $provider): OrderProviderInterface
+    {
+        while ($provider instanceof OrderProviderDecoratorInterface) {
+            $provider = $provider->innerOrderProvider();
+        }
+
+        return $provider;
+    }
+
+    /**
+     * @param array<string,mixed> $planOrder
+     */
+    private function mapPlanOrder(array $planOrder): ?ExchangeOrderDto
+    {
+        $orderId = $planOrder['plan_order_id'] ?? $planOrder['order_id'] ?? null;
+        $triggerPrice = $planOrder['trigger_price']
+            ?? $planOrder['preset_stop_loss_price']
+            ?? $planOrder['preset_take_profit_price']
+            ?? null;
+        if ($orderId === null || $triggerPrice === null || $triggerPrice === '') {
+            return null;
+        }
+
+        [$side, $positionSide] = $this->mapOrderSideFromMetadata(
+            new OrderDto(
+                orderId: (string) $orderId,
+                symbol: (string) ($planOrder['symbol'] ?? ''),
+                side: OrderSide::BUY,
+                type: OrderType::STOP,
+                status: ProviderOrderStatus::PENDING,
+                quantity: \Brick\Math\BigDecimal::of('0'),
+                price: null,
+                stopPrice: null,
+                filledQuantity: \Brick\Math\BigDecimal::of('0'),
+                remainingQuantity: \Brick\Math\BigDecimal::of('0'),
+                averagePrice: null,
+                createdAt: $this->clock->now(),
+            ),
+            $planOrder,
+        );
+        $quantity = $this->floatPlanOrderValue($planOrder, ['size', 'quantity', 'vol', 'volume']);
+
+        return new ExchangeOrderDto(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: strtoupper((string) ($planOrder['symbol'] ?? '')),
+            exchangeOrderId: (string) $orderId,
+            clientOrderId: isset($planOrder['client_order_id']) ? (string) $planOrder['client_order_id'] : null,
+            side: $side,
+            positionSide: $positionSide,
+            orderType: ExchangeOrderType::TRIGGER,
+            status: $this->mapPlanOrderStatus($planOrder['state'] ?? $planOrder['status'] ?? null),
+            quantity: $quantity,
+            filledQuantity: 0.0,
+            remainingQuantity: $quantity,
+            price: null,
+            averagePrice: null,
+            stopPrice: (float) $triggerPrice,
+            reduceOnly: true,
+            postOnly: false,
+            timeInForce: ExchangeTimeInForce::GTC,
+            createdAt: $this->clock->now(),
+            metadata: ['source' => 'bitmart_plan_order'] + $planOrder,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $planOrder
+     * @param string[] $keys
+     */
+    private function floatPlanOrderValue(array $planOrder, array $keys): float
+    {
+        foreach ($keys as $key) {
+            if (isset($planOrder[$key]) && is_numeric($planOrder[$key])) {
+                return (float) $planOrder[$key];
+            }
+        }
+
+        return 0.0;
+    }
+
+    private function mapPlanOrderStatus(mixed $state): ExchangeOrderStatus
+    {
+        return match ((int) $state) {
+            2 => ExchangeOrderStatus::PARTIALLY_FILLED,
+            3 => ExchangeOrderStatus::FILLED,
+            4 => ExchangeOrderStatus::CANCELLED,
+            5 => ExchangeOrderStatus::REJECTED,
+            default => ExchangeOrderStatus::PENDING,
+        };
     }
 
     /**

--- a/trading-app/src/MtfValidator/Command/MtfRunCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfRunCommand.php
@@ -869,12 +869,20 @@ class MtfRunCommand extends Command
         $io->definitionList(
             ['Total' => (string) $ordersCount['total']],
             ['Soumis (réels)' => (string) $ordersCount['submitted']],
+            ['En attente protection/fill' => (string) ($ordersCount['pending'] ?? 0)],
+            ['Protection échouée / emergency' => (string) ($ordersCount['protection_failed'] ?? 0)],
             ['Simulés (dry-run)' => (string) $ordersCount['simulated']],
         );
 
         $io->writeln('<comment>Détails des ordres:</comment>');
         foreach ($ordersPlaced as $order) {
-            $statusLabel = $order['status'] === 'submitted' ? '<fg=green>SOUMIS</>' : '<fg=yellow>SIMULÉ</>';
+            $statusLabel = match ($order['status']) {
+                'submitted', 'submitted_protected' => '<fg=green>SOUMIS</>',
+                'entry_submitted' => '<fg=cyan>EN ATTENTE</>',
+                'failed_unprotected_closed' => '<fg=red>FERMÉ URGENCE</>',
+                'critical_unprotected_position' => '<fg=red>CRITIQUE</>',
+                default => '<fg=yellow>SIMULÉ</>',
+            };
             $io->writeln(sprintf(
                 '  <info>%s</info> - %s',
                 $order['symbol'],

--- a/trading-app/src/MtfValidator/Service/Helper/OrdersExtractor.php
+++ b/trading-app/src/MtfValidator/Service/Helper/OrdersExtractor.php
@@ -10,7 +10,7 @@ namespace App\MtfValidator\Service\Helper;
 final class OrdersExtractor
 {
     /**
-     * Extrait tous les ordres placés (submitted et simulated) depuis les résultats MTF
+     * Extrait tous les ordres places depuis les resultats MTF.
      * 
      * @param array<string, array<string, mixed>> $results Résultats MTF par symbole
      * @return array<int, array{
@@ -47,8 +47,14 @@ final class OrdersExtractor
                 continue;
             }
 
-            // Inclure les ordres submitted et simulated
-            if (!in_array($status, ['submitted', 'simulated'], true)) {
+            if (!in_array($status, [
+                'submitted',
+                'submitted_protected',
+                'entry_submitted',
+                'failed_unprotected_closed',
+                'critical_unprotected_position',
+                'simulated',
+            ], true)) {
                 continue;
             }
 
@@ -81,7 +87,48 @@ final class OrdersExtractor
     public static function extractSubmittedOrders(array $results): array
     {
         $allOrders = self::extractPlacedOrders($results);
-        return array_filter($allOrders, fn($order) => $order['status'] === 'submitted');
+        return array_filter($allOrders, fn($order) => in_array($order['status'], ['submitted', 'submitted_protected'], true));
+    }
+
+    /**
+     * Extrait les entrees soumises mais pas encore protegees/fill.
+     *
+     * @param array<string, array<string, mixed>> $results Résultats MTF par symbole
+     * @return array<int, array{
+     *     symbol: string,
+     *     status: string,
+     *     client_order_id: ?string,
+     *     exchange_order_id: ?string,
+     *     decision_key: ?string,
+     *     raw: array
+     * }>
+     */
+    public static function extractPendingEntryOrders(array $results): array
+    {
+        $allOrders = self::extractPlacedOrders($results);
+        return array_filter($allOrders, fn($order) => $order['status'] === 'entry_submitted');
+    }
+
+    /**
+     * Extrait les entrees qui ont ete remplies puis fermees/alertees par le garde-fou protection.
+     *
+     * @param array<string, array<string, mixed>> $results Résultats MTF par symbole
+     * @return array<int, array{
+     *     symbol: string,
+     *     status: string,
+     *     client_order_id: ?string,
+     *     exchange_order_id: ?string,
+     *     decision_key: ?string,
+     *     raw: array
+     * }>
+     */
+    public static function extractProtectionFailureOrders(array $results): array
+    {
+        $allOrders = self::extractPlacedOrders($results);
+        return array_filter($allOrders, fn($order) => in_array($order['status'], [
+            'failed_unprotected_closed',
+            'critical_unprotected_position',
+        ], true));
     }
 
     /**
@@ -107,19 +154,22 @@ final class OrdersExtractor
      * Compte les ordres par statut
      * 
      * @param array<string, array<string, mixed>> $results Résultats MTF par symbole
-     * @return array{total: int, submitted: int, simulated: int}
+     * @return array{total: int, submitted: int, pending: int, protection_failed: int, simulated: int}
      */
     public static function countOrdersByStatus(array $results): array
     {
         $allOrders = self::extractPlacedOrders($results);
         $submitted = count(self::extractSubmittedOrders($results));
+        $pending = count(self::extractPendingEntryOrders($results));
+        $protectionFailed = count(self::extractProtectionFailureOrders($results));
         $simulated = count(self::extractSimulatedOrders($results));
 
         return [
             'total' => count($allOrders),
             'submitted' => $submitted,
+            'pending' => $pending,
+            'protection_failed' => $protectionFailed,
             'simulated' => $simulated,
         ];
     }
 }
-

--- a/trading-app/src/TradeEntry/Dto/ExecutionResult.php
+++ b/trading-app/src/TradeEntry/Dto/ExecutionResult.php
@@ -5,6 +5,15 @@ namespace App\TradeEntry\Dto;
 
 final class ExecutionResult
 {
+    public const STATUS_SUBMITTED = 'submitted';
+    public const STATUS_SUBMITTED_PROTECTED = 'submitted_protected';
+    public const STATUS_ENTRY_SUBMITTED = 'entry_submitted';
+    public const STATUS_FAILED_UNPROTECTED_CLOSED = 'failed_unprotected_closed';
+    public const STATUS_CRITICAL_UNPROTECTED_POSITION = 'critical_unprotected_position';
+    public const STATUS_SKIPPED = 'skipped';
+    public const STATUS_ERROR = 'error';
+    public const STATUS_SIMULATED = 'simulated';
+
     public function __construct(
         public readonly string $clientOrderId,
         public readonly ?string $exchangeOrderId,

--- a/trading-app/src/TradeEntry/Execution/EmergencyCloseResult.php
+++ b/trading-app/src/TradeEntry/Execution/EmergencyCloseResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\Execution;
+
+final readonly class EmergencyCloseResult
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $status,
+        public bool $closed,
+        public bool $critical,
+        public ?string $exchangeOrderId = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/TradeEntry/Execution/EmergencyCloseService.php
+++ b/trading-app/src/TradeEntry/Execution/EmergencyCloseService.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\Execution;
+
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\TradeEntry\Dto\ExecutionResult;
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+use App\TradeEntry\Service\TradeEntryMetricsService;
+use App\TradeEntry\Types\Side;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class EmergencyCloseService
+{
+    public function __construct(
+        private readonly TradeEntryMetricsService $metrics,
+        #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
+    ) {
+    }
+
+    public function closeUnprotectedPosition(
+        ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        string $parentClientOrderId,
+        ?string $decisionKey = null,
+    ): EmergencyCloseResult {
+        try {
+            $position = $this->findPosition($adapter, $plan);
+        } catch (\Throwable $e) {
+            return $this->criticalLookupFailure($plan, $decisionKey, 'emergency_close_position_lookup_failed', $e);
+        }
+
+        if (!$position instanceof ExchangePositionDto) {
+            $this->positionsLogger->info('protection.emergency_close.no_position', [
+                'symbol' => $plan->symbol,
+                'decision_key' => $decisionKey,
+                'reason' => 'no_open_position_after_protection_failure',
+            ]);
+
+            return new EmergencyCloseResult(
+                status: ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED,
+                closed: true,
+                critical: false,
+                metadata: ['reason' => 'no_open_position_after_protection_failure'],
+            );
+        }
+
+        $clientOrderId = $this->emergencyClientOrderId($parentClientOrderId);
+        $this->positionsLogger->critical('protection.emergency_close.submit', [
+            'symbol' => $plan->symbol,
+            'side' => $plan->side->value,
+            'quantity' => $position->size,
+            'client_order_id' => $clientOrderId,
+            'decision_key' => $decisionKey,
+            'reason' => 'emergency_close_no_sl',
+        ]);
+
+        try {
+            $result = $adapter->placeOrder(new PlaceOrderRequest(
+                exchange: $adapter->exchange(),
+                marketType: $adapter->marketType(),
+                symbol: $plan->symbol,
+                side: $this->exitOrderSide($plan->side),
+                positionSide: $this->positionSide($plan->side),
+                orderType: ExchangeOrderType::MARKET,
+                timeInForce: ExchangeTimeInForce::IOC,
+                quantity: $position->size,
+                price: null,
+                stopPrice: null,
+                reduceOnly: true,
+                postOnly: false,
+                leverage: $plan->leverage,
+                marginMode: $plan->openType,
+                clientOrderId: $clientOrderId,
+                metadata: [
+                    'decision_key' => $decisionKey,
+                    'reason' => 'emergency_close_no_sl',
+                    'parent_client_order_id' => $parentClientOrderId,
+                ],
+            ));
+        } catch (\Throwable $e) {
+            $this->metrics->incr('critical_unprotected_position');
+            $this->positionsLogger->critical('protection.emergency_close.exception', [
+                'symbol' => $plan->symbol,
+                'decision_key' => $decisionKey,
+                'error' => $e->getMessage(),
+                'reason' => 'critical_unprotected_position',
+            ]);
+
+            return new EmergencyCloseResult(
+                status: ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION,
+                closed: false,
+                critical: true,
+                metadata: ['reason' => 'emergency_close_exception', 'error' => $e->getMessage()],
+            );
+        }
+
+        $this->metrics->incr('emergency_close');
+
+        try {
+            $positionStillOpen = $this->findPosition($adapter, $plan) instanceof ExchangePositionDto;
+        } catch (\Throwable $e) {
+            return $this->criticalLookupFailure($plan, $decisionKey, 'emergency_close_verify_position_failed', $e, $result->exchangeOrderId);
+        }
+
+        if ($positionStillOpen) {
+            $this->metrics->incr('critical_unprotected_position');
+            $this->positionsLogger->critical('protection.emergency_close.critical', [
+                'symbol' => $plan->symbol,
+                'exchange_order_id' => $result->exchangeOrderId,
+                'status' => $result->status->value,
+                'accepted' => $result->accepted,
+                'position_still_open' => $positionStillOpen,
+                'decision_key' => $decisionKey,
+                'reason' => 'critical_unprotected_position',
+            ]);
+
+            return new EmergencyCloseResult(
+                status: ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION,
+                closed: false,
+                critical: true,
+                exchangeOrderId: $result->exchangeOrderId,
+                metadata: [
+                    'reason' => 'critical_unprotected_position',
+                    'close_status' => $result->status->value,
+                    'close_accepted' => $result->accepted,
+                    'position_still_open' => $positionStillOpen,
+                ],
+            );
+        }
+
+        $this->positionsLogger->critical('protection.emergency_close.closed', [
+            'symbol' => $plan->symbol,
+            'exchange_order_id' => $result->exchangeOrderId,
+            'decision_key' => $decisionKey,
+            'reason' => 'emergency_close_no_sl',
+        ]);
+
+        return new EmergencyCloseResult(
+            status: ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED,
+            closed: true,
+            critical: false,
+            exchangeOrderId: $result->exchangeOrderId,
+            metadata: [
+                'reason' => 'emergency_close_no_sl',
+                'close_status' => $result->status->value,
+            ],
+        );
+    }
+
+    private function findPosition(ExchangeAdapterInterface $adapter, OrderPlanModel $plan): ?ExchangePositionDto
+    {
+        $positionSide = $this->positionSide($plan->side);
+        foreach ($adapter->getOpenPositions($plan->symbol) as $position) {
+            if ($position->symbol === strtoupper($plan->symbol) && $position->side === $positionSide && $position->size > 0.0) {
+                return $position;
+            }
+        }
+
+        return null;
+    }
+
+    private function criticalLookupFailure(
+        OrderPlanModel $plan,
+        ?string $decisionKey,
+        string $reason,
+        \Throwable $e,
+        ?string $exchangeOrderId = null,
+    ): EmergencyCloseResult {
+        $this->metrics->incr('critical_unprotected_position');
+        $this->positionsLogger->critical('protection.emergency_close.position_lookup_failed', [
+            'symbol' => $plan->symbol,
+            'exchange_order_id' => $exchangeOrderId,
+            'decision_key' => $decisionKey,
+            'error' => $e->getMessage(),
+            'reason' => 'critical_unprotected_position',
+        ]);
+
+        return new EmergencyCloseResult(
+            status: ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION,
+            closed: false,
+            critical: true,
+            exchangeOrderId: $exchangeOrderId,
+            metadata: [
+                'reason' => $reason,
+                'error' => $e->getMessage(),
+            ],
+        );
+    }
+
+    private function emergencyClientOrderId(string $parentClientOrderId): string
+    {
+        return substr($parentClientOrderId, 0, 44) . '-emergency-close';
+    }
+
+    private function positionSide(Side $side): ExchangePositionSide
+    {
+        return $side === Side::Long ? ExchangePositionSide::LONG : ExchangePositionSide::SHORT;
+    }
+
+    private function exitOrderSide(Side $side): ExchangeOrderSide
+    {
+        return $side === Side::Long ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY;
+    }
+}

--- a/trading-app/src/TradeEntry/Execution/ExchangeExecutionService.php
+++ b/trading-app/src/TradeEntry/Execution/ExchangeExecutionService.php
@@ -1,0 +1,708 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\Execution;
+
+use App\Common\Enum\Exchange;
+use App\Config\TradeEntryConfigResolver;
+use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\CancelOrderResult;
+use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Provider\Context\ExchangeContext;
+use App\TradeEntry\Dto\ExecutionResult;
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+use App\TradeEntry\Policy\IdempotencyPolicy;
+use App\TradeEntry\Policy\OrderModePolicyInterface;
+use App\TradeEntry\Types\Side;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class ExchangeExecutionService
+{
+    public function __construct(
+        private readonly ExchangeAdapterRegistryInterface $adapters,
+        private readonly ProtectionEnforcer $protectionEnforcer,
+        private readonly IdempotencyPolicy $idempotency,
+        private readonly OrderModePolicyInterface $orderModePolicy,
+        private readonly TradeEntryConfigResolver $tradeEntryConfigResolver,
+        #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
+    ) {
+    }
+
+    public function execute(
+        OrderPlanModel $plan,
+        ?string $decisionKey = null,
+        ?string $mode = null,
+        ?string $executionTf = null,
+    ): ExecutionResult
+    {
+        $this->orderModePolicy->enforce($plan);
+        $plan = $this->applyTimeframeMultiplier($plan, $mode, $executionTf, $decisionKey);
+        if ($plan->size < 1) {
+            return $this->skipBelowMinimum($plan, $decisionKey, 'size_below_min', 'size', $plan->size, 1);
+        }
+        if ($plan->leverage < 1) {
+            return $this->skipBelowMinimum($plan, $decisionKey, 'leverage_below_min', 'leverage', $plan->leverage, 1);
+        }
+
+        $context = ExchangeContext::resolve($plan->exchangeContext);
+        $adapter = $this->adapters->get($context->exchange, $context->marketType);
+        $clientOrderId = $this->idempotency->newClientOrderId();
+        $capabilities = $adapter->capabilities();
+        if ($this->shouldRejectUnprotectableBitmartMarket($context, $plan, $capabilities)) {
+            $this->positionsLogger->error('exchange_execution.entry_rejected_unprotectable_market', [
+                'symbol' => $plan->symbol,
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+                'order_type' => $plan->orderType,
+                'client_order_id' => $clientOrderId,
+                'decision_key' => $decisionKey,
+                'reason' => 'bitmart_market_entry_without_protection_path',
+            ]);
+
+            return new ExecutionResult(
+                clientOrderId: $clientOrderId,
+                exchangeOrderId: null,
+                status: ExecutionResult::STATUS_ERROR,
+                raw: [
+                    'reason' => 'bitmart_market_entry_without_protection_path',
+                    'exchange' => $context->exchange->value,
+                    'market_type' => $context->marketType->value,
+                    'order_type' => $plan->orderType,
+                    'supports_trigger_orders' => $capabilities->supportsTriggerOrders,
+                    'supports_attached_stop_loss_on_entry' => $capabilities->supportsAttachedStopLossOnEntry,
+                ],
+            );
+        }
+        $attachedStopLossRequested = $capabilities->supportsAttachedStopLossOnEntry
+            && $plan->stop > 0.0
+            && !($context->exchange === Exchange::BITMART && $plan->orderType === 'market');
+        $attachedTakeProfitRequested = $attachedStopLossRequested
+            && $capabilities->supportsAttachedTakeProfitOnEntry
+            && $plan->takeProfit > 0.0;
+
+        $this->positionsLogger->info('exchange_execution.entry_submitted', [
+            'symbol' => $plan->symbol,
+            'exchange' => $context->exchange->value,
+            'market_type' => $context->marketType->value,
+            'order_type' => $plan->orderType,
+            'side' => $plan->side->value,
+            'client_order_id' => $clientOrderId,
+            'attached_stop_loss_requested' => $attachedStopLossRequested,
+            'attached_take_profit_requested' => $attachedTakeProfitRequested,
+            'decision_key' => $decisionKey,
+        ]);
+
+        $leverageSet = null;
+        if ($plan->leverage > 0 && ($capabilities->requiresSeparateLeverageSubmit || $capabilities->supportsPerSymbolLeverage)) {
+            $leverageSet = $adapter->setLeverage($plan->symbol, $plan->leverage, $plan->openType);
+        }
+
+        try {
+            $entryResult = $adapter->placeOrder($this->entryRequest(
+                plan: $plan,
+                context: $context,
+                clientOrderId: $clientOrderId,
+                attachStopLoss: $attachedStopLossRequested,
+                attachTakeProfit: $attachedTakeProfitRequested,
+                decisionKey: $decisionKey,
+            ));
+        } catch (\Throwable $e) {
+            $this->positionsLogger->error('exchange_execution.entry_submit_failed', [
+                'symbol' => $plan->symbol,
+                'client_order_id' => $clientOrderId,
+                'error' => $e->getMessage(),
+                'decision_key' => $decisionKey,
+            ]);
+
+            return new ExecutionResult(
+                clientOrderId: $clientOrderId,
+                exchangeOrderId: null,
+                status: ExecutionResult::STATUS_ERROR,
+                raw: [
+                    'reason' => 'entry_submit_failed',
+                    'error' => $e->getMessage(),
+                    'leverage_submit_success' => $leverageSet,
+                ],
+            );
+        }
+
+        if (!$entryResult->accepted || $entryResult->status === ExchangeOrderStatus::REJECTED) {
+            return new ExecutionResult(
+                clientOrderId: $clientOrderId,
+                exchangeOrderId: $entryResult->exchangeOrderId,
+                status: ExecutionResult::STATUS_ERROR,
+                raw: [
+                    'reason' => 'entry_rejected_exchange',
+                    'order' => $this->placeOrderResultPayload($entryResult),
+                    'leverage_submit_success' => $leverageSet,
+                ],
+            );
+        }
+
+        if (!$this->entryFilled($entryResult) && $this->entryActive($entryResult)) {
+            $cancel = $this->cancelEntryRemainder($adapter, $plan, $entryResult, $decisionKey);
+            if (($cancel['filled_after_cancel'] ?? false) === true) {
+                $protection = $this->protectionEnforcer->emergencyCloseAfterEntryRisk(
+                    adapter: $adapter,
+                    plan: $plan,
+                    entryClientOrderId: $clientOrderId,
+                    decisionKey: $decisionKey,
+                    reason: 'entry_filled_during_cancel_race',
+                    extra: ['cancel' => $cancel],
+                );
+
+                return $this->executionResultFromProtection(
+                    $clientOrderId,
+                    $entryResult,
+                    ($cancel['cancelled'] ?? false) === true
+                        ? $protection
+                        : $this->criticalResidualEntryRisk($protection, $plan, $entryResult, $decisionKey),
+                    $leverageSet,
+                );
+            }
+            $status = ($cancel['cancelled'] ?? false) === true
+                ? ExecutionResult::STATUS_ERROR
+                : ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION;
+
+            return new ExecutionResult(
+                clientOrderId: $clientOrderId,
+                exchangeOrderId: $entryResult->exchangeOrderId,
+                status: $status,
+                raw: [
+                    'reason' => ($cancel['cancelled'] ?? false) === true
+                        ? 'entry_pending_cancelled_without_fill'
+                        : 'entry_pending_cancel_failed',
+                    'order' => $this->placeOrderResultPayload($entryResult),
+                    'cancel' => $cancel,
+                    'leverage_submit_success' => $leverageSet,
+                ],
+            );
+        }
+
+        if (!$this->entryFilled($entryResult)) {
+            return new ExecutionResult(
+                clientOrderId: $clientOrderId,
+                exchangeOrderId: $entryResult->exchangeOrderId,
+                status: ExecutionResult::STATUS_ERROR,
+                raw: [
+                    'reason' => 'entry_closed_without_fill',
+                    'order' => $this->placeOrderResultPayload($entryResult),
+                    'leverage_submit_success' => $leverageSet,
+                ],
+            );
+        }
+
+        $this->positionsLogger->info('exchange_execution.entry_filled', [
+            'symbol' => $plan->symbol,
+            'exchange_order_id' => $entryResult->exchangeOrderId,
+            'client_order_id' => $clientOrderId,
+            'status' => $entryResult->status->value,
+            'decision_key' => $decisionKey,
+        ]);
+
+        if ($entryResult->status === ExchangeOrderStatus::PARTIALLY_FILLED && $this->entryHasResidual($entryResult)) {
+            $cancel = $this->cancelEntryRemainder($adapter, $plan, $entryResult, $decisionKey);
+            if (($cancel['cancelled'] ?? false) !== true) {
+                $protection = $this->protectionEnforcer->emergencyCloseAfterEntryRisk(
+                    adapter: $adapter,
+                    plan: $plan,
+                    entryClientOrderId: $clientOrderId,
+                    decisionKey: $decisionKey,
+                    reason: 'partial_entry_remainder_cancel_failed',
+                    extra: ['cancel' => $cancel],
+                );
+
+                return $this->executionResultFromProtection(
+                    $clientOrderId,
+                    $entryResult,
+                    $this->criticalResidualEntryRisk($protection, $plan, $entryResult, $decisionKey),
+                    $leverageSet,
+                );
+            }
+        }
+
+        $protection = $this->protectionEnforcer->enforceAfterEntryFill(
+            adapter: $adapter,
+            plan: $plan,
+            entryResult: $entryResult,
+            entryClientOrderId: $clientOrderId,
+            attachedProtectionRequested: $attachedStopLossRequested,
+            decisionKey: $decisionKey,
+        );
+
+        return $this->executionResultFromProtection($clientOrderId, $entryResult, $protection, $leverageSet);
+    }
+
+    private function executionResultFromProtection(
+        string $clientOrderId,
+        PlaceOrderResult $entryResult,
+        ProtectionEnforcementResult $protection,
+        ?bool $leverageSet,
+    ): ExecutionResult {
+        return new ExecutionResult(
+            clientOrderId: $clientOrderId,
+            exchangeOrderId: $entryResult->exchangeOrderId,
+            status: $protection->status,
+            raw: [
+                'leverage_submit_success' => $leverageSet,
+                'order' => $this->placeOrderResultPayload($entryResult),
+                'protection' => [
+                    'protected' => $protection->protected,
+                    'protection_order_id' => $protection->protectionOrderId,
+                    'emergency_order_id' => $protection->emergencyOrderId,
+                ] + $protection->metadata,
+            ],
+        );
+    }
+
+    private function entryRequest(
+        OrderPlanModel $plan,
+        ExchangeContext $context,
+        string $clientOrderId,
+        bool $attachStopLoss,
+        bool $attachTakeProfit,
+        ?string $decisionKey,
+    ): PlaceOrderRequest {
+        $orderType = $plan->orderType === 'market' ? ExchangeOrderType::MARKET : ExchangeOrderType::LIMIT;
+
+        return new PlaceOrderRequest(
+            exchange: $context->exchange,
+            marketType: $context->marketType,
+            symbol: $plan->symbol,
+            side: $this->entryOrderSide($plan->side),
+            positionSide: $this->positionSide($plan->side),
+            orderType: $orderType,
+            timeInForce: $this->timeInForce($plan),
+            quantity: (float) $plan->size,
+            price: $orderType === ExchangeOrderType::LIMIT ? $plan->entry : null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: $plan->orderType !== 'market' && $plan->orderMode === 4,
+            leverage: $plan->leverage,
+            marginMode: $plan->openType,
+            clientOrderId: $clientOrderId,
+            attachedStopLossPrice: $attachStopLoss ? $plan->stop : null,
+            attachedTakeProfitPrice: $attachTakeProfit ? $plan->takeProfit : null,
+            metadata: [
+                'decision_key' => $decisionKey,
+                'source' => 'exchange_execution_service',
+            ],
+        );
+    }
+
+    private function shouldRejectUnprotectableBitmartMarket(
+        ExchangeContext $context,
+        OrderPlanModel $plan,
+        ExchangeCapabilities $capabilities,
+    ): bool {
+        return $context->exchange === Exchange::BITMART
+            && $plan->orderType === 'market'
+            && $plan->stop > 0.0
+            && !$capabilities->supportsTriggerOrders;
+    }
+
+    private function skipBelowMinimum(
+        OrderPlanModel $plan,
+        ?string $decisionKey,
+        string $reason,
+        string $field,
+        int $value,
+        int $minRequired,
+    ): ExecutionResult {
+        $clientOrderId = $this->idempotency->newClientOrderId();
+        $this->positionsLogger->warning('exchange_execution.' . $reason, [
+            'symbol' => $plan->symbol,
+            $field => $value,
+            'min_required' => $minRequired,
+            'decision_key' => $decisionKey,
+            'client_order_id' => $clientOrderId,
+        ]);
+
+        return new ExecutionResult(
+            clientOrderId: $clientOrderId,
+            exchangeOrderId: null,
+            status: ExecutionResult::STATUS_SKIPPED,
+            raw: [
+                'reason' => $reason,
+                $field => $value,
+                'min_required' => $minRequired,
+            ],
+        );
+    }
+
+    private function entryFilled(PlaceOrderResult $result): bool
+    {
+        return \in_array($result->status, [
+            ExchangeOrderStatus::FILLED,
+            ExchangeOrderStatus::PARTIALLY_FILLED,
+        ], true);
+    }
+
+    private function entryActive(PlaceOrderResult $result): bool
+    {
+        return \in_array($result->status, [
+            ExchangeOrderStatus::PENDING,
+            ExchangeOrderStatus::OPEN,
+        ], true);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function cancelEntryRemainder(
+        \App\Exchange\Contract\ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        PlaceOrderResult $entryResult,
+        ?string $decisionKey,
+    ): array {
+        if ($entryResult->exchangeOrderId === null) {
+            return ['cancelled' => false, 'reason' => 'entry_exchange_order_id_missing'];
+        }
+
+        try {
+            $cancel = $adapter->cancelOrder(new CancelOrderRequest(
+                exchange: $adapter->exchange(),
+                marketType: $adapter->marketType(),
+                symbol: $plan->symbol,
+                exchangeOrderId: $entryResult->exchangeOrderId,
+                clientOrderId: $entryResult->clientOrderId,
+            ));
+        } catch (\Throwable $e) {
+            $this->positionsLogger->critical('exchange_execution.entry_cancel_exception', [
+                'symbol' => $plan->symbol,
+                'exchange_order_id' => $entryResult->exchangeOrderId,
+                'decision_key' => $decisionKey,
+                'error' => $e->getMessage(),
+            ]);
+
+            return ['cancelled' => false, 'reason' => 'entry_cancel_exception', 'error' => $e->getMessage()];
+        }
+
+        try {
+            $cancelState = $this->entryCancelState($adapter, $plan, $entryResult, $cancel);
+        } catch (\Throwable $e) {
+            $this->positionsLogger->critical('exchange_execution.entry_cancel_verification_exception', [
+                'symbol' => $plan->symbol,
+                'exchange_order_id' => $entryResult->exchangeOrderId,
+                'cancelled' => $cancel->cancelled,
+                'cancel_status' => $cancel->status->value,
+                'decision_key' => $decisionKey,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [
+                'cancelled' => false,
+                'reason' => 'entry_cancel_verification_exception',
+                'cancel_status' => $cancel->status->value,
+                'cancel_exchange_order_id' => $cancel->exchangeOrderId,
+                'cancel_metadata' => $cancel->metadata,
+                'error' => $e->getMessage(),
+            ];
+        }
+        $cancelled = $cancelState['remainder_inactive'];
+        $this->positionsLogger->info($cancelled ? 'exchange_execution.entry_remainder_cancelled' : 'exchange_execution.entry_remainder_cancel_failed', [
+            'symbol' => $plan->symbol,
+            'exchange_order_id' => $entryResult->exchangeOrderId,
+            'cancelled' => $cancel->cancelled,
+            'cancel_status' => $cancel->status->value,
+            'decision_key' => $decisionKey,
+            'filled_after_cancel' => $cancelState['filled_after_cancel'],
+        ]);
+
+        return [
+            'cancelled' => $cancelled,
+            'filled_after_cancel' => $cancelState['filled_after_cancel'],
+            'post_cancel_order_status' => $cancelState['order_status'],
+            'post_cancel_filled_quantity' => $cancelState['filled_quantity'],
+            'post_cancel_remaining_quantity' => $cancelState['remaining_quantity'],
+            'post_cancel_position_size' => $cancelState['position_size'],
+            'cancel_status' => $cancel->status->value,
+            'cancel_exchange_order_id' => $cancel->exchangeOrderId,
+            'cancel_metadata' => $cancel->metadata,
+        ];
+    }
+
+    /**
+     * @return array{remainder_inactive: bool, filled_after_cancel: bool, order_status: ?string, filled_quantity: ?float, remaining_quantity: ?float, position_size: ?float}
+     */
+    private function entryCancelState(
+        \App\Exchange\Contract\ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        PlaceOrderResult $entryResult,
+        CancelOrderResult $cancel,
+    ): array {
+        $order = null;
+        if ($entryResult->exchangeOrderId === null) {
+            return [
+                'remainder_inactive' => $cancel->cancelled,
+                'filled_after_cancel' => $this->positionSize($adapter, $plan) > 0.00000001,
+                'order_status' => null,
+                'filled_quantity' => null,
+                'remaining_quantity' => null,
+                'position_size' => $this->positionSize($adapter, $plan),
+            ];
+        }
+
+        $order = $adapter->getOrder($plan->symbol, $entryResult->exchangeOrderId);
+        $positionSize = $this->positionSize($adapter, $plan);
+        if ($order === null) {
+            return [
+                'remainder_inactive' => $cancel->cancelled,
+                'filled_after_cancel' => $positionSize > 0.00000001,
+                'order_status' => null,
+                'filled_quantity' => null,
+                'remaining_quantity' => null,
+                'position_size' => $positionSize,
+            ];
+        }
+
+        $remainderInactive = !$this->activeOrderStatus($order->status)
+            || $order->remainingQuantity <= 0.00000001;
+
+        return [
+            'remainder_inactive' => $remainderInactive,
+            'filled_after_cancel' => $order->filledQuantity > 0.00000001 || $positionSize > 0.00000001,
+            'order_status' => $order->status->value,
+            'filled_quantity' => $order->filledQuantity,
+            'remaining_quantity' => $order->remainingQuantity,
+            'position_size' => $positionSize,
+        ];
+    }
+
+    private function positionSize(
+        \App\Exchange\Contract\ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+    ): float {
+        foreach ($adapter->getOpenPositions($plan->symbol) as $position) {
+            if ($position instanceof ExchangePositionDto && $position->side === $this->positionSide($plan->side)) {
+                return max(0.0, $position->size);
+            }
+        }
+
+        return 0.0;
+    }
+
+    private function activeOrderStatus(ExchangeOrderStatus $status): bool
+    {
+        return \in_array($status, [
+            ExchangeOrderStatus::PENDING,
+            ExchangeOrderStatus::OPEN,
+            ExchangeOrderStatus::PARTIALLY_FILLED,
+        ], true);
+    }
+
+    private function criticalResidualEntryRisk(
+        ProtectionEnforcementResult $protection,
+        OrderPlanModel $plan,
+        PlaceOrderResult $entryResult,
+        ?string $decisionKey,
+    ): ProtectionEnforcementResult {
+        if ($protection->status === ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION) {
+            return $protection;
+        }
+
+        $this->positionsLogger->critical('exchange_execution.entry_remainder_cancel_unconfirmed', [
+            'symbol' => $plan->symbol,
+            'exchange_order_id' => $entryResult->exchangeOrderId,
+            'decision_key' => $decisionKey,
+            'reason' => 'entry_remainder_cancel_unconfirmed',
+        ]);
+
+        return new ProtectionEnforcementResult(
+            status: ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION,
+            protected: false,
+            protectionOrderId: $protection->protectionOrderId,
+            emergencyOrderId: $protection->emergencyOrderId,
+            metadata: [
+                'residual_entry_risk' => true,
+                'critical_reason' => 'entry_remainder_cancel_unconfirmed',
+            ] + $protection->metadata,
+        );
+    }
+
+    private function entryHasResidual(PlaceOrderResult $entryResult): bool
+    {
+        return $entryResult->order === null || $entryResult->order->remainingQuantity > 0.00000001;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function placeOrderResultPayload(PlaceOrderResult $result): array
+    {
+        return [
+            'accepted' => $result->accepted,
+            'symbol' => $result->symbol,
+            'client_order_id' => $result->clientOrderId,
+            'exchange_order_id' => $result->exchangeOrderId,
+            'status' => $result->status->value,
+            'metadata' => $result->metadata,
+            'order' => $result->order !== null ? [
+                'status' => $result->order->status->value,
+                'filled_quantity' => $result->order->filledQuantity,
+                'remaining_quantity' => $result->order->remainingQuantity,
+                'average_price' => $result->order->averagePrice,
+                'metadata' => $result->order->metadata,
+            ] : null,
+        ];
+    }
+
+    private function timeInForce(OrderPlanModel $plan): ExchangeTimeInForce
+    {
+        if ($plan->orderType === 'market') {
+            return ExchangeTimeInForce::IOC;
+        }
+
+        return match ($plan->orderMode) {
+            2 => ExchangeTimeInForce::FOK,
+            3 => ExchangeTimeInForce::IOC,
+            default => ExchangeTimeInForce::GTC,
+        };
+    }
+
+    private function positionSide(Side $side): ExchangePositionSide
+    {
+        return $side === Side::Long ? ExchangePositionSide::LONG : ExchangePositionSide::SHORT;
+    }
+
+    private function entryOrderSide(Side $side): ExchangeOrderSide
+    {
+        return $side === Side::Long ? ExchangeOrderSide::BUY : ExchangeOrderSide::SELL;
+    }
+
+    private function applyTimeframeMultiplier(
+        OrderPlanModel $plan,
+        ?string $mode,
+        ?string $executionTf,
+        ?string $decisionKey,
+    ): OrderPlanModel {
+        $tfKey = '5m';
+        if (is_string($executionTf) && trim($executionTf) !== '') {
+            $tfKey = strtolower(trim($executionTf));
+        }
+
+        try {
+            $config = $this->tradeEntryConfigResolver->resolve($mode);
+        } catch (\Throwable $e) {
+            $this->positionsLogger->warning('exchange_execution.timeframe_multiplier.resolve_failed', [
+                'mode' => $mode,
+                'execution_tf' => $tfKey,
+                'error' => $e->getMessage(),
+                'decision_key' => $decisionKey,
+            ]);
+
+            return $plan;
+        }
+
+        $defaults = $config->getDefaults();
+        $leverageCfg = $config->getLeverage();
+        $multipliers = $leverageCfg['timeframe_multipliers'] ?? [];
+        if (!\is_array($multipliers)) {
+            $multipliers = [];
+        }
+
+        $tfMultiplier = (float)($multipliers[$tfKey] ?? 1.0);
+        if (!\is_finite($tfMultiplier) || $tfMultiplier <= 0.0) {
+            $tfMultiplier = 1.0;
+        }
+
+        $effectiveMultiplier = $tfMultiplier;
+        $maxLossPct = $this->normalizedPositivePct($leverageCfg['max_loss_pct'] ?? null);
+        $maxLossUsdt = null;
+        $maxSizeAllowed = null;
+        if ($maxLossPct !== null) {
+            $capital = (float)($defaults['initial_margin_usdt'] ?? 0.0);
+            $riskPerContract = abs($plan->entry - $plan->stop) * $plan->contractSize;
+            if ($capital > 0.0 && $riskPerContract > 0.0) {
+                $maxLossUsdt = $capital * $maxLossPct;
+                $maxSizeAllowed = (int)floor($maxLossUsdt / $riskPerContract);
+                if ($maxSizeAllowed > 0) {
+                    $maxMultiplier = $maxSizeAllowed / max(1.0, (float)$plan->size);
+                    $effectiveMultiplier = \is_finite($maxMultiplier) && $maxMultiplier > 0.0
+                        ? min($effectiveMultiplier, $maxMultiplier)
+                        : 0.0;
+                } else {
+                    $effectiveMultiplier = 0.0;
+                }
+            }
+        }
+
+        $scaledSize = max(0, (int)floor($plan->size * $effectiveMultiplier));
+        $scaledLeverageRaw = $plan->leverage * $effectiveMultiplier;
+        $roundMode = strtolower((string)($leverageCfg['rounding']['mode'] ?? 'ceil'));
+        $scaledLeverage = match ($roundMode) {
+            'floor' => (int)floor($scaledLeverageRaw),
+            'round' => (int)round($scaledLeverageRaw),
+            default => (int)ceil($scaledLeverageRaw),
+        };
+
+        $scaledLeverage = max(0, $scaledLeverage);
+        if ($scaledLeverage < 1 && $scaledSize > 0) {
+            $scaledLeverage = 1;
+        }
+
+        $floorCfg = isset($leverageCfg['floor']) ? (float)$leverageCfg['floor'] : null;
+        if ($floorCfg !== null && \is_finite($floorCfg) && $floorCfg > 0.0) {
+            $scaledLeverage = max($scaledLeverage, (int)ceil($floorCfg));
+        }
+
+        if ($tfMultiplier === 1.0) {
+            $exchangeCapCfg = isset($leverageCfg['exchange_cap']) ? (float)$leverageCfg['exchange_cap'] : null;
+            if ($exchangeCapCfg !== null && \is_finite($exchangeCapCfg) && $exchangeCapCfg > 0.0) {
+                $scaledLeverage = min($scaledLeverage, (int)floor($exchangeCapCfg));
+            }
+        }
+
+        $multiplierCapped = abs($effectiveMultiplier - $tfMultiplier) > 1e-9;
+        if ($scaledSize === $plan->size && $scaledLeverage === $plan->leverage && !$multiplierCapped) {
+            return $plan;
+        }
+
+        $this->positionsLogger->debug('exchange_execution.timeframe_multiplier_applied', [
+            'symbol' => $plan->symbol,
+            'execution_tf' => $tfKey,
+            'tf_multiplier' => $tfMultiplier,
+            'effective_multiplier' => $effectiveMultiplier,
+            'max_loss_pct' => $maxLossPct,
+            'max_loss_usdt' => $maxLossUsdt,
+            'risk_per_contract' => abs($plan->entry - $plan->stop) * $plan->contractSize,
+            'max_size_allowed' => $maxSizeAllowed,
+            'base_size' => $plan->size,
+            'scaled_size' => $scaledSize,
+            'base_leverage' => $plan->leverage,
+            'scaled_leverage' => $scaledLeverage,
+            'mode' => $mode,
+            'decision_key' => $decisionKey,
+        ]);
+
+        return $plan->copyWith(size: $scaledSize, leverage: $scaledLeverage);
+    }
+
+    private function normalizedPositivePct(mixed $value): ?float
+    {
+        if ($value === null || !is_numeric($value)) {
+            return null;
+        }
+
+        $pct = (float)$value;
+        if (!\is_finite($pct)) {
+            return null;
+        }
+        if ($pct > 1.0) {
+            $pct *= 0.01;
+        }
+
+        return $pct > 0.0 ? $pct : null;
+    }
+}

--- a/trading-app/src/TradeEntry/Execution/ProtectionEnforcementResult.php
+++ b/trading-app/src/TradeEntry/Execution/ProtectionEnforcementResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\Execution;
+
+final readonly class ProtectionEnforcementResult
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $status,
+        public bool $protected,
+        public ?string $protectionOrderId = null,
+        public ?string $emergencyOrderId = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/TradeEntry/Execution/ProtectionEnforcer.php
+++ b/trading-app/src/TradeEntry/Execution/ProtectionEnforcer.php
@@ -1,0 +1,447 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\Execution;
+
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\TradeEntry\Dto\ExecutionResult;
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+use App\TradeEntry\Service\TradeEntryMetricsService;
+use App\TradeEntry\Types\Side;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class ProtectionEnforcer
+{
+    public function __construct(
+        private readonly EmergencyCloseService $emergencyClose,
+        private readonly TradeEntryMetricsService $metrics,
+        #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
+    ) {
+    }
+
+    public function enforceAfterEntryFill(
+        ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        PlaceOrderResult $entryResult,
+        string $entryClientOrderId,
+        bool $attachedProtectionRequested,
+        ?string $decisionKey = null,
+    ): ProtectionEnforcementResult {
+        if (!$this->entryFilled($entryResult)) {
+            return new ProtectionEnforcementResult(
+                status: ExecutionResult::STATUS_ENTRY_SUBMITTED,
+                protected: false,
+                metadata: [
+                    'reason' => 'entry_not_filled_yet',
+                    'entry_status' => $entryResult->status->value,
+                ],
+            );
+        }
+
+        if ($attachedProtectionRequested) {
+            try {
+                $confirmed = $this->findConfirmedStopLoss($adapter, $plan);
+            } catch (\Throwable $e) {
+                return $this->failAndEmergencyClose(
+                    adapter: $adapter,
+                    plan: $plan,
+                    entryClientOrderId: $entryClientOrderId,
+                    decisionKey: $decisionKey,
+                    reason: 'protection_confirmation_failed',
+                    extra: ['error' => $e->getMessage()],
+                );
+            }
+            if ($confirmed instanceof ExchangeOrderDto) {
+                return $this->confirmed($confirmed, 'attached', $decisionKey);
+            }
+
+            return $this->failAndEmergencyClose(
+                adapter: $adapter,
+                plan: $plan,
+                entryClientOrderId: $entryClientOrderId,
+                decisionKey: $decisionKey,
+                reason: 'attached_stop_loss_not_confirmed',
+            );
+        }
+
+        $capabilities = $adapter->capabilities();
+        if (!$capabilities->supportsReduceOnly || !$capabilities->supportsTriggerOrders) {
+            return $this->failAndEmergencyClose(
+                adapter: $adapter,
+                plan: $plan,
+                entryClientOrderId: $entryClientOrderId,
+                decisionKey: $decisionKey,
+                reason: 'separate_stop_loss_not_supported',
+            );
+        }
+
+        try {
+            $stopResult = $adapter->placeOrder(new PlaceOrderRequest(
+                exchange: $adapter->exchange(),
+                marketType: $adapter->marketType(),
+                symbol: $plan->symbol,
+                side: $this->exitOrderSide($plan->side),
+                positionSide: $this->positionSide($plan->side),
+                orderType: ExchangeOrderType::STOP_LOSS,
+                timeInForce: ExchangeTimeInForce::GTC,
+                quantity: $this->requiredProtectionQuantity($adapter, $plan, $entryResult),
+                price: null,
+                stopPrice: $plan->stop,
+                reduceOnly: true,
+                postOnly: false,
+                leverage: $plan->leverage,
+                marginMode: $plan->openType,
+                clientOrderId: $this->stopLossClientOrderId($entryClientOrderId),
+                metadata: [
+                    'decision_key' => $decisionKey,
+                    'protection_mode' => 'separate_reduce_only_stop',
+                    'parent_exchange_order_id' => $entryResult->exchangeOrderId,
+                    'parent_client_order_id' => $entryClientOrderId,
+                ],
+            ));
+        } catch (\Throwable $e) {
+            return $this->failAndEmergencyClose(
+                adapter: $adapter,
+                plan: $plan,
+                entryClientOrderId: $entryClientOrderId,
+                decisionKey: $decisionKey,
+                reason: 'separate_stop_loss_submit_exception',
+                extra: ['error' => $e->getMessage()],
+            );
+        }
+
+        if (!$stopResult->accepted || !$this->activeOrderStatus($stopResult->status)) {
+            return $this->failAndEmergencyClose(
+                adapter: $adapter,
+                plan: $plan,
+                entryClientOrderId: $entryClientOrderId,
+                decisionKey: $decisionKey,
+                reason: 'separate_stop_loss_rejected',
+                extra: [
+                    'protection_status' => $stopResult->status->value,
+                    'protection_order_id' => $stopResult->exchangeOrderId,
+                ],
+            );
+        }
+
+        try {
+            $confirmed = $this->findConfirmedStopLoss($adapter, $plan);
+        } catch (\Throwable $e) {
+            return $this->failAndEmergencyClose(
+                adapter: $adapter,
+                plan: $plan,
+                entryClientOrderId: $entryClientOrderId,
+                decisionKey: $decisionKey,
+                reason: 'protection_confirmation_failed',
+                extra: ['error' => $e->getMessage()],
+            );
+        }
+        if ($confirmed instanceof ExchangeOrderDto) {
+            return $this->confirmed($confirmed, 'separate_reduce_only_stop', $decisionKey);
+        }
+
+        return $this->failAndEmergencyClose(
+            adapter: $adapter,
+            plan: $plan,
+            entryClientOrderId: $entryClientOrderId,
+            decisionKey: $decisionKey,
+            reason: 'separate_stop_loss_not_confirmed',
+            extra: [
+                'protection_order_id' => $stopResult->exchangeOrderId,
+                'protection_status' => $stopResult->status->value,
+            ],
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    public function emergencyCloseAfterEntryRisk(
+        ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        string $entryClientOrderId,
+        ?string $decisionKey,
+        string $reason,
+        array $extra = [],
+    ): ProtectionEnforcementResult {
+        return $this->failAndEmergencyClose($adapter, $plan, $entryClientOrderId, $decisionKey, $reason, $extra);
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    private function failAndEmergencyClose(
+        ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        string $entryClientOrderId,
+        ?string $decisionKey,
+        string $reason,
+        array $extra = [],
+    ): ProtectionEnforcementResult {
+        $this->metrics->incr('protection_failed');
+        $this->positionsLogger->critical('protection.failed', [
+            'symbol' => $plan->symbol,
+            'side' => $plan->side->value,
+            'stop' => $plan->stop,
+            'decision_key' => $decisionKey,
+            'reason' => $reason,
+        ] + $extra);
+
+        $emergency = $this->emergencyClose->closeUnprotectedPosition(
+            adapter: $adapter,
+            plan: $plan,
+            parentClientOrderId: $entryClientOrderId,
+            decisionKey: $decisionKey,
+        );
+        $staleProtectionCancel = null;
+        if ($emergency->closed && !$emergency->critical) {
+            $staleProtectionCancel = $this->cancelMatchingProtectionOrders($adapter, $plan, $decisionKey);
+        }
+
+        return new ProtectionEnforcementResult(
+            status: $emergency->status,
+            protected: false,
+            emergencyOrderId: $emergency->exchangeOrderId,
+            metadata: [
+                'reason' => $reason,
+                'emergency_close' => $emergency->metadata,
+                'stale_protection_cancel' => $staleProtectionCancel,
+            ] + $extra,
+        );
+    }
+
+    private function confirmed(ExchangeOrderDto $order, string $mode, ?string $decisionKey): ProtectionEnforcementResult
+    {
+        $this->metrics->incr('protection_confirmed');
+        $this->positionsLogger->info('protection.confirmed', [
+            'symbol' => $order->symbol,
+            'protection_order_id' => $order->exchangeOrderId,
+            'client_order_id' => $order->clientOrderId,
+            'mode' => $mode,
+            'stop_price' => $order->stopPrice,
+            'decision_key' => $decisionKey,
+        ]);
+
+        return new ProtectionEnforcementResult(
+            status: ExecutionResult::STATUS_SUBMITTED_PROTECTED,
+            protected: true,
+            protectionOrderId: $order->exchangeOrderId,
+            metadata: [
+                'protection_mode' => $mode,
+                'protection_status' => $order->status->value,
+                'protection_stop_price' => $order->stopPrice,
+            ],
+        );
+    }
+
+    private function findConfirmedStopLoss(ExchangeAdapterInterface $adapter, OrderPlanModel $plan): ?ExchangeOrderDto
+    {
+        $requiredQuantity = $this->requiredProtectionQuantity($adapter, $plan, null);
+        $coveredQuantity = 0.0;
+        $confirmed = null;
+
+        foreach ($adapter->getOpenOrders($plan->symbol) as $order) {
+            if (!$this->activeOrderStatus($order->status)) {
+                continue;
+            }
+            if (!\in_array($order->orderType, [ExchangeOrderType::STOP_LOSS, ExchangeOrderType::TRIGGER], true) || !$order->reduceOnly) {
+                continue;
+            }
+            if ($order->positionSide !== $this->positionSide($plan->side) || $order->side !== $this->exitOrderSide($plan->side)) {
+                continue;
+            }
+            if ($order->stopPrice === null || !$this->samePrice($order->stopPrice, $plan->stop)) {
+                continue;
+            }
+            $coveredQuantity += $order->remainingQuantity;
+            $confirmed = $order;
+
+            if ($coveredQuantity + 0.00000001 >= $requiredQuantity) {
+                return $confirmed;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function cancelMatchingProtectionOrders(
+        ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        ?string $decisionKey,
+    ): array {
+        try {
+            $orders = $adapter->getOpenOrders($plan->symbol);
+        } catch (\Throwable $e) {
+            $this->positionsLogger->warning('protection.stale_stop_cancel.list_failed', [
+                'symbol' => $plan->symbol,
+                'decision_key' => $decisionKey,
+                'error' => $e->getMessage(),
+            ]);
+
+            return [
+                'attempted' => true,
+                'cancelled' => 0,
+                'failed' => 0,
+                'reason' => 'open_orders_lookup_failed',
+                'error' => $e->getMessage(),
+            ];
+        }
+
+        $cancelled = 0;
+        $failed = 0;
+        $errors = [];
+        foreach ($orders as $order) {
+            if (!$this->matchesProtectionOrder($order, $plan)) {
+                continue;
+            }
+
+            try {
+                $result = $adapter->cancelOrder(new CancelOrderRequest(
+                    exchange: $adapter->exchange(),
+                    marketType: $adapter->marketType(),
+                    symbol: $plan->symbol,
+                    exchangeOrderId: $order->exchangeOrderId,
+                    clientOrderId: $order->clientOrderId,
+                    metadata: [
+                        'decision_key' => $decisionKey,
+                        'reason' => 'stale_protection_after_emergency_close',
+                    ],
+                ));
+            } catch (\Throwable $e) {
+                ++$failed;
+                $errors[] = [
+                    'exchange_order_id' => $order->exchangeOrderId,
+                    'client_order_id' => $order->clientOrderId,
+                    'error' => $e->getMessage(),
+                ];
+                $this->positionsLogger->warning('protection.stale_stop_cancel.exception', [
+                    'symbol' => $plan->symbol,
+                    'exchange_order_id' => $order->exchangeOrderId,
+                    'client_order_id' => $order->clientOrderId,
+                    'decision_key' => $decisionKey,
+                    'error' => $e->getMessage(),
+                ]);
+                continue;
+            }
+
+            if ($result->cancelled) {
+                ++$cancelled;
+                $this->positionsLogger->info('protection.stale_stop_cancel.cancelled', [
+                    'symbol' => $plan->symbol,
+                    'exchange_order_id' => $order->exchangeOrderId,
+                    'client_order_id' => $order->clientOrderId,
+                    'decision_key' => $decisionKey,
+                ]);
+            } else {
+                ++$failed;
+                $errors[] = [
+                    'exchange_order_id' => $order->exchangeOrderId,
+                    'client_order_id' => $order->clientOrderId,
+                    'cancel_status' => $result->status->value,
+                    'metadata' => $result->metadata,
+                ];
+                $this->positionsLogger->warning('protection.stale_stop_cancel.failed', [
+                    'symbol' => $plan->symbol,
+                    'exchange_order_id' => $order->exchangeOrderId,
+                    'client_order_id' => $order->clientOrderId,
+                    'cancel_status' => $result->status->value,
+                    'decision_key' => $decisionKey,
+                ]);
+            }
+        }
+
+        return [
+            'attempted' => true,
+            'cancelled' => $cancelled,
+            'failed' => $failed,
+            'errors' => $errors,
+        ];
+    }
+
+    private function matchesProtectionOrder(ExchangeOrderDto $order, OrderPlanModel $plan): bool
+    {
+        if (!$this->activeOrderStatus($order->status)) {
+            return false;
+        }
+        if (!\in_array($order->orderType, [ExchangeOrderType::STOP_LOSS, ExchangeOrderType::TAKE_PROFIT, ExchangeOrderType::TRIGGER], true) || !$order->reduceOnly) {
+            return false;
+        }
+        if ($order->positionSide !== $this->positionSide($plan->side) || $order->side !== $this->exitOrderSide($plan->side)) {
+            return false;
+        }
+
+        return $order->stopPrice !== null
+            && ($this->samePrice($order->stopPrice, $plan->stop)
+                || ($plan->takeProfit > 0.0 && $this->samePrice($order->stopPrice, $plan->takeProfit)));
+    }
+
+    private function requiredProtectionQuantity(
+        ExchangeAdapterInterface $adapter,
+        OrderPlanModel $plan,
+        ?PlaceOrderResult $entryResult,
+    ): float {
+        foreach ($adapter->getOpenPositions($plan->symbol) as $position) {
+            if ($position instanceof ExchangePositionDto && $position->side === $this->positionSide($plan->side)) {
+                return max($position->size, 0.00000001);
+            }
+        }
+
+        if ($entryResult?->order instanceof ExchangeOrderDto && $entryResult->order->filledQuantity > 0.0) {
+            return $entryResult->order->filledQuantity;
+        }
+
+        return (float) $plan->size;
+    }
+
+    private function entryFilled(PlaceOrderResult $result): bool
+    {
+        return \in_array($result->status, [
+            ExchangeOrderStatus::FILLED,
+            ExchangeOrderStatus::PARTIALLY_FILLED,
+        ], true);
+    }
+
+    private function activeOrderStatus(ExchangeOrderStatus $status): bool
+    {
+        return \in_array($status, [
+            ExchangeOrderStatus::PENDING,
+            ExchangeOrderStatus::OPEN,
+            ExchangeOrderStatus::PARTIALLY_FILLED,
+        ], true);
+    }
+
+    private function stopLossClientOrderId(string $entryClientOrderId): string
+    {
+        return substr($entryClientOrderId, 0, 56) . '-sl';
+    }
+
+    private function samePrice(float $a, float $b): bool
+    {
+        return abs($a - $b) <= max(0.00000001, abs($b) * 0.000001);
+    }
+
+    private function positionSide(Side $side): ExchangePositionSide
+    {
+        return $side === Side::Long ? ExchangePositionSide::LONG : ExchangePositionSide::SHORT;
+    }
+
+    private function exitOrderSide(Side $side): ExchangeOrderSide
+    {
+        return $side === Side::Long ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY;
+    }
+}

--- a/trading-app/src/TradeEntry/Service/TradeEntryService.php
+++ b/trading-app/src/TradeEntry/Service/TradeEntryService.php
@@ -292,9 +292,9 @@ final class TradeEntryService
         ]);
 
         $result = ($this->executor)($plan, $decisionKey, $lifecycleContext, $mode, $request->executionTf);
-        if ($result->status === 'submitted') {
+        if ($this->isSubmittedStatus($result->status)) {
             $this->logOrderSubmittedEvent($plan, $result, $request, $decisionKey, $mode, $lifecycleContext, $runId);
-        } elseif ($result->status === 'skipped') {
+        } elseif ($result->status === ExecutionResult::STATUS_SKIPPED) {
             $this->logSymbolSkippedEvent(
                 request: $request,
                 reasonCode: (string)($result->raw['reason'] ?? TradeLifecycleReason::SUBMIT_FAILED),
@@ -315,15 +315,18 @@ final class TradeEntryService
             'reason' => 'execution_finished',
         ]);
 
-        $metric = match ($result->status) {
-            'submitted' => 'submitted',
-            'skipped' => 'skipped',
+        $metric = match (true) {
+            $this->isSubmittedStatus($result->status) => 'submitted',
+            $result->status === ExecutionResult::STATUS_SKIPPED => 'skipped',
+            $result->status === ExecutionResult::STATUS_ENTRY_SUBMITTED => 'entry_submitted',
+            $result->status === ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED => 'failed_unprotected_closed',
+            $result->status === ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION => 'critical_unprotected_position',
             default => 'errors',
         };
         $this->metrics->incr($metric);
 
         // Appeler le hook si fourni et si l'ordre a été soumis
-        if ($hook !== null && $result->status === 'submitted') {
+        if ($hook !== null && $this->shouldRunSubmittedHook($result->status)) {
             $hook->onSubmitted($request, $result, $decisionKey);
         }
 
@@ -615,6 +618,19 @@ final class TradeEntryService
         }
 
         return ($zoneMax - $zoneMin) / $mid;
+    }
+
+    private function isSubmittedStatus(string $status): bool
+    {
+        return \in_array($status, [
+            ExecutionResult::STATUS_SUBMITTED,
+            ExecutionResult::STATUS_SUBMITTED_PROTECTED,
+        ], true);
+    }
+
+    private function shouldRunSubmittedHook(string $status): bool
+    {
+        return $this->isSubmittedStatus($status) || $status === ExecutionResult::STATUS_ENTRY_SUBMITTED;
     }
 
     private function computeAtrPct(?float $atrValue, float $referencePrice): ?float

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 namespace App\TradeEntry\Workflow;
 
 use App\TradeEntry\Dto\ExecutionResult;
+use App\TradeEntry\Execution\ExchangeExecutionService;
 use App\TradeEntry\Execution\ExecutionBox;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
 use App\Logging\Dto\LifecycleContextBuilder;
+use App\Provider\Context\ExchangeContext;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -14,6 +16,7 @@ final class ExecuteOrderPlan
 {
     public function __construct(
         private readonly ExecutionBox $execution,
+        private readonly ExchangeExecutionService $exchangeExecution,
         #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
     ) {}
 
@@ -39,7 +42,9 @@ final class ExecuteOrderPlan
         ]);
 
         try {
-            $result = $this->execution->execute($plan, $decisionKey, $contextBuilder, $mode, $executionTf);
+            $result = $this->shouldUseApiFirstExecution($plan)
+                ? $this->exchangeExecution->execute($plan, $decisionKey, $mode, $executionTf)
+                : $this->execution->execute($plan, $decisionKey, $contextBuilder, $mode, $executionTf);
 
             $context = [
                 'symbol' => $plan->symbol,
@@ -49,9 +54,11 @@ final class ExecuteOrderPlan
                 'exchange_order_id' => $result->exchangeOrderId,
             ];
 
-            if ($result->status === 'submitted') {
+            if ($this->isSubmitSuccess($result->status)) {
                 $this->positionsLogger->info('execute_order_plan.submitted', $context + ['decision_key' => $decisionKey]);
-            } elseif ($result->status === 'skipped') {
+            } elseif ($result->status === ExecutionResult::STATUS_ENTRY_SUBMITTED) {
+                $this->positionsLogger->info('execute_order_plan.entry_submitted', $context + ['decision_key' => $decisionKey, 'raw' => $result->raw]);
+            } elseif ($result->status === ExecutionResult::STATUS_SKIPPED) {
                 $this->positionsLogger->warning('execute_order_plan.skipped', $context + ['decision_key' => $decisionKey, 'raw' => $result->raw]);
             } else {
                 $this->positionsLogger->error('execute_order_plan.failed', $context + ['decision_key' => $decisionKey, 'raw' => $result->raw]);
@@ -73,5 +80,20 @@ final class ExecuteOrderPlan
             ]);
             throw $e;
         }
+    }
+
+    private function shouldUseApiFirstExecution(OrderPlanModel $plan): bool
+    {
+        $context = ExchangeContext::resolve($plan->exchangeContext);
+
+        return $plan->exchangeContext !== null || !$context->isLegacyDefault();
+    }
+
+    private function isSubmitSuccess(string $status): bool
+    {
+        return \in_array($status, [
+            ExecutionResult::STATUS_SUBMITTED,
+            ExecutionResult::STATUS_SUBMITTED_PROTECTED,
+        ], true);
     }
 }

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -12,6 +12,7 @@ use App\Common\Enum\OrderType;
 use App\Contract\Provider\AccountProviderInterface;
 use App\Contract\Provider\ContractProviderInterface;
 use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
 use App\Contract\Provider\ExchangeProviderRegistryInterface;
 use App\Contract\Provider\KlineProviderInterface;
 use App\Contract\Provider\OrderProviderInterface;
@@ -333,6 +334,32 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertTrue($result->order?->metadata['submit_only'] ?? false);
     }
 
+    public function testGetOpenOrdersIncludesBitmartPlanOrders(): void
+    {
+        $adapter = $this->createAdapterWithOrderProvider(new PlanOrderProviderStub([
+            [
+                'plan_order_id' => 'plan-sl-1',
+                'symbol' => 'BTCUSDT',
+                'side' => 3,
+                'state' => 1,
+                'size' => '10',
+                'trigger_price' => '24800',
+            ],
+        ]));
+
+        $orders = $adapter->getOpenOrders('BTCUSDT');
+
+        self::assertCount(1, $orders);
+        self::assertSame('plan-sl-1', $orders[0]->exchangeOrderId);
+        self::assertSame(ExchangeOrderType::TRIGGER, $orders[0]->orderType);
+        self::assertSame(ExchangeOrderStatus::PENDING, $orders[0]->status);
+        self::assertSame(ExchangeOrderSide::SELL, $orders[0]->side);
+        self::assertSame(ExchangePositionSide::LONG, $orders[0]->positionSide);
+        self::assertTrue($orders[0]->reduceOnly);
+        self::assertEqualsWithDelta(24800.0, $orders[0]->stopPrice, 0.000001);
+        self::assertEqualsWithDelta(10.0, $orders[0]->remainingQuantity, 0.000001);
+    }
+
     public function testCancelFailureWithExchangeOrderIdDoesNotReportClientIdUnsupported(): void
     {
         $orderProvider = $this->createMock(OrderProviderInterface::class);
@@ -462,5 +489,70 @@ final class BitmartExchangeAdapterTest extends TestCase
             createdAt: new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
             metadata: $metadata,
         );
+    }
+}
+
+final readonly class PlanOrderProviderStub implements OrderProviderInterface
+{
+    /**
+     * @param array<int,array<string,mixed>> $planOrders
+     */
+    public function __construct(private array $planOrders)
+    {
+    }
+
+    public function placeOrder(
+        string $symbol,
+        OrderSide $side,
+        OrderType $type,
+        float $quantity,
+        ?float $price = null,
+        ?float $stopPrice = null,
+        array $options = []
+    ): ?OrderDto {
+        throw new \RuntimeException('placeOrder should not be called');
+    }
+
+    public function cancelOrder(string $symbol, string $orderId): bool
+    {
+        throw new \RuntimeException('cancelOrder should not be called');
+    }
+
+    public function getOrder(string $symbol, string $orderId): ?OrderDto
+    {
+        return null;
+    }
+
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return [];
+    }
+
+    public function getOrderHistory(string $symbol, int $limit = 100): array
+    {
+        return [];
+    }
+
+    public function cancelAllOrders(string $symbol): bool
+    {
+        return true;
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        throw new \RuntimeException('getOrderBookTop should not be called');
+    }
+
+    public function submitLeverage(string $symbol, int $leverage, string $openType = 'isolated'): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function getPlanOrders(?string $symbol = null): array
+    {
+        return $this->planOrders;
     }
 }

--- a/trading-app/tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
+++ b/trading-app/tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
@@ -1,0 +1,1217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\TradeEntry\Execution;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Config\TradeEntryConfigProvider;
+use App\Config\TradeEntryConfigResolver;
+use App\Config\TradeEntryModeContext;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\CancelOrderResult;
+use App\Exchange\Dto\ExchangeBalanceDto;
+use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\ExchangeReconciliationResult;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeScenarioService;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Registry\ExchangeAdapterRegistry;
+use App\Provider\Context\ExchangeContext;
+use App\TradeEntry\Dto\ExecutionResult;
+use App\TradeEntry\Execution\EmergencyCloseService;
+use App\TradeEntry\Execution\ExecutionBox;
+use App\TradeEntry\Execution\ExchangeExecutionService;
+use App\TradeEntry\Execution\ProtectionEnforcer;
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+use App\TradeEntry\Policy\IdempotencyPolicy;
+use App\TradeEntry\Policy\OrderModePolicyInterface;
+use App\TradeEntry\Service\TradeEntryMetricsService;
+use App\TradeEntry\Types\Side;
+use App\TradeEntry\Workflow\ExecuteOrderPlan;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+#[CoversClass(ExchangeExecutionService::class)]
+#[CoversClass(ProtectionEnforcer::class)]
+#[CoversClass(EmergencyCloseService::class)]
+final class ExchangeExecutionServiceTest extends TestCase
+{
+    private FakeExchangeAdapter $adapter;
+    private FakeExchangeScenarioService $scenario;
+    private TradeEntryMetricsService $metrics;
+
+    protected function setUp(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->fixedClock());
+
+        $this->adapter = new FakeExchangeAdapter($state, $book, $engine, $this->fixedClock());
+        $this->scenario = new FakeExchangeScenarioService($state, $book, $engine);
+        $this->metrics = new TradeEntryMetricsService();
+    }
+
+    public function testMarketFillWithAttachedStopLossReturnsSubmittedProtected(): void
+    {
+        $result = $this->service()->execute($this->plan(orderType: 'market'), 'decision-1');
+
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $result->status);
+        self::assertTrue($result->raw['protection']['protected']);
+        self::assertSame('attached', $result->raw['protection']['protection_mode']);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+
+        $stopOrders = $this->stopLossOrders($this->adapter);
+        self::assertCount(1, $stopOrders);
+        self::assertTrue($stopOrders[0]->reduceOnly);
+        self::assertEqualsWithDelta(24800.0, $stopOrders[0]->stopPrice, 0.000001);
+    }
+
+    public function testBitmartMarketEntryWithoutSeparateProtectionIsRejectedBeforeSubmit(): void
+    {
+        $adapter = new BitmartMarketRejectAdapter();
+        $plan = $this->plan(
+            orderType: 'market',
+            exchangeContext: new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+        );
+
+        $result = $this->service($adapter)->execute($plan, 'decision-bitmart-market');
+
+        self::assertSame(ExecutionResult::STATUS_ERROR, $result->status);
+        self::assertSame('bitmart_market_entry_without_protection_path', $result->raw['reason']);
+        self::assertSame(0, $adapter->placeOrderCalls);
+    }
+
+    public function testZeroSizeApiFirstPlanIsSkippedBeforeSubmit(): void
+    {
+        $result = $this->service()->execute($this->plan(orderType: 'limit', size: 0), 'decision-size-zero');
+
+        self::assertSame(ExecutionResult::STATUS_SKIPPED, $result->status);
+        self::assertSame('size_below_min', $result->raw['reason']);
+        self::assertSame(0, $result->raw['size']);
+    }
+
+    public function testMarketFillWithRejectedAttachedStopLossEmergencyClosesPosition(): void
+    {
+        $this->scenario->rejectNextProtectionOrder();
+
+        $result = $this->service()->execute($this->plan(orderType: 'market'), 'decision-2');
+
+        self::assertSame(ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED, $result->status);
+        self::assertFalse($result->raw['protection']['protected']);
+        self::assertSame('attached_stop_loss_not_confirmed', $result->raw['protection']['reason']);
+        self::assertNotNull($result->raw['protection']['emergency_order_id']);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertSame(1, $this->metrics->snapshot()['protection_failed']);
+        self::assertSame(1, $this->metrics->snapshot()['emergency_close']);
+    }
+
+    public function testMarketFillWithRejectedStopLossBecomesCriticalWhenEmergencyCloseFails(): void
+    {
+        $this->scenario->rejectNextProtectionOrder();
+        $adapter = new CapabilityOverrideAdapter(
+            $this->adapter,
+            $this->adapter->capabilities(),
+            rejectEmergencyClose: true,
+        );
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'market'), 'decision-3');
+
+        self::assertSame(ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION, $result->status);
+        self::assertFalse($result->raw['protection']['protected']);
+        self::assertSame('critical_unprotected_position', $result->raw['protection']['emergency_close']['reason']);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertSame(1, $this->metrics->snapshot()['critical_unprotected_position']);
+    }
+
+    public function testExchangeWithoutAttachedStopLossUsesSeparateReduceOnlyStop(): void
+    {
+        $adapter = new CapabilityOverrideAdapter(
+            $this->adapter,
+            new ExchangeCapabilities(
+                supportsTestnet: true,
+                supportsWebSocketPrivate: true,
+                supportsClientOrderId: true,
+                supportsCancelByClientOrderId: true,
+                supportsPostOnly: true,
+                supportsIoc: true,
+                supportsReduceOnly: true,
+                supportsAttachedStopLossOnEntry: false,
+                supportsAttachedTakeProfitOnEntry: false,
+                supportsTriggerOrders: true,
+                supportsModifyOrder: false,
+                requiresSeparateLeverageSubmit: false,
+                supportsPerSymbolLeverage: true,
+            ),
+        );
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'market'), 'decision-4');
+
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $result->status);
+        self::assertSame('separate_reduce_only_stop', $result->raw['protection']['protection_mode']);
+
+        $stopOrders = $this->stopLossOrders($this->adapter);
+        self::assertCount(1, $stopOrders);
+        self::assertTrue($stopOrders[0]->reduceOnly);
+        self::assertEqualsWithDelta(1.0, $stopOrders[0]->remainingQuantity, 0.000001);
+    }
+
+    public function testCrossingLimitWithAttachedStopLossIsConfirmedBeforeProtectedStatus(): void
+    {
+        $result = $this->service()->execute($this->plan(orderType: 'limit', entry: 26000.0), 'decision-5');
+
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $result->status);
+        self::assertSame(ExchangeOrderStatus::FILLED->value, $result->raw['order']['status']);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(1, $this->stopLossOrders($this->adapter));
+    }
+
+    public function testExpiredEntryDoesNotReturnEntrySubmitted(): void
+    {
+        $result = $this->service()->execute($this->plan(orderType: 'limit', entry: 24950.0, orderMode: 3), 'decision-6');
+
+        self::assertSame(ExecutionResult::STATUS_ERROR, $result->status);
+        self::assertSame('entry_closed_without_fill', $result->raw['reason']);
+        self::assertSame(ExchangeOrderStatus::EXPIRED->value, $result->raw['order']['status']);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+    }
+
+    public function testOpenEntryIsCancelledInsteadOfReturnedPendingWithoutWatcher(): void
+    {
+        $result = $this->service()->execute($this->plan(orderType: 'limit', entry: 24950.0), 'decision-7');
+
+        self::assertSame(ExecutionResult::STATUS_ERROR, $result->status);
+        self::assertSame('entry_pending_cancelled_without_fill', $result->raw['reason']);
+        self::assertTrue($result->raw['cancel']['cancelled']);
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+    }
+
+    public function testFillDuringPendingCancelRaceEmergencyClosesPosition(): void
+    {
+        $adapter = new FillDuringCancelAdapter($this->adapter);
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'limit', entry: 24950.0), 'decision-cancel-race');
+
+        self::assertSame(ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED, $result->status);
+        self::assertSame('entry_filled_during_cancel_race', $result->raw['protection']['reason']);
+        self::assertTrue($result->raw['protection']['cancel']['filled_after_cancel']);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+    }
+
+    public function testPartiallyFilledEntryCancelsRemainderBeforeProtection(): void
+    {
+        $adapter = new PartialFillOnEntryAdapter($this->adapter);
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'limit', entry: 24950.0), 'decision-8');
+
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $result->status);
+        self::assertSame(ExchangeOrderStatus::PARTIALLY_FILLED->value, $result->raw['order']['status']);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertEqualsWithDelta(0.4, $this->adapter->getOpenPositions('BTCUSDT')[0]->size, 0.000001);
+
+        $stopOrders = $this->stopLossOrders($this->adapter);
+        self::assertCount(1, $stopOrders);
+        self::assertEqualsWithDelta(0.4, $stopOrders[0]->remainingQuantity, 0.000001);
+    }
+
+    public function testPartialFillCancelVerificationFailureReturnsCriticalAfterEmergencyClose(): void
+    {
+        $adapter = new CancelVerificationFailureAdapter(new PartialFillOnEntryAdapter($this->adapter));
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'limit', entry: 24950.0), 'decision-8b');
+
+        self::assertSame(ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION, $result->status);
+        self::assertSame('partial_entry_remainder_cancel_failed', $result->raw['protection']['reason']);
+        self::assertTrue($result->raw['protection']['residual_entry_risk']);
+        self::assertSame('entry_cancel_verification_exception', $result->raw['protection']['cancel']['reason']);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertNotEmpty($this->adapter->getOpenOrders('BTCUSDT'));
+    }
+
+    public function testConfirmationFailureEmergencyClosesFilledPosition(): void
+    {
+        $adapter = new ThrowingOpenOrdersAdapter($this->adapter);
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'market'), 'decision-9');
+
+        self::assertSame(ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED, $result->status);
+        self::assertSame('protection_confirmation_failed', $result->raw['protection']['reason']);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+    }
+
+    public function testConfirmationFailureCancelsStaleStopAfterEmergencyClose(): void
+    {
+        $adapter = new FlakyOpenOrdersAdapter($this->adapter);
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'market'), 'decision-stale-stop');
+
+        self::assertSame(ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED, $result->status);
+        self::assertSame('protection_confirmation_failed', $result->raw['protection']['reason']);
+        self::assertSame(2, $result->raw['protection']['stale_protection_cancel']['cancelled']);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+    }
+
+    public function testPendingEmergencyCloseWithNoRemainingPositionIsSuccessful(): void
+    {
+        $this->scenario->rejectNextProtectionOrder();
+        $adapter = new PendingEmergencyCloseAdapter($this->adapter);
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'market'), 'decision-pending-close');
+
+        self::assertSame(ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED, $result->status);
+        self::assertSame('pending', $result->raw['protection']['emergency_close']['close_status']);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+    }
+
+    public function testEmergencyCloseReturnsCriticalWhenPositionLookupFails(): void
+    {
+        $adapter = new ThrowingPositionsAdapter($this->adapter);
+
+        $result = $this->service($adapter)->execute($this->plan(orderType: 'market'), 'decision-lookup-failure');
+
+        self::assertSame(ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION, $result->status);
+        self::assertSame('emergency_close_position_lookup_failed', $result->raw['protection']['emergency_close']['reason']);
+        self::assertSame(1, $this->metrics->snapshot()['critical_unprotected_position']);
+    }
+
+
+    public function testPartiallyConsumedStopDoesNotConfirmCurrentPositionCoverage(): void
+    {
+        $this->adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: \App\Exchange\Enum\ExchangeOrderSide::BUY,
+            positionSide: \App\Exchange\Enum\ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: \App\Exchange\Enum\ExchangeTimeInForce::IOC,
+            quantity: 1.0,
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'existing-entry',
+            attachedStopLossPrice: 24800.0,
+        ));
+        $stop = $this->stopLossOrders($this->adapter)[0];
+        $this->scenario->fillOrder($stop->exchangeOrderId, 0.6, 24800.0);
+
+        $result = $this->service()->execute($this->plan(orderType: 'market'), 'decision-10');
+
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $result->status);
+        self::assertNotSame($stop->exchangeOrderId, $result->raw['protection']['protection_order_id']);
+        self::assertEqualsWithDelta(1.4, $this->adapter->getOpenPositions('BTCUSDT')[0]->size, 0.000001);
+        self::assertEqualsWithDelta(1.4, array_sum(array_map(
+            static fn (ExchangeOrderDto $order): float => $order->remainingQuantity,
+            $this->stopLossOrders($this->adapter),
+        )), 0.000001);
+    }
+
+    public function testExplicitBitmartContextUsesApiFirstExecution(): void
+    {
+        $execution = (new \ReflectionClass(ExecutionBox::class))->newInstanceWithoutConstructor();
+        $exchangeExecution = (new \ReflectionClass(ExchangeExecutionService::class))->newInstanceWithoutConstructor();
+        $workflow = new ExecuteOrderPlan($execution, $exchangeExecution, new NullLogger());
+        $method = new \ReflectionMethod(ExecuteOrderPlan::class, 'shouldUseApiFirstExecution');
+        $method->setAccessible(true);
+
+        self::assertFalse($method->invoke($workflow, $this->plan(
+            orderType: 'limit',
+            exchangeContext: null,
+            useDefaultExchangeContext: false,
+        )));
+        self::assertTrue($method->invoke($workflow, $this->plan(
+            orderType: 'limit',
+            exchangeContext: new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+        )));
+    }
+
+    private function service(?ExchangeAdapterInterface $adapter = null): ExchangeExecutionService
+    {
+        $logger = new NullLogger();
+        $emergencyClose = new EmergencyCloseService($this->metrics, $logger);
+        $enforcer = new ProtectionEnforcer($emergencyClose, $this->metrics, $logger);
+
+        return new ExchangeExecutionService(
+            new ExchangeAdapterRegistry([$adapter ?? $this->adapter]),
+            $enforcer,
+            new IdempotencyPolicy(),
+            new class implements OrderModePolicyInterface {
+                public function enforce(OrderPlanModel $plan): void
+                {
+                }
+            },
+            $this->configResolver(),
+            $logger,
+        );
+    }
+
+    private function configResolver(): TradeEntryConfigResolver
+    {
+        $projectDir = sys_get_temp_dir() . '/trade_entry_api04_' . bin2hex(random_bytes(4));
+        $configDir = $projectDir . '/config/app';
+        mkdir($configDir, 0777, true);
+        file_put_contents($configDir . '/trade_entry.unit.yaml', <<<YAML
+trade_entry:
+  defaults:
+    initial_margin_usdt: 100.0
+  leverage: {}
+YAML);
+
+        $provider = new TradeEntryConfigProvider(new ParameterBag([
+            'kernel.project_dir' => $projectDir,
+            'mode' => [],
+        ]));
+
+        return new TradeEntryConfigResolver(
+            provider: $provider,
+            modeContext: new TradeEntryModeContext($provider, 'unit', new NullLogger()),
+            logger: new NullLogger(),
+        );
+    }
+
+    private function plan(
+        string $orderType,
+        float $entry = 25000.0,
+        int $orderMode = 1,
+        ?ExchangeContext $exchangeContext = null,
+        int $size = 1,
+        int $leverage = 3,
+        bool $useDefaultExchangeContext = true,
+    ): OrderPlanModel
+    {
+        return new OrderPlanModel(
+            symbol: 'BTCUSDT',
+            side: Side::Long,
+            orderType: $orderType,
+            openType: 'isolated',
+            orderMode: $orderMode,
+            entry: $entry,
+            stop: 24800.0,
+            takeProfit: 25200.0,
+            size: $size,
+            leverage: $leverage,
+            pricePrecision: 2,
+            contractSize: 1.0,
+            exchangeContext: $useDefaultExchangeContext
+                ? ($exchangeContext ?? new ExchangeContext(Exchange::FAKE, MarketType::PERPETUAL))
+                : $exchangeContext,
+        );
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    private function stopLossOrders(ExchangeAdapterInterface $adapter): array
+    {
+        return array_values(array_filter(
+            $adapter->getOpenOrders('BTCUSDT'),
+            static fn (ExchangeOrderDto $order): bool => $order->orderType === ExchangeOrderType::STOP_LOSS,
+        ));
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        };
+    }
+}
+
+final readonly class CapabilityOverrideAdapter implements ExchangeAdapterInterface
+{
+    public function __construct(
+        private ExchangeAdapterInterface $inner,
+        private ExchangeCapabilities $capabilities,
+        private bool $rejectEmergencyClose = false,
+    ) {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return $this->capabilities;
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->inner->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        if ($this->rejectEmergencyClose && $request->reduceOnly && $request->orderType === ExchangeOrderType::MARKET) {
+            return new PlaceOrderResult(
+                accepted: false,
+                symbol: $request->symbol,
+                clientOrderId: $request->clientOrderId,
+                exchangeOrderId: null,
+                status: ExchangeOrderStatus::REJECTED,
+                submittedAt: new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
+                metadata: ['reason' => 'forced_emergency_close_rejection'],
+            );
+        }
+
+        return $this->inner->placeOrder($request);
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        return $this->inner->cancelOrder($request);
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return $this->inner->getOrder($symbol, $exchangeOrderId);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final readonly class PartialFillOnEntryAdapter implements ExchangeAdapterInterface
+{
+    public function __construct(private ExchangeAdapterInterface $inner)
+    {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return new ExchangeCapabilities(
+            supportsTestnet: true,
+            supportsWebSocketPrivate: true,
+            supportsClientOrderId: true,
+            supportsCancelByClientOrderId: true,
+            supportsPostOnly: true,
+            supportsIoc: true,
+            supportsReduceOnly: true,
+            supportsAttachedStopLossOnEntry: false,
+            supportsAttachedTakeProfitOnEntry: false,
+            supportsTriggerOrders: true,
+            supportsModifyOrder: false,
+            requiresSeparateLeverageSubmit: false,
+            supportsPerSymbolLeverage: true,
+        );
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->inner->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        $placed = $this->inner->placeOrder($request);
+        if (!$request->reduceOnly && $request->orderType === ExchangeOrderType::LIMIT && $placed->exchangeOrderId !== null) {
+            $engine = $this->inner;
+            if ($engine instanceof FakeExchangeAdapter) {
+                $state = (new \ReflectionProperty(FakeExchangeAdapter::class, 'matchingEngine'));
+                $state->setAccessible(true);
+                /** @var FakeExchangeMatchingEngine $matching */
+                $matching = $state->getValue($engine);
+                $order = $matching->fillOrder($placed->exchangeOrderId, 0.4);
+
+                return new PlaceOrderResult(
+                    accepted: true,
+                    symbol: $placed->symbol,
+                    clientOrderId: $placed->clientOrderId,
+                    exchangeOrderId: $placed->exchangeOrderId,
+                    status: $order?->status ?? $placed->status,
+                    submittedAt: $placed->submittedAt,
+                    order: $order,
+                    metadata: $placed->metadata,
+                );
+            }
+        }
+
+        return $placed;
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        return $this->inner->cancelOrder($request);
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return $this->inner->getOrder($symbol, $exchangeOrderId);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final readonly class FillDuringCancelAdapter implements ExchangeAdapterInterface
+{
+    public function __construct(private ExchangeAdapterInterface $inner)
+    {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return $this->inner->capabilities();
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->inner->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        return $this->inner->placeOrder($request);
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        if ($this->inner instanceof FakeExchangeAdapter && $request->exchangeOrderId !== null) {
+            $state = (new \ReflectionProperty(FakeExchangeAdapter::class, 'matchingEngine'));
+            $state->setAccessible(true);
+            /** @var FakeExchangeMatchingEngine $matching */
+            $matching = $state->getValue($this->inner);
+            $matching->fillOrder($request->exchangeOrderId, 0.4);
+        }
+
+        return $this->inner->cancelOrder($request);
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return $this->inner->getOrder($symbol, $exchangeOrderId);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final readonly class PendingEmergencyCloseAdapter implements ExchangeAdapterInterface
+{
+    public function __construct(private ExchangeAdapterInterface $inner)
+    {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return $this->inner->capabilities();
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->inner->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        $placed = $this->inner->placeOrder($request);
+        if ($request->reduceOnly && $request->orderType === ExchangeOrderType::MARKET) {
+            return new PlaceOrderResult(
+                accepted: true,
+                symbol: $placed->symbol,
+                clientOrderId: $placed->clientOrderId,
+                exchangeOrderId: $placed->exchangeOrderId,
+                status: ExchangeOrderStatus::PENDING,
+                submittedAt: $placed->submittedAt,
+                order: $placed->order,
+                metadata: $placed->metadata,
+            );
+        }
+
+        return $placed;
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        return $this->inner->cancelOrder($request);
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return $this->inner->getOrder($symbol, $exchangeOrderId);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final readonly class ThrowingOpenOrdersAdapter implements ExchangeAdapterInterface
+{
+    public function __construct(private ExchangeAdapterInterface $inner)
+    {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return $this->inner->capabilities();
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->inner->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        throw new \RuntimeException('open orders unavailable');
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        return $this->inner->placeOrder($request);
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        return $this->inner->cancelOrder($request);
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return $this->inner->getOrder($symbol, $exchangeOrderId);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final class FlakyOpenOrdersAdapter implements ExchangeAdapterInterface
+{
+    private int $openOrderCalls = 0;
+
+    public function __construct(private readonly ExchangeAdapterInterface $inner)
+    {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return $this->inner->capabilities();
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->inner->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        if ($this->openOrderCalls++ === 0) {
+            throw new \RuntimeException('open orders temporarily unavailable');
+        }
+
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        return $this->inner->placeOrder($request);
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        return $this->inner->cancelOrder($request);
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return $this->inner->getOrder($symbol, $exchangeOrderId);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final readonly class ThrowingPositionsAdapter implements ExchangeAdapterInterface
+{
+    public function __construct(private ExchangeAdapterInterface $inner)
+    {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return $this->inner->capabilities();
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        throw new \RuntimeException('positions unavailable');
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        return $this->inner->placeOrder($request);
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        return $this->inner->cancelOrder($request);
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return $this->inner->getOrder($symbol, $exchangeOrderId);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final readonly class CancelVerificationFailureAdapter implements ExchangeAdapterInterface
+{
+    public function __construct(private ExchangeAdapterInterface $inner)
+    {
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->inner->exchange();
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->inner->marketType();
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return $this->inner->capabilities();
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return $this->inner->getBalances();
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->inner->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return $this->inner->getOpenOrders($symbol);
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        return $this->inner->placeOrder($request);
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        return new CancelOrderResult(
+            cancelled: false,
+            symbol: strtoupper($request->symbol),
+            exchangeOrderId: $request->exchangeOrderId,
+            clientOrderId: $request->clientOrderId,
+            status: ExchangeOrderStatus::UNKNOWN,
+            metadata: ['reason' => 'cancel_status_unconfirmed'],
+        );
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        throw new \RuntimeException('order lookup unavailable after cancel');
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return $this->inner->getOrderBookTop($symbol);
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        return $this->inner->setLeverage($symbol, $leverage, $marginMode);
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        return $this->inner->reconcile($symbol);
+    }
+}
+
+final class BitmartMarketRejectAdapter implements ExchangeAdapterInterface
+{
+    public int $placeOrderCalls = 0;
+
+    public function exchange(): Exchange
+    {
+        return Exchange::BITMART;
+    }
+
+    public function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return new ExchangeCapabilities(
+            supportsClientOrderId: true,
+            supportsIoc: true,
+            supportsReduceOnly: true,
+            supportsAttachedStopLossOnEntry: true,
+            supportsAttachedTakeProfitOnEntry: true,
+            supportsTriggerOrders: false,
+        );
+    }
+
+    /**
+     * @return ExchangeBalanceDto[]
+     */
+    public function getBalances(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return ExchangePositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return [];
+    }
+
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return [];
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        ++$this->placeOrderCalls;
+        throw new \RuntimeException('Bitmart market entry should be rejected before submit');
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        throw new \RuntimeException('cancelOrder should not be called');
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        return null;
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        throw new \RuntimeException('getOrderBookTop should not be called');
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        throw new \RuntimeException('setLeverage should not be called');
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        throw new \RuntimeException('reconcile should not be called');
+    }
+}


### PR DESCRIPTION
## Summary
- Add API-first `ExchangeExecutionService` that routes non-legacy exchange contexts through `ExchangeAdapterInterface`.
- Add `ProtectionEnforcer` and `EmergencyCloseService` so filled entries only return `submitted_protected` after a confirmed reduce-only stop-loss, or return `failed_unprotected_closed` / `critical_unprotected_position` after emergency close handling.
- Extend MTF order extraction/status display for `submitted_protected` and `entry_submitted`.
- Cover FakeExchange safety scenarios: attached SL accepted, attached SL rejected with emergency close, critical emergency-close failure, separate reduce-only stop, and crossing limit with confirmed SL.

Closes #82

## Validation
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug`
- `git diff --check`

## Note
- `tests/MtfValidator/Service/TradingDecisionHandlerTest.php` still fails on the existing PHPUnit limitation around mocking final `TradeEntryService`; this PR does not change that test seam.
