### PR TITLE
[API-09] Add OKX demo adapter scaffold

### DIFF
--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -41,6 +41,15 @@ parameters:
     env(HYPERLIQUID_API_BASE_URI): ''
     env(HYPERLIQUID_WS_URI): ''
     env(HYPERLIQUID_MAINNET_ENABLED): '0'
+    env(OKX_ENV): 'demo'
+    env(OKX_API_KEY): ''
+    env(OKX_API_SECRET): ''
+    env(OKX_API_PASSPHRASE): ''
+    env(OKX_API_BASE_URI): ''
+    env(OKX_WS_PUBLIC_URI): ''
+    env(OKX_WS_PRIVATE_URI): ''
+    env(OKX_DEMO_TRADING_ENABLED): '0'
+    env(OKX_LIVE_ENABLED): '0'
     app.trade_entry_default_mode: 'scalper_micro'
 
     # Configuration TradeEntry - Valeurs par défaut (déplacées dans services_trade_entry.yaml)
@@ -142,6 +151,18 @@ services:
             $apiBaseUri: '%env(string:HYPERLIQUID_API_BASE_URI)%'
             $wsUri: '%env(string:HYPERLIQUID_WS_URI)%'
             $mainnetEnabled: '%env(bool:HYPERLIQUID_MAINNET_ENABLED)%'
+
+    App\Exchange\Okx\OkxConfig:
+        arguments:
+            $environment: '%env(string:OKX_ENV)%'
+            $apiKey: '%env(string:OKX_API_KEY)%'
+            $apiSecret: '%env(string:OKX_API_SECRET)%'
+            $apiPassphrase: '%env(string:OKX_API_PASSPHRASE)%'
+            $apiBaseUri: '%env(string:OKX_API_BASE_URI)%'
+            $wsPublicUri: '%env(string:OKX_WS_PUBLIC_URI)%'
+            $wsPrivateUri: '%env(string:OKX_WS_PRIVATE_URI)%'
+            $demoTradingEnabled: '%env(bool:OKX_DEMO_TRADING_ENABLED)%'
+            $liveEnabled: '%env(bool:OKX_LIVE_ENABLED)%'
 
     # Provider pour la configuration des contrats MTF (support par profil avec fallback)
     App\Config\MtfContractsConfigProvider:

--- a/trading-app/src/Common/Enum/Exchange.php
+++ b/trading-app/src/Common/Enum/Exchange.php
@@ -10,6 +10,7 @@ enum Exchange: string
     case BINANCE = 'binance';
     case FAKE = 'fake';
     case HYPERLIQUID = 'hyperliquid';
+    case OKX = 'okx';
 
     /**
      * Human readable label for logging/UI.
@@ -21,6 +22,7 @@ enum Exchange: string
             self::BINANCE => 'Binance',
             self::FAKE => 'Fake Exchange',
             self::HYPERLIQUID => 'Hyperliquid',
+            self::OKX => 'OKX',
         };
     }
 }

--- a/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
@@ -1,0 +1,517 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Adapter;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\CancelOrderResult;
+use App\Exchange\Dto\ExchangeBalanceDto;
+use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\ExchangeReconciliationResult;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Okx\OkxActionFactory;
+use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Okx\OkxInstrumentResolver;
+use App\Exchange\Okx\OkxRestClientInterface;
+use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.exchange_adapter')]
+final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, ExchangeRestSnapshotProviderInterface
+{
+    public function __construct(
+        private OkxRestClientInterface $client,
+        private OkxInstrumentResolver $instruments,
+        private OkxActionFactory $actions,
+        private OkxConfig $config,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function exchange(): Exchange
+    {
+        return Exchange::OKX;
+    }
+
+    public function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    public function capabilities(): ExchangeCapabilities
+    {
+        return new ExchangeCapabilities(
+            supportsTestnet: true,
+            supportsWebSocketPrivate: false,
+            supportsClientOrderId: true,
+            supportsCancelByClientOrderId: true,
+            supportsPostOnly: true,
+            supportsIoc: true,
+            supportsReduceOnly: true,
+            supportsAttachedStopLossOnEntry: false,
+            supportsAttachedTakeProfitOnEntry: false,
+            supportsTriggerOrders: true,
+            supportsModifyOrder: false,
+            requiresSeparateLeverageSubmit: true,
+            supportsPerSymbolLeverage: true,
+        );
+    }
+
+    public function getBalances(): array
+    {
+        $payload = $this->client->privateGet('/api/v5/account/balance');
+        $account = $this->firstDataRow($payload);
+        $balances = [];
+        foreach (($account['details'] ?? []) as $detail) {
+            if (!\is_array($detail)) {
+                continue;
+            }
+            $currency = strtoupper((string)($detail['ccy'] ?? ''));
+            if ($currency === '') {
+                continue;
+            }
+            $balances[] = new ExchangeBalanceDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                currency: $currency,
+                available: $this->float($detail['availEq'] ?? $detail['availBal'] ?? null),
+                total: $this->float($detail['eq'] ?? null),
+                equity: $this->float($detail['eq'] ?? null),
+                unrealizedPnl: $this->float($detail['upl'] ?? null),
+                metadata: $detail,
+            );
+        }
+
+        return $balances;
+    }
+
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        $query = ['instType' => 'SWAP'];
+        if ($symbol !== null) {
+            $query['instId'] = $this->instruments->instId($symbol);
+        }
+        $payload = $this->client->privateGet('/api/v5/account/positions', $query);
+        $positions = [];
+        foreach ($this->dataRows($payload) as $row) {
+            $size = $this->float($row['pos'] ?? null);
+            if (abs($size) <= 0.00000001) {
+                continue;
+            }
+            $side = $this->positionSide($row['posSide'] ?? null, $size);
+            $positions[] = new ExchangePositionDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                symbol: $this->instruments->symbol((string)($row['instId'] ?? '')),
+                side: $side,
+                size: abs($size),
+                entryPrice: $this->float($row['avgPx'] ?? null),
+                markPrice: $this->float($row['markPx'] ?? null),
+                unrealizedPnl: $this->float($row['upl'] ?? null),
+                realizedPnl: $this->float($row['realizedPnl'] ?? null),
+                margin: $this->float($row['margin'] ?? $row['imr'] ?? null),
+                leverage: $this->float($row['lever'] ?? null),
+                updatedAt: $this->time($row['uTime'] ?? null),
+                metadata: $row,
+            );
+        }
+
+        return $positions;
+    }
+
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        $query = ['instType' => 'SWAP'];
+        if ($symbol !== null) {
+            $query['instId'] = $this->instruments->instId($symbol);
+        }
+
+        $orders = [];
+        foreach ($this->dataRows($this->client->privateGet('/api/v5/trade/orders-pending', $query)) as $row) {
+            $orders[] = $this->mapOrder($row, false);
+        }
+
+        $algoQuery = $query + ['ordType' => 'conditional'];
+        foreach ($this->dataRows($this->client->privateGet('/api/v5/trade/orders-algo-pending', $algoQuery)) as $row) {
+            $orders[] = $this->mapOrder($row, true);
+        }
+
+        return $orders;
+    }
+
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        $this->assertContext($request->exchange, $request->marketType);
+        $this->config->assertTradingConfigured();
+        $instId = $this->instruments->instId($request->symbol);
+        $isAlgo = $this->actions->isTriggerOrder($request);
+        $response = $isAlgo
+            ? $this->client->privatePost('/api/v5/trade/order-algo', $this->actions->algoOrder($instId, $request))
+            : $this->client->privatePost('/api/v5/trade/order', $this->actions->order($instId, $request));
+        $status = $this->responseStatus($response);
+        $exchangeOrderId = $this->responseOrderId($response, $isAlgo) ?? $request->clientOrderId;
+        $accepted = $status !== ExchangeOrderStatus::REJECTED;
+
+        return new PlaceOrderResult(
+            accepted: $accepted,
+            symbol: $request->symbol,
+            clientOrderId: $request->clientOrderId,
+            exchangeOrderId: $exchangeOrderId,
+            status: $status,
+            submittedAt: $this->clock->now(),
+            order: new ExchangeOrderDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                symbol: strtoupper($request->symbol),
+                exchangeOrderId: $exchangeOrderId,
+                clientOrderId: $request->clientOrderId,
+                side: $request->side,
+                positionSide: $request->positionSide,
+                orderType: $request->orderType,
+                status: $status,
+                quantity: $request->quantity,
+                filledQuantity: 0.0,
+                remainingQuantity: $request->quantity,
+                price: $request->price,
+                averagePrice: null,
+                stopPrice: $request->stopPrice,
+                reduceOnly: $request->reduceOnly,
+                postOnly: $request->postOnly,
+                timeInForce: $request->timeInForce,
+                createdAt: $this->clock->now(),
+                metadata: ['source' => $isAlgo ? 'okx_algo_order' : 'okx_order'] + $response,
+            ),
+            metadata: $response,
+        );
+    }
+
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
+    {
+        $this->assertContext($request->exchange, $request->marketType);
+        $this->config->assertTradingConfigured();
+        $instId = $this->instruments->instId($request->symbol);
+        $isAlgo = $request->exchangeOrderId !== null && str_starts_with($request->exchangeOrderId, 'algo:');
+        $response = $isAlgo
+            ? $this->client->privatePost('/api/v5/trade/cancel-algos', [$this->actions->cancelAlgo($instId, $request)])
+            : $this->client->privatePost('/api/v5/trade/cancel-order', $this->actions->cancelOrder($instId, $request));
+        $status = $this->responseStatus($response);
+        $cancelled = $status !== ExchangeOrderStatus::REJECTED;
+
+        return new CancelOrderResult(
+            cancelled: $cancelled,
+            symbol: $request->symbol,
+            exchangeOrderId: $request->exchangeOrderId,
+            clientOrderId: $request->clientOrderId,
+            status: $cancelled ? ExchangeOrderStatus::CANCELLED : ExchangeOrderStatus::REJECTED,
+            metadata: $response,
+        );
+    }
+
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
+    {
+        foreach ($this->getOpenOrders($symbol) as $order) {
+            if ($order->exchangeOrderId === $exchangeOrderId || $order->clientOrderId === $exchangeOrderId) {
+                return $order;
+            }
+        }
+
+        return null;
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        $payload = $this->client->publicGet('/api/v5/market/books', [
+            'instId' => $this->instruments->instId($symbol),
+            'sz' => 1,
+        ]);
+        $book = $this->firstDataRow($payload);
+        $bids = \is_array($book['bids'] ?? null) ? $book['bids'] : [];
+        $asks = \is_array($book['asks'] ?? null) ? $book['asks'] : [];
+
+        return new SymbolBidAskDto(
+            symbol: strtoupper($symbol),
+            bid: $this->float($bids[0][0] ?? null),
+            ask: $this->float($asks[0][0] ?? null),
+            timestamp: $this->clock->now(),
+        );
+    }
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
+    {
+        $this->config->assertTradingConfigured();
+        $response = $this->client->privatePost('/api/v5/account/set-leverage', $this->actions->setLeverage(
+            $this->instruments->instId($symbol),
+            $leverage,
+            $marginMode,
+        ));
+
+        return $this->responseStatus($response) !== ExchangeOrderStatus::REJECTED;
+    }
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult
+    {
+        $now = $this->clock->now();
+
+        return new ExchangeReconciliationResult(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $symbol !== null ? strtoupper($symbol) : null,
+            startedAt: $now,
+            completedAt: $now,
+            ordersChecked: \count($this->getOrdersSnapshot($symbol)),
+            positionsChecked: \count($this->getOpenPositions($symbol)),
+            fillsImported: \count($this->getFillsSnapshot($symbol)),
+            metadata: ['source' => 'okx_rest_snapshot'],
+        );
+    }
+
+    public function getOrdersSnapshot(?string $symbol = null): array
+    {
+        return $this->getOpenOrders($symbol);
+    }
+
+    public function getFillsSnapshot(?string $symbol = null): array
+    {
+        $query = ['instType' => 'SWAP'];
+        if ($symbol !== null) {
+            $query['instId'] = $this->instruments->instId($symbol);
+        }
+
+        $fills = [];
+        foreach ($this->dataRows($this->client->privateGet('/api/v5/trade/fills', $query)) as $row) {
+            $fills[] = new ExchangeFillDto(
+                exchange: $this->exchange(),
+                marketType: $this->marketType(),
+                symbol: $this->instruments->symbol((string)($row['instId'] ?? '')),
+                exchangeOrderId: (string)($row['ordId'] ?? ''),
+                clientOrderId: isset($row['clOrdId']) ? (string) $row['clOrdId'] : null,
+                fillId: isset($row['tradeId']) ? (string) $row['tradeId'] : null,
+                side: $this->orderSide($row['side'] ?? null),
+                positionSide: $this->nullablePositionSide($row['posSide'] ?? null),
+                quantity: $this->float($row['fillSz'] ?? null),
+                price: $this->float($row['fillPx'] ?? null),
+                fee: $this->float($row['fee'] ?? null),
+                feeCurrency: isset($row['feeCcy']) ? (string) $row['feeCcy'] : null,
+                filledAt: $this->time($row['ts'] ?? null),
+                metadata: $row,
+            );
+        }
+
+        return $fills;
+    }
+
+    public function hasAuthoritativePositionSnapshot(?string $symbol = null): bool
+    {
+        return trim($this->config->apiKey) !== ''
+            && trim($this->config->apiSecret) !== ''
+            && trim($this->config->apiPassphrase) !== '';
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function mapOrder(array $row, bool $algo): ExchangeOrderDto
+    {
+        $side = $this->orderSide($row['side'] ?? null);
+        $orderType = $this->orderType($row, $algo);
+        $quantity = $this->float($row['sz'] ?? null);
+        $filled = $this->float($row['accFillSz'] ?? null);
+        $exchangeOrderId = $algo
+            ? 'algo:' . (string)($row['algoId'] ?? '')
+            : (string)($row['ordId'] ?? '');
+
+        return new ExchangeOrderDto(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $this->instruments->symbol((string)($row['instId'] ?? '')),
+            exchangeOrderId: $exchangeOrderId,
+            clientOrderId: isset($row[$algo ? 'algoClOrdId' : 'clOrdId']) ? (string) $row[$algo ? 'algoClOrdId' : 'clOrdId'] : null,
+            side: $side,
+            positionSide: $this->nullablePositionSide($row['posSide'] ?? null),
+            orderType: $orderType,
+            status: $this->orderStatus($row['state'] ?? null),
+            quantity: $quantity,
+            filledQuantity: $filled,
+            remainingQuantity: max(0.0, $quantity - $filled),
+            price: $this->floatOrNull($row['px'] ?? null),
+            averagePrice: $this->floatOrNull($row['avgPx'] ?? null),
+            stopPrice: $this->stopPrice($row, $orderType),
+            reduceOnly: $this->bool($row['reduceOnly'] ?? false),
+            postOnly: strtolower((string)($row['ordType'] ?? '')) === 'post_only',
+            timeInForce: $this->timeInForce($row['ordType'] ?? null),
+            createdAt: $this->time($row['cTime'] ?? $row['uTime'] ?? null),
+            updatedAt: $this->time($row['uTime'] ?? null),
+            metadata: $row,
+        );
+    }
+
+    private function orderType(array $row, bool $algo): ExchangeOrderType
+    {
+        if ($algo) {
+            return isset($row['tpTriggerPx']) && (string) $row['tpTriggerPx'] !== ''
+                ? ExchangeOrderType::TAKE_PROFIT
+                : ExchangeOrderType::STOP_LOSS;
+        }
+
+        return strtolower((string)($row['ordType'] ?? '')) === 'market'
+            ? ExchangeOrderType::MARKET
+            : ExchangeOrderType::LIMIT;
+    }
+
+    private function stopPrice(array $row, ExchangeOrderType $orderType): ?float
+    {
+        if ($orderType === ExchangeOrderType::TAKE_PROFIT) {
+            return $this->floatOrNull($row['tpTriggerPx'] ?? null);
+        }
+        if ($orderType === ExchangeOrderType::STOP_LOSS) {
+            return $this->floatOrNull($row['slTriggerPx'] ?? null);
+        }
+
+        return null;
+    }
+
+    private function orderSide(mixed $side): ExchangeOrderSide
+    {
+        return strtolower((string) $side) === 'sell' ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY;
+    }
+
+    private function positionSide(mixed $side, float $size): ExchangePositionSide
+    {
+        $normalized = strtolower((string) $side);
+        if ($normalized === 'short') {
+            return ExchangePositionSide::SHORT;
+        }
+        if ($normalized === 'long') {
+            return ExchangePositionSide::LONG;
+        }
+
+        return $size < 0 ? ExchangePositionSide::SHORT : ExchangePositionSide::LONG;
+    }
+
+    private function nullablePositionSide(mixed $side): ?ExchangePositionSide
+    {
+        $normalized = strtolower((string) $side);
+
+        return match ($normalized) {
+            'long' => ExchangePositionSide::LONG,
+            'short' => ExchangePositionSide::SHORT,
+            default => null,
+        };
+    }
+
+    private function timeInForce(mixed $ordType): ExchangeTimeInForce
+    {
+        return match (strtolower((string) $ordType)) {
+            'ioc' => ExchangeTimeInForce::IOC,
+            'fok' => ExchangeTimeInForce::FOK,
+            default => ExchangeTimeInForce::GTC,
+        };
+    }
+
+    private function orderStatus(mixed $state): ExchangeOrderStatus
+    {
+        return match (strtolower((string) $state)) {
+            'filled' => ExchangeOrderStatus::FILLED,
+            'partially_filled' => ExchangeOrderStatus::PARTIALLY_FILLED,
+            'canceled', 'cancelled' => ExchangeOrderStatus::CANCELLED,
+            'rejected' => ExchangeOrderStatus::REJECTED,
+            'live', 'effective' => ExchangeOrderStatus::OPEN,
+            default => ExchangeOrderStatus::PENDING,
+        };
+    }
+
+    private function responseStatus(array $response): ExchangeOrderStatus
+    {
+        if ((string)($response['code'] ?? '') !== '0') {
+            return ExchangeOrderStatus::REJECTED;
+        }
+        $row = $this->firstDataRow($response);
+        if ($row !== [] && (string)($row['sCode'] ?? '0') !== '0') {
+            return ExchangeOrderStatus::REJECTED;
+        }
+
+        return ExchangeOrderStatus::PENDING;
+    }
+
+    private function responseOrderId(array $response, bool $algo): ?string
+    {
+        $row = $this->firstDataRow($response);
+        if ($algo && isset($row['algoId'])) {
+            return 'algo:' . (string) $row['algoId'];
+        }
+        if (!$algo && isset($row['ordId'])) {
+            return (string) $row['ordId'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function dataRows(array $response): array
+    {
+        $data = $response['data'] ?? [];
+        if (!\is_array($data)) {
+            return [];
+        }
+
+        return array_values(array_filter($data, \is_array(...)));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function firstDataRow(array $response): array
+    {
+        $rows = $this->dataRows($response);
+
+        return $rows[0] ?? [];
+    }
+
+    private function assertContext(Exchange $exchange, MarketType $marketType): void
+    {
+        if ($exchange !== $this->exchange() || $marketType !== $this->marketType()) {
+            throw new \InvalidArgumentException(sprintf('OKX adapter cannot handle "%s::%s"', $exchange->value, $marketType->value));
+        }
+    }
+
+    private function time(mixed $milliseconds): \DateTimeImmutable
+    {
+        if (is_numeric($milliseconds)) {
+            return (new \DateTimeImmutable('@' . ((int) floor(((float) $milliseconds) / 1000))))->setTimezone(new \DateTimeZone('UTC'));
+        }
+
+        return $this->clock->now();
+    }
+
+    private function bool(mixed $value): bool
+    {
+        return \filter_var($value, \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE) ?? (bool) $value;
+    }
+
+    private function float(mixed $value): float
+    {
+        return is_numeric($value) ? (float) $value : 0.0;
+    }
+
+    private function floatOrNull(mixed $value): ?float
+    {
+        return is_numeric($value) ? (float) $value : null;
+    }
+}

--- a/trading-app/src/Exchange/Okx/OkxActionFactory.php
+++ b/trading-app/src/Exchange/Okx/OkxActionFactory.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Okx;
+
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+
+final class OkxActionFactory
+{
+    /**
+     * @return array<string,mixed>
+     */
+    public function order(string $instId, PlaceOrderRequest $request): array
+    {
+        if ($request->attachedStopLossPrice !== null || $request->attachedTakeProfitPrice !== null) {
+            throw new \InvalidArgumentException('OKX adapter does not support attached TP/SL on entry');
+        }
+
+        return [
+            'instId' => $instId,
+            'tdMode' => $this->tdMode($request->marginMode),
+            'clOrdId' => $this->clientOrderId($request->clientOrderId),
+            'side' => $request->side->value,
+            'posSide' => $this->posSide($request->positionSide),
+            'ordType' => $this->ordType($request),
+            'sz' => $this->decimal($request->quantity),
+            'reduceOnly' => $request->reduceOnly ? 'true' : 'false',
+        ] + $this->priceFields($request);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function algoOrder(string $instId, PlaceOrderRequest $request): array
+    {
+        if (!$this->isTriggerOrder($request)) {
+            throw new \InvalidArgumentException('OKX algo order requires a trigger order type');
+        }
+        if ($request->stopPrice === null) {
+            throw new \InvalidArgumentException('OKX trigger orders require stopPrice');
+        }
+
+        $body = [
+            'instId' => $instId,
+            'tdMode' => $this->tdMode($request->marginMode),
+            'algoClOrdId' => $this->clientOrderId($request->clientOrderId),
+            'side' => $request->side->value,
+            'posSide' => $this->posSide($request->positionSide),
+            'ordType' => 'conditional',
+            'sz' => $this->decimal($request->quantity),
+            'reduceOnly' => $request->reduceOnly ? 'true' : 'false',
+        ];
+
+        $orderPrice = $request->price !== null ? $this->decimal($request->price) : '-1';
+        if ($request->orderType === ExchangeOrderType::TAKE_PROFIT || $this->triggerKind($request) === 'tp') {
+            $body['tpTriggerPx'] = $this->decimal($request->stopPrice);
+            $body['tpOrdPx'] = $orderPrice;
+            $body['tpTriggerPxType'] = 'mark';
+        } else {
+            $body['slTriggerPx'] = $this->decimal($request->stopPrice);
+            $body['slOrdPx'] = $orderPrice;
+            $body['slTriggerPxType'] = 'mark';
+        }
+
+        return $body;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function cancelOrder(string $instId, CancelOrderRequest $request): array
+    {
+        $body = ['instId' => $instId];
+        if ($request->exchangeOrderId !== null && trim($request->exchangeOrderId) !== '') {
+            $body['ordId'] = $request->exchangeOrderId;
+
+            return $body;
+        }
+        if ($request->clientOrderId !== null && trim($request->clientOrderId) !== '') {
+            $body['clOrdId'] = $this->clientOrderId($request->clientOrderId);
+
+            return $body;
+        }
+
+        throw new \InvalidArgumentException('OKX cancel requires exchangeOrderId or clientOrderId');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function cancelAlgo(string $instId, CancelOrderRequest $request): array
+    {
+        $body = ['instId' => $instId];
+        if ($request->exchangeOrderId !== null && str_starts_with($request->exchangeOrderId, 'algo:')) {
+            $body['algoId'] = substr($request->exchangeOrderId, 5);
+
+            return $body;
+        }
+        if ($request->clientOrderId !== null && trim($request->clientOrderId) !== '') {
+            $body['algoClOrdId'] = $this->clientOrderId($request->clientOrderId);
+
+            return $body;
+        }
+
+        throw new \InvalidArgumentException('OKX algo cancel requires algo exchangeOrderId or clientOrderId');
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function setLeverage(string $instId, int $leverage, string $marginMode): array
+    {
+        return [
+            'instId' => $instId,
+            'lever' => (string) $leverage,
+            'mgnMode' => $this->tdMode($marginMode),
+        ];
+    }
+
+    public function clientOrderId(string $clientOrderId): string
+    {
+        $candidate = trim($clientOrderId);
+        if (preg_match('/^[A-Za-z0-9]{1,32}$/', $candidate) === 1) {
+            return $candidate;
+        }
+
+        return 'OKX' . substr(strtoupper(hash('sha256', $candidate)), 0, 29);
+    }
+
+    public function isTriggerOrder(PlaceOrderRequest $request): bool
+    {
+        return \in_array($request->orderType, [
+            ExchangeOrderType::STOP_LOSS,
+            ExchangeOrderType::TAKE_PROFIT,
+            ExchangeOrderType::TRIGGER,
+        ], true);
+    }
+
+    private function tdMode(string $marginMode): string
+    {
+        $mode = strtolower(trim($marginMode));
+
+        return \in_array($mode, ['cross', 'isolated', 'cash'], true) ? $mode : 'cross';
+    }
+
+    private function posSide(ExchangePositionSide $side): string
+    {
+        return $side === ExchangePositionSide::SHORT ? 'short' : 'long';
+    }
+
+    private function ordType(PlaceOrderRequest $request): string
+    {
+        if ($request->orderType === ExchangeOrderType::MARKET) {
+            return 'market';
+        }
+        if ($request->postOnly) {
+            return 'post_only';
+        }
+
+        return match ($request->timeInForce) {
+            ExchangeTimeInForce::IOC => 'ioc',
+            ExchangeTimeInForce::FOK => 'fok',
+            default => 'limit',
+        };
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function priceFields(PlaceOrderRequest $request): array
+    {
+        if ($request->orderType === ExchangeOrderType::MARKET) {
+            return [];
+        }
+        if ($request->price === null) {
+            throw new \InvalidArgumentException('OKX limit orders require price');
+        }
+
+        return ['px' => $this->decimal($request->price)];
+    }
+
+    private function triggerKind(PlaceOrderRequest $request): string
+    {
+        $kind = strtolower(trim((string)($request->metadata['okx_trigger_kind'] ?? $request->metadata['tpsl'] ?? '')));
+        if (\in_array($kind, ['tp', 'sl'], true)) {
+            return $kind;
+        }
+
+        return 'sl';
+    }
+
+    private function decimal(float $value): string
+    {
+        if (!\is_finite($value) || $value <= 0.0) {
+            throw new \InvalidArgumentException('OKX decimal values must be positive and finite');
+        }
+
+        return rtrim(rtrim(sprintf('%.12F', $value), '0'), '.');
+    }
+}

--- a/trading-app/src/Exchange/Okx/OkxConfig.php
+++ b/trading-app/src/Exchange/Okx/OkxConfig.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Okx;
+
+final readonly class OkxConfig
+{
+    public function __construct(
+        public string $environment = '',
+        public string $apiKey = '',
+        public string $apiSecret = '',
+        public string $apiPassphrase = '',
+        public string $apiBaseUri = '',
+        public string $wsPublicUri = '',
+        public string $wsPrivateUri = '',
+        public bool $demoTradingEnabled = false,
+        public bool $liveEnabled = false,
+    ) {
+    }
+
+    public function normalizedEnvironment(): string
+    {
+        $env = strtolower(trim($this->environment));
+
+        return $env === 'live' ? 'live' : 'demo';
+    }
+
+    public function isDemo(): bool
+    {
+        return $this->normalizedEnvironment() === 'demo';
+    }
+
+    public function apiBaseUri(): string
+    {
+        $configured = rtrim(trim($this->apiBaseUri), '/');
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        return 'https://www.okx.com';
+    }
+
+    public function wsPublicUri(): string
+    {
+        $configured = trim($this->wsPublicUri);
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        return 'wss://ws.okx.com:8443/ws/v5/public';
+    }
+
+    public function wsPrivateUri(): string
+    {
+        $configured = trim($this->wsPrivateUri);
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        return $this->isDemo()
+            ? 'wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999'
+            : 'wss://ws.okx.com:8443/ws/v5/private';
+    }
+
+    public function assertLiveAllowed(): void
+    {
+        if (!$this->isDemo() && !$this->liveEnabled) {
+            throw new \RuntimeException('OKX live trading is disabled by default; set OKX_LIVE_ENABLED=1 explicitly.');
+        }
+    }
+
+    public function assertPrivateConfigured(): void
+    {
+        $this->assertLiveAllowed();
+
+        if (trim($this->apiKey) === '') {
+            throw new \RuntimeException('OKX_API_KEY is required for OKX private requests.');
+        }
+        if (trim($this->apiSecret) === '') {
+            throw new \RuntimeException('OKX_API_SECRET is required for OKX private requests.');
+        }
+        if (trim($this->apiPassphrase) === '') {
+            throw new \RuntimeException('OKX_API_PASSPHRASE is required for OKX private requests.');
+        }
+    }
+
+    public function assertTradingConfigured(): void
+    {
+        $this->assertPrivateConfigured();
+
+        if ($this->isDemo() && !$this->demoTradingEnabled) {
+            throw new \RuntimeException('OKX demo trading is disabled by default; set OKX_DEMO_TRADING_ENABLED=1 explicitly.');
+        }
+    }
+}

--- a/trading-app/src/Exchange/Okx/OkxInstrumentResolver.php
+++ b/trading-app/src/Exchange/Okx/OkxInstrumentResolver.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Okx;
+
+final class OkxInstrumentResolver
+{
+    public function instId(string $symbol): string
+    {
+        $symbol = strtoupper(trim($symbol));
+        if ($symbol === '') {
+            throw new \InvalidArgumentException('OKX symbol cannot be blank');
+        }
+        if (str_contains($symbol, '-')) {
+            return str_ends_with($symbol, '-SWAP') ? $symbol : $symbol . '-SWAP';
+        }
+
+        foreach (['USDT', 'USDC', 'USD'] as $quote) {
+            if (str_ends_with($symbol, $quote) && strlen($symbol) > strlen($quote)) {
+                return substr($symbol, 0, -strlen($quote)) . '-' . $quote . '-SWAP';
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unable to normalize OKX swap symbol "%s"', $symbol));
+    }
+
+    public function symbol(string $instId): string
+    {
+        $instId = strtoupper(trim($instId));
+        if (str_ends_with($instId, '-SWAP')) {
+            $instId = substr($instId, 0, -5);
+        }
+
+        return str_replace('-', '', $instId);
+    }
+}

--- a/trading-app/src/Exchange/Okx/OkxRestClient.php
+++ b/trading-app/src/Exchange/Okx/OkxRestClient.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Okx;
+
+use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Attribute\AsAlias;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[AsAlias(id: OkxRestClientInterface::class)]
+final readonly class OkxRestClient implements OkxRestClientInterface
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private OkxConfig $config,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function publicGet(string $path, array $query = []): array
+    {
+        /** @var array<string,mixed> $data */
+        $data = $this->httpClient
+            ->request('GET', $this->config->apiBaseUri() . $this->requestPath($path, $query))
+            ->toArray(false);
+
+        return $data;
+    }
+
+    public function privateGet(string $path, array $query = []): array
+    {
+        $this->config->assertPrivateConfigured();
+        $requestPath = $this->requestPath($path, $query);
+
+        /** @var array<string,mixed> $data */
+        $data = $this->httpClient
+            ->request('GET', $this->config->apiBaseUri() . $requestPath, [
+                'headers' => $this->signedHeaders('GET', $requestPath),
+            ])
+            ->toArray(false);
+
+        return $data;
+    }
+
+    public function privatePost(string $path, array $body = []): array
+    {
+        $this->config->assertTradingConfigured();
+        $json = $this->json($body);
+
+        /** @var array<string,mixed> $data */
+        $data = $this->httpClient
+            ->request('POST', $this->config->apiBaseUri() . $path, [
+                'headers' => $this->signedHeaders('POST', $path, $json),
+                'body' => $json,
+            ])
+            ->toArray(false);
+
+        return $data;
+    }
+
+    /**
+     * @param array<string,mixed> $query
+     */
+    private function requestPath(string $path, array $query): string
+    {
+        if ($query === []) {
+            return $path;
+        }
+
+        return $path . '?' . http_build_query($query, '', '&', \PHP_QUERY_RFC3986);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function signedHeaders(string $method, string $requestPath, string $body = ''): array
+    {
+        $timestamp = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s.v\Z');
+        $prehash = $timestamp . strtoupper($method) . $requestPath . $body;
+
+        $headers = [
+            'Content-Type' => 'application/json',
+            'OK-ACCESS-KEY' => $this->config->apiKey,
+            'OK-ACCESS-SIGN' => base64_encode(hash_hmac('sha256', $prehash, $this->config->apiSecret, true)),
+            'OK-ACCESS-TIMESTAMP' => $timestamp,
+            'OK-ACCESS-PASSPHRASE' => $this->config->apiPassphrase,
+        ];
+
+        if ($this->config->isDemo()) {
+            $headers['x-simulated-trading'] = '1';
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param array<string,mixed> $body
+     */
+    private function json(array $body): string
+    {
+        $json = json_encode($body, \JSON_UNESCAPED_SLASHES);
+        if (!\is_string($json)) {
+            throw new \InvalidArgumentException('Unable to encode OKX request body as JSON.');
+        }
+
+        return $json;
+    }
+}

--- a/trading-app/src/Exchange/Okx/OkxRestClientInterface.php
+++ b/trading-app/src/Exchange/Okx/OkxRestClientInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Okx;
+
+interface OkxRestClientInterface
+{
+    /**
+     * @param array<string,mixed> $query
+     * @return array<string,mixed>
+     */
+    public function publicGet(string $path, array $query = []): array;
+
+    /**
+     * @param array<string,mixed> $query
+     * @return array<string,mixed>
+     */
+    public function privateGet(string $path, array $query = []): array;
+
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
+    public function privatePost(string $path, array $body = []): array;
+}

--- a/trading-app/src/Exchange/Okx/README.md
+++ b/trading-app/src/Exchange/Okx/README.md
@@ -1,0 +1,29 @@
+# OKX Adapter
+
+API-first OKX demo integration slice for SWAP instruments.
+
+- Official docs used:
+  - https://www.okx.com/docs-v5/en/#overview-demo-trading-services
+  - https://www.okx.com/docs-v5/en/#rest-api-trade-place-order
+  - https://www.okx.com/docs-v5/en/#rest-api-trade-place-algo-order
+  - https://www.okx.com/docs-v5/en/#rest-api-authentication-signature
+- Defaults to demo. Live requires `OKX_ENV=live` and `OKX_LIVE_ENABLED=1`.
+- Demo order submission also requires `OKX_DEMO_TRADING_ENABLED=1`; private reads only require credentials.
+- REST private calls are signed with `OK-ACCESS-*` headers. Demo calls include `x-simulated-trading: 1`.
+- Internal symbols are normalized as SWAP instruments, for example `BTCUSDT` to `BTC-USDT-SWAP`.
+- Entry orders use `/api/v5/trade/order`; standalone stop-loss/take-profit protection uses `/api/v5/trade/order-algo` conditional orders.
+- WebSocket private ingestion is intentionally not implemented in this slice.
+
+Environment:
+
+```dotenv
+OKX_ENV=demo
+OKX_API_KEY=
+OKX_API_SECRET=
+OKX_API_PASSPHRASE=
+OKX_API_BASE_URI=https://www.okx.com
+OKX_WS_PUBLIC_URI=wss://ws.okx.com:8443/ws/v5/public
+OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999
+OKX_DEMO_TRADING_ENABLED=0
+OKX_LIVE_ENABLED=0
+```

--- a/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
@@ -1,0 +1,349 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Adapter;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\OkxExchangeAdapter;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Okx\OkxActionFactory;
+use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Okx\OkxInstrumentResolver;
+use App\Exchange\Okx\OkxRestClientInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(OkxExchangeAdapter::class)]
+#[CoversClass(OkxActionFactory::class)]
+#[CoversClass(OkxInstrumentResolver::class)]
+#[CoversClass(OkxConfig::class)]
+final class OkxExchangeAdapterTest extends TestCase
+{
+    public function testCapabilitiesAdvertiseDemoAndProtectionBoundaries(): void
+    {
+        $capabilities = $this->adapter()->capabilities();
+
+        self::assertTrue($capabilities->supportsTestnet);
+        self::assertTrue($capabilities->supportsClientOrderId);
+        self::assertTrue($capabilities->supportsCancelByClientOrderId);
+        self::assertFalse($capabilities->supportsAttachedStopLossOnEntry);
+        self::assertTrue($capabilities->supportsTriggerOrders);
+        self::assertFalse($capabilities->supportsModifyOrder);
+    }
+
+    public function testBuildsLimitOrderAndMapsAcceptedResponse(): void
+    {
+        $client = new FakeOkxClient();
+        $adapter = $this->adapter($client);
+
+        $result = $adapter->placeOrder($this->limitRequest());
+
+        self::assertTrue($result->accepted);
+        self::assertSame('12345', $result->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::PENDING, $result->status);
+        self::assertSame('/api/v5/trade/order', $client->lastPostPath);
+        self::assertSame('BTC-USDT-SWAP', $client->lastPostBody['instId'] ?? null);
+        self::assertSame('isolated', $client->lastPostBody['tdMode'] ?? null);
+        self::assertSame('buy', $client->lastPostBody['side'] ?? null);
+        self::assertSame('long', $client->lastPostBody['posSide'] ?? null);
+        self::assertSame('post_only', $client->lastPostBody['ordType'] ?? null);
+        self::assertSame($this->expectedClientOrderId('cid-okx-1'), $client->lastPostBody['clOrdId'] ?? null);
+    }
+
+    public function testBuildsStopLossAlgoAndMapsPendingAlgoOrder(): void
+    {
+        $client = new FakeOkxClient();
+        $adapter = $this->adapter($client);
+
+        $result = $adapter->placeOrder($this->stopLossRequest());
+
+        self::assertTrue($result->accepted);
+        self::assertSame('algo:90001', $result->exchangeOrderId);
+        self::assertSame('/api/v5/trade/order-algo', $client->lastPostPath);
+        self::assertSame('conditional', $client->lastPostBody['ordType'] ?? null);
+        self::assertSame('24800', $client->lastPostBody['slTriggerPx'] ?? null);
+        self::assertSame('-1', $client->lastPostBody['slOrdPx'] ?? null);
+        self::assertSame('true', $client->lastPostBody['reduceOnly'] ?? null);
+
+        $stopOrders = array_values(array_filter(
+            $adapter->getOpenOrders('BTCUSDT'),
+            static fn ($order): bool => $order->orderType === ExchangeOrderType::STOP_LOSS,
+        ));
+
+        self::assertCount(1, $stopOrders);
+        self::assertSame('algo:90001', $stopOrders[0]->exchangeOrderId);
+        self::assertSame(ExchangeOrderSide::SELL, $stopOrders[0]->side);
+        self::assertSame(ExchangePositionSide::LONG, $stopOrders[0]->positionSide);
+        self::assertTrue($stopOrders[0]->reduceOnly);
+        self::assertEqualsWithDelta(24800.0, $stopOrders[0]->stopPrice, 0.000001);
+    }
+
+    public function testMapsRestSnapshots(): void
+    {
+        $adapter = $this->adapter();
+
+        $top = $adapter->getOrderBookTop('BTCUSDT');
+        $balances = $adapter->getBalances();
+        $positions = $adapter->getOpenPositions('BTCUSDT');
+        $fills = $adapter->getFillsSnapshot('BTCUSDT');
+
+        self::assertSame(24999.5, $top->bid);
+        self::assertSame(25000.5, $top->ask);
+        self::assertCount(1, $balances);
+        self::assertSame('USDT', $balances[0]->currency);
+        self::assertCount(1, $positions);
+        self::assertSame(ExchangePositionSide::LONG, $positions[0]->side);
+        self::assertSame(0.2, $positions[0]->size);
+        self::assertCount(1, $fills);
+        self::assertSame('fill-1', $fills[0]->fillId);
+        self::assertSame(ExchangeOrderSide::BUY, $fills[0]->side);
+    }
+
+    public function testCancelsNormalAndAlgoOrders(): void
+    {
+        $client = new FakeOkxClient();
+        $adapter = $this->adapter($client);
+
+        $normal = $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: null,
+            clientOrderId: 'cid-okx-1',
+        ));
+        self::assertTrue($normal->cancelled);
+        self::assertSame('/api/v5/trade/cancel-order', $client->lastPostPath);
+        self::assertSame($this->expectedClientOrderId('cid-okx-1'), $client->lastPostBody['clOrdId'] ?? null);
+
+        $algo = $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: 'algo:90001',
+            clientOrderId: 'cid-okx-sl',
+        ));
+        self::assertTrue($algo->cancelled);
+        self::assertSame('/api/v5/trade/cancel-algos', $client->lastPostPath);
+        self::assertSame('90001', $client->lastPostBody[0]['algoId'] ?? null);
+    }
+
+    public function testLiveAndDemoTradingAreDisabledByDefault(): void
+    {
+        $live = new OkxConfig(environment: 'live');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('live trading is disabled');
+        $live->assertLiveAllowed();
+    }
+
+    public function testDemoTradingRequiresExplicitFlag(): void
+    {
+        $demo = new OkxConfig(
+            environment: 'demo',
+            apiKey: 'test-key',
+            apiSecret: 'test-secret',
+            apiPassphrase: 'test-passphrase',
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('demo trading is disabled');
+        $demo->assertTradingConfigured();
+    }
+
+    private function adapter(?FakeOkxClient $client = null): OkxExchangeAdapter
+    {
+        $client ??= new FakeOkxClient();
+
+        return new OkxExchangeAdapter(
+            $client,
+            new OkxInstrumentResolver(),
+            new OkxActionFactory(),
+            new OkxConfig(
+                environment: 'demo',
+                apiKey: 'test-key',
+                apiSecret: 'test-secret',
+                apiPassphrase: 'test-passphrase',
+                demoTradingEnabled: true,
+            ),
+            $this->fixedClock(),
+        );
+    }
+
+    private function limitRequest(): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::LIMIT,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.01,
+            price: 25000.0,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-okx-1',
+        );
+    }
+
+    private function stopLossRequest(): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::SELL,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::STOP_LOSS,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.01,
+            price: null,
+            stopPrice: 24800.0,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-okx-sl',
+        );
+    }
+
+    private function expectedClientOrderId(string $clientOrderId): string
+    {
+        return 'OKX' . substr(strtoupper(hash('sha256', $clientOrderId)), 0, 29);
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}
+
+final class FakeOkxClient implements OkxRestClientInterface
+{
+    public ?string $lastPostPath = null;
+
+    /** @var array<mixed> */
+    public array $lastPostBody = [];
+
+    public function publicGet(string $path, array $query = []): array
+    {
+        if ($path === '/api/v5/market/books') {
+            return ['code' => '0', 'data' => [[
+                'bids' => [['24999.5', '1']],
+                'asks' => [['25000.5', '1']],
+            ]]];
+        }
+
+        return ['code' => '0', 'data' => []];
+    }
+
+    public function privateGet(string $path, array $query = []): array
+    {
+        return match ($path) {
+            '/api/v5/account/balance' => ['code' => '0', 'data' => [[
+                'details' => [[
+                    'ccy' => 'USDT',
+                    'availEq' => '1000',
+                    'eq' => '1200',
+                    'upl' => '100',
+                ]],
+            ]]],
+            '/api/v5/account/positions' => ['code' => '0', 'data' => [[
+                'instId' => 'BTC-USDT-SWAP',
+                'posSide' => 'long',
+                'pos' => '0.2',
+                'avgPx' => '24500',
+                'markPx' => '25000',
+                'upl' => '100',
+                'margin' => '200',
+                'lever' => '3',
+                'uTime' => '1767225600000',
+            ]],
+            ],
+            '/api/v5/trade/orders-pending' => ['code' => '0', 'data' => [[
+                'instId' => 'BTC-USDT-SWAP',
+                'ordId' => '12345',
+                'clOrdId' => 'OKX1',
+                'side' => 'buy',
+                'posSide' => 'long',
+                'ordType' => 'post_only',
+                'state' => 'live',
+                'sz' => '0.01',
+                'accFillSz' => '0',
+                'px' => '25000',
+                'reduceOnly' => 'false',
+                'cTime' => '1767225600000',
+                'uTime' => '1767225600000',
+            ]],
+            ],
+            '/api/v5/trade/orders-algo-pending' => ['code' => '0', 'data' => [[
+                'instId' => 'BTC-USDT-SWAP',
+                'algoId' => '90001',
+                'algoClOrdId' => 'OKXSL',
+                'side' => 'sell',
+                'posSide' => 'long',
+                'ordType' => 'conditional',
+                'state' => 'live',
+                'sz' => '0.01',
+                'slTriggerPx' => '24800',
+                'slOrdPx' => '-1',
+                'reduceOnly' => 'true',
+                'cTime' => '1767225600000',
+                'uTime' => '1767225600000',
+            ]],
+            ],
+            '/api/v5/trade/fills' => ['code' => '0', 'data' => [[
+                'instId' => 'BTC-USDT-SWAP',
+                'ordId' => '12345',
+                'clOrdId' => 'OKX1',
+                'tradeId' => 'fill-1',
+                'side' => 'buy',
+                'posSide' => 'long',
+                'fillSz' => '0.01',
+                'fillPx' => '25000',
+                'fee' => '-0.01',
+                'feeCcy' => 'USDT',
+                'ts' => '1767225600000',
+            ]],
+            ],
+            default => ['code' => '0', 'data' => []],
+        };
+    }
+
+    public function privatePost(string $path, array $body = []): array
+    {
+        $this->lastPostPath = $path;
+        $this->lastPostBody = $body;
+
+        return match ($path) {
+            '/api/v5/trade/order' => ['code' => '0', 'data' => [[
+                'ordId' => '12345',
+                'clOrdId' => (string)($body['clOrdId'] ?? ''),
+                'sCode' => '0',
+            ]]],
+            '/api/v5/trade/order-algo' => ['code' => '0', 'data' => [[
+                'algoId' => '90001',
+                'algoClOrdId' => (string)($body['algoClOrdId'] ?? ''),
+                'sCode' => '0',
+            ]]],
+            default => ['code' => '0', 'data' => [['sCode' => '0']]],
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add OKX to exchange enum and env-backed safe demo/live config
- add signed OKX REST client, instrument resolver, action factory, and SWAP adapter
- map orderbook, balances, positions, open orders, algo protection orders, fills, leverage, and REST reconciliation snapshots
- document demo activation, live guardrails, and supported REST endpoints

Refs #87

## Tests
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check
- git diff --cached --check