### PR TITLE
[API-05] Add deterministic order intent idempotency

### DIFF
--- a/trading-app/migrations/Version20260531020000.php
+++ b/trading-app/migrations/Version20260531020000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260531020000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add deterministic order intent idempotency fields and active decision key uniqueness.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE order_intent ADD COLUMN IF NOT EXISTS decision_key VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE order_intent ADD COLUMN IF NOT EXISTS strategy_profile VARCHAR(80) DEFAULT NULL');
+        $this->addSql('ALTER TABLE order_intent ADD COLUMN IF NOT EXISTS strategy_version VARCHAR(80) DEFAULT NULL');
+        $this->addSql('ALTER TABLE order_intent ADD COLUMN IF NOT EXISTS timeframe VARCHAR(16) DEFAULT NULL');
+        $this->addSql('ALTER TABLE order_intent ADD COLUMN IF NOT EXISTS candle_open_ts TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE order_intent ADD COLUMN IF NOT EXISTS exchange_order_id VARCHAR(80) DEFAULT NULL');
+        $this->addSql('UPDATE order_intent SET exchange_order_id = order_id WHERE exchange_order_id IS NULL AND order_id IS NOT NULL');
+
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_order_intent_exchange_market_decision_key ON order_intent (exchange, market_type, decision_key)');
+        $this->addSql("CREATE UNIQUE INDEX IF NOT EXISTS ux_order_intent_exchange_market_active_decision_key ON order_intent (exchange, market_type, decision_key) WHERE decision_key IS NOT NULL AND status IN ('DRAFT','VALIDATED','READY_TO_SEND','SENT')");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS ux_order_intent_exchange_market_active_decision_key');
+        $this->addSql('DROP INDEX IF EXISTS idx_order_intent_exchange_market_decision_key');
+        $this->addSql('ALTER TABLE order_intent DROP COLUMN IF EXISTS exchange_order_id');
+        $this->addSql('ALTER TABLE order_intent DROP COLUMN IF EXISTS candle_open_ts');
+        $this->addSql('ALTER TABLE order_intent DROP COLUMN IF EXISTS timeframe');
+        $this->addSql('ALTER TABLE order_intent DROP COLUMN IF EXISTS strategy_version');
+        $this->addSql('ALTER TABLE order_intent DROP COLUMN IF EXISTS strategy_profile');
+        $this->addSql('ALTER TABLE order_intent DROP COLUMN IF EXISTS decision_key');
+    }
+}

--- a/trading-app/src/Entity/OrderIntent.php
+++ b/trading-app/src/Entity/OrderIntent.php
@@ -15,9 +15,11 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: OrderIntentRepository::class)]
 #[ORM\Table(name: 'order_intent')]
 #[ORM\UniqueConstraint(name: 'ux_order_intent_exchange_market_client_order_id', columns: ['exchange', 'market_type', 'client_order_id'])]
+#[ORM\UniqueConstraint(name: 'ux_order_intent_exchange_market_active_decision_key', columns: ['exchange', 'market_type', 'decision_key'], options: ['where' => "decision_key IS NOT NULL AND status IN ('DRAFT','VALIDATED','READY_TO_SEND','SENT')"])]
 #[ORM\Index(name: 'idx_order_intent_symbol', columns: ['exchange', 'market_type', 'symbol'])]
 #[ORM\Index(name: 'idx_order_intent_status', columns: ['status'])]
 #[ORM\Index(name: 'idx_order_intent_client_order_id', columns: ['client_order_id'])]
+#[ORM\Index(name: 'idx_order_intent_exchange_market_decision_key', columns: ['exchange', 'market_type', 'decision_key'])]
 class OrderIntent
 {
     public const STATUS_DRAFT = 'DRAFT';
@@ -51,8 +53,23 @@ class OrderIntent
     #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
     private string $marketType = 'perpetual';
 
+    #[ORM\Column(name: 'decision_key', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $decisionKey = null;
+
+    #[ORM\Column(name: 'strategy_profile', type: Types::STRING, length: 80, nullable: true)]
+    private ?string $strategyProfile = null;
+
+    #[ORM\Column(name: 'strategy_version', type: Types::STRING, length: 80, nullable: true)]
+    private ?string $strategyVersion = null;
+
     #[ORM\Column(type: Types::STRING, length: 50)]
     private string $symbol;
+
+    #[ORM\Column(type: Types::STRING, length: 16, nullable: true)]
+    private ?string $timeframe = null;
+
+    #[ORM\Column(name: 'candle_open_ts', type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $candleOpenTs = null;
 
     #[ORM\Column(type: Types::INTEGER)]
     private int $side; // 1=open_long, 2=close_long, 3=close_short, 4=open_short
@@ -95,6 +112,9 @@ class OrderIntent
 
     #[ORM\Column(type: Types::STRING, length: 80, nullable: true)]
     private ?string $orderId = null; // Order ID de l'exchange après envoi
+
+    #[ORM\Column(name: 'exchange_order_id', type: Types::STRING, length: 80, nullable: true)]
+    private ?string $exchangeOrderId = null;
 
     #[ORM\Column(type: Types::STRING, length: 500, nullable: true)]
     private ?string $failureReason = null; // Raison de l'échec
@@ -146,6 +166,42 @@ class OrderIntent
         return $this->touch();
     }
 
+    public function getDecisionKey(): ?string
+    {
+        return $this->decisionKey;
+    }
+
+    public function setDecisionKey(?string $decisionKey): self
+    {
+        $decisionKey = $decisionKey !== null ? trim($decisionKey) : null;
+        $this->decisionKey = $decisionKey !== '' ? $decisionKey : null;
+        return $this->touch();
+    }
+
+    public function getStrategyProfile(): ?string
+    {
+        return $this->strategyProfile;
+    }
+
+    public function setStrategyProfile(?string $strategyProfile): self
+    {
+        $strategyProfile = $strategyProfile !== null ? trim($strategyProfile) : null;
+        $this->strategyProfile = $strategyProfile !== '' ? $strategyProfile : null;
+        return $this->touch();
+    }
+
+    public function getStrategyVersion(): ?string
+    {
+        return $this->strategyVersion;
+    }
+
+    public function setStrategyVersion(?string $strategyVersion): self
+    {
+        $strategyVersion = $strategyVersion !== null ? trim($strategyVersion) : null;
+        $this->strategyVersion = $strategyVersion !== '' ? $strategyVersion : null;
+        return $this->touch();
+    }
+
     public function getSymbol(): string
     {
         return $this->symbol;
@@ -154,6 +210,29 @@ class OrderIntent
     public function setSymbol(string $symbol): self
     {
         $this->symbol = strtoupper($symbol);
+        return $this->touch();
+    }
+
+    public function getTimeframe(): ?string
+    {
+        return $this->timeframe;
+    }
+
+    public function setTimeframe(?string $timeframe): self
+    {
+        $timeframe = $timeframe !== null ? strtolower(trim($timeframe)) : null;
+        $this->timeframe = $timeframe !== '' ? $timeframe : null;
+        return $this->touch();
+    }
+
+    public function getCandleOpenTs(): ?\DateTimeImmutable
+    {
+        return $this->candleOpenTs;
+    }
+
+    public function setCandleOpenTs(?\DateTimeImmutable $candleOpenTs): self
+    {
+        $this->candleOpenTs = $candleOpenTs;
         return $this->touch();
     }
 
@@ -346,6 +425,17 @@ class OrderIntent
         return $this->touch();
     }
 
+    public function getExchangeOrderId(): ?string
+    {
+        return $this->exchangeOrderId;
+    }
+
+    public function setExchangeOrderId(?string $exchangeOrderId): self
+    {
+        $this->exchangeOrderId = $exchangeOrderId;
+        return $this->touch();
+    }
+
     public function getFailureReason(): ?string
     {
         return $this->failureReason;
@@ -454,6 +544,7 @@ class OrderIntent
         $this->setStatus(self::STATUS_SENT);
         if ($orderId !== null) {
             $this->setOrderId($orderId);
+            $this->setExchangeOrderId($orderId);
         }
         $this->setSentAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
         return $this->touch();

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -387,6 +387,11 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             $options['preset_take_profit_price'] = (string) $request->attachedTakeProfitPrice;
             $options['preset_take_profit_price_type'] = 1;
         }
+        foreach (['decision_key', 'order_intent_id'] as $metadataKey) {
+            if (isset($request->metadata[$metadataKey]) && $request->metadata[$metadataKey] !== null && $request->metadata[$metadataKey] !== '') {
+                $options[$metadataKey] = $request->metadata[$metadataKey];
+            }
+        }
 
         return $options;
     }

--- a/trading-app/src/Indicator/Provider/IndicatorEngineProvider.php
+++ b/trading-app/src/Indicator/Provider/IndicatorEngineProvider.php
@@ -112,7 +112,13 @@ final class IndicatorEngineProvider implements IndicatorEngineInterface
         if (isset($options['stop_loss'])) $builder->stopLoss((float)$options['stop_loss']);
         if (isset($options['atr_k'])) $builder->atrK((float)$options['atr_k']);
 
-        return $builder->build();
+        $context = $builder->build();
+        if ($lastOpenTime instanceof \DateTimeImmutable) {
+            $context['kline_time'] = $lastOpenTime->format('Y-m-d H:i:s');
+            $context['candle_open_ts'] = $lastOpenTime->getTimestamp();
+        }
+
+        return $context;
     }
 
     public function evaluateYaml(string $timeframe, array $context): array

--- a/trading-app/src/MtfValidator/MessageHandler/MtfTradingDecisionMessageHandler.php
+++ b/trading-app/src/MtfValidator/MessageHandler/MtfTradingDecisionMessageHandler.php
@@ -47,8 +47,12 @@ final class MtfTradingDecisionMessageHandler
             tradingDecision: null,
             error: null,
             context: [
+                'evaluated_at' => $result->evaluatedAt->format(\DateTimeInterface::ATOM),
+                'profile' => $result->profile,
+                'mode' => $result->mode,
                 'context' => $result->context->toArray(),
                 'execution' => $result->execution->toArray(),
+                'extra' => $result->extra,
             ],
             currentPrice: null,
             atr: null,

--- a/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
+++ b/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
@@ -17,6 +17,7 @@ use App\Contract\Provider\MainProviderInterface;
 use App\Common\Enum\Timeframe;
 use App\Logging\LifecycleContextFactory;
 use App\Provider\Context\ExchangeContext;
+use App\TradeEntry\Idempotency\DecisionKeyFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -43,6 +44,7 @@ final class TradingDecisionHandler
         private readonly AuditLoggerInterface $auditLogger,
         private readonly LifecycleContextFactory $lifecycleContextFactory,
         private readonly ?MainProviderInterface $mainProvider = null,
+        private readonly ?DecisionKeyFactory $decisionKeyFactory = null,
     ) {}
 
     public function handleTradingDecision(SymbolResultDto $symbolResult, MtfRunDto $mtfRunDto, string $runId): SymbolResultDto
@@ -55,8 +57,15 @@ final class TradingDecisionHandler
             return $symbolResult;
         }
 
-        $decisionKey = $this->generateDecisionKey($symbolResult->symbol);
         $exchangeContext = ExchangeContext::fromArray($mtfRunDto->options);
+        $resolvedMode = $this->tradeEntryConfigResolver->resolveMode($symbolResult->tradeEntryModeUsed);
+        $tradeEntryConfig = $this->tradeEntryConfigResolver->resolve($symbolResult->tradeEntryModeUsed);
+        $decisionKey = $this->generateDecisionKey(
+            symbolResult: $symbolResult,
+            exchangeContext: $exchangeContext,
+            strategyProfile: $resolvedMode,
+            strategyVersion: $tradeEntryConfig->getVersion(),
+        );
         // trade_id global pour ce cycle de trade (zone → ouverture → clôture)
         try {
             $tradeId = sprintf(
@@ -69,9 +78,6 @@ final class TradingDecisionHandler
         }
         // Force ATR to the 5m timeframe so downstream sizing/guards stay consistent across execution TFs.
         $forcedAtr5m = $this->indicatorProvider->getAtr(symbol: $symbolResult->symbol, tf: '5m', context: $exchangeContext);
-
-        $resolvedMode = $this->tradeEntryConfigResolver->resolveMode($symbolResult->tradeEntryModeUsed);
-        $tradeEntryConfig = $this->tradeEntryConfigResolver->resolve($symbolResult->tradeEntryModeUsed);
 
         $this->mtfLogger->info('order_journey.signal_ready', [
             'symbol' => $symbolResult->symbol,
@@ -866,12 +872,83 @@ final class TradingDecisionHandler
         }
     }
 
-    private function generateDecisionKey(string $symbol): string
+    private function generateDecisionKey(
+        SymbolResultDto $symbolResult,
+        ExchangeContext $exchangeContext,
+        string $strategyProfile,
+        string $strategyVersion,
+    ): string {
+        $factory = $this->decisionKeyFactory ?? new DecisionKeyFactory();
+        $timeframe = $symbolResult->executionTf;
+        $evaluatedAt = $this->extractEvaluatedAt($symbolResult);
+
+        return $factory->key(
+            context: $exchangeContext,
+            symbol: $symbolResult->symbol,
+            timeframe: $timeframe,
+            candleOpenTs: $this->extractCandleOpenTs($symbolResult, $timeframe),
+            side: $symbolResult->signalSide,
+            strategyProfile: $strategyProfile,
+            strategyVersion: $strategyVersion,
+            evaluatedAt: $evaluatedAt,
+        );
+    }
+
+    private function extractEvaluatedAt(SymbolResultDto $symbolResult): ?\DateTimeImmutable
     {
-        try {
-            return sprintf('mtf:%s:%s', $symbol, bin2hex(random_bytes(6)));
-        } catch (\Throwable) {
-            return uniqid('mtf:' . $symbol . ':', true);
+        $context = $symbolResult->context ?? [];
+        $candidate = $context['evaluated_at'] ?? null;
+        if (\is_string($candidate) && trim($candidate) !== '') {
+            try {
+                return new \DateTimeImmutable($candidate, new \DateTimeZone('UTC'));
+            } catch (\Throwable) {
+                return null;
+            }
         }
+
+        return null;
+    }
+
+    private function extractCandleOpenTs(SymbolResultDto $symbolResult, ?string $timeframe): mixed
+    {
+        $context = $symbolResult->context ?? [];
+        foreach (['candle_open_ts', 'kline_time'] as $key) {
+            if (isset($context[$key])) {
+                return $context[$key];
+            }
+        }
+
+        foreach (['execution', 'context'] as $section) {
+            $decisions = $context[$section]['timeframe_decisions'] ?? null;
+            if (!\is_array($decisions)) {
+                continue;
+            }
+
+            foreach ($decisions as $decision) {
+                if (!\is_array($decision) || strtolower((string)($decision['timeframe'] ?? '')) !== strtolower((string)$timeframe)) {
+                    continue;
+                }
+
+                $extra = $decision['extra'] ?? [];
+                if (\is_array($extra)) {
+                    foreach (['candle_open_ts', 'kline_time'] as $key) {
+                        if (isset($extra[$key])) {
+                            return $extra[$key];
+                        }
+                    }
+
+                    $indicatorContext = $extra['indicator_context'] ?? null;
+                    if (\is_array($indicatorContext)) {
+                        foreach (['candle_open_ts', 'kline_time'] as $key) {
+                            if (isset($indicatorContext[$key])) {
+                                return $indicatorContext[$key];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
@@ -107,19 +107,40 @@ final class BitmartOrderProvider implements ContextualOrderProviderInterface
                 'options' => $options,
             ];
 
-            $intent = $this->intentManager->createIntent($payload, $quantization, $rawInputs);
+            $managedUpstream = isset($options['order_intent_id']) && is_numeric($options['order_intent_id']);
+            if ($this->intentManager !== null && $managedUpstream) {
+                $intent = $this->intentManager->findIntentById((int) $options['order_intent_id']);
+                if (!$intent instanceof OrderIntent) {
+                    $this->logger->error('[BitmartOrderProvider] Upstream order intent not found', [
+                        'order_intent_id' => $options['order_intent_id'],
+                        'client_order_id' => $payload['client_order_id'] ?? null,
+                    ]);
 
-            // Valider l'intent (validation basique)
-            $validationErrors = $this->validateOrderParams($payload);
-            if (!$this->intentManager->validateIntent($intent, $validationErrors)) {
-                // Validation échouée, mais on continue quand même l'envoi
-                $this->logger->warning('[BitmartOrderProvider] Intent validation failed but continuing', [
-                    'client_order_id' => $intent->getClientOrderId(),
-                    'errors' => $validationErrors,
-                ]);
+                    return null;
+                }
+            } elseif ($this->intentManager !== null) {
+                $reservation = $this->intentManager->reserveIntent($payload, $quantization, $rawInputs);
+                if ($reservation->blocked) {
+                    return $this->dtoForBlockedIntent($reservation->intent, $symbol, $side, $type, $quantity, $price, $stopPrice, $context);
+                }
+
+                $intent = $reservation->intent;
+                $validationErrors = $this->intentManager->validateOrderParams($payload);
+                if (!$this->intentManager->validateIntent($intent, $validationErrors)) {
+                    $this->logger->warning('[BitmartOrderProvider] Intent validation failed, order submission blocked', [
+                        'client_order_id' => $intent->getClientOrderId(),
+                        'decision_key' => $intent->getDecisionKey(),
+                        'errors' => $validationErrors,
+                    ]);
+
+                    return null;
+                }
+
+                $this->intentManager->markReadyToSend($intent);
             }
-
-            $this->intentManager->markReadyToSend($intent);
+            if ($intent instanceof OrderIntent) {
+                $payload['client_order_id'] = $intent->getClientOrderId();
+            }
 
             $orderPayload = $this->toExchangeOrderPayload($payload);
 
@@ -130,13 +151,15 @@ final class BitmartOrderProvider implements ContextualOrderProviderInterface
                 $orderId = (string) $response['data']['order_id'];
 
                 // Marquer l'intent comme SENT
-                try {
-                    $this->intentManager->markAsSent($intent, $orderId);
-                } catch (\Throwable $e) {
-                    $this->logger->warning('[BitmartOrderProvider] Failed to mark intent as sent', [
-                        'order_id' => $orderId,
-                        'error' => $e->getMessage(),
-                    ]);
+                if ($intent instanceof OrderIntent && $this->intentManager !== null) {
+                    try {
+                        $this->intentManager->markAsSent($intent, $orderId);
+                    } catch (\Throwable $e) {
+                        $this->logger->warning('[BitmartOrderProvider] Failed to mark intent as sent', [
+                            'order_id' => $orderId,
+                            'error' => $e->getMessage(),
+                        ]);
+                    }
                 }
 
                 // Synchroniser la réponse de soumission si disponible
@@ -349,6 +372,60 @@ final class BitmartOrderProvider implements ContextualOrderProviderInterface
         }
 
         return count($errors) > 0 ? $errors : null;
+    }
+
+    private function dtoForBlockedIntent(
+        OrderIntent $intent,
+        string $symbol,
+        OrderSide $side,
+        OrderType $type,
+        float $quantity,
+        ?float $price,
+        ?float $stopPrice,
+        ExchangeContext $context,
+    ): ?OrderDto {
+        $orderId = $intent->getExchangeOrderId() ?? $intent->getOrderId();
+        if ($orderId === null || trim($orderId) === '') {
+            $this->logger->warning('[BitmartOrderProvider] Idempotent replay blocked before exchange submission', [
+                'order_intent_id' => $intent->getId(),
+                'client_order_id' => $intent->getClientOrderId(),
+                'decision_key' => $intent->getDecisionKey(),
+                'status' => $intent->getStatus(),
+            ]);
+
+            return null;
+        }
+
+        $existing = $this->getOrder($symbol, $orderId, $context);
+        if ($existing instanceof OrderDto) {
+            return $existing;
+        }
+
+        return OrderDto::fromArray([
+            'order_id' => $orderId,
+            'symbol' => $symbol,
+            'side' => $side->value,
+            'type' => $type->value,
+            'status' => 'pending',
+            'quantity' => (string) $quantity,
+            'price' => $price !== null ? (string) $price : null,
+            'stop_price' => $stopPrice !== null ? (string) $stopPrice : null,
+            'filled_quantity' => '0',
+            'remaining_quantity' => (string) $quantity,
+            'average_price' => null,
+            'created_at' => $intent->getCreatedAt()->format('Y-m-d H:i:s'),
+            'updated_at' => null,
+            'filled_at' => null,
+            'metadata' => [
+                'provider' => 'bitmart',
+                'idempotent_replay' => true,
+                'order_intent_id' => $intent->getId(),
+                'client_order_id' => $intent->getClientOrderId(),
+                'decision_key' => $intent->getDecisionKey(),
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+            ],
+        ]);
     }
 
     public function getOrder(string $symbol, string $orderId, ?ExchangeContext $context = null): ?OrderDto
@@ -962,6 +1039,12 @@ final class BitmartOrderProvider implements ContextualOrderProviderInterface
             $payload['exchange'],
             $payload['market_type'],
             $payload['marketType'],
+            $payload['decision_key'],
+            $payload['order_intent_id'],
+            $payload['strategy_profile'],
+            $payload['strategy_version'],
+            $payload['timeframe'],
+            $payload['candle_open_ts'],
         );
 
         return $payload;

--- a/trading-app/src/Repository/OrderIntentRepository.php
+++ b/trading-app/src/Repository/OrderIntentRepository.php
@@ -28,13 +28,32 @@ final class OrderIntentRepository extends ServiceEntityRepository
         ]);
     }
 
-    public function findOneByOrderId(string $orderId, ?ExchangeContext $context = null): ?OrderIntent
+    public function findOneByDecisionKey(string $decisionKey, ?ExchangeContext $context = null): ?OrderIntent
     {
         return $this->findOneBy([
             'exchange' => ExchangeContext::exchangeValue($context),
             'marketType' => ExchangeContext::marketTypeValue($context),
-            'orderId' => $orderId,
-        ]);
+            'decisionKey' => $decisionKey,
+        ], ['createdAt' => 'DESC']);
+    }
+
+    public function findOneByOrderId(string $orderId, ?ExchangeContext $context = null): ?OrderIntent
+    {
+        return $this->createQueryBuilder('oi')
+            ->where('oi.exchange = :exchange')
+            ->andWhere('oi.marketType = :marketType')
+            ->andWhere('(oi.orderId = :orderId OR oi.exchangeOrderId = :orderId)')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
+            ->setParameter('orderId', $orderId)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findOneById(int $id): ?OrderIntent
+    {
+        return $this->find($id);
     }
 
     /**

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -8,15 +8,27 @@ use App\Entity\OrderIntent;
 use App\Entity\OrderProtection;
 use App\Provider\Context\ExchangeContext;
 use App\Repository\OrderIntentRepository;
+use App\TradeEntry\Idempotency\DecisionKeyFactory;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 
 final class OrderIntentManager
 {
+    private const BLOCKING_STATUSES = [
+        OrderIntent::STATUS_DRAFT,
+        OrderIntent::STATUS_VALIDATED,
+        OrderIntent::STATUS_READY_TO_SEND,
+        OrderIntent::STATUS_SENT,
+        OrderIntent::STATUS_FAILED,
+        OrderIntent::STATUS_CANCELLED,
+    ];
+
     public function __construct(
         private readonly OrderIntentRepository $orderIntentRepository,
         private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
+        private readonly DecisionKeyFactory $decisionKeyFactory,
     ) {
     }
 
@@ -31,68 +43,13 @@ final class OrderIntentManager
         array $quantization = [],
         ?array $rawInputs = null
     ): OrderIntent {
-        $intent = new OrderIntent();
-
-        $intent->setExchange((string)($orderParams['exchange'] ?? ExchangeContext::exchangeValue(null)));
-        $intent->setMarketType((string)($orderParams['market_type'] ?? $orderParams['marketType'] ?? ExchangeContext::marketTypeValue(null)));
-        $intent->setSymbol($orderParams['symbol'] ?? '');
-        $intent->setSide((int)($orderParams['side'] ?? 1));
-        $intent->setType($orderParams['type'] ?? OrderIntent::TYPE_LIMIT);
-        $intent->setOpenType($orderParams['open_type'] ?? OrderIntent::OPEN_TYPE_ISOLATED);
-        
-        if (isset($orderParams['leverage'])) {
-            $intent->setLeverage((int)$orderParams['leverage']);
-        }
-
-        $intent->setPositionMode(
-            $orderParams['position_mode'] ?? OrderIntent::POSITION_MODE_ONE_WAY
-        );
-
-        if (isset($orderParams['price'])) {
-            $intent->setPrice((string)$orderParams['price']);
-        }
-
-        $intent->setSize((int)($orderParams['size'] ?? 0));
-        
-        // Générer un client_order_id unique s'il n'est pas fourni
-        $clientOrderId = $orderParams['client_order_id'] 
-            ?? $this->generateClientOrderId($intent->getSymbol());
-        $intent->setClientOrderId($clientOrderId);
-
-        $intent->setPresetMode(
-            $orderParams['preset_mode'] ?? OrderIntent::PRESET_MODE_NONE
-        );
-
-        $intent->setQuantization($quantization);
-        $intent->setRawInputs($rawInputs);
-        $intent->setStatus(OrderIntent::STATUS_DRAFT);
-
-        // Ajouter les protections TP/SL si présentes
-        if (isset($orderParams['preset_take_profit_price'])) {
-            $tp = new OrderProtection();
-            $tp->setExchange($intent->getExchange());
-            $tp->setMarketType($intent->getMarketType());
-            $tp->setType(OrderProtection::TYPE_TAKE_PROFIT);
-            $tp->setPrice((string)$orderParams['preset_take_profit_price']);
-            $tp->setPriceType($orderParams['preset_take_profit_price_type'] ?? 1);
-            $intent->addProtection($tp);
-        }
-
-        if (isset($orderParams['preset_stop_loss_price'])) {
-            $sl = new OrderProtection();
-            $sl->setExchange($intent->getExchange());
-            $sl->setMarketType($intent->getMarketType());
-            $sl->setType(OrderProtection::TYPE_STOP_LOSS);
-            $sl->setPrice((string)$orderParams['preset_stop_loss_price']);
-            $sl->setPriceType($orderParams['preset_stop_loss_price_type'] ?? 1);
-            $intent->addProtection($sl);
-        }
+        $intent = $this->buildIntent($orderParams, $quantization, $rawInputs);
 
         $this->entityManager->persist($intent);
         $this->entityManager->flush();
 
         $this->logger->debug('[OrderIntentManager] Created intent', [
-            'client_order_id' => $clientOrderId,
+            'client_order_id' => $intent->getClientOrderId(),
             'exchange' => $intent->getExchange(),
             'market_type' => $intent->getMarketType(),
             'symbol' => $intent->getSymbol(),
@@ -100,6 +57,117 @@ final class OrderIntentManager
         ]);
 
         return $intent;
+    }
+
+    /**
+     * @param array<string,mixed> $orderParams
+     * @param array<string,mixed> $quantization
+     * @param array<string,mixed>|null $rawInputs
+     */
+    public function reserveIntent(
+        array $orderParams,
+        array $quantization = [],
+        ?array $rawInputs = null,
+    ): OrderIntentReservation {
+        $decisionKey = isset($orderParams['decision_key']) ? trim((string) $orderParams['decision_key']) : '';
+        if ($decisionKey === '') {
+            $context = $this->contextFromParams($orderParams);
+            $clientOrderId = isset($orderParams['client_order_id']) ? trim((string) $orderParams['client_order_id']) : '';
+            if ($clientOrderId !== '') {
+                $existing = $this->orderIntentRepository->findOneByClientOrderId($clientOrderId, $context);
+                if ($existing instanceof OrderIntent) {
+                    $this->logger->warning('[OrderIntentManager] Duplicate client_order_id replay blocked', [
+                        'order_intent_id' => $existing->getId(),
+                        'client_order_id' => $existing->getClientOrderId(),
+                        'exchange_order_id' => $existing->getExchangeOrderId() ?? $existing->getOrderId(),
+                        'status' => $existing->getStatus(),
+                    ]);
+
+                    return OrderIntentReservation::blocked($existing, 'idempotent_client_order_id_replay');
+                }
+            }
+
+            return OrderIntentReservation::created($this->createIntent($orderParams, $quantization, $rawInputs));
+        }
+
+        $context = $this->contextFromParams($orderParams);
+
+        try {
+            $connection = $this->entityManager->getConnection();
+            $connection->beginTransaction();
+            try {
+                $this->lockDecisionKey($context, $decisionKey);
+
+                $existing = $this->orderIntentRepository->findOneByDecisionKey($decisionKey, $context);
+                if ($existing instanceof OrderIntent) {
+                    $connection->commit();
+                    return $this->reservationForExisting($existing);
+                }
+
+                $intent = $this->buildIntent($orderParams, $quantization, $rawInputs);
+                $this->entityManager->persist($intent);
+                $this->entityManager->flush();
+                $connection->commit();
+
+                $this->logger->debug('[OrderIntentManager] Reserved intent', [
+                    'order_intent_id' => $intent->getId(),
+                    'client_order_id' => $intent->getClientOrderId(),
+                    'decision_key' => $intent->getDecisionKey(),
+                    'exchange' => $intent->getExchange(),
+                    'market_type' => $intent->getMarketType(),
+                    'symbol' => $intent->getSymbol(),
+                    'status' => $intent->getStatus(),
+                ]);
+
+                return OrderIntentReservation::created($intent);
+            } catch (\Throwable $e) {
+                if ($connection->isTransactionActive()) {
+                    $connection->rollBack();
+                }
+
+                throw $e;
+            }
+        } catch (UniqueConstraintViolationException $e) {
+            $existing = $this->orderIntentRepository->findOneByDecisionKey($decisionKey, $context);
+            if ($existing instanceof OrderIntent) {
+                return $this->reservationForExisting($existing);
+            }
+
+            throw $e;
+        }
+    }
+
+    public function findIntentById(int $id): ?OrderIntent
+    {
+        return $this->orderIntentRepository->findOneById($id);
+    }
+
+    /**
+     * @param array<string,mixed> $orderParams
+     * @return array<string,string>|null
+     */
+    public function validateOrderParams(array $orderParams): ?array
+    {
+        $errors = [];
+        $type = strtolower((string)($orderParams['type'] ?? ''));
+
+        if (trim((string)($orderParams['symbol'] ?? '')) === '') {
+            $errors['symbol'] = 'Symbol is required';
+        }
+        if (!\in_array((int)($orderParams['side'] ?? 0), [1, 2, 3, 4], true)) {
+            $errors['side'] = 'Invalid side value';
+        }
+        if (!\in_array($type, [OrderIntent::TYPE_LIMIT, OrderIntent::TYPE_MARKET], true)) {
+            $errors['type'] = 'Invalid type value';
+        }
+        if ((int)($orderParams['size'] ?? 0) <= 0) {
+            $errors['size'] = 'Size must be positive';
+        }
+        if ($type === OrderIntent::TYPE_LIMIT && trim((string)($orderParams['price'] ?? '')) === '') {
+            $errors['price'] = 'Price is required for limit orders';
+        }
+
+        return $errors !== [] ? $errors : null;
     }
 
     /**
@@ -191,6 +259,7 @@ final class OrderIntentManager
         ?string $clientOrderId = null,
         ?string $orderId = null,
         ?ExchangeContext $context = null,
+        ?string $decisionKey = null,
     ): ?OrderIntent
     {
         if ($clientOrderId !== null) {
@@ -201,7 +270,163 @@ final class OrderIntentManager
             return $this->orderIntentRepository->findOneByOrderId($orderId, $context);
         }
 
+        if ($decisionKey !== null) {
+            return $this->orderIntentRepository->findOneByDecisionKey($decisionKey, $context);
+        }
+
         return null;
+    }
+
+    /**
+     * @param array<string,mixed> $orderParams
+     * @param array<string,mixed> $quantization
+     * @param array<string,mixed>|null $rawInputs
+     */
+    private function buildIntent(
+        array $orderParams,
+        array $quantization = [],
+        ?array $rawInputs = null,
+    ): OrderIntent {
+        $intent = new OrderIntent();
+
+        $intent->setExchange((string)($orderParams['exchange'] ?? ExchangeContext::exchangeValue(null)));
+        $intent->setMarketType((string)($orderParams['market_type'] ?? $orderParams['marketType'] ?? ExchangeContext::marketTypeValue(null)));
+        $intent->setSymbol($orderParams['symbol'] ?? '');
+        $intent->setSide((int)($orderParams['side'] ?? 1));
+        $intent->setType($orderParams['type'] ?? OrderIntent::TYPE_LIMIT);
+        $intent->setOpenType($orderParams['open_type'] ?? OrderIntent::OPEN_TYPE_ISOLATED);
+
+        if (isset($orderParams['leverage'])) {
+            $intent->setLeverage((int)$orderParams['leverage']);
+        }
+
+        $intent->setPositionMode(
+            $orderParams['position_mode'] ?? OrderIntent::POSITION_MODE_ONE_WAY
+        );
+
+        if (isset($orderParams['price'])) {
+            $intent->setPrice((string)$orderParams['price']);
+        }
+
+        $intent->setSize((int)($orderParams['size'] ?? 0));
+
+        $clientOrderId = $orderParams['client_order_id']
+            ?? $this->generateClientOrderId($intent->getSymbol());
+        $intent->setClientOrderId((string) $clientOrderId);
+
+        $intent->setPresetMode(
+            $orderParams['preset_mode'] ?? OrderIntent::PRESET_MODE_NONE
+        );
+
+        $this->hydrateIdempotencyFields($intent, $orderParams);
+
+        $intent->setQuantization($quantization);
+        $intent->setRawInputs($rawInputs);
+        $intent->setStatus(OrderIntent::STATUS_DRAFT);
+
+        if (isset($orderParams['preset_take_profit_price'])) {
+            $tp = new OrderProtection();
+            $tp->setExchange($intent->getExchange());
+            $tp->setMarketType($intent->getMarketType());
+            $tp->setType(OrderProtection::TYPE_TAKE_PROFIT);
+            $tp->setPrice((string)$orderParams['preset_take_profit_price']);
+            $tp->setPriceType($orderParams['preset_take_profit_price_type'] ?? 1);
+            $intent->addProtection($tp);
+        }
+
+        if (isset($orderParams['preset_stop_loss_price'])) {
+            $sl = new OrderProtection();
+            $sl->setExchange($intent->getExchange());
+            $sl->setMarketType($intent->getMarketType());
+            $sl->setType(OrderProtection::TYPE_STOP_LOSS);
+            $sl->setPrice((string)$orderParams['preset_stop_loss_price']);
+            $sl->setPriceType($orderParams['preset_stop_loss_price_type'] ?? 1);
+            $intent->addProtection($sl);
+        }
+
+        return $intent;
+    }
+
+    /**
+     * @param array<string,mixed> $orderParams
+     */
+    private function hydrateIdempotencyFields(OrderIntent $intent, array $orderParams): void
+    {
+        $decisionKey = isset($orderParams['decision_key']) ? trim((string) $orderParams['decision_key']) : '';
+        if ($decisionKey === '') {
+            return;
+        }
+
+        $intent->setDecisionKey($decisionKey);
+        $parsed = $this->decisionKeyFactory->parse($decisionKey);
+
+        $intent->setStrategyProfile((string)($orderParams['strategy_profile'] ?? $parsed['strategy_profile'] ?? ''));
+        $intent->setStrategyVersion((string)($orderParams['strategy_version'] ?? $parsed['strategy_version'] ?? ''));
+        $intent->setTimeframe((string)($orderParams['timeframe'] ?? $parsed['timeframe'] ?? ''));
+
+        $candleOpenTs = $orderParams['candle_open_ts'] ?? $parsed['candle_open_ts'] ?? null;
+        $timestamp = $this->decisionKeyFactory->normalizeCandleOpenTs($candleOpenTs, $intent->getTimeframe());
+        $intent->setCandleOpenTs((new \DateTimeImmutable('@' . $timestamp))->setTimezone(new \DateTimeZone('UTC')));
+    }
+
+    /**
+     * @param array<string,mixed> $orderParams
+     */
+    private function contextFromParams(array $orderParams): ExchangeContext
+    {
+        return ExchangeContext::fromValues(
+            $orderParams['exchange'] ?? null,
+            $orderParams['market_type'] ?? $orderParams['marketType'] ?? null,
+        );
+    }
+
+    private function reservationForExisting(OrderIntent $existing): OrderIntentReservation
+    {
+        $reason = $this->blockingReason($existing);
+        $this->logger->info('[OrderIntentManager] Existing intent found for decision key', [
+            'order_intent_id' => $existing->getId(),
+            'client_order_id' => $existing->getClientOrderId(),
+            'exchange_order_id' => $existing->getExchangeOrderId() ?? $existing->getOrderId(),
+            'decision_key' => $existing->getDecisionKey(),
+            'status' => $existing->getStatus(),
+            'reason' => $reason,
+        ]);
+
+        if ($reason !== null) {
+            return OrderIntentReservation::blocked($existing, $reason);
+        }
+
+        return OrderIntentReservation::existing($existing);
+    }
+
+    private function blockingReason(OrderIntent $intent): ?string
+    {
+        if (!\in_array($intent->getStatus(), self::BLOCKING_STATUSES, true)) {
+            return null;
+        }
+
+        return match ($intent->getStatus()) {
+            OrderIntent::STATUS_FAILED => 'idempotent_failed_not_replayed',
+            OrderIntent::STATUS_CANCELLED => 'idempotent_cancelled_not_replayed',
+            OrderIntent::STATUS_SENT => 'idempotent_sent_replay',
+            default => 'idempotent_in_flight',
+        };
+    }
+
+    private function lockDecisionKey(ExchangeContext $context, string $decisionKey): void
+    {
+        $connection = $this->entityManager->getConnection();
+        if ($connection->getDatabasePlatform()->getName() !== 'postgresql') {
+            return;
+        }
+
+        $connection->executeStatement(
+            'SELECT pg_advisory_xact_lock(hashtext(:scope), hashtext(:decision_key))',
+            [
+                'scope' => $context->key(),
+                'decision_key' => $decisionKey,
+            ],
+        );
     }
 
     /**

--- a/trading-app/src/Service/OrderIntentReservation.php
+++ b/trading-app/src/Service/OrderIntentReservation.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\OrderIntent;
+
+final class OrderIntentReservation
+{
+    private function __construct(
+        public readonly OrderIntent $intent,
+        public readonly bool $created,
+        public readonly bool $blocked,
+        public readonly ?string $reason = null,
+    ) {
+    }
+
+    public static function created(OrderIntent $intent): self
+    {
+        return new self($intent, true, false);
+    }
+
+    public static function existing(OrderIntent $intent): self
+    {
+        return new self($intent, false, false);
+    }
+
+    public static function blocked(OrderIntent $intent, string $reason): self
+    {
+        return new self($intent, false, true, $reason);
+    }
+}

--- a/trading-app/src/TradeEntry/Execution/ExchangeExecutionService.php
+++ b/trading-app/src/TradeEntry/Execution/ExchangeExecutionService.php
@@ -44,20 +44,25 @@ final class ExchangeExecutionService
         ?string $decisionKey = null,
         ?string $mode = null,
         ?string $executionTf = null,
+        ?string $clientOrderId = null,
+        ?int $orderIntentId = null,
+        bool $planPrepared = false,
     ): ExecutionResult
     {
-        $this->orderModePolicy->enforce($plan);
-        $plan = $this->applyTimeframeMultiplier($plan, $mode, $executionTf, $decisionKey);
+        if (!$planPrepared) {
+            $plan = $this->preparePlan($plan, $mode, $executionTf, $decisionKey);
+        }
+
         if ($plan->size < 1) {
-            return $this->skipBelowMinimum($plan, $decisionKey, 'size_below_min', 'size', $plan->size, 1);
+            return $this->skipBelowMinimum($plan, $decisionKey, 'size_below_min', 'size', $plan->size, 1, $clientOrderId);
         }
         if ($plan->leverage < 1) {
-            return $this->skipBelowMinimum($plan, $decisionKey, 'leverage_below_min', 'leverage', $plan->leverage, 1);
+            return $this->skipBelowMinimum($plan, $decisionKey, 'leverage_below_min', 'leverage', $plan->leverage, 1, $clientOrderId);
         }
 
         $context = ExchangeContext::resolve($plan->exchangeContext);
         $adapter = $this->adapters->get($context->exchange, $context->marketType);
-        $clientOrderId = $this->idempotency->newClientOrderId();
+        $clientOrderId ??= $this->idempotency->newClientOrderId($decisionKey);
         $capabilities = $adapter->capabilities();
         if ($this->shouldRejectUnprotectableBitmartMarket($context, $plan, $capabilities)) {
             $this->positionsLogger->error('exchange_execution.entry_rejected_unprotectable_market', [
@@ -116,6 +121,7 @@ final class ExchangeExecutionService
                 attachStopLoss: $attachedStopLossRequested,
                 attachTakeProfit: $attachedTakeProfitRequested,
                 decisionKey: $decisionKey,
+                orderIntentId: $orderIntentId,
             ));
         } catch (\Throwable $e) {
             $this->positionsLogger->error('exchange_execution.entry_submit_failed', [
@@ -244,6 +250,17 @@ final class ExchangeExecutionService
         return $this->executionResultFromProtection($clientOrderId, $entryResult, $protection, $leverageSet);
     }
 
+    public function preparePlan(
+        OrderPlanModel $plan,
+        ?string $mode = null,
+        ?string $executionTf = null,
+        ?string $decisionKey = null,
+    ): OrderPlanModel {
+        $this->orderModePolicy->enforce($plan);
+
+        return $this->applyTimeframeMultiplier($plan, $mode, $executionTf, $decisionKey);
+    }
+
     private function executionResultFromProtection(
         string $clientOrderId,
         PlaceOrderResult $entryResult,
@@ -273,6 +290,7 @@ final class ExchangeExecutionService
         bool $attachStopLoss,
         bool $attachTakeProfit,
         ?string $decisionKey,
+        ?int $orderIntentId,
     ): PlaceOrderRequest {
         $orderType = $plan->orderType === 'market' ? ExchangeOrderType::MARKET : ExchangeOrderType::LIMIT;
 
@@ -296,6 +314,7 @@ final class ExchangeExecutionService
             attachedTakeProfitPrice: $attachTakeProfit ? $plan->takeProfit : null,
             metadata: [
                 'decision_key' => $decisionKey,
+                'order_intent_id' => $orderIntentId,
                 'source' => 'exchange_execution_service',
             ],
         );
@@ -319,8 +338,9 @@ final class ExchangeExecutionService
         string $field,
         int $value,
         int $minRequired,
+        ?string $clientOrderId = null,
     ): ExecutionResult {
-        $clientOrderId = $this->idempotency->newClientOrderId();
+        $clientOrderId ??= $this->idempotency->newClientOrderId($decisionKey);
         $this->positionsLogger->warning('exchange_execution.' . $reason, [
             'symbol' => $plan->symbol,
             $field => $value,

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -51,11 +51,15 @@ final class ExecutionBox
         ?string $decisionKey = null,
         ?LifecycleContextBuilder $contextBuilder = null,
         ?string $mode = null,
-        ?string $executionTf = null
+        ?string $executionTf = null,
+        ?string $clientOrderId = null,
+        ?int $orderIntentId = null,
+        bool $planPrepared = false,
     ): ExecutionResult
     {
-        $this->orderModePolicy->enforce($plan);
-        $plan = $this->applyTimeframeMultiplier($plan, $mode, $executionTf, $decisionKey);
+        if (!$planPrepared) {
+            $plan = $this->preparePlan($plan, $mode, $executionTf, $decisionKey);
+        }
         $this->positionsLogger->debug('execution.start', [
             'symbol' => $plan->symbol,
             'side' => $plan->side->value,
@@ -68,7 +72,7 @@ final class ExecutionBox
         ]);
 
         if ($plan->size < 1) {
-            $clientOrderId = $this->idempotency->newClientOrderId();
+            $clientOrderId ??= $this->idempotency->newClientOrderId($decisionKey);
             $this->positionsLogger->warning('execution.size_below_min', [
                 'symbol' => $plan->symbol,
                 'size' => $plan->size,
@@ -91,7 +95,7 @@ final class ExecutionBox
         }
 
         if ($plan->leverage < 1) {
-            $clientOrderId = $this->idempotency->newClientOrderId();
+            $clientOrderId ??= $this->idempotency->newClientOrderId($decisionKey);
             $this->positionsLogger->warning('execution.leverage_below_min', [
                 'symbol' => $plan->symbol,
                 'leverage' => $plan->leverage,
@@ -113,7 +117,7 @@ final class ExecutionBox
             );
         }
 
-        $clientOrderId = $this->idempotency->newClientOrderId();
+        $clientOrderId ??= $this->idempotency->newClientOrderId($decisionKey);
 
         $this->positionsLogger->debug('execution.leverage_submit', [
             'symbol' => $plan->symbol,
@@ -132,12 +136,13 @@ final class ExecutionBox
 
         // Router vers le flux market si nécessaire
         if ($plan->orderType === 'market') {
-            return $this->executeMarketOrder($plan, $clientOrderId, $decisionKey, $leverageResult);
+            return $this->executeMarketOrder($plan, $clientOrderId, $decisionKey, $leverageResult, $orderIntentId);
         }
 
        // $plan = $this->enforceTakeProfitCap($plan, $decisionKey);
 
         $payload = $this->tpSl->presetInSubmitPayload($plan, $clientOrderId);
+        $payload = $this->withIntentMetadata($payload, $decisionKey, $orderIntentId);
 
         // Mapper side BitMart (1,2,3,4) vers OrderSide enum
         $side = match($payload['side']) {
@@ -351,6 +356,17 @@ final class ExecutionBox
         );
     }
 
+    public function preparePlan(
+        OrderPlanModel $plan,
+        ?string $mode = null,
+        ?string $executionTf = null,
+        ?string $decisionKey = null,
+    ): OrderPlanModel {
+        $this->orderModePolicy->enforce($plan);
+
+        return $this->applyTimeframeMultiplier($plan, $mode, $executionTf, $decisionKey);
+    }
+
     /**
      * Prépare les options Bitmart pour l'appel placeOrder.
      *
@@ -369,6 +385,8 @@ final class ExecutionBox
         ];
 
         foreach ([
+            'decision_key',
+            'order_intent_id',
             'preset_take_profit_price',
             'preset_take_profit_price_type',
             'preset_stop_loss_price',
@@ -383,6 +401,22 @@ final class ExecutionBox
             $options,
             static fn($value) => $value !== null && $value !== ''
         );
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    private function withIntentMetadata(array $payload, ?string $decisionKey, ?int $orderIntentId): array
+    {
+        if ($decisionKey !== null && trim($decisionKey) !== '') {
+            $payload['decision_key'] = $decisionKey;
+        }
+        if ($orderIntentId !== null) {
+            $payload['order_intent_id'] = $orderIntentId;
+        }
+
+        return $payload;
     }
 
     private function applyTimeframeMultiplier(
@@ -568,7 +602,8 @@ final class ExecutionBox
         OrderPlanModel $plan,
         string $clientOrderId,
         ?string $decisionKey,
-        bool $leverageResult
+        bool $leverageResult,
+        ?int $orderIntentId = null,
     ): ExecutionResult {
         $this->positionsLogger->info('execution.market_order.start', [
             'symbol' => $plan->symbol,
@@ -580,6 +615,7 @@ final class ExecutionBox
 
         // 1) Soumettre l'ordre market sans TP/SL
         $payload = $this->tpSl->presetInSubmitPayload($plan, $clientOrderId);
+        $payload = $this->withIntentMetadata($payload, $decisionKey, $orderIntentId);
         $side = match($payload['side']) {
             1 => OrderSide::BUY,
             2 => OrderSide::SELL,

--- a/trading-app/src/TradeEntry/Idempotency/DecisionKeyFactory.php
+++ b/trading-app/src/TradeEntry/Idempotency/DecisionKeyFactory.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradeEntry\Idempotency;
+
+use App\Provider\Context\ExchangeContext;
+use App\TradeEntry\Types\Side;
+
+final class DecisionKeyFactory
+{
+    /**
+     * @return array{
+     *     exchange: string,
+     *     market_type: string,
+     *     symbol: string,
+     *     timeframe: string,
+     *     candle_open_ts: int,
+     *     side: string,
+     *     strategy_profile: string,
+     *     strategy_version: string
+     * }
+     */
+    public function create(
+        ?ExchangeContext $context,
+        string $symbol,
+        ?string $timeframe,
+        mixed $candleOpenTs,
+        Side|string|null $side,
+        ?string $strategyProfile,
+        ?string $strategyVersion,
+        ?\DateTimeInterface $evaluatedAt = null,
+    ): array {
+        $resolved = ExchangeContext::resolve($context);
+        $tf = $this->normalizeTimeframe($timeframe);
+
+        return [
+            'exchange' => $resolved->exchange->value,
+            'market_type' => $resolved->marketType->value,
+            'symbol' => strtoupper(trim($symbol)),
+            'timeframe' => $tf,
+            'candle_open_ts' => $this->normalizeCandleOpenTs($candleOpenTs, $tf, $evaluatedAt),
+            'side' => $this->normalizeSide($side),
+            'strategy_profile' => $this->normalizeToken($strategyProfile, 'default'),
+            'strategy_version' => $this->normalizeToken($strategyVersion, 'unknown'),
+        ];
+    }
+
+    public function key(
+        ?ExchangeContext $context,
+        string $symbol,
+        ?string $timeframe,
+        mixed $candleOpenTs,
+        Side|string|null $side,
+        ?string $strategyProfile,
+        ?string $strategyVersion,
+        ?\DateTimeInterface $evaluatedAt = null,
+    ): string {
+        $parts = $this->create(
+            context: $context,
+            symbol: $symbol,
+            timeframe: $timeframe,
+            candleOpenTs: $candleOpenTs,
+            side: $side,
+            strategyProfile: $strategyProfile,
+            strategyVersion: $strategyVersion,
+            evaluatedAt: $evaluatedAt,
+        );
+
+        return implode(':', [
+            $parts['exchange'],
+            $parts['market_type'],
+            $parts['symbol'],
+            $parts['timeframe'],
+            (string) $parts['candle_open_ts'],
+            $parts['side'],
+            $parts['strategy_profile'],
+            $parts['strategy_version'],
+        ]);
+    }
+
+    /**
+     * @return array{
+     *     exchange?: string,
+     *     market_type?: string,
+     *     symbol?: string,
+     *     timeframe?: string,
+     *     candle_open_ts?: int,
+     *     side?: string,
+     *     strategy_profile?: string,
+     *     strategy_version?: string
+     * }
+     */
+    public function parse(string $decisionKey): array
+    {
+        $parts = explode(':', trim($decisionKey), 8);
+        if (\count($parts) !== 8) {
+            return [];
+        }
+
+        [$exchange, $marketType, $symbol, $timeframe, $candleOpenTs, $side, $profile, $version] = $parts;
+        if ($exchange === '' || $marketType === '' || $symbol === '' || $timeframe === '' || !is_numeric($candleOpenTs)) {
+            return [];
+        }
+
+        return [
+            'exchange' => strtolower($exchange),
+            'market_type' => strtolower($marketType),
+            'symbol' => strtoupper($symbol),
+            'timeframe' => strtolower($timeframe),
+            'candle_open_ts' => (int) $candleOpenTs,
+            'side' => strtolower($side),
+            'strategy_profile' => strtolower($profile),
+            'strategy_version' => $version,
+        ];
+    }
+
+    public function normalizeCandleOpenTs(
+        mixed $candleOpenTs,
+        ?string $timeframe,
+        ?\DateTimeInterface $evaluatedAt = null,
+    ): int {
+        $timestamp = $this->timestamp($candleOpenTs);
+        if ($timestamp === null && $evaluatedAt !== null) {
+            $timestamp = $evaluatedAt->getTimestamp();
+        }
+        if ($timestamp === null) {
+            $timestamp = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->getTimestamp();
+        }
+
+        $seconds = $this->timeframeSeconds($timeframe);
+        if ($seconds === null || $seconds <= 0) {
+            return $timestamp;
+        }
+
+        return intdiv($timestamp, $seconds) * $seconds;
+    }
+
+    private function timestamp(mixed $value): ?int
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->getTimestamp();
+        }
+        if (is_int($value)) {
+            return $value > 9999999999 ? (int) round($value / 1000) : $value;
+        }
+        if (is_float($value)) {
+            $int = (int) round($value);
+            return $int > 9999999999 ? (int) round($int / 1000) : $int;
+        }
+        if (is_string($value) && trim($value) !== '') {
+            $value = trim($value);
+            if (is_numeric($value)) {
+                $int = (int) $value;
+                return $int > 9999999999 ? (int) round($int / 1000) : $int;
+            }
+
+            try {
+                return (new \DateTimeImmutable($value, new \DateTimeZone('UTC')))->getTimestamp();
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private function timeframeSeconds(?string $timeframe): ?int
+    {
+        $timeframe = $this->normalizeTimeframe($timeframe);
+        if (!preg_match('/^(\d+)([smhd])$/', $timeframe, $matches)) {
+            return null;
+        }
+
+        $value = (int) $matches[1];
+        return match ($matches[2]) {
+            's' => $value,
+            'm' => $value * 60,
+            'h' => $value * 3600,
+            'd' => $value * 86400,
+            default => null,
+        };
+    }
+
+    private function normalizeTimeframe(?string $timeframe): string
+    {
+        $timeframe = strtolower(trim((string) $timeframe));
+
+        return $timeframe !== '' ? $timeframe : 'unknown';
+    }
+
+    private function normalizeSide(Side|string|null $side): string
+    {
+        if ($side instanceof Side) {
+            return $side->value;
+        }
+
+        $side = strtolower(trim((string) $side));
+        if ($side === 'long' || $side === 'short') {
+            return $side;
+        }
+
+        return 'unknown';
+    }
+
+    private function normalizeToken(?string $value, string $fallback): string
+    {
+        $value = strtolower(trim((string) $value));
+        if ($value === '') {
+            return $fallback;
+        }
+
+        return str_replace(':', '_', $value);
+    }
+}

--- a/trading-app/src/TradeEntry/Policy/IdempotencyPolicy.php
+++ b/trading-app/src/TradeEntry/Policy/IdempotencyPolicy.php
@@ -7,13 +7,22 @@ final class IdempotencyPolicy
 {
     public function __construct() {}
 
-    public function newClientOrderId(): string
+    public function newClientOrderId(?string $decisionKey = null): string
     {
+        if ($decisionKey !== null && trim($decisionKey) !== '') {
+            return $this->clientOrderIdFromDecisionKey($decisionKey);
+        }
+
         // Bitmart requires client_order_id to be alphanumeric (max 32 chars)
         // Generate an uppercase base36 + hex combo, no separators
         $randBase36 = strtoupper(base_convert((string) random_int(1, PHP_INT_MAX), 10, 36));
         $randHex = strtoupper(bin2hex(random_bytes(4))); // 8 hex chars
         $id = 'CLI' . $randBase36 . $randHex;
         return substr($id, 0, 32);
+    }
+
+    public function clientOrderIdFromDecisionKey(string $decisionKey): string
+    {
+        return 'CID' . substr(strtoupper(hash('sha256', $decisionKey)), 0, 29);
     }
 }

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -3,10 +3,13 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\Workflow;
 
+use App\Entity\OrderIntent;
+use App\Service\OrderIntentManager;
 use App\TradeEntry\Dto\ExecutionResult;
 use App\TradeEntry\Execution\ExchangeExecutionService;
 use App\TradeEntry\Execution\ExecutionBox;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
+use App\TradeEntry\Policy\IdempotencyPolicy;
 use App\Logging\Dto\LifecycleContextBuilder;
 use App\Provider\Context\ExchangeContext;
 use Psr\Log\LoggerInterface;
@@ -18,6 +21,8 @@ final class ExecuteOrderPlan
         private readonly ExecutionBox $execution,
         private readonly ExchangeExecutionService $exchangeExecution,
         #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
+        private readonly ?OrderIntentManager $orderIntentManager = null,
+        private readonly ?IdempotencyPolicy $idempotency = null,
     ) {}
 
     public function __invoke(
@@ -41,14 +46,83 @@ final class ExecuteOrderPlan
             'reason' => 'send_plan_to_execution_box',
         ]);
 
+        $intent = null;
+        $clientOrderId = null;
+
         try {
-            $result = $this->shouldUseApiFirstExecution($plan)
-                ? $this->exchangeExecution->execute($plan, $decisionKey, $mode, $executionTf)
-                : $this->execution->execute($plan, $decisionKey, $contextBuilder, $mode, $executionTf);
+            $useApiFirstExecution = $this->shouldUseApiFirstExecution($plan);
+            $executionPlan = $useApiFirstExecution
+                ? $this->exchangeExecution->preparePlan($plan, $mode, $executionTf, $decisionKey)
+                : $this->execution->preparePlan($plan, $mode, $executionTf, $decisionKey);
+
+            if ($decisionKey !== null && trim($decisionKey) !== '' && $this->orderIntentManager !== null) {
+                $clientOrderId = ($this->idempotency ?? new IdempotencyPolicy())->newClientOrderId($decisionKey);
+                $reservation = $this->orderIntentManager->reserveIntent(
+                    orderParams: $this->intentOrderParams($executionPlan, $decisionKey, $clientOrderId),
+                    quantization: $this->intentQuantization($executionPlan),
+                    rawInputs: [
+                        'source' => 'execute_order_plan',
+                        'decision_key' => $decisionKey,
+                        'mode' => $mode,
+                        'execution_tf' => $executionTf,
+                        'plan' => $this->intentPlanPayload($executionPlan),
+                    ],
+                );
+
+                if ($reservation->blocked) {
+                    $this->positionsLogger->warning('execute_order_plan.idempotent_replay_blocked', [
+                        'symbol' => $executionPlan->symbol,
+                        'decision_key' => $decisionKey,
+                        'client_order_id' => $reservation->intent->getClientOrderId(),
+                        'exchange_order_id' => $reservation->intent->getExchangeOrderId() ?? $reservation->intent->getOrderId(),
+                        'order_intent_id' => $reservation->intent->getId(),
+                        'status' => $reservation->intent->getStatus(),
+                        'reason' => $reservation->reason,
+                    ]);
+
+                    return new ExecutionResult(
+                        clientOrderId: $reservation->intent->getClientOrderId(),
+                        exchangeOrderId: $reservation->intent->getExchangeOrderId() ?? $reservation->intent->getOrderId(),
+                        status: ExecutionResult::STATUS_SKIPPED,
+                        raw: [
+                            'reason' => $reservation->reason ?? 'idempotent_replay',
+                            'decision_key' => $decisionKey,
+                            'order_intent_id' => $reservation->intent->getId(),
+                            'existing_status' => $reservation->intent->getStatus(),
+                        ],
+                    );
+                }
+
+                $intent = $reservation->intent;
+                $validationErrors = $this->orderIntentManager->validateOrderParams($this->intentOrderParams($executionPlan, $decisionKey, $clientOrderId));
+                if (!$this->orderIntentManager->validateIntent($intent, $validationErrors)) {
+                    return new ExecutionResult(
+                        clientOrderId: $intent->getClientOrderId(),
+                        exchangeOrderId: null,
+                        status: ExecutionResult::STATUS_SKIPPED,
+                        raw: [
+                            'reason' => 'order_intent_validation_failed',
+                            'decision_key' => $decisionKey,
+                            'order_intent_id' => $intent->getId(),
+                            'validation_errors' => $validationErrors,
+                        ],
+                    );
+                }
+
+                $this->orderIntentManager->markReadyToSend($intent);
+            }
+
+            $result = $useApiFirstExecution
+                ? $this->exchangeExecution->execute($executionPlan, $decisionKey, $mode, $executionTf, $clientOrderId, $intent?->getId(), true)
+                : $this->execution->execute($executionPlan, $decisionKey, $contextBuilder, $mode, $executionTf, $clientOrderId, $intent?->getId(), true);
+
+            if ($intent instanceof OrderIntent && $this->orderIntentManager !== null) {
+                $this->syncIntentAfterExecution($intent, $result);
+            }
 
             $context = [
-                'symbol' => $plan->symbol,
-                'side' => $plan->side->value,
+                'symbol' => $executionPlan->symbol,
+                'side' => $executionPlan->side->value,
                 'status' => $result->status,
                 'client_order_id' => $result->clientOrderId,
                 'exchange_order_id' => $result->exchangeOrderId,
@@ -71,6 +145,10 @@ final class ExecuteOrderPlan
 
             return $result;
         } catch (\Throwable $e) {
+            if ($intent instanceof OrderIntent && $this->orderIntentManager !== null) {
+                $this->markIntentFailedAfterException($intent, $e);
+            }
+
             $this->positionsLogger->error('execute_order_plan.exception', [
                 'symbol' => $plan->symbol,
                 'message' => $e->getMessage(),
@@ -94,6 +172,152 @@ final class ExecuteOrderPlan
         return \in_array($status, [
             ExecutionResult::STATUS_SUBMITTED,
             ExecutionResult::STATUS_SUBMITTED_PROTECTED,
+        ], true);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function intentOrderParams(OrderPlanModel $plan, string $decisionKey, string $clientOrderId): array
+    {
+        $context = ExchangeContext::resolve($plan->exchangeContext);
+
+        return [
+            'exchange' => $context->exchange->value,
+            'market_type' => $context->marketType->value,
+            'decision_key' => $decisionKey,
+            'symbol' => $plan->symbol,
+            'timeframe' => $this->parsedDecisionKeyPart($decisionKey, 3),
+            'candle_open_ts' => $this->parsedDecisionKeyPart($decisionKey, 4),
+            'strategy_profile' => $this->parsedDecisionKeyPart($decisionKey, 6),
+            'strategy_version' => $this->parsedDecisionKeyPart($decisionKey, 7),
+            'side' => $plan->side->value === 'long' ? 1 : 4,
+            'type' => $plan->orderType,
+            'open_type' => $plan->openType,
+            'leverage' => $plan->leverage,
+            'position_mode' => OrderIntent::POSITION_MODE_HEDGE,
+            'price' => $plan->orderType === 'limit' ? (string) $plan->entry : null,
+            'size' => $plan->size,
+            'client_order_id' => $clientOrderId,
+            'preset_mode' => ($plan->stop > 0.0 || $plan->takeProfit > 0.0)
+                ? OrderIntent::PRESET_MODE_PRESET_ON_ENTRY
+                : OrderIntent::PRESET_MODE_NONE,
+            'preset_stop_loss_price' => $plan->stop > 0.0 ? (string) $plan->stop : null,
+            'preset_take_profit_price' => $plan->takeProfit > 0.0 ? (string) $plan->takeProfit : null,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function intentQuantization(OrderPlanModel $plan): array
+    {
+        return [
+            'price_precision' => $plan->pricePrecision,
+            'contract_size' => $plan->contractSize,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function intentPlanPayload(OrderPlanModel $plan): array
+    {
+        return [
+            'symbol' => $plan->symbol,
+            'side' => $plan->side->value,
+            'order_type' => $plan->orderType,
+            'open_type' => $plan->openType,
+            'order_mode' => $plan->orderMode,
+            'entry' => $plan->entry,
+            'stop' => $plan->stop,
+            'take_profit' => $plan->takeProfit,
+            'size' => $plan->size,
+            'leverage' => $plan->leverage,
+        ];
+    }
+
+    private function parsedDecisionKeyPart(string $decisionKey, int $index): ?string
+    {
+        $parts = explode(':', $decisionKey, 8);
+
+        return $parts[$index] ?? null;
+    }
+
+    private function syncIntentAfterExecution(OrderIntent $intent, ExecutionResult $result): void
+    {
+        if ($this->orderIntentManager === null) {
+            return;
+        }
+
+        try {
+            if ($result->exchangeOrderId !== null && $this->shouldMarkIntentSent($result)) {
+                $this->orderIntentManager->markAsSent($intent, $result->exchangeOrderId);
+                return;
+            }
+
+            if ($result->exchangeOrderId !== null && $this->shouldMarkIntentCancelled($result)) {
+                $this->orderIntentManager->markAsCancelled($intent);
+                return;
+            }
+
+            if ($result->status === ExecutionResult::STATUS_SKIPPED || $result->status === ExecutionResult::STATUS_ERROR) {
+                $this->orderIntentManager->markAsFailed(
+                    $intent,
+                    (string)($result->raw['reason'] ?? $result->status),
+                );
+            }
+        } catch (\Throwable $e) {
+            $this->positionsLogger->warning('execute_order_plan.intent_status_sync_failed', [
+                'order_intent_id' => $intent->getId(),
+                'client_order_id' => $intent->getClientOrderId(),
+                'status' => $result->status,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function markIntentFailedAfterException(OrderIntent $intent, \Throwable $e): void
+    {
+        if ($this->orderIntentManager === null) {
+            return;
+        }
+
+        try {
+            $this->orderIntentManager->markAsFailed(
+                $intent,
+                substr('execution_exception: ' . $e->getMessage(), 0, 500),
+            );
+        } catch (\Throwable $syncError) {
+            $this->positionsLogger->warning('execute_order_plan.intent_exception_sync_failed', [
+                'order_intent_id' => $intent->getId(),
+                'client_order_id' => $intent->getClientOrderId(),
+                'error' => $syncError->getMessage(),
+                'execution_error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function shouldMarkIntentSent(ExecutionResult $result): bool
+    {
+        return \in_array($result->status, [
+            ExecutionResult::STATUS_SUBMITTED,
+            ExecutionResult::STATUS_SUBMITTED_PROTECTED,
+            ExecutionResult::STATUS_ENTRY_SUBMITTED,
+            ExecutionResult::STATUS_FAILED_UNPROTECTED_CLOSED,
+            ExecutionResult::STATUS_CRITICAL_UNPROTECTED_POSITION,
+        ], true);
+    }
+
+    private function shouldMarkIntentCancelled(ExecutionResult $result): bool
+    {
+        if ($result->status !== ExecutionResult::STATUS_ERROR) {
+            return false;
+        }
+
+        return \in_array((string)($result->raw['reason'] ?? ''), [
+            'entry_pending_cancelled_without_fill',
+            'entry_closed_without_fill',
         ], true);
     }
 }

--- a/trading-app/tests/TradeEntry/Idempotency/DecisionKeyFactoryTest.php
+++ b/trading-app/tests/TradeEntry/Idempotency/DecisionKeyFactoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\TradeEntry\Idempotency;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Provider\Context\ExchangeContext;
+use App\TradeEntry\Idempotency\DecisionKeyFactory;
+use App\TradeEntry\Policy\IdempotencyPolicy;
+use App\TradeEntry\Types\Side;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DecisionKeyFactory::class)]
+#[CoversClass(IdempotencyPolicy::class)]
+final class DecisionKeyFactoryTest extends TestCase
+{
+    public function testBuildsStableBusinessDecisionKey(): void
+    {
+        $factory = new DecisionKeyFactory();
+        $context = new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL);
+        $evaluatedAt = new \DateTimeImmutable('2025-11-26 12:34:56 UTC');
+
+        $key = $factory->key(
+            context: $context,
+            symbol: 'btcusdt',
+            timeframe: '1m',
+            candleOpenTs: null,
+            side: Side::Long,
+            strategyProfile: 'scalper_micro',
+            strategyVersion: 'v1.1.7',
+            evaluatedAt: $evaluatedAt,
+        );
+
+        self::assertSame('bitmart:perpetual:BTCUSDT:1m:1764160440:long:scalper_micro:v1.1.7', $key);
+        self::assertSame([
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'BTCUSDT',
+            'timeframe' => '1m',
+            'candle_open_ts' => 1764160440,
+            'side' => 'long',
+            'strategy_profile' => 'scalper_micro',
+            'strategy_version' => 'v1.1.7',
+        ], $factory->parse($key));
+    }
+
+    public function testClientOrderIdIsDeterministicAndBitmartSafe(): void
+    {
+        $policy = new IdempotencyPolicy();
+        $decisionKey = 'bitmart:perpetual:BTCUSDT:1m:1764160440:long:scalper_micro:v1.1.7';
+
+        $first = $policy->newClientOrderId($decisionKey);
+        $second = $policy->newClientOrderId($decisionKey);
+
+        self::assertSame($first, $second);
+        self::assertMatchesRegularExpression('/^CID[A-F0-9]{29}$/', $first);
+        self::assertSame(32, strlen($first));
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic `DecisionKeyFactory` keys and Bitmart-safe client order IDs derived from the business signal
- reserve `order_intent` before exchange submission with DB/advisory single-flight locking, active decision-key uniqueness, and replay blocking for in-flight/SENT/FAILED/CANCELLED intents
- propagate `order_intent_id` and `decision_key` through legacy/API-first execution into Bitmart without leaking metadata into exchange payloads
- persist idempotency fields on `order_intent` and expose real candle open timestamps from indicator contexts when available

Closes #83

## Validation
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Idempotency/DecisionKeyFactoryTest.php tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction`
- `git diff --check`

## Notes
- Broader `phpunit tests/TradeEntry` still hits existing unrelated legacy test failures (`TradeEntryBox` missing, `OrderStatus::NEW`) plus existing coverage-target risky tests.
