### PR TITLE
[API-07] Refactor BitMart legacy order mapping

### DIFF
--- a/trading-app/src/Exchange/Adapter/BitmartLegacyOrderMapper.php
+++ b/trading-app/src/Exchange/Adapter/BitmartLegacyOrderMapper.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Adapter;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Entity\OrderIntent;
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+use App\TradeEntry\Types\Side;
+
+final class BitmartLegacyOrderMapper
+{
+    private const SIDE_OPEN_LONG = 1;
+    private const SIDE_CLOSE_SHORT = 2;
+    private const SIDE_CLOSE_LONG = 3;
+    private const SIDE_OPEN_SHORT = 4;
+
+    private const MODE_IOC = 3;
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function entrySubmitPayload(OrderPlanModel $plan, string $clientOrderId): array
+    {
+        $payload = [
+            'symbol' => $plan->symbol,
+            'side' => $this->entrySideCode($plan),
+            'type' => $plan->orderType,
+            'mode' => $this->enforcedOrderMode($plan),
+            'open_type' => $plan->openType,
+            'size' => $plan->size,
+            'leverage' => $plan->leverage,
+            'client_order_id' => $clientOrderId,
+        ];
+
+        if ($plan->orderType === 'limit') {
+            $payload['price'] = (string) $plan->entry;
+            $payload['preset_take_profit_price'] = (string) $plan->takeProfit;
+            $payload['preset_take_profit_price_type'] = 1;
+            $payload['preset_stop_loss_price'] = (string) $plan->stop;
+            $payload['preset_stop_loss_price_type'] = 1;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    public function orderOptions(array $payload): array
+    {
+        $options = [
+            'side' => $payload['side'],
+            'mode' => $payload['mode'] ?? null,
+            'open_type' => $payload['open_type'],
+            'client_order_id' => $payload['client_order_id'],
+            'leverage' => $payload['leverage'] ?? null,
+        ];
+
+        foreach ([
+            'decision_key',
+            'order_intent_id',
+            'preset_take_profit_price',
+            'preset_take_profit_price_type',
+            'preset_stop_loss_price',
+            'preset_stop_loss_price_type',
+        ] as $key) {
+            if (isset($payload[$key])) {
+                $options[$key] = $payload[$key];
+            }
+        }
+
+        return array_filter(
+            $options,
+            static fn ($value) => $value !== null && $value !== '',
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     * @return array<string,mixed>
+     */
+    public function withoutAttachedProtectionOptions(array $options): array
+    {
+        unset($options['preset_take_profit_price'], $options['preset_take_profit_price_type']);
+        unset($options['preset_stop_loss_price'], $options['preset_stop_loss_price_type']);
+
+        return $options;
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function providerSide(array $payload): OrderSide
+    {
+        return match ((int) $payload['side']) {
+            self::SIDE_OPEN_LONG, self::SIDE_CLOSE_SHORT => OrderSide::BUY,
+            self::SIDE_CLOSE_LONG, self::SIDE_OPEN_SHORT => OrderSide::SELL,
+            default => throw new \InvalidArgumentException(sprintf('Unsupported BitMart side code "%s"', (string) $payload['side'])),
+        };
+    }
+
+    public function providerOrderType(OrderPlanModel $plan): OrderType
+    {
+        return $plan->orderType === 'market' ? OrderType::MARKET : OrderType::LIMIT;
+    }
+
+    public function enforcedOrderMode(OrderPlanModel $plan): int
+    {
+        return $plan->orderType === 'market' ? self::MODE_IOC : $plan->orderMode;
+    }
+
+    public function legacyIocMode(): int
+    {
+        return self::MODE_IOC;
+    }
+
+    public function entrySideCode(OrderPlanModel $plan): int
+    {
+        return $plan->side === Side::Long ? self::SIDE_OPEN_LONG : self::SIDE_OPEN_SHORT;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function orderIntentExecutionParams(OrderPlanModel $plan, string $clientOrderId): array
+    {
+        return [
+            'side' => $this->entrySideCode($plan),
+            'type' => $plan->orderType,
+            'open_type' => $plan->openType,
+            'leverage' => $plan->leverage,
+            'position_mode' => OrderIntent::POSITION_MODE_HEDGE,
+            'price' => $plan->orderType === 'limit' ? (string) $plan->entry : null,
+            'size' => $plan->size,
+            'client_order_id' => $clientOrderId,
+            'preset_mode' => ($plan->stop > 0.0 || $plan->takeProfit > 0.0)
+                ? OrderIntent::PRESET_MODE_PRESET_ON_ENTRY
+                : OrderIntent::PRESET_MODE_NONE,
+            'preset_stop_loss_price' => $plan->stop > 0.0 ? (string) $plan->stop : null,
+            'preset_take_profit_price' => $plan->takeProfit > 0.0 ? (string) $plan->takeProfit : null,
+        ];
+    }
+}

--- a/trading-app/src/MtfValidator/Command/ListOpenPositionsOrdersCommand.php
+++ b/trading-app/src/MtfValidator/Command/ListOpenPositionsOrdersCommand.php
@@ -10,7 +10,6 @@ use App\Contract\Provider\OrderProviderInterface;
 use App\Contract\Provider\MainProviderInterface;
 use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
-use App\Provider\Bitmart\BitmartOrderProvider;
 use App\Provider\Context\ExchangeContext;
 use Brick\Math\RoundingMode;
 use Psr\Log\LoggerInterface;
@@ -246,14 +245,12 @@ Exemples:
                 }
 
                 // 3. Récupération des ordres planifiés (TP/SL)
-                // Note: getPlanOrders() est spécifique à BitmartOrderProvider
                 $io->section('Récupération des ordres planifiés (TP/SL)...');
                 try {
                     $planOrders = [];
-                    // Vérifier si le provider supporte getPlanOrders (méthode spécifique BitMart)
-                    $bitmartProvider = $this->unwrapOrderProvider($orderProvider);
-                    if ($bitmartProvider instanceof BitmartOrderProvider) {
-                        $planOrders = $bitmartProvider->getPlanOrders($symbol);
+                    $planOrderProvider = $this->unwrapOrderProvider($orderProvider);
+                    if (method_exists($planOrderProvider, 'getPlanOrders')) {
+                        $planOrders = $planOrderProvider->getPlanOrders($symbol);
                     } else {
                         $io->note('Le provider ne supporte pas la récupération des ordres planifiés (TP/SL)');
                         $data['plan_orders'] = [];

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -3,13 +3,11 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\Execution;
 
-use App\Common\Enum\OrderSide;
-use App\Common\Enum\OrderType;
 use App\Contract\Provider\MainProviderInterface;
 use App\Contract\Provider\OrderProviderDecoratorInterface;
 use App\Contract\Provider\OrderProviderInterface;
+use App\Exchange\Adapter\BitmartLegacyOrderMapper;
 use App\Provider\Context\ExchangeContext;
-use App\Provider\Bitmart\BitmartOrderProvider;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
 use App\TradeEntry\Message\LimitFillWatchMessage;
 use App\TradeEntry\Pricing\TickQuantizer;
@@ -43,6 +41,7 @@ final class ExecutionBox
         private readonly TradeEntryConfigResolver $tradeEntryConfigResolver,
         #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
         private readonly MessageBusInterface $bus,
+        private readonly BitmartLegacyOrderMapper $bitmartOrders,
         private readonly ?TpSlTwoTargetsService $tpSlService = null,
     ) {}
 
@@ -144,22 +143,15 @@ final class ExecutionBox
         $payload = $this->tpSl->presetInSubmitPayload($plan, $clientOrderId);
         $payload = $this->withIntentMetadata($payload, $decisionKey, $orderIntentId);
 
-        // Mapper side BitMart (1,2,3,4) vers OrderSide enum
-        $side = match($payload['side']) {
-            1 => OrderSide::BUY,   // open_long
-            2 => OrderSide::SELL,  // close_long
-            3 => OrderSide::BUY,   // close_short
-            4 => OrderSide::SELL,  // open_short
-        };
+        $side = $this->bitmartOrders->providerSide($payload);
 
         // Extra visibility before submit
-        // Convertir le type du plan en enum OrderType pour le provider
-        $enforcedOrderType = ($plan->orderType === 'market') ? OrderType::MARKET : OrderType::LIMIT;
+        $enforcedOrderType = $this->bitmartOrders->providerOrderType($plan);
 
         $this->positionsLogger->debug('execution.presubmit_check', [
             'symbol' => $plan->symbol,
             'side_enum' => $side->value,
-            'side_numeric' => $payload['side'],
+            'legacy_side' => $payload['side'],
             'type' => $payload['type'],
             'size' => (int)$payload['size'],
             'price' => $payload['price'] ?? null,
@@ -174,9 +166,8 @@ final class ExecutionBox
         ]);
 
         $orderPayload = $payload;
-        // Utiliser le type du plan (déjà dans payload via TpSlAttacher, mais s'assurer de la cohérence)
-        $orderPayload['type'] = ($plan->orderType === 'market') ? OrderType::MARKET->value : OrderType::LIMIT->value;
-        $orderPayload['mode'] = (int)$plan->orderMode;
+        $orderPayload['type'] = $enforcedOrderType->value;
+        $orderPayload['mode'] = $this->bitmartOrders->enforcedOrderMode($plan);
 
         // Politique: forcer une fenêtre de surveillance locale à 120s pour les LIMIT
         // et désactiver le dead-man switch exchange (cancel-all-after) afin d'éviter
@@ -207,7 +198,7 @@ final class ExecutionBox
             'attempt_label' => $attemptLabel,
             'decision_key' => $decisionKey,
         ]);
-        $orderOptions = $this->extractOrderOptions($orderPayload);
+        $orderOptions = $this->bitmartOrders->orderOptions($orderPayload);
         if ($cancelAfterTimeout !== null && $cancelAfterTimeout > 0) {
             // cas général (non utilisé ici car on désarme côté exchange)
             $orderOptions['cancel_after_timeout'] = $cancelAfterTimeout;
@@ -365,42 +356,6 @@ final class ExecutionBox
         $this->orderModePolicy->enforce($plan);
 
         return $this->applyTimeframeMultiplier($plan, $mode, $executionTf, $decisionKey);
-    }
-
-    /**
-     * Prépare les options Bitmart pour l'appel placeOrder.
-     *
-     * @param array<string, mixed> $payload
-     *
-     * @return array<string, mixed>
-     */
-    private function extractOrderOptions(array $payload): array
-    {
-        $options = [
-            'side' => $payload['side'],
-            'mode' => $payload['mode'] ?? null,
-            'open_type' => $payload['open_type'],
-            'client_order_id' => $payload['client_order_id'],
-            'leverage' => $payload['leverage'] ?? null,
-        ];
-
-        foreach ([
-            'decision_key',
-            'order_intent_id',
-            'preset_take_profit_price',
-            'preset_take_profit_price_type',
-            'preset_stop_loss_price',
-            'preset_stop_loss_price_type',
-        ] as $key) {
-            if (isset($payload[$key])) {
-                $options[$key] = $payload[$key];
-            }
-        }
-
-        return array_filter(
-            $options,
-            static fn($value) => $value !== null && $value !== ''
-        );
     }
 
     /**
@@ -616,17 +571,11 @@ final class ExecutionBox
         // 1) Soumettre l'ordre market sans TP/SL
         $payload = $this->tpSl->presetInSubmitPayload($plan, $clientOrderId);
         $payload = $this->withIntentMetadata($payload, $decisionKey, $orderIntentId);
-        $side = match($payload['side']) {
-            1 => OrderSide::BUY,
-            2 => OrderSide::SELL,
-            3 => OrderSide::BUY,
-            4 => OrderSide::SELL,
-        };
+        $side = $this->bitmartOrders->providerSide($payload);
 
-        $orderOptions = $this->extractOrderOptions($payload);
-        // Retirer TP/SL du payload pour market
-        unset($orderOptions['preset_take_profit_price'], $orderOptions['preset_take_profit_price_type']);
-        unset($orderOptions['preset_stop_loss_price'], $orderOptions['preset_stop_loss_price_type']);
+        $orderOptions = $this->bitmartOrders->withoutAttachedProtectionOptions(
+            $this->bitmartOrders->orderOptions($payload),
+        );
 
         $this->positionsLogger->debug('execution.market_order.submit', [
             'symbol' => $plan->symbol,
@@ -639,7 +588,7 @@ final class ExecutionBox
         $orderResult = $providers->getOrderProvider()->placeOrder(
             symbol: $plan->symbol,
             side: $side,
-            type: OrderType::MARKET,
+            type: $this->bitmartOrders->providerOrderType($plan),
             quantity: (float)$plan->size,
             price: null,
             stopPrice: null,
@@ -755,24 +704,6 @@ final class ExecutionBox
             // 5) Vérifier les plans TP/SL
             $this->verifyPlanOrders($plan->symbol, $tpSlResult['submitted'], $decisionKey, $plan->exchangeContext);
 
-            // 6) Désarmer le dead-man switch symbolique (cancel-all-after) une fois la position ouverte et TP/SL soumis.
-           /* $orderProvider = $this->providers->getOrderProvider();
-            if ($orderProvider instanceof \App\Provider\Bitmart\BitmartOrderProvider) {
-                try {
-                    $orderProvider->cancelAllAfter($plan->symbol, 0);
-                    $this->positionsLogger->info('execution.deadman_disarmed', [
-                        'symbol' => $plan->symbol,
-                        'reason' => 'position_opened_tp_sl_active',
-                        'decision_key' => $decisionKey,
-                    ]);
-                } catch (\Throwable $e) {
-                    $this->positionsLogger->warning('execution.deadman_disarm_failed', [
-                        'symbol' => $plan->symbol,
-                        'error' => $e->getMessage(),
-                        'decision_key' => $decisionKey,
-                    ]);
-                }
-            }*/
         } catch (\Throwable $e) {
             $this->positionsLogger->error('execution.market_order.tp_sl_submit_failed', [
                 'symbol' => $plan->symbol,
@@ -919,9 +850,8 @@ final class ExecutionBox
     ): void
     {
         $orderProvider = $this->providersFor($context)->getOrderProvider();
-        $bitmartProvider = $this->unwrapOrderProvider($orderProvider);
-        // Vérifier si le provider supporte getPlanOrders (spécifique BitMart)
-        if (!$bitmartProvider instanceof BitmartOrderProvider) {
+        $planOrderProvider = $this->unwrapOrderProvider($orderProvider);
+        if (!method_exists($planOrderProvider, 'getPlanOrders')) {
             $this->positionsLogger->debug('execution.market_order.verify_skip', [
                 'symbol' => $symbol,
                 'reason' => 'getPlanOrders_not_available',
@@ -931,7 +861,7 @@ final class ExecutionBox
         }
 
         try {
-            $planOrders = $bitmartProvider->getPlanOrders($symbol);
+            $planOrders = $planOrderProvider->getPlanOrders($symbol);
             $submittedIds = array_column($submitted, 'order_id');
             $foundIds = [];
 
@@ -1036,8 +966,7 @@ final class ExecutionBox
             'reason' => 'end_of_zone_fallback',
         ]);
 
-        // BitMart Futures V2: IOC = mode=3 ; MakerOnly = mode=4 ; type reste 'limit'
-        return $plan->copyWith(orderType: 'limit', orderMode: 3, entry: $cap);
+        return $plan->copyWith(orderType: 'limit', orderMode: $this->bitmartOrders->legacyIocMode(), entry: $cap);
     }
 
     /**

--- a/trading-app/src/TradeEntry/Execution/TpSlAttacher.php
+++ b/trading-app/src/TradeEntry/Execution/TpSlAttacher.php
@@ -3,38 +3,28 @@ declare(strict_types=1);
 
 namespace App\TradeEntry\Execution;
 
+use App\Exchange\Adapter\BitmartLegacyOrderMapper;
 use App\TradeEntry\OrderPlan\OrderPlanModel;
-use App\TradeEntry\Types\Side;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class TpSlAttacher
 {
+    private readonly BitmartLegacyOrderMapper $bitmartOrders;
+
     public function __construct(
         #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
-    ) {}
+        ?BitmartLegacyOrderMapper $bitmartOrders = null,
+    ) {
+        $this->bitmartOrders = $bitmartOrders ?? new BitmartLegacyOrderMapper();
+    }
 
+    /**
+     * @return array<string,mixed>
+     */
     public function presetInSubmitPayload(OrderPlanModel $plan, string $clientOrderId): array
     {
-        $payload = [
-            'symbol' => $plan->symbol,
-            'side' => $plan->side === Side::Long ? 1 : 4,
-            'type' => $plan->orderType,
-            'mode' => $plan->orderMode,
-            'open_type' => $plan->openType,
-            'size' => $plan->size,
-            'leverage' => $plan->leverage,
-            'client_order_id' => $clientOrderId,
-        ];
-
-        if ($plan->orderType === 'limit') {
-            // Pour LIMIT: fournir le prix et les TP/SL préconfigurés
-            $payload['price'] = (string)$plan->entry;
-            $payload['preset_take_profit_price'] = (string)$plan->takeProfit;
-            $payload['preset_take_profit_price_type'] = 1;
-            $payload['preset_stop_loss_price'] = (string)$plan->stop;
-            $payload['preset_stop_loss_price_type'] = 1;
-        }
+        $payload = $this->bitmartOrders->entrySubmitPayload($plan, $clientOrderId);
 
         $this->positionsLogger->debug('tp_sl_attacher.payload_ready', [
             'symbol' => $plan->symbol,

--- a/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
@@ -10,7 +10,6 @@ use App\Contract\Provider\OrderProviderDecoratorInterface;
 use App\Contract\Provider\OrderProviderInterface;
 use App\Logging\TradeLifecycleLogger;
 use App\Logging\TradeLifecycleReason;
-use App\Provider\Bitmart\BitmartOrderProvider;
 use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Message\LimitFillWatchMessage;
 use Brick\Math\RoundingMode;
@@ -61,10 +60,10 @@ final class LimitFillWatchMessageHandler
 
             if ($status === OrderStatus::FILLED || $status === OrderStatus::PARTIALLY_FILLED) {
                 // Position ouverte: désarmer le dead-man switch pour ce symbole
-                $bitmartProvider = $this->unwrapOrderProvider($orderProvider);
-                if ($bitmartProvider instanceof BitmartOrderProvider) {
+                $deadmanProvider = $this->unwrapOrderProvider($orderProvider);
+                if (method_exists($deadmanProvider, 'cancelAllAfter')) {
                     try {
-                        $bitmartProvider->cancelAllAfter($message->symbol, 0);
+                        $deadmanProvider->cancelAllAfter($message->symbol, 0);
                         $this->positionsLogger->info('limit_watch.deadman_disarmed', [
                             'symbol' => $message->symbol,
                             'exchange_order_id' => $message->exchangeOrderId,

--- a/trading-app/src/TradeEntry/README.md
+++ b/trading-app/src/TradeEntry/README.md
@@ -130,8 +130,8 @@ Pour `order_type=market`, on prend simplement `bestAsk` ou `bestBid`.
 3. **Market orders** :
    - Soumission via `executeMarketOrder()` avec watchers WS/REST (timeouts 3s WS, 10s total) + vérification via `getPlanOrders`.
 4. **Limit orders** :
-   - `TpSlAttacher::presetInSubmitPayload()` encode SL/TP directement dans le `placeOrder`.
-   - `orderModePolicy` force MakerOnly (mode=4) ou Taker (mode=3) selon config.
+   - `TpSlAttacher::presetInSubmitPayload()` délègue l'encodage legacy Bitmart à `BitmartLegacyOrderMapper`.
+   - `orderModePolicy` force MakerOnly ou Taker selon config, puis l'adapter convertit vers le mode exchange.
    - Dead-man switch Bitmart désactivé (`cancel_after_timeout=0`), un watcher interne (`LimitFillWatchMessage`) annule l’ordre si non rempli sous 120s.
    - `MakerTakerSwitchPolicy` peut convertir une LIMIT en IOC taker si la zone expire ou si le spread est trop élevé (cf. `applyMakerTakerSwitch`).
    - `applyEndOfZoneFallback()` autorise un passage en taker (market ou limit capée) lorsque la zone va expirer, le spread ≤ `maxSpreadBps` et le prix reste dans la zone.

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\TradeEntry\Workflow;
 
 use App\Entity\OrderIntent;
+use App\Exchange\Adapter\BitmartLegacyOrderMapper;
 use App\Service\OrderIntentManager;
 use App\TradeEntry\Dto\ExecutionResult;
 use App\TradeEntry\Execution\ExchangeExecutionService;
@@ -17,13 +18,18 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class ExecuteOrderPlan
 {
+    private readonly BitmartLegacyOrderMapper $bitmartOrders;
+
     public function __construct(
         private readonly ExecutionBox $execution,
         private readonly ExchangeExecutionService $exchangeExecution,
         #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
         private readonly ?OrderIntentManager $orderIntentManager = null,
         private readonly ?IdempotencyPolicy $idempotency = null,
-    ) {}
+        ?BitmartLegacyOrderMapper $bitmartOrders = null,
+    ) {
+        $this->bitmartOrders = $bitmartOrders ?? new BitmartLegacyOrderMapper();
+    }
 
     public function __invoke(
         OrderPlanModel $plan,
@@ -191,20 +197,7 @@ final class ExecuteOrderPlan
             'candle_open_ts' => $this->parsedDecisionKeyPart($decisionKey, 4),
             'strategy_profile' => $this->parsedDecisionKeyPart($decisionKey, 6),
             'strategy_version' => $this->parsedDecisionKeyPart($decisionKey, 7),
-            'side' => $plan->side->value === 'long' ? 1 : 4,
-            'type' => $plan->orderType,
-            'open_type' => $plan->openType,
-            'leverage' => $plan->leverage,
-            'position_mode' => OrderIntent::POSITION_MODE_HEDGE,
-            'price' => $plan->orderType === 'limit' ? (string) $plan->entry : null,
-            'size' => $plan->size,
-            'client_order_id' => $clientOrderId,
-            'preset_mode' => ($plan->stop > 0.0 || $plan->takeProfit > 0.0)
-                ? OrderIntent::PRESET_MODE_PRESET_ON_ENTRY
-                : OrderIntent::PRESET_MODE_NONE,
-            'preset_stop_loss_price' => $plan->stop > 0.0 ? (string) $plan->stop : null,
-            'preset_take_profit_price' => $plan->takeProfit > 0.0 ? (string) $plan->takeProfit : null,
-        ];
+        ] + $this->bitmartOrders->orderIntentExecutionParams($plan, $clientOrderId);
     }
 
     /**

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -125,6 +125,27 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertSame(2, $capturedOptions['mode'] ?? null);
     }
 
+    public function testMapsAttachedProtectionToLegacyPresetOptions(): void
+    {
+        $capturedOptions = null;
+        $adapter = $this->createAdapter(function (array $options) use (&$capturedOptions): void {
+            $capturedOptions = $options;
+        });
+
+        $adapter->placeOrder($this->placeOrderRequest(
+            positionSide: ExchangePositionSide::LONG,
+            side: ExchangeOrderSide::BUY,
+            attachedStopLossPrice: 24000.0,
+            attachedTakeProfitPrice: 26000.0,
+        ));
+
+        self::assertSame('24000', $capturedOptions['preset_stop_loss_price'] ?? null);
+        self::assertSame(1, $capturedOptions['preset_stop_loss_price_type'] ?? null);
+        self::assertSame('26000', $capturedOptions['preset_take_profit_price'] ?? null);
+        self::assertSame(1, $capturedOptions['preset_take_profit_price_type'] ?? null);
+        self::assertSame('cid-1', $capturedOptions['client_order_id'] ?? null);
+    }
+
     public function testRejectsPostOnlyWithIocOrFok(): void
     {
         $registry = $this->createMock(ExchangeProviderRegistryInterface::class);

--- a/trading-app/tests/Exchange/Adapter/BitmartLegacyOrderMapperTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartLegacyOrderMapperTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Adapter;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Entity\OrderIntent;
+use App\Exchange\Adapter\BitmartLegacyOrderMapper;
+use App\TradeEntry\OrderPlan\OrderPlanModel;
+use App\TradeEntry\Types\Side;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(BitmartLegacyOrderMapper::class)]
+final class BitmartLegacyOrderMapperTest extends TestCase
+{
+    public function testBuildsLegacyLimitPayloadAndOptionsForLongEntry(): void
+    {
+        $mapper = new BitmartLegacyOrderMapper();
+        $payload = $mapper->entrySubmitPayload($this->plan(side: Side::Long), 'cid-1');
+
+        self::assertSame(1, $payload['side']);
+        self::assertSame('limit', $payload['type']);
+        self::assertSame(4, $payload['mode']);
+        self::assertSame('isolated', $payload['open_type']);
+        self::assertSame('26000', $payload['preset_take_profit_price']);
+        self::assertSame('24000', $payload['preset_stop_loss_price']);
+        self::assertSame(OrderSide::BUY, $mapper->providerSide($payload));
+        self::assertSame(OrderType::LIMIT, $mapper->providerOrderType($this->plan(side: Side::Long)));
+
+        $options = $mapper->orderOptions($payload + [
+            'decision_key' => 'dk-1',
+            'order_intent_id' => 42,
+        ]);
+
+        self::assertSame(1, $options['side']);
+        self::assertSame(4, $options['mode']);
+        self::assertSame('isolated', $options['open_type']);
+        self::assertSame('cid-1', $options['client_order_id']);
+        self::assertSame('dk-1', $options['decision_key']);
+        self::assertSame(42, $options['order_intent_id']);
+    }
+
+    public function testBuildsMarketPayloadWithoutAttachedProtectionOptions(): void
+    {
+        $mapper = new BitmartLegacyOrderMapper();
+        $payload = $mapper->entrySubmitPayload($this->plan(side: Side::Short, orderType: 'market', orderMode: 1), 'cid-2');
+
+        self::assertSame(4, $payload['side']);
+        self::assertSame('market', $payload['type']);
+        self::assertSame(3, $payload['mode']);
+        self::assertArrayNotHasKey('price', $payload);
+        self::assertArrayNotHasKey('preset_stop_loss_price', $payload);
+        self::assertArrayNotHasKey('preset_take_profit_price', $payload);
+        self::assertSame(OrderSide::SELL, $mapper->providerSide($payload));
+        self::assertSame(OrderType::MARKET, $mapper->providerOrderType($this->plan(side: Side::Short, orderType: 'market')));
+
+        $options = $mapper->withoutAttachedProtectionOptions($mapper->orderOptions($payload + [
+            'preset_stop_loss_price' => '24000',
+            'preset_take_profit_price' => '26000',
+        ]));
+
+        self::assertSame(3, $options['mode']);
+        self::assertArrayNotHasKey('preset_stop_loss_price', $options);
+        self::assertArrayNotHasKey('preset_take_profit_price', $options);
+    }
+
+    public function testMapsLegacyCloseSidesToProviderSides(): void
+    {
+        $mapper = new BitmartLegacyOrderMapper();
+
+        self::assertSame(OrderSide::BUY, $mapper->providerSide(['side' => 2]));
+        self::assertSame(OrderSide::SELL, $mapper->providerSide(['side' => 3]));
+    }
+
+    public function testBuildsLegacyOrderIntentExecutionParams(): void
+    {
+        $mapper = new BitmartLegacyOrderMapper();
+        $params = $mapper->orderIntentExecutionParams($this->plan(side: Side::Short), 'cid-3');
+
+        self::assertSame(4, $params['side']);
+        self::assertSame('limit', $params['type']);
+        self::assertSame('isolated', $params['open_type']);
+        self::assertSame(OrderIntent::POSITION_MODE_HEDGE, $params['position_mode']);
+        self::assertSame(OrderIntent::PRESET_MODE_PRESET_ON_ENTRY, $params['preset_mode']);
+        self::assertSame('24000', $params['preset_stop_loss_price']);
+        self::assertSame('26000', $params['preset_take_profit_price']);
+    }
+
+    private function plan(Side $side, string $orderType = 'limit', int $orderMode = 4): OrderPlanModel
+    {
+        return new OrderPlanModel(
+            symbol: 'BTCUSDT',
+            side: $side,
+            orderType: $orderType,
+            openType: 'isolated',
+            orderMode: $orderMode,
+            entry: 25000.0,
+            stop: 24000.0,
+            takeProfit: 26000.0,
+            size: 10,
+            leverage: 3,
+            pricePrecision: 2,
+            contractSize: 0.001,
+        );
+    }
+}


### PR DESCRIPTION
Closes #85

## Summary
- centralize BitMart legacy side/mode/preset option mapping in `BitmartLegacyOrderMapper`
- route legacy ExecutionBox, TpSlAttacher, order intent params, and plan-order checks through mapper/capability methods instead of direct BitMart codes/classes
- add adapter and mapper regression tests for side codes, market/limit options, attached TP/SL, and order intent params

## Tests
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --cached --check
- git diff --check