### PR TITLE
[API-08] Add Hyperliquid testnet adapter scaffold

### DIFF
--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -35,6 +35,12 @@ parameters:
     env(LOG_LEVEL_INDICATORS): 'info'
     env(LOG_LEVEL_HIGHCONVICTION): 'info'
     env(LOG_LEVEL_PIPELINE_EXEC): 'info'
+    env(HYPERLIQUID_ENV): 'testnet'
+    env(HYPERLIQUID_PRIVATE_KEY): ''
+    env(HYPERLIQUID_ACCOUNT_ADDRESS): ''
+    env(HYPERLIQUID_API_BASE_URI): ''
+    env(HYPERLIQUID_WS_URI): ''
+    env(HYPERLIQUID_MAINNET_ENABLED): '0'
     app.trade_entry_default_mode: 'scalper_micro'
 
     # Configuration TradeEntry - Valeurs par défaut (déplacées dans services_trade_entry.yaml)
@@ -127,6 +133,16 @@ services:
             $apiSecret: '%env(BITMART_SECRET_KEY)%'
             $apiMemo: '%env(BITMART_API_MEMO)%'
         public: true
+
+    App\Exchange\Hyperliquid\HyperliquidConfig:
+        arguments:
+            $environment: '%env(string:HYPERLIQUID_ENV)%'
+            $accountAddress: '%env(string:HYPERLIQUID_ACCOUNT_ADDRESS)%'
+            $privateKey: '%env(string:HYPERLIQUID_PRIVATE_KEY)%'
+            $apiBaseUri: '%env(string:HYPERLIQUID_API_BASE_URI)%'
+            $wsUri: '%env(string:HYPERLIQUID_WS_URI)%'
+            $mainnetEnabled: '%env(bool:HYPERLIQUID_MAINNET_ENABLED)%'
+
     # Provider pour la configuration des contrats MTF (support par profil avec fallback)
     App\Config\MtfContractsConfigProvider:
         public: true

--- a/trading-app/src/Common/Enum/Exchange.php
+++ b/trading-app/src/Common/Enum/Exchange.php
@@ -9,6 +9,7 @@ enum Exchange: string
     case BITMART = 'bitmart';
     case BINANCE = 'binance';
     case FAKE = 'fake';
+    case HYPERLIQUID = 'hyperliquid';
 
     /**
      * Human readable label for logging/UI.
@@ -19,6 +20,7 @@ enum Exchange: string
             self::BITMART => 'Bitmart',
             self::BINANCE => 'Binance',
             self::FAKE => 'Fake Exchange',
+            self::HYPERLIQUID => 'Hyperliquid',
         };
     }
 }

--- a/trading-app/src/Exchange/Adapter/HyperliquidExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/HyperliquidExchangeAdapter.php
@@ -1,0 +1,550 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Adapter;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\CancelOrderResult;
+use App\Exchange\Dto\ExchangeBalanceDto;
+use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\ExchangeReconciliationResult;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Hyperliquid\HyperliquidActionFactory;
+use App\Exchange\Hyperliquid\HyperliquidAssetResolver;
+use App\Exchange\Hyperliquid\HyperliquidConfig;
+use App\Exchange\Hyperliquid\HyperliquidRestClientInterface;
+use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.exchange_adapter')]
+final readonly class HyperliquidExchangeAdapter implements ExchangeAdapterInterface, ExchangeRestSnapshotProviderInterface
+{
+    private const DEFAULT_MARKET_SLIPPAGE = 0.05;
+
+    public function __construct(
+        private HyperliquidRestClientInterface $client,
+        private HyperliquidAssetResolver $assets,
+        private HyperliquidActionFactory $actions,
+        private HyperliquidConfig $config,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function exchange(): Exchange
+    {
+        return Exchange::HYPERLIQUID;
+    }
+
+    public function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return new ExchangeCapabilities(
+            supportsTestnet: true,
+            supportsWebSocketPrivate: true,
+            supportsClientOrderId: true,
+            supportsCancelByClientOrderId: true,
+            supportsPostOnly: true,
+            supportsIoc: true,
+            supportsReduceOnly: true,
+            supportsAttachedStopLossOnEntry: false,
+            supportsAttachedTakeProfitOnEntry: false,
+            supportsTriggerOrders: true,
+            supportsModifyOrder: false,
+            requiresSeparateLeverageSubmit: true,
+            supportsPerSymbolLeverage: true,
+        );
+    }
+
+    public function getBalances(): array
+    {
+        $state = $this->userState();
+        $margin = \is_array($state['marginSummary'] ?? null) ? $state['marginSummary'] : [];
+
+        return [
+            new ExchangeBalanceDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                currency: 'USDC',
+                available: $this->float($state['withdrawable'] ?? null),
+                total: $this->float($margin['accountValue'] ?? null),
+                equity: $this->float($margin['accountValue'] ?? null),
+                unrealizedPnl: $this->unrealizedPnl($state),
+                metadata: ['source' => 'hyperliquid_clearinghouse_state'] + $margin,
+            ),
+        ];
+    }
+
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        $target = $symbol !== null ? $this->assets->coin($symbol) : null;
+        $positions = [];
+        foreach (($this->userState()['assetPositions'] ?? []) as $row) {
+            if (!\is_array($row) || !\is_array($row['position'] ?? null)) {
+                continue;
+            }
+            $position = $row['position'];
+            $coin = strtoupper((string)($position['coin'] ?? ''));
+            if ($target !== null && $coin !== $target) {
+                continue;
+            }
+            $size = $this->float($position['szi'] ?? null);
+            if (abs($size) <= 0.00000001) {
+                continue;
+            }
+            $positions[] = new ExchangePositionDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                symbol: $coin . 'USDC',
+                side: $size < 0 ? ExchangePositionSide::SHORT : ExchangePositionSide::LONG,
+                size: abs($size),
+                entryPrice: $this->float($position['entryPx'] ?? null),
+                markPrice: $this->float($position['markPx'] ?? null),
+                unrealizedPnl: $this->float($position['unrealizedPnl'] ?? null),
+                realizedPnl: null,
+                margin: $this->float($position['marginUsed'] ?? null),
+                leverage: $this->float($position['leverage']['value'] ?? null),
+                metadata: $position,
+            );
+        }
+
+        return $positions;
+    }
+
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        $orders = $this->client->info([
+            'type' => 'frontendOpenOrders',
+            'user' => $this->accountAddress(),
+        ]);
+        $target = $symbol !== null ? $this->assets->coin($symbol) : null;
+        $mapped = [];
+        foreach ($orders as $order) {
+            if (!\is_array($order)) {
+                continue;
+            }
+            $coin = strtoupper((string)($order['coin'] ?? ''));
+            if ($target !== null && $coin !== $target) {
+                continue;
+            }
+            $mapped[] = $this->mapOrder($order, ExchangeOrderStatus::OPEN);
+        }
+
+        return $mapped;
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        $this->assertContext($request->exchange, $request->marketType);
+        $this->config->assertTradingConfigured();
+        $request = $this->withHyperliquidExecutionPrice($request);
+        $assetId = $this->assets->assetId($request->symbol);
+        $response = $this->client->exchange($this->actions->order($assetId, $request));
+        $status = $this->extractOrderStatus($response);
+        $exchangeOrderId = $this->extractOrderId($response) ?? $request->clientOrderId;
+        $accepted = $status !== ExchangeOrderStatus::REJECTED;
+
+        return new PlaceOrderResult(
+            accepted: $accepted,
+            symbol: $request->symbol,
+            clientOrderId: $request->clientOrderId,
+            exchangeOrderId: $exchangeOrderId,
+            status: $status,
+            submittedAt: $this->clock->now(),
+            order: new ExchangeOrderDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                symbol: strtoupper($request->symbol),
+                exchangeOrderId: $exchangeOrderId,
+                clientOrderId: $request->clientOrderId,
+                side: $request->side,
+                positionSide: $request->positionSide,
+                orderType: $request->orderType,
+                status: $status,
+                quantity: $request->quantity,
+                filledQuantity: 0.0,
+                remainingQuantity: $request->quantity,
+                price: $request->price,
+                averagePrice: null,
+                stopPrice: $request->stopPrice,
+                reduceOnly: $request->reduceOnly,
+                postOnly: $request->postOnly,
+                timeInForce: $request->timeInForce,
+                createdAt: $this->clock->now(),
+                metadata: ['source' => 'hyperliquid_exchange'] + $response,
+            ),
+            metadata: $response,
+        );
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        $this->assertContext($request->exchange, $request->marketType);
+        $this->config->assertTradingConfigured();
+        $assetId = $this->assets->assetId($request->symbol);
+        $response = $this->client->exchange($this->actions->cancel($assetId, $request));
+        $status = $this->extractOrderStatus($response);
+        $cancelled = $status !== ExchangeOrderStatus::REJECTED;
+
+        return new CancelOrderResult(
+            cancelled: $cancelled,
+            symbol: $request->symbol,
+            exchangeOrderId: $request->exchangeOrderId,
+            clientOrderId: $request->clientOrderId,
+            status: $cancelled ? ExchangeOrderStatus::CANCELLED : ExchangeOrderStatus::REJECTED,
+            metadata: $response,
+        );
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        foreach ($this->getOpenOrders($symbol) as $order) {
+            if ($order->exchangeOrderId === $exchangeOrderId || $order->clientOrderId === $exchangeOrderId) {
+                return $order;
+            }
+        }
+
+        return null;
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        $book = $this->client->info([
+            'type' => 'l2Book',
+            'coin' => $this->assets->coin($symbol),
+        ]);
+        $levels = $book['levels'] ?? [];
+        $bids = \is_array($levels[0] ?? null) ? $levels[0] : [];
+        $asks = \is_array($levels[1] ?? null) ? $levels[1] : [];
+
+        return new SymbolBidAskDto(
+            symbol: strtoupper($symbol),
+            bid: $this->float($bids[0]['px'] ?? null),
+            ask: $this->float($asks[0]['px'] ?? null),
+            timestamp: $this->clock->now(),
+        );
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        $this->config->assertTradingConfigured();
+        $response = $this->client->exchange($this->actions->updateLeverage(
+            $this->assets->assetId($symbol),
+            $leverage,
+            $marginMode,
+        ));
+
+        return $this->extractOrderStatus($response) !== ExchangeOrderStatus::REJECTED;
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        $now = $this->clock->now();
+
+        return new ExchangeReconciliationResult(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $symbol !== null ? strtoupper($symbol) : null,
+            startedAt: $now,
+            completedAt: $now,
+            ordersChecked: \count($this->getOrdersSnapshot($symbol)),
+            positionsChecked: \count($this->getOpenPositions($symbol)),
+            fillsImported: \count($this->getFillsSnapshot($symbol)),
+            metadata: ['source' => 'hyperliquid_rest_snapshot'],
+        );
+    }
+
+    public function getOrdersSnapshot(?string $symbol = null): array
+    {
+        return $this->getOpenOrders($symbol);
+    }
+
+    public function getFillsSnapshot(?string $symbol = null): array
+    {
+        $fills = $this->client->info([
+            'type' => 'userFills',
+            'user' => $this->accountAddress(),
+        ]);
+        $target = $symbol !== null ? $this->assets->coin($symbol) : null;
+        $mapped = [];
+        foreach ($fills as $fill) {
+            if (!\is_array($fill)) {
+                continue;
+            }
+            $coin = strtoupper((string)($fill['coin'] ?? ''));
+            if ($target !== null && $coin !== $target) {
+                continue;
+            }
+            $side = strtolower((string)($fill['side'] ?? '')) === 'b' ? ExchangeOrderSide::BUY : ExchangeOrderSide::SELL;
+            $mapped[] = new ExchangeFillDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                symbol: $coin . 'USDC',
+                exchangeOrderId: (string)($fill['oid'] ?? ''),
+                clientOrderId: isset($fill['cloid']) ? (string) $fill['cloid'] : null,
+                fillId: isset($fill['hash']) ? (string) $fill['hash'] : null,
+                side: $side,
+                positionSide: null,
+                quantity: $this->float($fill['sz'] ?? null),
+                price: $this->float($fill['px'] ?? null),
+                fee: $this->float($fill['fee'] ?? null),
+                feeCurrency: 'USDC',
+                filledAt: $this->time($fill['time'] ?? null),
+                metadata: $fill,
+            );
+        }
+
+        return $mapped;
+    }
+
+    public function hasAuthoritativePositionSnapshot(?string $symbol = null): bool
+    {
+        return trim($this->config->accountAddress) !== '';
+    }
+
+    private function userState(): array
+    {
+        return $this->client->info([
+            'type' => 'clearinghouseState',
+            'user' => $this->accountAddress(),
+        ]);
+    }
+
+    private function accountAddress(): string
+    {
+        $address = trim($this->config->accountAddress);
+        if ($address === '') {
+            throw new \RuntimeException('HYPERLIQUID_ACCOUNT_ADDRESS is required for account snapshots.');
+        }
+
+        return $address;
+    }
+
+    /**
+     * @param array<string,mixed> $order
+     */
+    private function mapOrder(array $order, ExchangeOrderStatus $status): ExchangeOrderDto
+    {
+        $side = strtolower((string)($order['side'] ?? '')) === 'b' ? ExchangeOrderSide::BUY : ExchangeOrderSide::SELL;
+        $orderType = $this->mapOrderType($order);
+        $timeInForce = $this->mapTimeInForce($order);
+        $reduceOnly = (bool)($order['reduceOnly'] ?? false);
+
+        return new ExchangeOrderDto(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: strtoupper((string)($order['coin'] ?? '')) . 'USDC',
+            exchangeOrderId: (string)($order['oid'] ?? ''),
+            clientOrderId: isset($order['cloid']) ? (string) $order['cloid'] : null,
+            side: $side,
+            positionSide: $this->positionSide($side, $reduceOnly),
+            orderType: $orderType,
+            status: $status,
+            quantity: $this->float($order['sz'] ?? null),
+            filledQuantity: max(0.0, $this->float($order['origSz'] ?? null) - $this->float($order['sz'] ?? null)),
+            remainingQuantity: $this->float($order['sz'] ?? null),
+            price: $this->float($order['limitPx'] ?? $order['px'] ?? null),
+            averagePrice: null,
+            stopPrice: $this->triggerPrice($orderType, $order),
+            reduceOnly: $reduceOnly,
+            postOnly: $timeInForce === ExchangeTimeInForce::GTC && strtolower((string)($order['tif'] ?? $order['orderType'] ?? '')) === 'alo',
+            timeInForce: $timeInForce,
+            createdAt: $this->time($order['timestamp'] ?? null),
+            metadata: $order,
+        );
+    }
+
+    private function withHyperliquidExecutionPrice(PlaceOrderRequest $request): PlaceOrderRequest
+    {
+        if ($request->orderType === ExchangeOrderType::MARKET && $request->price === null) {
+            return $this->copyRequestWithPrice($request, $this->marketOrderPriceCap($request->symbol, $request->side));
+        }
+
+        return $request;
+    }
+
+    private function marketOrderPriceCap(string $symbol, ExchangeOrderSide $side): float
+    {
+        $top = $this->getOrderBookTop($symbol);
+        $bid = $top->bid;
+        $ask = $top->ask;
+        if ($bid > 0.0 && $ask > 0.0) {
+            $reference = ($bid + $ask) / 2.0;
+        } else {
+            $reference = $side === ExchangeOrderSide::BUY ? $ask : $bid;
+        }
+        if ($reference <= 0.0 || !\is_finite($reference)) {
+            throw new \RuntimeException(sprintf('Cannot derive Hyperliquid market slippage cap for "%s"', $symbol));
+        }
+
+        return $this->slippageCap($reference, $side);
+    }
+
+    private function slippageCap(float $reference, ExchangeOrderSide $side): float
+    {
+        $cap = $side === ExchangeOrderSide::BUY
+            ? $reference * (1.0 + self::DEFAULT_MARKET_SLIPPAGE)
+            : $reference * (1.0 - self::DEFAULT_MARKET_SLIPPAGE);
+
+        return max(0.00000001, $cap);
+    }
+
+    private function copyRequestWithPrice(PlaceOrderRequest $request, float $price): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: $request->exchange,
+            marketType: $request->marketType,
+            symbol: $request->symbol,
+            side: $request->side,
+            positionSide: $request->positionSide,
+            orderType: $request->orderType,
+            timeInForce: $request->timeInForce,
+            quantity: $request->quantity,
+            price: $price,
+            stopPrice: $request->stopPrice,
+            reduceOnly: $request->reduceOnly,
+            postOnly: $request->postOnly,
+            leverage: $request->leverage,
+            marginMode: $request->marginMode,
+            clientOrderId: $request->clientOrderId,
+            attachedStopLossPrice: $request->attachedStopLossPrice,
+            attachedTakeProfitPrice: $request->attachedTakeProfitPrice,
+            metadata: $request->metadata,
+        );
+    }
+
+    private function mapOrderType(array $order): ExchangeOrderType
+    {
+        $orderType = strtolower((string)($order['orderType'] ?? ''));
+        $triggerCondition = strtolower((string)($order['triggerCondition'] ?? ''));
+        $tpsl = strtolower((string)($order['tpsl'] ?? ''));
+        $isTrigger = ($order['isTrigger'] ?? false) === true || isset($order['triggerPx']);
+
+        if ($isTrigger) {
+            if ($tpsl === 'tp' || str_contains($orderType, 'take') || str_contains($triggerCondition, 'take profit')) {
+                return ExchangeOrderType::TAKE_PROFIT;
+            }
+
+            return ExchangeOrderType::STOP_LOSS;
+        }
+
+        return ExchangeOrderType::LIMIT;
+    }
+
+    private function mapTimeInForce(array $order): ExchangeTimeInForce
+    {
+        return match (strtolower((string)($order['tif'] ?? $order['orderType'] ?? ''))) {
+            'ioc' => ExchangeTimeInForce::IOC,
+            default => ExchangeTimeInForce::GTC,
+        };
+    }
+
+    private function triggerPrice(ExchangeOrderType $orderType, array $order): ?float
+    {
+        if (!\in_array($orderType, [ExchangeOrderType::STOP_LOSS, ExchangeOrderType::TAKE_PROFIT, ExchangeOrderType::TRIGGER], true)) {
+            return null;
+        }
+
+        return $this->float($order['triggerPx'] ?? null);
+    }
+
+    private function positionSide(ExchangeOrderSide $side, bool $reduceOnly): ExchangePositionSide
+    {
+        if ($reduceOnly) {
+            return $side === ExchangeOrderSide::SELL ? ExchangePositionSide::LONG : ExchangePositionSide::SHORT;
+        }
+
+        return $side === ExchangeOrderSide::BUY ? ExchangePositionSide::LONG : ExchangePositionSide::SHORT;
+    }
+
+    private function extractOrderStatus(array $response): ExchangeOrderStatus
+    {
+        $status = strtolower((string)($response['status'] ?? ''));
+        if ($status === 'err' || $status === 'error') {
+            return ExchangeOrderStatus::REJECTED;
+        }
+
+        $statuses = $response['response']['data']['statuses'] ?? null;
+        if (\is_array($statuses) && isset($statuses[0]['error'])) {
+            return ExchangeOrderStatus::REJECTED;
+        }
+        if (\is_array($statuses) && isset($statuses[0]['filled'])) {
+            return ExchangeOrderStatus::FILLED;
+        }
+
+        return ExchangeOrderStatus::PENDING;
+    }
+
+    private function extractOrderId(array $response): ?string
+    {
+        $statuses = $response['response']['data']['statuses'] ?? null;
+        if (\is_array($statuses)) {
+            $resting = $statuses[0]['resting'] ?? null;
+            $filled = $statuses[0]['filled'] ?? null;
+            if (\is_array($resting) && isset($resting['oid'])) {
+                return (string) $resting['oid'];
+            }
+            if (\is_array($filled) && isset($filled['oid'])) {
+                return (string) $filled['oid'];
+            }
+        }
+
+        return null;
+    }
+
+    private function assertContext(Exchange $exchange, MarketType $marketType): void
+    {
+        if ($exchange !== $this->exchange() || $marketType !== $this->marketType()) {
+            throw new \InvalidArgumentException(sprintf('Hyperliquid adapter cannot handle "%s::%s"', $exchange->value, $marketType->value));
+        }
+    }
+
+    private function time(mixed $milliseconds): \DateTimeImmutable
+    {
+        if (is_numeric($milliseconds)) {
+            return (new \DateTimeImmutable('@' . ((int) floor(((float) $milliseconds) / 1000))))->setTimezone(new \DateTimeZone('UTC'));
+        }
+
+        return $this->clock->now();
+    }
+
+    /**
+     * @param array<string,mixed> $state
+     */
+    private function unrealizedPnl(array $state): float
+    {
+        $total = 0.0;
+        foreach (($state['assetPositions'] ?? []) as $row) {
+            if (!\is_array($row) || !\is_array($row['position'] ?? null)) {
+                continue;
+            }
+
+            $total += $this->float($row['position']['unrealizedPnl'] ?? null);
+        }
+
+        return $total;
+    }
+
+    private function float(mixed $value): float
+    {
+        return is_numeric($value) ? (float) $value : 0.0;
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/HyperliquidActionFactory.php
+++ b/trading-app/src/Exchange/Hyperliquid/HyperliquidActionFactory.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid;
+
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangeTimeInForce;
+
+final class HyperliquidActionFactory
+{
+    private const DEFAULT_MARKET_SLIPPAGE = 0.05;
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function order(int $assetId, PlaceOrderRequest $request): array
+    {
+        if (trim($request->clientOrderId) === '') {
+            throw new \InvalidArgumentException('Hyperliquid orders require clientOrderId');
+        }
+        if ($request->attachedStopLossPrice !== null || $request->attachedTakeProfitPrice !== null) {
+            throw new \InvalidArgumentException('Hyperliquid adapter does not support attached TP/SL on entry');
+        }
+
+        return [
+            'type' => 'order',
+            'orders' => [[
+                'a' => $assetId,
+                'b' => $request->side === ExchangeOrderSide::BUY,
+                'p' => $this->price($request),
+                's' => $this->decimal($request->quantity),
+                'r' => $request->reduceOnly,
+                't' => $this->orderType($request),
+                'c' => $this->cloid($request->clientOrderId),
+            ]],
+            'grouping' => 'na',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function cancel(int $assetId, CancelOrderRequest $request): array
+    {
+        if ($request->exchangeOrderId !== null && trim($request->exchangeOrderId) !== '') {
+            return [
+                'type' => 'cancel',
+                'cancels' => [[
+                    'a' => $assetId,
+                    'o' => (int) $request->exchangeOrderId,
+                ]],
+            ];
+        }
+
+        if ($request->clientOrderId !== null && trim($request->clientOrderId) !== '') {
+            return [
+                'type' => 'cancelByCloid',
+                'cancels' => [[
+                    'asset' => $assetId,
+                    'cloid' => $this->cloid($request->clientOrderId),
+                ]],
+            ];
+        }
+
+        throw new \InvalidArgumentException('Hyperliquid cancel requires exchangeOrderId or clientOrderId');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function updateLeverage(int $assetId, int $leverage, string $marginMode): array
+    {
+        return [
+            'type' => 'updateLeverage',
+            'asset' => $assetId,
+            'isCross' => strtolower($marginMode) === 'cross',
+            'leverage' => $leverage,
+        ];
+    }
+
+    public function cloid(string $clientOrderId): string
+    {
+        $candidate = trim($clientOrderId);
+        if (preg_match('/^0x[0-9a-fA-F]{32}$/', $candidate) === 1) {
+            return strtolower($candidate);
+        }
+
+        return '0x' . substr(hash('sha256', $candidate), 0, 32);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function orderType(PlaceOrderRequest $request): array
+    {
+        if ($request->orderType === ExchangeOrderType::MARKET) {
+            return ['limit' => ['tif' => 'Ioc']];
+        }
+
+        if ($this->isTriggerOrder($request)) {
+            return ['trigger' => [
+                'isMarket' => $request->price === null,
+                'triggerPx' => $this->decimal($this->triggerPrice($request)),
+                'tpsl' => $this->tpsl($request),
+            ]];
+        }
+
+        if ($request->postOnly) {
+            return ['limit' => ['tif' => 'Alo']];
+        }
+
+        return ['limit' => ['tif' => match ($request->timeInForce) {
+            ExchangeTimeInForce::IOC => 'Ioc',
+            ExchangeTimeInForce::FOK => 'Ioc',
+            default => 'Gtc',
+        }]];
+    }
+
+    private function price(PlaceOrderRequest $request): string
+    {
+        $price = $request->price;
+        if ($request->orderType === ExchangeOrderType::MARKET && $price === null) {
+            throw new \InvalidArgumentException('Hyperliquid market orders require an explicit slippage cap price');
+        }
+        if ($this->isTriggerOrder($request) && $price === null) {
+            $triggerPrice = $this->triggerPrice($request);
+            $price = $request->side === ExchangeOrderSide::BUY
+                ? $triggerPrice * (1.0 + self::DEFAULT_MARKET_SLIPPAGE)
+                : $triggerPrice * (1.0 - self::DEFAULT_MARKET_SLIPPAGE);
+        }
+        if ($price === null || $price <= 0.0 || !\is_finite($price)) {
+            throw new \InvalidArgumentException('Hyperliquid order requires a positive limit or slippage cap price');
+        }
+
+        return $this->decimal($price);
+    }
+
+    private function isTriggerOrder(PlaceOrderRequest $request): bool
+    {
+        return \in_array($request->orderType, [
+            ExchangeOrderType::STOP_LOSS,
+            ExchangeOrderType::TAKE_PROFIT,
+            ExchangeOrderType::TRIGGER,
+        ], true);
+    }
+
+    private function triggerPrice(PlaceOrderRequest $request): float
+    {
+        if ($request->stopPrice === null || $request->stopPrice <= 0.0 || !\is_finite($request->stopPrice)) {
+            throw new \InvalidArgumentException('Hyperliquid trigger orders require a positive stopPrice');
+        }
+
+        return $request->stopPrice;
+    }
+
+    private function tpsl(PlaceOrderRequest $request): string
+    {
+        if ($request->orderType === ExchangeOrderType::STOP_LOSS) {
+            return 'sl';
+        }
+        if ($request->orderType === ExchangeOrderType::TAKE_PROFIT) {
+            return 'tp';
+        }
+
+        $configured = strtolower(trim((string)($request->metadata['hyperliquid_tpsl'] ?? $request->metadata['tpsl'] ?? '')));
+        if (\in_array($configured, ['sl', 'tp'], true)) {
+            return $configured;
+        }
+
+        throw new \InvalidArgumentException('Hyperliquid generic trigger orders require metadata tpsl="sl" or "tp"');
+    }
+
+    private function decimal(float $value): string
+    {
+        if (!\is_finite($value)) {
+            throw new \InvalidArgumentException('Hyperliquid decimal values must be finite');
+        }
+
+        $rounded = sprintf('%.8F', $value);
+        if (abs((float) $rounded - $value) >= 1.0e-12) {
+            throw new \InvalidArgumentException(sprintf('Hyperliquid decimal value "%s" has more than 8 wire decimals', $value));
+        }
+
+        return rtrim(rtrim($rounded, '0'), '.');
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/HyperliquidAssetResolver.php
+++ b/trading-app/src/Exchange/Hyperliquid/HyperliquidAssetResolver.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid;
+
+final class HyperliquidAssetResolver
+{
+    /** @var array<string,int> */
+    private array $assetIds = [];
+
+    public function __construct(private readonly HyperliquidRestClientInterface $client)
+    {
+    }
+
+    public function assetId(string $symbol): int
+    {
+        $normalized = $this->normalizeSymbol($symbol);
+        if (isset($this->assetIds[$normalized])) {
+            return $this->assetIds[$normalized];
+        }
+
+        $meta = $this->client->info(['type' => 'meta']);
+        $universe = $meta['universe'] ?? [];
+        if (!\is_array($universe)) {
+            throw new \RuntimeException('Hyperliquid meta response missing universe');
+        }
+
+        foreach (array_values($universe) as $index => $asset) {
+            if (!\is_array($asset) || !isset($asset['name'])) {
+                continue;
+            }
+            $name = $this->normalizeSymbol((string) $asset['name']);
+            $this->assetIds[$name] = (int) $index;
+        }
+
+        if (!isset($this->assetIds[$normalized])) {
+            throw new \InvalidArgumentException(sprintf('Unknown Hyperliquid asset "%s"', $symbol));
+        }
+
+        return $this->assetIds[$normalized];
+    }
+
+    public function coin(string $symbol): string
+    {
+        return $this->normalizeSymbol($symbol);
+    }
+
+    private function normalizeSymbol(string $symbol): string
+    {
+        $symbol = strtoupper(trim($symbol));
+        foreach (['-PERP', 'PERP', '/USDC', '-USDC', 'USDC', '/USDT', '-USDT', 'USDT'] as $suffix) {
+            if (str_ends_with($symbol, $suffix)) {
+                $symbol = substr($symbol, 0, -strlen($suffix));
+                break;
+            }
+        }
+
+        return $symbol;
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/HyperliquidConfig.php
+++ b/trading-app/src/Exchange/Hyperliquid/HyperliquidConfig.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid;
+
+final readonly class HyperliquidConfig
+{
+    public function __construct(
+        public string $environment = '',
+        public string $accountAddress = '',
+        public string $privateKey = '',
+        public string $apiBaseUri = '',
+        public string $wsUri = '',
+        public bool $mainnetEnabled = false,
+    ) {
+    }
+
+    public static function fromEnv(): self
+    {
+        return new self(
+            environment: (string)($_ENV['HYPERLIQUID_ENV'] ?? $_SERVER['HYPERLIQUID_ENV'] ?? 'testnet'),
+            accountAddress: (string)($_ENV['HYPERLIQUID_ACCOUNT_ADDRESS'] ?? $_SERVER['HYPERLIQUID_ACCOUNT_ADDRESS'] ?? ''),
+            privateKey: (string)($_ENV['HYPERLIQUID_PRIVATE_KEY'] ?? $_SERVER['HYPERLIQUID_PRIVATE_KEY'] ?? ''),
+            apiBaseUri: (string)($_ENV['HYPERLIQUID_API_BASE_URI'] ?? $_SERVER['HYPERLIQUID_API_BASE_URI'] ?? ''),
+            wsUri: (string)($_ENV['HYPERLIQUID_WS_URI'] ?? $_SERVER['HYPERLIQUID_WS_URI'] ?? ''),
+            mainnetEnabled: filter_var($_ENV['HYPERLIQUID_MAINNET_ENABLED'] ?? $_SERVER['HYPERLIQUID_MAINNET_ENABLED'] ?? false, \FILTER_VALIDATE_BOOL),
+        );
+    }
+
+    public function normalizedEnvironment(): string
+    {
+        $env = strtolower(trim($this->environment));
+
+        return $env === 'mainnet' ? 'mainnet' : 'testnet';
+    }
+
+    public function isTestnet(): bool
+    {
+        return $this->normalizedEnvironment() === 'testnet';
+    }
+
+    public function chainName(): string
+    {
+        return $this->isTestnet() ? 'Testnet' : 'Mainnet';
+    }
+
+    public function apiBaseUri(): string
+    {
+        $configured = rtrim(trim($this->apiBaseUri), '/');
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        return $this->isTestnet()
+            ? 'https://api.hyperliquid-testnet.xyz'
+            : 'https://api.hyperliquid.xyz';
+    }
+
+    public function wsUri(): string
+    {
+        $configured = trim($this->wsUri);
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        return $this->isTestnet()
+            ? 'wss://api.hyperliquid-testnet.xyz/ws'
+            : 'wss://api.hyperliquid.xyz/ws';
+    }
+
+    public function assertMainnetAllowed(): void
+    {
+        if (!$this->isTestnet() && !$this->mainnetEnabled) {
+            throw new \RuntimeException('Hyperliquid mainnet is disabled by default; set HYPERLIQUID_MAINNET_ENABLED=1 explicitly.');
+        }
+    }
+
+    public function assertTradingConfigured(): void
+    {
+        $this->assertMainnetAllowed();
+
+        if (trim($this->accountAddress) === '') {
+            throw new \RuntimeException('HYPERLIQUID_ACCOUNT_ADDRESS is required for Hyperliquid trading.');
+        }
+        if (trim($this->privateKey) === '') {
+            throw new \RuntimeException('HYPERLIQUID_PRIVATE_KEY is required for Hyperliquid trading.');
+        }
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/HyperliquidRestClient.php
+++ b/trading-app/src/Exchange/Hyperliquid/HyperliquidRestClient.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid;
+
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AsAlias(id: HyperliquidRestClientInterface::class)]
+final readonly class HyperliquidRestClient implements HyperliquidRestClientInterface
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private HyperliquidConfig $config,
+    ) {
+    }
+
+    public function info(array $request): array
+    {
+        /** @var array<string,mixed> $data */
+        $data = $this->httpClient
+            ->request('POST', $this->config->apiBaseUri() . '/info', ['json' => $request])
+            ->toArray(false);
+
+        return $data;
+    }
+
+    public function exchange(array $action): array
+    {
+        $this->config->assertTradingConfigured();
+
+        throw new \RuntimeException('Hyperliquid exchange signing is not enabled in this adapter yet; inject a signed client before live trading.');
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/HyperliquidRestClientInterface.php
+++ b/trading-app/src/Exchange/Hyperliquid/HyperliquidRestClientInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid;
+
+interface HyperliquidRestClientInterface
+{
+    /**
+     * @param array<string,mixed> $request
+     * @return array<string,mixed>
+     */
+    public function info(array $request): array;
+
+    /**
+     * @param array<string,mixed> $action
+     * @return array<string,mixed>
+     */
+    public function exchange(array $action): array;
+}

--- a/trading-app/src/Exchange/Hyperliquid/README.md
+++ b/trading-app/src/Exchange/Hyperliquid/README.md
@@ -1,0 +1,25 @@
+# Hyperliquid Adapter
+
+First API-first Hyperliquid integration slice.
+
+- Official docs used:
+  - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint
+  - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
+- Defaults to testnet. Mainnet requires `HYPERLIQUID_ENV=mainnet` and `HYPERLIQUID_MAINNET_ENABLED=1`.
+- REST public/account reads use the official `/info` endpoint (`meta`, `l2Book`, `clearinghouseState`, `frontendOpenOrders`, `userFills`).
+- Open-order reconciliation uses `frontendOpenOrders` so standalone trigger protection orders expose `triggerPx`, `reduceOnly`, and frontend order type metadata.
+- Trading actions are built in official `/exchange` wire format (`order`, `cancel`, `cancelByCloid`, `updateLeverage`).
+- Market orders are sent as IOC limit orders with a 5% slippage cap derived from the current L2 top. Stop-loss/take-profit trigger market orders use the same 5% cap around `stopPrice`.
+- Internal app client order IDs are deterministically mapped to Hyperliquid Cloid values (`0x` + 128-bit hex) before they reach `/exchange`.
+- Live signing is intentionally not enabled by the default REST client. Inject a signed `HyperliquidRestClientInterface` implementation before sending real testnet orders.
+
+Environment:
+
+```dotenv
+HYPERLIQUID_ENV=testnet
+HYPERLIQUID_PRIVATE_KEY=
+HYPERLIQUID_ACCOUNT_ADDRESS=
+HYPERLIQUID_API_BASE_URI=https://api.hyperliquid-testnet.xyz
+HYPERLIQUID_WS_URI=wss://api.hyperliquid-testnet.xyz/ws
+HYPERLIQUID_MAINNET_ENABLED=0
+```

--- a/trading-app/tests/Exchange/Adapter/HyperliquidExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/HyperliquidExchangeAdapterTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Adapter;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\HyperliquidExchangeAdapter;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Hyperliquid\HyperliquidActionFactory;
+use App\Exchange\Hyperliquid\HyperliquidAssetResolver;
+use App\Exchange\Hyperliquid\HyperliquidConfig;
+use App\Exchange\Hyperliquid\HyperliquidRestClientInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(HyperliquidExchangeAdapter::class)]
+#[CoversClass(HyperliquidActionFactory::class)]
+#[CoversClass(HyperliquidAssetResolver::class)]
+#[CoversClass(HyperliquidConfig::class)]
+final class HyperliquidExchangeAdapterTest extends TestCase
+{
+    public function testCapabilitiesAdvertiseTestnetAndClientOrderIds(): void
+    {
+        $capabilities = $this->adapter()->capabilities();
+
+        self::assertTrue($capabilities->supportsTestnet);
+        self::assertTrue($capabilities->supportsClientOrderId);
+        self::assertTrue($capabilities->supportsCancelByClientOrderId);
+        self::assertFalse($capabilities->supportsAttachedStopLossOnEntry);
+        self::assertTrue($capabilities->supportsTriggerOrders);
+        self::assertFalse($capabilities->supportsModifyOrder);
+    }
+
+    public function testBuildsOrderActionAndMapsAcceptedResponse(): void
+    {
+        $client = new FakeHyperliquidClient();
+        $adapter = $this->adapter($client);
+
+        $result = $adapter->placeOrder($this->placeOrderRequest());
+
+        self::assertTrue($result->accepted);
+        self::assertSame('12345', $result->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::PENDING, $result->status);
+        self::assertSame('order', $client->lastExchangeAction['type'] ?? null);
+        self::assertSame(0, $client->lastExchangeAction['orders'][0]['a'] ?? null);
+        self::assertTrue($client->lastExchangeAction['orders'][0]['b'] ?? false);
+        self::assertSame('Alo', $client->lastExchangeAction['orders'][0]['t']['limit']['tif'] ?? null);
+        self::assertSame($this->expectedCloid('cid-hl-1'), $client->lastExchangeAction['orders'][0]['c'] ?? null);
+    }
+
+    public function testMapsCancelByClientOrderId(): void
+    {
+        $client = new FakeHyperliquidClient();
+        $adapter = $this->adapter($client);
+
+        $result = $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::HYPERLIQUID,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDC',
+            exchangeOrderId: null,
+            clientOrderId: 'cid-hl-1',
+        ));
+
+        self::assertTrue($result->cancelled);
+        self::assertSame('cancelByCloid', $client->lastExchangeAction['type'] ?? null);
+        self::assertSame($this->expectedCloid('cid-hl-1'), $client->lastExchangeAction['cancels'][0]['cloid'] ?? null);
+    }
+
+    public function testBuildsMarketOrderWithBookDerivedSlippageCap(): void
+    {
+        $client = new FakeHyperliquidClient();
+        $adapter = $this->adapter($client);
+
+        $adapter->placeOrder($this->marketOrderRequest());
+
+        self::assertSame('order', $client->lastExchangeAction['type'] ?? null);
+        self::assertSame('26250', $client->lastExchangeAction['orders'][0]['p'] ?? null);
+        self::assertSame('Ioc', $client->lastExchangeAction['orders'][0]['t']['limit']['tif'] ?? null);
+    }
+
+    public function testBuildsStopLossTriggerAndMapsFrontendOrder(): void
+    {
+        $client = new FakeHyperliquidClient();
+        $adapter = $this->adapter($client);
+
+        $adapter->placeOrder($this->stopLossRequest());
+
+        self::assertSame('order', $client->lastExchangeAction['type'] ?? null);
+        self::assertSame('23560', $client->lastExchangeAction['orders'][0]['p'] ?? null);
+        self::assertSame('24800', $client->lastExchangeAction['orders'][0]['t']['trigger']['triggerPx'] ?? null);
+        self::assertTrue($client->lastExchangeAction['orders'][0]['t']['trigger']['isMarket'] ?? false);
+        self::assertSame('sl', $client->lastExchangeAction['orders'][0]['t']['trigger']['tpsl'] ?? null);
+
+        $stopOrders = array_values(array_filter(
+            $adapter->getOpenOrders('BTCUSDC'),
+            static fn ($order): bool => $order->orderType === ExchangeOrderType::STOP_LOSS,
+        ));
+
+        self::assertCount(1, $stopOrders);
+        self::assertSame(ExchangeOrderSide::SELL, $stopOrders[0]->side);
+        self::assertSame(ExchangePositionSide::LONG, $stopOrders[0]->positionSide);
+        self::assertTrue($stopOrders[0]->reduceOnly);
+        self::assertEqualsWithDelta(24800.0, $stopOrders[0]->stopPrice, 0.000001);
+    }
+
+    public function testMapsOrderBookAndPositions(): void
+    {
+        $adapter = $this->adapter();
+
+        $top = $adapter->getOrderBookTop('BTCUSDC');
+        $positions = $adapter->getOpenPositions('BTCUSDC');
+
+        self::assertSame(24999.5, $top->bid);
+        self::assertSame(25000.5, $top->ask);
+        self::assertCount(1, $positions);
+        self::assertSame(ExchangePositionSide::LONG, $positions[0]->side);
+        self::assertSame(0.2, $positions[0]->size);
+        self::assertSame(24500.0, $positions[0]->entryPrice);
+    }
+
+    public function testMainnetIsDisabledByDefault(): void
+    {
+        $config = new HyperliquidConfig(environment: 'mainnet');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('mainnet is disabled');
+
+        $config->assertMainnetAllowed();
+    }
+
+    private function adapter(?FakeHyperliquidClient $client = null): HyperliquidExchangeAdapter
+    {
+        $client ??= new FakeHyperliquidClient();
+
+        return new HyperliquidExchangeAdapter(
+            $client,
+            new HyperliquidAssetResolver($client),
+            new HyperliquidActionFactory(),
+            new HyperliquidConfig(
+                environment: 'testnet',
+                accountAddress: '0x0000000000000000000000000000000000000001',
+                privateKey: 'test-private-key',
+            ),
+            $this->fixedClock(),
+        );
+    }
+
+    private function placeOrderRequest(): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::HYPERLIQUID,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDC',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::LIMIT,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.01,
+            price: 25000.0,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-hl-1',
+        );
+    }
+
+    private function marketOrderRequest(): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::HYPERLIQUID,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDC',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::IOC,
+            quantity: 0.01,
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-market',
+        );
+    }
+
+    private function stopLossRequest(): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::HYPERLIQUID,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDC',
+            side: ExchangeOrderSide::SELL,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::STOP_LOSS,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.01,
+            price: null,
+            stopPrice: 24800.0,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-stop',
+        );
+    }
+
+    private function expectedCloid(string $clientOrderId): string
+    {
+        return '0x' . substr(hash('sha256', $clientOrderId), 0, 32);
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}
+
+final class FakeHyperliquidClient implements HyperliquidRestClientInterface
+{
+    /** @var array<string,mixed> */
+    public array $lastExchangeAction = [];
+
+    public function info(array $request): array
+    {
+        return match ($request['type'] ?? null) {
+            'meta' => ['universe' => [['name' => 'BTC'], ['name' => 'ETH']]],
+            'l2Book' => ['levels' => [
+                [['px' => '24999.5', 'sz' => '1']],
+                [['px' => '25000.5', 'sz' => '1']],
+            ]],
+            'clearinghouseState' => [
+                'withdrawable' => '1000',
+                'marginSummary' => ['accountValue' => '1200', 'totalNtlPos' => '5000'],
+                'assetPositions' => [[
+                    'position' => [
+                        'coin' => 'BTC',
+                        'szi' => '0.2',
+                        'entryPx' => '24500',
+                        'markPx' => '25000',
+                        'unrealizedPnl' => '100',
+                        'marginUsed' => '200',
+                        'leverage' => ['value' => 3],
+                    ],
+                ]],
+            ],
+            'openOrders', 'frontendOpenOrders' => [[
+                'coin' => 'BTC',
+                'oid' => 12345,
+                'cloid' => '0x70cbb9b0f9837bdbb41f93be2d77a2e7',
+                'side' => 'B',
+                'sz' => '0.01',
+                'origSz' => '0.01',
+                'limitPx' => '25000',
+                'orderType' => 'Limit',
+                'tif' => 'Alo',
+                'timestamp' => 1767225600000,
+            ], [
+                'coin' => 'BTC',
+                'oid' => 12346,
+                'cloid' => '0x827bdc348063ff94f8839dfff50e121d',
+                'side' => 'A',
+                'sz' => '0.01',
+                'origSz' => '0.01',
+                'limitPx' => '23560',
+                'orderType' => 'Stop Market',
+                'isTrigger' => true,
+                'reduceOnly' => true,
+                'tif' => 'Gtc',
+                'triggerPx' => '24800',
+                'triggerCondition' => 'Stop Loss',
+                'timestamp' => 1767225600000,
+            ]],
+            'userFills' => [],
+            default => [],
+        };
+    }
+
+    public function exchange(array $action): array
+    {
+        $this->lastExchangeAction = $action;
+
+        return [
+            'status' => 'ok',
+            'response' => [
+                'type' => 'order',
+                'data' => ['statuses' => [['resting' => ['oid' => 12345]]]],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Refs #86

## Summary
- add `Exchange::HYPERLIQUID`, testnet-safe config defaults, and DI wiring
- add Hyperliquid REST/info client interface, asset resolver, action factory, and API-first adapter
- map orderbook, balances, open positions/orders, REST snapshots/fills, place/cancel/leverage action shapes
- add tests for capabilities, action construction, cancel-by-client-id, orderbook/positions, and mainnet safety
- document official Hyperliquid `/info` and `/exchange` endpoints and the current signing boundary

## Notes
- Mainnet remains disabled by default.
- The default REST client does not sign `/exchange` actions; live testnet trading requires injecting a signed `HyperliquidRestClientInterface`.
- This PR establishes the adapter contract and testnet-safe wiring; it does not send real signed orders with the default client.

## Tests
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction`
- `git diff --cached --check`
- `git diff --check`
