### PR TITLE
[API-06] Add exchange event ingestion and reconciliation

### DIFF
--- a/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
@@ -12,19 +12,22 @@ use App\Exchange\Dto\CancelOrderRequest;
 use App\Exchange\Dto\CancelOrderResult;
 use App\Exchange\Dto\ExchangeBalanceDto;
 use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangeFillDto;
 use App\Exchange\Dto\ExchangeOrderDto;
 use App\Exchange\Dto\ExchangePositionDto;
 use App\Exchange\Dto\ExchangeReconciliationResult;
 use App\Exchange\Dto\PlaceOrderRequest;
 use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Fake\FakeExchangeEvent;
 use App\Exchange\Fake\FakeExchangeMatchingEngine;
 use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[AutoconfigureTag('app.exchange_adapter')]
-final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface
+final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, ExchangeRestSnapshotProviderInterface
 {
     public function __construct(
         private FakeExchangeStateStore $stateStore,
@@ -87,6 +90,43 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface
         return $this->stateStore->getOpenOrders($symbol);
     }
 
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOrdersSnapshot(?string $symbol = null): array
+    {
+        return $this->stateStore->getOrders($symbol);
+    }
+
+    /**
+     * @return ExchangeFillDto[]
+     */
+    public function getFillsSnapshot(?string $symbol = null): array
+    {
+        $normalizedSymbol = $symbol !== null ? strtoupper($symbol) : null;
+        $fills = [];
+        foreach ($this->stateStore->events() as $index => $event) {
+            if (!\in_array($event->type, ['order.filled', 'order.partially_filled'], true)) {
+                continue;
+            }
+            if ($normalizedSymbol !== null && $event->symbol !== $normalizedSymbol) {
+                continue;
+            }
+
+            $fill = $this->fillFromEvent($event, $index);
+            if ($fill instanceof ExchangeFillDto) {
+                $fills[] = $fill;
+            }
+        }
+
+        return $fills;
+    }
+
+    public function hasAuthoritativePositionSnapshot(?string $symbol = null): bool
+    {
+        return true;
+    }
+
     public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
     {
         return $this->matchingEngine->submit($request);
@@ -137,6 +177,50 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface
                 'source' => 'fake_exchange',
                 'events_seen' => \count($this->stateStore->events()),
             ],
+        );
+    }
+
+    private function fillFromEvent(FakeExchangeEvent $event, int $index): ?ExchangeFillDto
+    {
+        $orderId = $event->payload['order_id'] ?? null;
+        if (!\is_scalar($orderId) || trim((string)$orderId) === '') {
+            return null;
+        }
+
+        $order = $this->stateStore->getOrder((string)$orderId);
+        if (!$order instanceof ExchangeOrderDto) {
+            return null;
+        }
+
+        $fillQuantity = isset($event->payload['fill_quantity']) && is_numeric($event->payload['fill_quantity'])
+            ? (float)$event->payload['fill_quantity']
+            : max(0.0, $order->filledQuantity);
+        $fillPrice = isset($event->payload['fill_price']) && is_numeric($event->payload['fill_price'])
+            ? (float)$event->payload['fill_price']
+            : ($order->averagePrice ?? $order->price ?? 0.0);
+
+        return new ExchangeFillDto(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: $order->symbol,
+            exchangeOrderId: $order->exchangeOrderId,
+            clientOrderId: $order->clientOrderId,
+            fillId: 'fake-fill-' . substr(hash('sha256', implode(':', [
+                (string)($event->payload['event_sequence'] ?? $index),
+                $event->type,
+                $order->exchangeOrderId,
+                $event->occurredAt->format('U.u'),
+                (string)$fillQuantity,
+                (string)$fillPrice,
+            ])), 0, 32),
+            side: $order->side,
+            positionSide: $order->positionSide,
+            quantity: $fillQuantity,
+            price: $fillPrice,
+            fee: null,
+            feeCurrency: null,
+            filledAt: $event->occurredAt,
+            metadata: ['source' => 'fake_exchange_rest_reconciliation'],
         );
     }
 }

--- a/trading-app/src/Exchange/Event/AbstractExchangeEvent.php
+++ b/trading-app/src/Exchange/Event/AbstractExchangeEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+abstract readonly class AbstractExchangeEvent implements ExchangeEventInterface
+{
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function __construct(
+        private Exchange $exchange,
+        private MarketType $marketType,
+        private string $symbol,
+        private \DateTimeImmutable $occurredAt,
+        private array $payload = [],
+    ) {
+        if (trim($this->symbol) === '') {
+            throw new \InvalidArgumentException('exchange event symbol cannot be blank');
+        }
+    }
+
+    public function exchange(): Exchange
+    {
+        return $this->exchange;
+    }
+
+    public function marketType(): MarketType
+    {
+        return $this->marketType;
+    }
+
+    public function symbol(): string
+    {
+        return strtoupper($this->symbol);
+    }
+
+    public function occurredAt(): \DateTimeImmutable
+    {
+        return $this->occurredAt;
+    }
+
+    public function payload(): array
+    {
+        return $this->payload;
+    }
+}

--- a/trading-app/src/Exchange/Event/AbstractExchangeOrderEvent.php
+++ b/trading-app/src/Exchange/Event/AbstractExchangeOrderEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Exchange\Dto\ExchangeOrderDto;
+
+abstract readonly class AbstractExchangeOrderEvent extends AbstractExchangeEvent
+{
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function __construct(
+        private ExchangeOrderDto $order,
+        \DateTimeImmutable $occurredAt,
+        array $payload = [],
+    ) {
+        parent::__construct(
+            $order->exchange,
+            $order->marketType,
+            $order->symbol,
+            $occurredAt,
+            $payload,
+        );
+    }
+
+    public function order(): ExchangeOrderDto
+    {
+        return $this->order;
+    }
+}

--- a/trading-app/src/Exchange/Event/AbstractExchangePositionEvent.php
+++ b/trading-app/src/Exchange/Event/AbstractExchangePositionEvent.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Enum\ExchangePositionSide;
+
+abstract readonly class AbstractExchangePositionEvent extends AbstractExchangeEvent
+{
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function __construct(
+        Exchange $exchange,
+        MarketType $marketType,
+        string $symbol,
+        private ExchangePositionSide $side,
+        private float $size,
+        private ?ExchangePositionDto $position,
+        \DateTimeImmutable $occurredAt,
+        array $payload = [],
+    ) {
+        parent::__construct($exchange, $marketType, $symbol, $occurredAt, $payload);
+    }
+
+    public function side(): ExchangePositionSide
+    {
+        return $this->side;
+    }
+
+    public function size(): float
+    {
+        return $this->size;
+    }
+
+    public function position(): ?ExchangePositionDto
+    {
+        return $this->position;
+    }
+}

--- a/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
+++ b/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Entity\Position;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\MtfRunner\Service\FuturesOrderSyncService;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\FuturesOrderRepository;
+use App\Repository\PositionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+
+#[AsAlias(id: ExchangeLocalProjectionStoreInterface::class)]
+final readonly class DoctrineExchangeLocalProjectionStore implements ExchangeLocalProjectionStoreInterface
+{
+    public function __construct(
+        private FuturesOrderSyncService $orderSync,
+        private FuturesOrderRepository $orders,
+        private PositionRepository $positions,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function hasOrder(ExchangeOrderDto $order): bool
+    {
+        $context = new ExchangeContext($order->exchange, $order->marketType);
+
+        if ($this->orders->findOneByOrderId($order->exchangeOrderId, $context) !== null) {
+            return true;
+        }
+
+        return $order->clientOrderId !== null
+            && $this->orders->findOneByClientOrderId($order->clientOrderId, $context) !== null;
+    }
+
+    public function openPositions(Exchange $exchange, MarketType $marketType, ?string $symbol = null): array
+    {
+        $context = new ExchangeContext($exchange, $marketType);
+        $normalizedSymbol = $symbol !== null ? strtoupper($symbol) : null;
+        $positions = [];
+
+        foreach ($this->positions->findAllOpen($context) as $position) {
+            if ($normalizedSymbol !== null && $position->getSymbol() !== $normalizedSymbol) {
+                continue;
+            }
+
+            try {
+                $side = ExchangePositionSide::from(strtolower($position->getSide()));
+            } catch (\ValueError) {
+                continue;
+            }
+
+            $positions[] = [
+                'symbol' => $position->getSymbol(),
+                'side' => $side,
+                'size' => is_numeric($position->getSize()) ? (float)$position->getSize() : 0.0,
+            ];
+        }
+
+        return $positions;
+    }
+
+    public function project(ExchangeEventInterface $event): void
+    {
+        if ($event instanceof AbstractExchangeOrderEvent) {
+            $this->orderSync->syncOrderFromApi($this->orderPayload($event->order(), $event));
+            return;
+        }
+
+        if ($event instanceof ExchangeFillReceived) {
+            $this->orderSync->syncTradeFromApi($this->fillPayload($event->fill(), $event));
+            return;
+        }
+
+        if ($event instanceof AbstractExchangePositionEvent) {
+            $this->projectPosition($event);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function orderPayload(ExchangeOrderDto $order, ExchangeEventInterface $event): array
+    {
+        $filledNotional = $order->averagePrice !== null && $order->filledQuantity > 0.0
+            ? (string)($order->averagePrice * $order->filledQuantity)
+            : null;
+
+        return [
+            'exchange' => $order->exchange->value,
+            'market_type' => $order->marketType->value,
+            'order_id' => $order->exchangeOrderId,
+            'client_order_id' => $order->clientOrderId,
+            'symbol' => $order->symbol,
+            'side' => $this->numericSide($order->side, $order->positionSide),
+            'type' => $order->orderType->value,
+            'status' => $order->status->value,
+            'price' => $order->price !== null ? (string)$order->price : null,
+            'size' => (int)round($order->quantity),
+            'filled_size' => (int)round($order->filledQuantity),
+            'filled_notional' => $filledNotional,
+            'open_type' => $order->metadata['open_type'] ?? $order->metadata['margin_mode'] ?? null,
+            'position_mode' => 1,
+            'leverage' => isset($order->metadata['leverage']) && is_numeric($order->metadata['leverage'])
+                ? (int)$order->metadata['leverage']
+                : null,
+            'filled_time' => $order->status->value === 'filled' ? $this->millis($order->updatedAt ?? $event->occurredAt()) : null,
+            'created_time' => $this->millis($order->createdAt),
+            'updated_time' => $this->millis($order->updatedAt ?? $event->occurredAt()),
+            'raw' => [
+                'event_type' => $event->eventType(),
+                'order_type' => $order->orderType->value,
+                'position_side' => $order->positionSide?->value,
+                'remaining_quantity' => $order->remainingQuantity,
+                'reduce_only' => $order->reduceOnly,
+                'post_only' => $order->postOnly,
+                'time_in_force' => $order->timeInForce?->value,
+                'metadata' => $order->metadata,
+                'payload' => $event->payload(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fillPayload(ExchangeFillDto $fill, ExchangeEventInterface $event): array
+    {
+        return [
+            'exchange' => $fill->exchange->value,
+            'market_type' => $fill->marketType->value,
+            'trade_id' => $this->projectionFillId($fill),
+            'order_id' => $fill->exchangeOrderId,
+            'symbol' => $fill->symbol,
+            'side' => $this->numericSide($fill->side, $fill->positionSide),
+            'price' => (string)$fill->price,
+            'size' => (int)round($fill->quantity),
+            'fee' => $fill->fee !== null ? (string)$fill->fee : null,
+            'fee_currency' => $fill->feeCurrency,
+            'trade_time' => $this->millis($fill->filledAt),
+            'raw' => [
+                'event_type' => $event->eventType(),
+                'client_order_id' => $fill->clientOrderId,
+                'position_side' => $fill->positionSide?->value,
+                'metadata' => $fill->metadata,
+                'payload' => $event->payload(),
+            ],
+        ];
+    }
+
+    private function projectPosition(AbstractExchangePositionEvent $event): void
+    {
+        $context = new ExchangeContext($event->exchange(), $event->marketType());
+        $position = $this->positions->findOneBySymbolSide($event->symbol(), $event->side()->value, $context);
+
+        if (!$position instanceof Position) {
+            $position = new Position($event->symbol(), $event->side()->value, $event->exchange(), $event->marketType());
+        }
+
+        if ($event instanceof ExchangePositionClosed) {
+            $position
+                ->setStatus('CLOSED')
+                ->setSize('0')
+                ->mergePayload($this->positionPayload($event, null));
+        } else {
+            $dto = $event->position();
+            $position
+                ->setStatus('OPEN')
+                ->setSize((string)$event->size())
+                ->setAvgEntryPrice($dto instanceof ExchangePositionDto ? (string)$dto->entryPrice : null)
+                ->setLeverage($dto instanceof ExchangePositionDto && $dto->leverage !== null ? (int)round($dto->leverage) : null)
+                ->setUnrealizedPnl($dto instanceof ExchangePositionDto && $dto->unrealizedPnl !== null ? (string)$dto->unrealizedPnl : null)
+                ->mergePayload($this->positionPayload($event, $dto));
+        }
+
+        $this->entityManager->persist($position);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function positionPayload(AbstractExchangePositionEvent $event, ?ExchangePositionDto $position): array
+    {
+        return [
+            'exchange_event_type' => $event->eventType(),
+            'occurred_at' => $event->occurredAt()->format(\DateTimeInterface::ATOM),
+            'size' => $event->size(),
+            'mark_price' => $position?->markPrice,
+            'realized_pnl' => $position?->realizedPnl,
+            'margin' => $position?->margin,
+            'metadata' => $position?->metadata ?? [],
+            'payload' => $event->payload(),
+        ];
+    }
+
+    private function numericSide(ExchangeOrderSide $side, ?ExchangePositionSide $positionSide): int
+    {
+        return match ([$side, $positionSide]) {
+            [ExchangeOrderSide::BUY, ExchangePositionSide::LONG] => 1,
+            [ExchangeOrderSide::SELL, ExchangePositionSide::LONG] => 3,
+            [ExchangeOrderSide::BUY, ExchangePositionSide::SHORT] => 2,
+            [ExchangeOrderSide::SELL, ExchangePositionSide::SHORT] => 4,
+            default => $side === ExchangeOrderSide::BUY ? 1 : 4,
+        };
+    }
+
+    private function deterministicFillId(ExchangeFillDto $fill): string
+    {
+        return 'fill-' . substr(hash('sha256', implode(':', [
+            $fill->exchange->value,
+            $fill->marketType->value,
+            $fill->symbol,
+            $fill->exchangeOrderId,
+            $fill->filledAt->format('U.u'),
+            (string)$fill->quantity,
+            (string)$fill->price,
+            $fill->side->value,
+            $fill->positionSide?->value ?? '',
+        ])), 0, 48);
+    }
+
+    private function projectionFillId(ExchangeFillDto $fill): string
+    {
+        $fillId = $fill->fillId !== null ? trim($fill->fillId) : '';
+
+        return $fillId !== '' ? $fillId : $this->deterministicFillId($fill);
+    }
+
+    private function millis(?\DateTimeImmutable $time): ?int
+    {
+        if (!$time instanceof \DateTimeImmutable) {
+            return null;
+        }
+
+        return ((int)$time->format('U') * 1000) + (int)floor(((int)$time->format('u')) / 1000);
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeBalanceUpdated.php
+++ b/trading-app/src/Exchange/Event/ExchangeBalanceUpdated.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Exchange\Dto\ExchangeBalanceDto;
+
+final readonly class ExchangeBalanceUpdated extends AbstractExchangeEvent
+{
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function __construct(
+        private ExchangeBalanceDto $balance,
+        \DateTimeImmutable $occurredAt,
+        array $payload = [],
+    ) {
+        parent::__construct(
+            $balance->exchange,
+            $balance->marketType,
+            $balance->currency,
+            $occurredAt,
+            $payload,
+        );
+    }
+
+    public function eventType(): string
+    {
+        return 'exchange.balance.updated';
+    }
+
+    public function balance(): ExchangeBalanceDto
+    {
+        return $this->balance;
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeEventBus.php
+++ b/trading-app/src/Exchange/Event/ExchangeEventBus.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class ExchangeEventBus
+{
+    public function __construct(
+        private ExchangeLocalProjectionStoreInterface $projectionStore,
+        #[Autowire(service: 'monolog.logger.positions')] private LoggerInterface $logger,
+    ) {
+    }
+
+    public function publish(ExchangeEventInterface $event): void
+    {
+        $this->projectionStore->project($event);
+        $this->logger->info('exchange_event.projected', [
+            'event_type' => $event->eventType(),
+            'exchange' => $event->exchange()->value,
+            'market_type' => $event->marketType()->value,
+            'symbol' => $event->symbol(),
+            'occurred_at' => $event->occurredAt()->format(\DateTimeInterface::ATOM),
+        ]);
+    }
+
+    /**
+     * @param iterable<ExchangeEventInterface> $events
+     */
+    public function publishMany(iterable $events): int
+    {
+        $count = 0;
+        foreach ($events as $event) {
+            $this->publish($event);
+            ++$count;
+        }
+
+        return $count;
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeEventInterface.php
+++ b/trading-app/src/Exchange/Event/ExchangeEventInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+interface ExchangeEventInterface
+{
+    public function eventType(): string;
+
+    public function exchange(): Exchange;
+
+    public function marketType(): MarketType;
+
+    public function symbol(): string;
+
+    public function occurredAt(): \DateTimeImmutable;
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function payload(): array;
+}

--- a/trading-app/src/Exchange/Event/ExchangeEventNormalizerInterface.php
+++ b/trading-app/src/Exchange/Event/ExchangeEventNormalizerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+interface ExchangeEventNormalizerInterface
+{
+    public function supports(mixed $event): bool;
+
+    /**
+     * @return ExchangeEventInterface[]
+     */
+    public function normalize(mixed $event): array;
+}

--- a/trading-app/src/Exchange/Event/ExchangeEventNormalizerRegistry.php
+++ b/trading-app/src/Exchange/Event/ExchangeEventNormalizerRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+final readonly class ExchangeEventNormalizerRegistry
+{
+    /**
+     * @param iterable<ExchangeEventNormalizerInterface> $normalizers
+     */
+    public function __construct(
+        #[AutowireIterator('app.exchange_event_normalizer')]
+        private iterable $normalizers,
+    ) {
+    }
+
+    /**
+     * @return ExchangeEventInterface[]
+     */
+    public function normalize(mixed $event): array
+    {
+        foreach ($this->normalizers as $normalizer) {
+            if ($normalizer->supports($event)) {
+                return $normalizer->normalize($event);
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'No exchange event normalizer supports "%s"',
+            is_object($event) ? $event::class : get_debug_type($event),
+        ));
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeFillReceived.php
+++ b/trading-app/src/Exchange/Event/ExchangeFillReceived.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Exchange\Dto\ExchangeFillDto;
+
+final readonly class ExchangeFillReceived extends AbstractExchangeEvent
+{
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function __construct(
+        private ExchangeFillDto $fill,
+        array $payload = [],
+    ) {
+        parent::__construct(
+            $fill->exchange,
+            $fill->marketType,
+            $fill->symbol,
+            $fill->filledAt,
+            $payload,
+        );
+    }
+
+    public function eventType(): string
+    {
+        return 'exchange.fill.received';
+    }
+
+    public function fill(): ExchangeFillDto
+    {
+        return $this->fill;
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeLocalProjectionStoreInterface.php
+++ b/trading-app/src/Exchange/Event/ExchangeLocalProjectionStoreInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\ExchangeOrderDto;
+
+interface ExchangeLocalProjectionStoreInterface
+{
+    public function hasOrder(ExchangeOrderDto $order): bool;
+
+    /**
+     * @return array<int,array{symbol: string, side: \App\Exchange\Enum\ExchangePositionSide, size: float}>
+     */
+    public function openPositions(Exchange $exchange, MarketType $marketType, ?string $symbol = null): array;
+
+    public function project(ExchangeEventInterface $event): void;
+}

--- a/trading-app/src/Exchange/Event/ExchangeOrderCancelled.php
+++ b/trading-app/src/Exchange/Event/ExchangeOrderCancelled.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeOrderCancelled extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.order.cancelled';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeOrderCreated.php
+++ b/trading-app/src/Exchange/Event/ExchangeOrderCreated.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeOrderCreated extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.order.created';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeOrderFilled.php
+++ b/trading-app/src/Exchange/Event/ExchangeOrderFilled.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeOrderFilled extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.order.filled';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeOrderPartiallyFilled.php
+++ b/trading-app/src/Exchange/Event/ExchangeOrderPartiallyFilled.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeOrderPartiallyFilled extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.order.partially_filled';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeOrderRejected.php
+++ b/trading-app/src/Exchange/Event/ExchangeOrderRejected.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeOrderRejected extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.order.rejected';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeOrderUpdated.php
+++ b/trading-app/src/Exchange/Event/ExchangeOrderUpdated.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeOrderUpdated extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.order.updated';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangePositionClosed.php
+++ b/trading-app/src/Exchange/Event/ExchangePositionClosed.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangePositionClosed extends AbstractExchangePositionEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.position.closed';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangePositionOpened.php
+++ b/trading-app/src/Exchange/Event/ExchangePositionOpened.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangePositionOpened extends AbstractExchangePositionEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.position.opened';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangePositionUpdated.php
+++ b/trading-app/src/Exchange/Event/ExchangePositionUpdated.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangePositionUpdated extends AbstractExchangePositionEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.position.updated';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeProtectionOrderCreated.php
+++ b/trading-app/src/Exchange/Event/ExchangeProtectionOrderCreated.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeProtectionOrderCreated extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.protection_order.created';
+    }
+}

--- a/trading-app/src/Exchange/Event/ExchangeProtectionOrderRejected.php
+++ b/trading-app/src/Exchange/Event/ExchangeProtectionOrderRejected.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Event;
+
+final readonly class ExchangeProtectionOrderRejected extends AbstractExchangeOrderEvent
+{
+    public function eventType(): string
+    {
+        return 'exchange.protection_order.rejected';
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeEventNormalizer.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeEventNormalizer.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Event\ExchangeEventInterface;
+use App\Exchange\Event\ExchangeEventNormalizerInterface;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Exchange\Event\ExchangeOrderCancelled;
+use App\Exchange\Event\ExchangeOrderCreated;
+use App\Exchange\Event\ExchangeOrderFilled;
+use App\Exchange\Event\ExchangeOrderPartiallyFilled;
+use App\Exchange\Event\ExchangeOrderRejected;
+use App\Exchange\Event\ExchangePositionClosed;
+use App\Exchange\Event\ExchangePositionOpened;
+use App\Exchange\Event\ExchangePositionUpdated;
+use App\Exchange\Event\ExchangeProtectionOrderCreated;
+use App\Exchange\Event\ExchangeProtectionOrderRejected;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.exchange_event_normalizer')]
+final readonly class FakeExchangeEventNormalizer implements ExchangeEventNormalizerInterface
+{
+    public function __construct(
+        private FakeExchangeStateStore $stateStore,
+    ) {
+    }
+
+    public function supports(mixed $event): bool
+    {
+        return $event instanceof FakeExchangeEvent;
+    }
+
+    /**
+     * @return ExchangeEventInterface[]
+     */
+    public function normalize(mixed $event): array
+    {
+        if (!$event instanceof FakeExchangeEvent) {
+            return [];
+        }
+
+        $order = $this->orderFromEvent($event);
+
+        return match ($event->type) {
+            'order.created' => $order instanceof ExchangeOrderDto
+                ? [new ExchangeOrderCreated($order, $event->occurredAt, $event->payload)]
+                : [],
+            'order.filled' => $order instanceof ExchangeOrderDto
+                ? [
+                    new ExchangeOrderFilled($order, $event->occurredAt, $event->payload),
+                    new ExchangeFillReceived($this->fillFromEvent($event, $order), $event->payload),
+                ]
+                : [],
+            'order.partially_filled' => $order instanceof ExchangeOrderDto
+                ? [
+                    new ExchangeOrderPartiallyFilled($order, $event->occurredAt, $event->payload),
+                    new ExchangeFillReceived($this->fillFromEvent($event, $order), $event->payload),
+                ]
+                : [],
+            'order.cancelled', 'order.expired' => $order instanceof ExchangeOrderDto
+                ? [new ExchangeOrderCancelled($order, $event->occurredAt, $event->payload)]
+                : [],
+            'order.rejected' => $order instanceof ExchangeOrderDto
+                ? [new ExchangeOrderRejected($order, $event->occurredAt, $event->payload)]
+                : [],
+            'protection_order.created' => $order instanceof ExchangeOrderDto
+                ? [new ExchangeProtectionOrderCreated($order, $event->occurredAt, $event->payload)]
+                : [],
+            'protection_order.rejected' => $order instanceof ExchangeOrderDto
+                ? [new ExchangeProtectionOrderRejected($order, $event->occurredAt, $event->payload)]
+                : [],
+            'position.opened' => $this->positionEvent($event, $order, ExchangePositionOpened::class),
+            'position.updated' => $this->positionEvent($event, $order, ExchangePositionUpdated::class),
+            'position.closed' => $this->positionEvent($event, $order, ExchangePositionClosed::class),
+            default => [],
+        };
+    }
+
+    private function orderFromEvent(FakeExchangeEvent $event): ?ExchangeOrderDto
+    {
+        if (\is_array($event->payload['order_snapshot'] ?? null)) {
+            return $this->orderFromSnapshot($event->payload['order_snapshot']);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    private function orderFromSnapshot(array $snapshot): ?ExchangeOrderDto
+    {
+        try {
+            return new ExchangeOrderDto(
+                exchange: Exchange::from((string)$snapshot['exchange']),
+                marketType: MarketType::from((string)$snapshot['market_type']),
+                symbol: (string)$snapshot['symbol'],
+                exchangeOrderId: (string)$snapshot['exchange_order_id'],
+                clientOrderId: isset($snapshot['client_order_id']) ? (string)$snapshot['client_order_id'] : null,
+                side: ExchangeOrderSide::from((string)$snapshot['side']),
+                positionSide: isset($snapshot['position_side']) && $snapshot['position_side'] !== null
+                    ? ExchangePositionSide::from((string)$snapshot['position_side'])
+                    : null,
+                orderType: ExchangeOrderType::from((string)$snapshot['order_type']),
+                status: ExchangeOrderStatus::from((string)$snapshot['status']),
+                quantity: (float)$snapshot['quantity'],
+                filledQuantity: (float)$snapshot['filled_quantity'],
+                remainingQuantity: (float)$snapshot['remaining_quantity'],
+                price: isset($snapshot['price']) && $snapshot['price'] !== null ? (float)$snapshot['price'] : null,
+                averagePrice: isset($snapshot['average_price']) && $snapshot['average_price'] !== null ? (float)$snapshot['average_price'] : null,
+                stopPrice: isset($snapshot['stop_price']) && $snapshot['stop_price'] !== null ? (float)$snapshot['stop_price'] : null,
+                reduceOnly: (bool)$snapshot['reduce_only'],
+                postOnly: (bool)$snapshot['post_only'],
+                timeInForce: isset($snapshot['time_in_force']) && $snapshot['time_in_force'] !== null
+                    ? ExchangeTimeInForce::from((string)$snapshot['time_in_force'])
+                    : null,
+                createdAt: new \DateTimeImmutable((string)$snapshot['created_at']),
+                updatedAt: isset($snapshot['updated_at']) && $snapshot['updated_at'] !== null
+                    ? new \DateTimeImmutable((string)$snapshot['updated_at'])
+                    : null,
+                metadata: \is_array($snapshot['metadata'] ?? null) ? $snapshot['metadata'] : [],
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function fillFromEvent(FakeExchangeEvent $event, ExchangeOrderDto $order): ExchangeFillDto
+    {
+        $fillQuantity = isset($event->payload['fill_quantity']) && is_numeric($event->payload['fill_quantity'])
+            ? (float)$event->payload['fill_quantity']
+            : max(0.0, $order->filledQuantity);
+        $fillPrice = isset($event->payload['fill_price']) && is_numeric($event->payload['fill_price'])
+            ? (float)$event->payload['fill_price']
+            : ($order->averagePrice ?? $order->price ?? 0.0);
+
+        return new ExchangeFillDto(
+            exchange: $order->exchange,
+            marketType: $order->marketType,
+            symbol: $order->symbol,
+            exchangeOrderId: $order->exchangeOrderId,
+            clientOrderId: $order->clientOrderId,
+            fillId: $this->fillId($event, $order, $fillQuantity, $fillPrice),
+            side: $order->side,
+            positionSide: $order->positionSide,
+            quantity: $fillQuantity,
+            price: $fillPrice,
+            fee: null,
+            feeCurrency: null,
+            filledAt: $event->occurredAt,
+            metadata: ['source' => 'fake_exchange_ws', 'order_status' => $order->status->value],
+        );
+    }
+
+    /**
+     * @param class-string<ExchangePositionOpened|ExchangePositionUpdated|ExchangePositionClosed> $eventClass
+     * @return ExchangeEventInterface[]
+     */
+    private function positionEvent(FakeExchangeEvent $event, ?ExchangeOrderDto $order, string $eventClass): array
+    {
+        $side = $order?->positionSide;
+        if (!$side instanceof ExchangePositionSide) {
+            return [];
+        }
+
+        $position = \is_array($event->payload['position_snapshot'] ?? null)
+            ? $this->positionFromSnapshot($event->payload['position_snapshot'])
+            : null;
+        $size = isset($event->payload['size']) && is_numeric($event->payload['size'])
+            ? (float)$event->payload['size']
+            : ($position?->size ?? 0.0);
+
+        return [new $eventClass(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: $event->symbol,
+            side: $side,
+            size: $eventClass === ExchangePositionClosed::class ? 0.0 : $size,
+            position: $eventClass === ExchangePositionClosed::class ? null : $position,
+            occurredAt: $event->occurredAt,
+            payload: $event->payload,
+        )];
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    private function positionFromSnapshot(array $snapshot): ?ExchangePositionDto
+    {
+        try {
+            return new ExchangePositionDto(
+                exchange: Exchange::from((string)$snapshot['exchange']),
+                marketType: MarketType::from((string)$snapshot['market_type']),
+                symbol: (string)$snapshot['symbol'],
+                side: ExchangePositionSide::from((string)$snapshot['side']),
+                size: (float)$snapshot['size'],
+                entryPrice: (float)$snapshot['entry_price'],
+                markPrice: isset($snapshot['mark_price']) && $snapshot['mark_price'] !== null ? (float)$snapshot['mark_price'] : null,
+                unrealizedPnl: isset($snapshot['unrealized_pnl']) && $snapshot['unrealized_pnl'] !== null ? (float)$snapshot['unrealized_pnl'] : null,
+                realizedPnl: isset($snapshot['realized_pnl']) && $snapshot['realized_pnl'] !== null ? (float)$snapshot['realized_pnl'] : null,
+                margin: isset($snapshot['margin']) && $snapshot['margin'] !== null ? (float)$snapshot['margin'] : null,
+                leverage: isset($snapshot['leverage']) && $snapshot['leverage'] !== null ? (float)$snapshot['leverage'] : null,
+                openedAt: isset($snapshot['opened_at']) && $snapshot['opened_at'] !== null ? new \DateTimeImmutable((string)$snapshot['opened_at']) : null,
+                updatedAt: isset($snapshot['updated_at']) && $snapshot['updated_at'] !== null ? new \DateTimeImmutable((string)$snapshot['updated_at']) : null,
+                metadata: \is_array($snapshot['metadata'] ?? null) ? $snapshot['metadata'] : [],
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function fillId(FakeExchangeEvent $event, ExchangeOrderDto $order, float $quantity, float $price): string
+    {
+        return 'fake-fill-' . substr(hash('sha256', implode(':', [
+            (string)($event->payload['event_sequence'] ?? ''),
+            $event->type,
+            $order->exchangeOrderId,
+            $event->occurredAt->format('U.u'),
+            (string)$quantity,
+            (string)$price,
+        ])), 0, 32);
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
@@ -198,6 +198,36 @@ final class FakeExchangeStateStore
 
     public function appendEvent(FakeExchangeEvent $event): void
     {
+        $payload = $event->payload;
+        if (!\array_key_exists('event_sequence', $event->payload)) {
+            $payload = ['event_sequence' => \count($this->events) + 1] + $payload;
+        }
+
+        $orderId = $payload['order_id'] ?? null;
+        if (!\array_key_exists('order_snapshot', $payload) && \is_scalar($orderId)) {
+            $order = $this->getOrder((string)$orderId);
+            if ($order instanceof ExchangeOrderDto) {
+                $payload['order_snapshot'] = $this->orderSnapshot($order);
+            }
+        }
+        $orderSnapshot = $payload['order_snapshot'] ?? null;
+        if (
+            !\array_key_exists('position_snapshot', $payload)
+            && \is_array($orderSnapshot)
+            && \in_array($event->type, ['position.opened', 'position.updated'], true)
+            && \is_string($orderSnapshot['position_side'] ?? null)
+        ) {
+            try {
+                $position = $this->getPosition($event->symbol, ExchangePositionSide::from($orderSnapshot['position_side']));
+            } catch (\ValueError) {
+                $position = null;
+            }
+            if ($position instanceof ExchangePositionDto) {
+                $payload['position_snapshot'] = $this->positionSnapshot($position);
+            }
+        }
+
+        $event = new FakeExchangeEvent($event->type, $event->symbol, $event->occurredAt, $payload);
         $this->events[] = $event;
         $this->persist();
     }
@@ -262,6 +292,59 @@ final class FakeExchangeStateStore
             ExchangeOrderStatus::OPEN,
             ExchangeOrderStatus::PARTIALLY_FILLED,
         ], true);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function orderSnapshot(ExchangeOrderDto $order): array
+    {
+        return [
+            'exchange' => $order->exchange->value,
+            'market_type' => $order->marketType->value,
+            'symbol' => $order->symbol,
+            'exchange_order_id' => $order->exchangeOrderId,
+            'client_order_id' => $order->clientOrderId,
+            'side' => $order->side->value,
+            'position_side' => $order->positionSide?->value,
+            'order_type' => $order->orderType->value,
+            'status' => $order->status->value,
+            'quantity' => $order->quantity,
+            'filled_quantity' => $order->filledQuantity,
+            'remaining_quantity' => $order->remainingQuantity,
+            'price' => $order->price,
+            'average_price' => $order->averagePrice,
+            'stop_price' => $order->stopPrice,
+            'reduce_only' => $order->reduceOnly,
+            'post_only' => $order->postOnly,
+            'time_in_force' => $order->timeInForce?->value,
+            'created_at' => $order->createdAt->format(\DateTimeInterface::ATOM),
+            'updated_at' => $order->updatedAt?->format(\DateTimeInterface::ATOM),
+            'metadata' => $order->metadata,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function positionSnapshot(ExchangePositionDto $position): array
+    {
+        return [
+            'exchange' => $position->exchange->value,
+            'market_type' => $position->marketType->value,
+            'symbol' => $position->symbol,
+            'side' => $position->side->value,
+            'size' => $position->size,
+            'entry_price' => $position->entryPrice,
+            'mark_price' => $position->markPrice,
+            'unrealized_pnl' => $position->unrealizedPnl,
+            'realized_pnl' => $position->realizedPnl,
+            'margin' => $position->margin,
+            'leverage' => $position->leverage,
+            'opened_at' => $position->openedAt?->format(\DateTimeInterface::ATOM),
+            'updated_at' => $position->updatedAt?->format(\DateTimeInterface::ATOM),
+            'metadata' => $position->metadata,
+        ];
     }
 
     private function restore(): bool

--- a/trading-app/src/Exchange/Fake/FakeExchangeWsClient.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeWsClient.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Ws\ExchangeWsClientInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.exchange_ws_client')]
+final class FakeExchangeWsClient implements ExchangeWsClientInterface
+{
+    /** @var array<string,bool> */
+    private array $consumedSequences = [];
+
+    public function __construct(
+        private readonly FakeExchangeStateStore $stateStore,
+    ) {
+    }
+
+    public function exchange(): Exchange
+    {
+        return Exchange::FAKE;
+    }
+
+    public function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    /**
+     * @return FakeExchangeEvent[]
+     */
+    public function drainPrivateEvents(?string $symbol = null): iterable
+    {
+        $normalizedSymbol = $symbol !== null ? strtoupper($symbol) : null;
+        $events = [];
+        foreach ($this->stateStore->events() as $index => $event) {
+            $sequence = $this->sequence($event, $index);
+            if (isset($this->consumedSequences[$sequence])) {
+                continue;
+            }
+            if ($normalizedSymbol !== null && $event->symbol !== $normalizedSymbol) {
+                continue;
+            }
+
+            $this->consumedSequences[$sequence] = true;
+            $events[] = $event;
+        }
+
+        return $events;
+    }
+
+    private function sequence(FakeExchangeEvent $event, int $index): string
+    {
+        $sequence = $event->payload['event_sequence'] ?? null;
+
+        return \is_scalar($sequence) ? (string)$sequence : 'idx-' . $index;
+    }
+}

--- a/trading-app/src/Exchange/Reconciliation/ExchangeReconciliationService.php
+++ b/trading-app/src/Exchange/Reconciliation/ExchangeReconciliationService.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Reconciliation;
+
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\ExchangeReconciliationResult;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Event\ExchangeEventBus;
+use App\Exchange\Event\ExchangeEventInterface;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Exchange\Event\ExchangeLocalProjectionStoreInterface;
+use App\Exchange\Event\ExchangeOrderCancelled;
+use App\Exchange\Event\ExchangeOrderFilled;
+use App\Exchange\Event\ExchangeOrderPartiallyFilled;
+use App\Exchange\Event\ExchangeOrderRejected;
+use App\Exchange\Event\ExchangeOrderUpdated;
+use App\Exchange\Event\ExchangePositionUpdated;
+use App\Exchange\Event\ExchangeProtectionOrderCreated;
+use App\Exchange\Event\ExchangeProtectionOrderRejected;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class ExchangeReconciliationService
+{
+    public function __construct(
+        private ExchangeEventBus $bus,
+        private ExchangeLocalProjectionStoreInterface $projectionStore,
+        private ClockInterface $clock,
+        #[Autowire(service: 'monolog.logger.positions')] private LoggerInterface $logger,
+    ) {
+    }
+
+    public function reconcile(ExchangeAdapterInterface $adapter, ?string $symbol = null): ExchangeReconciliationResult
+    {
+        $startedAt = $this->clock->now();
+        $normalizedSymbol = $symbol !== null ? strtoupper($symbol) : null;
+        $orders = $adapter instanceof ExchangeRestSnapshotProviderInterface
+            ? $adapter->getOrdersSnapshot($normalizedSymbol)
+            : $adapter->getOpenOrders($normalizedSymbol);
+        $positions = $adapter->getOpenPositions($normalizedSymbol);
+        $fills = $adapter instanceof ExchangeRestSnapshotProviderInterface
+            ? $adapter->getFillsSnapshot($normalizedSymbol)
+            : [];
+
+        $unknownOrders = [];
+        $eventsProjected = 0;
+        foreach ($orders as $order) {
+            if (!$this->projectionStore->hasOrder($order)) {
+                $unknownOrders[] = $order->exchangeOrderId;
+            }
+            $this->bus->publish($this->eventForOrder($order, $startedAt));
+            ++$eventsProjected;
+        }
+
+        foreach ($positions as $position) {
+            $this->bus->publish(new ExchangePositionUpdated(
+                exchange: $position->exchange,
+                marketType: $position->marketType,
+                symbol: $position->symbol,
+                side: $position->side,
+                size: $position->size,
+                position: $position,
+                occurredAt: $position->updatedAt ?? $startedAt,
+                payload: ['source' => 'rest_reconciliation'],
+            ));
+            ++$eventsProjected;
+        }
+
+        $positionSnapshotAuthoritative = $adapter instanceof ExchangeRestSnapshotProviderInterface
+            && $adapter->hasAuthoritativePositionSnapshot($normalizedSymbol);
+        if ($positionSnapshotAuthoritative) {
+            foreach ($this->missingLocalPositions($adapter, $positions, $normalizedSymbol) as $missingPosition) {
+                $this->bus->publish(new \App\Exchange\Event\ExchangePositionClosed(
+                    exchange: $adapter->exchange(),
+                    marketType: $adapter->marketType(),
+                    symbol: $missingPosition['symbol'],
+                    side: $missingPosition['side'],
+                    size: 0.0,
+                    position: null,
+                    occurredAt: $startedAt,
+                    payload: [
+                        'source' => 'rest_reconciliation',
+                        'reason' => 'missing_from_rest_position_snapshot',
+                        'previous_size' => $missingPosition['size'],
+                    ],
+                ));
+                ++$eventsProjected;
+            }
+        }
+
+        foreach ($fills as $fill) {
+            $this->bus->publish(new ExchangeFillReceived($fill, ['source' => 'rest_reconciliation']));
+            ++$eventsProjected;
+        }
+
+        $unprotectedPositions = $this->detectUnprotectedPositions($adapter, $positions);
+        $completedAt = $this->clock->now();
+        $result = new ExchangeReconciliationResult(
+            exchange: $adapter->exchange(),
+            marketType: $adapter->marketType(),
+            symbol: $normalizedSymbol,
+            startedAt: $startedAt,
+            completedAt: $completedAt,
+            ordersChecked: \count($orders),
+            positionsChecked: \count($positions),
+            fillsImported: \count($fills),
+            correctionsApplied: $eventsProjected,
+            unknownOrdersDetected: \count($unknownOrders),
+            metadata: [
+                'unknown_order_ids' => $unknownOrders,
+                'unprotected_positions' => $unprotectedPositions,
+                'events_projected' => $eventsProjected,
+                'position_snapshot_authoritative' => $positionSnapshotAuthoritative,
+            ],
+        );
+
+        $this->logger->info('exchange_reconciliation.completed', [
+            'exchange' => $result->exchange->value,
+            'market_type' => $result->marketType->value,
+            'symbol' => $result->symbol,
+            'orders_checked' => $result->ordersChecked,
+            'positions_checked' => $result->positionsChecked,
+            'fills_imported' => $result->fillsImported,
+            'unknown_orders_detected' => $result->unknownOrdersDetected,
+            'unprotected_positions' => \count($unprotectedPositions),
+        ]);
+
+        return $result;
+    }
+
+    /**
+     * @param ExchangePositionDto[] $snapshotPositions
+     * @return array<int,array{symbol: string, side: ExchangePositionSide, size: float}>
+     */
+    private function missingLocalPositions(
+        ExchangeAdapterInterface $adapter,
+        array $snapshotPositions,
+        ?string $symbol,
+    ): array {
+        $snapshotKeys = [];
+        foreach ($snapshotPositions as $position) {
+            $snapshotKeys[$this->positionKey($position->symbol, $position->side)] = true;
+        }
+
+        $missing = [];
+        foreach ($this->projectionStore->openPositions($adapter->exchange(), $adapter->marketType(), $symbol) as $localPosition) {
+            if (isset($snapshotKeys[$this->positionKey($localPosition['symbol'], $localPosition['side'])])) {
+                continue;
+            }
+
+            $missing[] = $localPosition;
+        }
+
+        return $missing;
+    }
+
+    private function eventForOrder(ExchangeOrderDto $order, \DateTimeImmutable $occurredAt): ExchangeEventInterface
+    {
+        if ($this->isProtectionOrder($order) && $order->status === ExchangeOrderStatus::REJECTED) {
+            return new ExchangeProtectionOrderRejected($order, $order->updatedAt ?? $occurredAt, ['source' => 'rest_reconciliation']);
+        }
+
+        if ($this->isProtectionOrder($order) && \in_array($order->status, [
+            ExchangeOrderStatus::PENDING,
+            ExchangeOrderStatus::OPEN,
+            ExchangeOrderStatus::PARTIALLY_FILLED,
+        ], true)) {
+            return new ExchangeProtectionOrderCreated($order, $order->updatedAt ?? $occurredAt, ['source' => 'rest_reconciliation']);
+        }
+
+        return match ($order->status) {
+            ExchangeOrderStatus::FILLED => new ExchangeOrderFilled($order, $order->updatedAt ?? $occurredAt, ['source' => 'rest_reconciliation']),
+            ExchangeOrderStatus::PARTIALLY_FILLED => new ExchangeOrderPartiallyFilled($order, $order->updatedAt ?? $occurredAt, ['source' => 'rest_reconciliation']),
+            ExchangeOrderStatus::CANCELLED, ExchangeOrderStatus::EXPIRED => new ExchangeOrderCancelled($order, $order->updatedAt ?? $occurredAt, ['source' => 'rest_reconciliation']),
+            ExchangeOrderStatus::REJECTED => new ExchangeOrderRejected($order, $order->updatedAt ?? $occurredAt, ['source' => 'rest_reconciliation']),
+            default => new ExchangeOrderUpdated($order, $order->updatedAt ?? $occurredAt, ['source' => 'rest_reconciliation']),
+        };
+    }
+
+    /**
+     * @param ExchangePositionDto[] $positions
+     * @return array<int,array<string,mixed>>
+     */
+    private function detectUnprotectedPositions(ExchangeAdapterInterface $adapter, array $positions): array
+    {
+        $unprotected = [];
+        foreach ($positions as $position) {
+            $hasProtection = false;
+            foreach ($adapter->getOpenOrders($position->symbol) as $order) {
+                if (!$this->isProtectionOrder($order)) {
+                    continue;
+                }
+                if ($order->positionSide !== $position->side || $order->remainingQuantity <= 0.0) {
+                    continue;
+                }
+                $hasProtection = true;
+                break;
+            }
+
+            if (!$hasProtection) {
+                $unprotected[] = [
+                    'symbol' => $position->symbol,
+                    'side' => $position->side->value,
+                    'size' => $position->size,
+                    'entry_price' => $position->entryPrice,
+                ];
+            }
+        }
+
+        return $unprotected;
+    }
+
+    private function isProtectionOrder(ExchangeOrderDto $order): bool
+    {
+        return $order->reduceOnly || \in_array($order->orderType, [
+            ExchangeOrderType::STOP_LOSS,
+            ExchangeOrderType::TAKE_PROFIT,
+            ExchangeOrderType::TRIGGER,
+        ], true);
+    }
+
+    private function positionKey(string $symbol, ExchangePositionSide $side): string
+    {
+        return strtoupper($symbol) . ':' . $side->value;
+    }
+}

--- a/trading-app/src/Exchange/Reconciliation/ExchangeRestSnapshotProviderInterface.php
+++ b/trading-app/src/Exchange/Reconciliation/ExchangeRestSnapshotProviderInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Reconciliation;
+
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Dto\ExchangeOrderDto;
+
+interface ExchangeRestSnapshotProviderInterface
+{
+    /**
+     * @return ExchangeOrderDto[]
+     */
+    public function getOrdersSnapshot(?string $symbol = null): array;
+
+    /**
+     * @return ExchangeFillDto[]
+     */
+    public function getFillsSnapshot(?string $symbol = null): array;
+
+    public function hasAuthoritativePositionSnapshot(?string $symbol = null): bool;
+}

--- a/trading-app/src/Exchange/Ws/ExchangeWsClientInterface.php
+++ b/trading-app/src/Exchange/Ws/ExchangeWsClientInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Ws;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+interface ExchangeWsClientInterface
+{
+    public function exchange(): Exchange;
+
+    public function marketType(): MarketType;
+
+    /**
+     * @return iterable<mixed>
+     */
+    public function drainPrivateEvents(?string $symbol = null): iterable;
+}

--- a/trading-app/src/Exchange/Ws/ExchangeWsIngestionResult.php
+++ b/trading-app/src/Exchange/Ws/ExchangeWsIngestionResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Ws;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+final readonly class ExchangeWsIngestionResult
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public ?string $symbol,
+        public int $rawEventsRead,
+        public int $eventsProjected,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Ws/ExchangeWsIngestionService.php
+++ b/trading-app/src/Exchange/Ws/ExchangeWsIngestionService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Ws;
+
+use App\Exchange\Event\ExchangeEventBus;
+use App\Exchange\Event\ExchangeEventNormalizerRegistry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class ExchangeWsIngestionService
+{
+    public function __construct(
+        private ExchangeEventNormalizerRegistry $normalizers,
+        private ExchangeEventBus $bus,
+        #[Autowire(service: 'monolog.logger.positions')] private LoggerInterface $logger,
+    ) {
+    }
+
+    public function drain(ExchangeWsClientInterface $client, ?string $symbol = null): ExchangeWsIngestionResult
+    {
+        $rawEventsRead = 0;
+        $eventsProjected = 0;
+
+        foreach ($client->drainPrivateEvents($symbol) as $rawEvent) {
+            ++$rawEventsRead;
+            $eventsProjected += $this->bus->publishMany($this->normalizers->normalize($rawEvent));
+        }
+
+        $result = new ExchangeWsIngestionResult(
+            exchange: $client->exchange(),
+            marketType: $client->marketType(),
+            symbol: $symbol !== null ? strtoupper($symbol) : null,
+            rawEventsRead: $rawEventsRead,
+            eventsProjected: $eventsProjected,
+        );
+
+        $this->logger->info('exchange_ws.ingestion_completed', [
+            'exchange' => $result->exchange->value,
+            'market_type' => $result->marketType->value,
+            'symbol' => $result->symbol,
+            'raw_events_read' => $rawEventsRead,
+            'events_projected' => $eventsProjected,
+        ]);
+
+        return $result;
+    }
+}

--- a/trading-app/tests/Exchange/Event/ExchangeWsIngestionServiceTest.php
+++ b/trading-app/tests/Exchange/Event/ExchangeWsIngestionServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Event;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Event\ExchangeEventBus;
+use App\Exchange\Event\ExchangeEventInterface;
+use App\Exchange\Event\ExchangeEventNormalizerRegistry;
+use App\Exchange\Event\ExchangeLocalProjectionStoreInterface;
+use App\Exchange\Event\ExchangeOrderFilled;
+use App\Exchange\Event\ExchangePositionOpened;
+use App\Exchange\Fake\FakeExchangeEventNormalizer;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Fake\FakeExchangeWsClient;
+use App\Exchange\Ws\ExchangeWsIngestionResult;
+use App\Exchange\Ws\ExchangeWsIngestionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Psr\Log\NullLogger;
+
+#[CoversClass(ExchangeWsIngestionService::class)]
+#[CoversClass(ExchangeWsIngestionResult::class)]
+#[CoversClass(ExchangeEventNormalizerRegistry::class)]
+#[CoversClass(ExchangeEventBus::class)]
+#[CoversClass(FakeExchangeWsClient::class)]
+#[CoversClass(FakeExchangeEventNormalizer::class)]
+#[CoversClass(ExchangeOrderFilled::class)]
+#[CoversClass(ExchangePositionOpened::class)]
+final class ExchangeWsIngestionServiceTest extends TestCase
+{
+    public function testDrainsFakePrivateEventsThroughNormalizerAndBus(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $adapter = $this->adapter($state);
+        $adapter->placeOrder($this->marketRequest(symbol: 'BTCUSDT', clientOrderId: 'btc-cid'));
+        $adapter->placeOrder($this->marketRequest(symbol: 'ETHUSDT', clientOrderId: 'eth-cid'));
+
+        $store = new RecordingProjectionStore();
+        $service = new ExchangeWsIngestionService(
+            new ExchangeEventNormalizerRegistry([new FakeExchangeEventNormalizer($state)]),
+            new ExchangeEventBus($store, new NullLogger()),
+            new NullLogger(),
+        );
+
+        $client = new FakeExchangeWsClient($state);
+        $result = $service->drain($client, 'BTCUSDT');
+        $secondDrain = $service->drain($client, 'BTCUSDT');
+        $globalDrain = $service->drain($client);
+
+        self::assertGreaterThanOrEqual(3, $result->rawEventsRead);
+        self::assertGreaterThanOrEqual(3, $result->eventsProjected);
+        self::assertSame(0, $secondDrain->rawEventsRead);
+        self::assertSame(0, $secondDrain->eventsProjected);
+        self::assertGreaterThanOrEqual(3, $globalDrain->rawEventsRead);
+        self::assertTrue($store->contains(ExchangeOrderFilled::class));
+        self::assertTrue($store->contains(ExchangePositionOpened::class));
+    }
+
+    private function adapter(FakeExchangeStateStore $state): FakeExchangeAdapter
+    {
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->fixedClock());
+
+        return new FakeExchangeAdapter($state, $book, $engine, $this->fixedClock());
+    }
+
+    private function marketRequest(string $symbol, string $clientOrderId): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 10.0,
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+        );
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        };
+    }
+}
+
+final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInterface
+{
+    /** @var ExchangeEventInterface[] */
+    public array $events = [];
+
+    public function hasOrder(ExchangeOrderDto $order): bool
+    {
+        return false;
+    }
+
+    public function openPositions(\App\Common\Enum\Exchange $exchange, \App\Common\Enum\MarketType $marketType, ?string $symbol = null): array
+    {
+        return [];
+    }
+
+    public function project(ExchangeEventInterface $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public function contains(string $class): bool
+    {
+        foreach ($this->events as $event) {
+            if ($event instanceof $class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/trading-app/tests/Exchange/Event/FakeExchangeEventNormalizerTest.php
+++ b/trading-app/tests/Exchange/Event/FakeExchangeEventNormalizerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Event;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Exchange\Event\ExchangeOrderCreated;
+use App\Exchange\Event\ExchangeOrderPartiallyFilled;
+use App\Exchange\Event\ExchangePositionOpened;
+use App\Exchange\Event\ExchangeProtectionOrderRejected;
+use App\Exchange\Fake\FakeExchangeEvent;
+use App\Exchange\Fake\FakeExchangeEventNormalizer;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeScenarioService;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(FakeExchangeEventNormalizer::class)]
+#[CoversClass(FakeExchangeEvent::class)]
+#[CoversClass(FakeExchangeStateStore::class)]
+#[CoversClass(FakeExchangeMatchingEngine::class)]
+#[CoversClass(FakeExchangeOrderBook::class)]
+#[CoversClass(FakeExchangeScenarioService::class)]
+#[CoversClass(ExchangeOrderPartiallyFilled::class)]
+#[CoversClass(ExchangeOrderCreated::class)]
+#[CoversClass(ExchangeFillReceived::class)]
+#[CoversClass(ExchangePositionOpened::class)]
+#[CoversClass(ExchangeProtectionOrderRejected::class)]
+final class FakeExchangeEventNormalizerTest extends TestCase
+{
+    private FakeExchangeStateStore $state;
+    private FakeExchangeScenarioService $scenario;
+    private FakeExchangeEventNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->state = new FakeExchangeStateStore();
+        $book = new FakeExchangeOrderBook($this->state);
+        $engine = new FakeExchangeMatchingEngine($this->state, $book, $this->fixedClock());
+        $this->scenario = new FakeExchangeScenarioService($this->state, $book, $engine);
+        $this->normalizer = new FakeExchangeEventNormalizer($this->state);
+    }
+
+    public function testNormalizesPartialFillIntoOrderAndFillEvents(): void
+    {
+        $placed = $this->scenarioAdapter()->placeOrder($this->request(price: 24950.0, quantity: 10.0, postOnly: true));
+        $this->scenario->fillOrder((string)$placed->exchangeOrderId, 4.0, 24950.0);
+
+        $events = $this->scenario->events('order.partially_filled');
+        $normalized = $this->normalizer->normalize($events[0]);
+
+        self::assertCount(2, $normalized);
+        self::assertInstanceOf(ExchangeOrderPartiallyFilled::class, $normalized[0]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $normalized[1]);
+        self::assertSame('exchange.order.partially_filled', $normalized[0]->eventType());
+        self::assertEqualsWithDelta(4.0, $normalized[1]->fill()->quantity, 0.000001);
+        self::assertSame('BTCUSDT', $normalized[1]->symbol());
+        self::assertSame(
+            $normalized[1]->fill()->fillId,
+            $this->scenarioAdapter()->getFillsSnapshot('BTCUSDT')[0]->fillId,
+        );
+    }
+
+    public function testNormalizesPositionOpenedEvent(): void
+    {
+        $this->scenarioAdapter()->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            quantity: 10.0,
+            postOnly: false,
+        ));
+
+        $events = $this->scenario->events('position.opened');
+        $normalized = $this->normalizer->normalize($events[0]);
+
+        self::assertCount(1, $normalized);
+        self::assertInstanceOf(ExchangePositionOpened::class, $normalized[0]);
+        self::assertSame('exchange.position.opened', $normalized[0]->eventType());
+        self::assertEqualsWithDelta(10.0, $normalized[0]->size(), 0.000001);
+    }
+
+    public function testNormalizesHistoricalOrderCreatedWithOriginalSnapshot(): void
+    {
+        $this->scenarioAdapter()->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            quantity: 10.0,
+            postOnly: false,
+        ));
+
+        $events = $this->scenario->events('order.created');
+        $normalized = $this->normalizer->normalize($events[0]);
+
+        self::assertCount(1, $normalized);
+        self::assertInstanceOf(ExchangeOrderCreated::class, $normalized[0]);
+        self::assertSame(ExchangeOrderStatus::OPEN, $normalized[0]->order()->status);
+        self::assertEqualsWithDelta(0.0, $normalized[0]->order()->filledQuantity, 0.000001);
+    }
+
+    public function testNormalizesProtectionRejectionEvent(): void
+    {
+        $this->scenario->rejectNextProtectionOrder();
+        $this->scenarioAdapter()->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            quantity: 10.0,
+            postOnly: false,
+            attachedStopLossPrice: 24800.0,
+        ));
+
+        $events = $this->scenario->events('protection_order.rejected');
+        $normalized = $this->normalizer->normalize($events[0]);
+
+        self::assertCount(1, $normalized);
+        self::assertInstanceOf(ExchangeProtectionOrderRejected::class, $normalized[0]);
+        self::assertSame('exchange.protection_order.rejected', $normalized[0]->eventType());
+    }
+
+    private function scenarioAdapter(): \App\Exchange\Adapter\FakeExchangeAdapter
+    {
+        $book = new FakeExchangeOrderBook($this->state);
+        $engine = new FakeExchangeMatchingEngine($this->state, $book, $this->fixedClock());
+
+        return new \App\Exchange\Adapter\FakeExchangeAdapter($this->state, $book, $engine, $this->fixedClock());
+    }
+
+    private function request(
+        ExchangeOrderType $orderType = ExchangeOrderType::LIMIT,
+        ?float $price = 24950.0,
+        float $quantity = 1.0,
+        bool $postOnly = false,
+        ?float $attachedStopLossPrice = null,
+    ): PlaceOrderRequest {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: $orderType,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: $quantity,
+            price: $price,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: $postOnly,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-1',
+            attachedStopLossPrice: $attachedStopLossPrice,
+        );
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        };
+    }
+}

--- a/trading-app/tests/Exchange/Reconciliation/ExchangeReconciliationServiceTest.php
+++ b/trading-app/tests/Exchange/Reconciliation/ExchangeReconciliationServiceTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Reconciliation;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Event\ExchangeEventBus;
+use App\Exchange\Event\ExchangeEventInterface;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Exchange\Event\ExchangeLocalProjectionStoreInterface;
+use App\Exchange\Event\ExchangeOrderFilled;
+use App\Exchange\Event\ExchangePositionClosed;
+use App\Exchange\Event\ExchangePositionUpdated;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Reconciliation\ExchangeReconciliationService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Psr\Log\NullLogger;
+
+#[CoversClass(ExchangeReconciliationService::class)]
+#[CoversClass(ExchangeEventBus::class)]
+#[CoversClass(FakeExchangeAdapter::class)]
+#[CoversClass(ExchangeOrderFilled::class)]
+#[CoversClass(ExchangeFillReceived::class)]
+#[CoversClass(ExchangePositionUpdated::class)]
+final class ExchangeReconciliationServiceTest extends TestCase
+{
+    public function testRestReconciliationProjectsMissedFillAndFlagsUnprotectedPosition(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $adapter = $this->adapter($state);
+        $adapter->placeOrder($this->marketRequest());
+        $store = new RecordingProjectionStore();
+        $service = new ExchangeReconciliationService(
+            new ExchangeEventBus($store, new NullLogger()),
+            $store,
+            $this->fixedClock(),
+            new NullLogger(),
+        );
+
+        $result = $service->reconcile($adapter, 'BTCUSDT');
+
+        self::assertSame(1, $result->ordersChecked);
+        self::assertSame(1, $result->positionsChecked);
+        self::assertSame(1, $result->fillsImported);
+        self::assertSame(1, $result->unknownOrdersDetected);
+        self::assertCount(1, $result->metadata['unprotected_positions'] ?? []);
+        self::assertTrue($store->contains(ExchangeOrderFilled::class));
+        self::assertTrue($store->contains(ExchangeFillReceived::class));
+        self::assertTrue($store->contains(ExchangePositionUpdated::class));
+    }
+
+    public function testRestReconciliationClosesLocalPositionMissingFromSnapshot(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $adapter = $this->adapter($state);
+        $store = new RecordingProjectionStore();
+        $store->localOpenPositions = [[
+            'symbol' => 'BTCUSDT',
+            'side' => ExchangePositionSide::LONG,
+            'size' => 10.0,
+        ]];
+        $service = new ExchangeReconciliationService(
+            new ExchangeEventBus($store, new NullLogger()),
+            $store,
+            $this->fixedClock(),
+            new NullLogger(),
+        );
+
+        $result = $service->reconcile($adapter, 'BTCUSDT');
+
+        self::assertSame(0, $result->positionsChecked);
+        self::assertTrue($store->contains(ExchangePositionClosed::class));
+    }
+
+    private function adapter(FakeExchangeStateStore $state): FakeExchangeAdapter
+    {
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->fixedClock());
+
+        return new FakeExchangeAdapter($state, $book, $engine, $this->fixedClock());
+    }
+
+    private function marketRequest(): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 10.0,
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-1',
+        );
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        };
+    }
+}
+
+final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInterface
+{
+    /** @var ExchangeEventInterface[] */
+    public array $events = [];
+
+    /** @var array<int,array{symbol: string, side: ExchangePositionSide, size: float}> */
+    public array $localOpenPositions = [];
+
+    public function hasOrder(ExchangeOrderDto $order): bool
+    {
+        return false;
+    }
+
+    public function openPositions(Exchange $exchange, MarketType $marketType, ?string $symbol = null): array
+    {
+        $normalizedSymbol = $symbol !== null ? strtoupper($symbol) : null;
+
+        return array_values(array_filter(
+            $this->localOpenPositions,
+            static fn (array $position): bool => $normalizedSymbol === null || $position['symbol'] === $normalizedSymbol,
+        ));
+    }
+
+    public function project(ExchangeEventInterface $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public function contains(string $class): bool
+    {
+        foreach ($this->events as $event) {
+            if ($event instanceof $class) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #84

Summary:
- add normalized exchange event classes for orders, fills, positions, balances, and protection orders;
- add exchange event normalizer registry, projection bus, Doctrine local projection store, and WS ingestion service;
- add FakeExchange WS client and normalizer backed by existing FakeExchange events;
- add REST snapshot reconciliation service that projects orders, positions, fills, detects unknown orders, and reports unprotected positions;
- extend FakeExchangeAdapter with full order/fill snapshots for reconciliation.

Local validations:
- php -d error_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit tests/Exchange
- php -d error_reporting="E_ALL & ~E_DEPRECATED" bin/console lint:container --no-debug
- php -d error_reporting="E_ALL & ~E_DEPRECATED" bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --cached --check

Notes:
- no new DB table; projections reuse futures_order, futures_order_trade, and positions.
- out-of-zone-watcher/ remains untracked and untouched.