### PR TITLE
[API-10] Add adapter contract tests and API-first runbook

### DIFF
--- a/trading-app/docs/API_FIRST_RUNBOOK.md
+++ b/trading-app/docs/API_FIRST_RUNBOOK.md
@@ -1,0 +1,130 @@
+# API-first Exchange Runbook
+
+Ce runbook decrit les commandes minimales pour travailler sur les adapters
+API-first sans contexte oral. Les examples partent du repertoire
+`trading-app/`.
+
+## FakeExchange
+
+FakeExchange sert de banc de contrat local: pas de reseau, pas de secrets, et
+des fills deterministes.
+
+```bash
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+```
+
+Pour remettre l'etat fake a zero dans un environnement Symfony, supprimer le
+fichier `var/fake_exchange_state.dat` ou reconstruire le service
+`FakeExchangeStateStore`.
+
+## Tests De Contrat
+
+`ExchangeAdapterContractTestCase` contient les invariants communs:
+
+- identite exchange/marketType et coherence des capabilities;
+- placement, listing, lookup et cancel d'un limit order;
+- fill market local et creation de position quand l'adapter le permet;
+- idempotence par `clientOrderId`;
+- confirmation d'un stop reduce-only separe quand `supportsTriggerOrders=true`;
+- snapshots REST positions/fills quand l'adapter implemente
+  `ExchangeRestSnapshotProviderInterface`.
+
+Commande large recommandee:
+
+```bash
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
+```
+
+## Hyperliquid Testnet
+
+Variables:
+
+```dotenv
+HYPERLIQUID_ENV=testnet
+HYPERLIQUID_PRIVATE_KEY=
+HYPERLIQUID_ACCOUNT_ADDRESS=
+HYPERLIQUID_API_BASE_URI=https://api.hyperliquid-testnet.xyz
+HYPERLIQUID_WS_URI=wss://api.hyperliquid-testnet.xyz/ws
+HYPERLIQUID_MAINNET_ENABLED=0
+```
+
+Le client REST par defaut lit `/info`, mais ne signe pas `/exchange`.
+Injecter une implementation signee de `HyperliquidRestClientInterface` avant
+tout ordre testnet reel. Mainnet reste bloque tant que
+`HYPERLIQUID_MAINNET_ENABLED=1` n'est pas explicite.
+
+## OKX Demo
+
+Variables:
+
+```dotenv
+OKX_ENV=demo
+OKX_API_KEY=
+OKX_API_SECRET=
+OKX_API_PASSPHRASE=
+OKX_API_BASE_URI=https://www.okx.com
+OKX_WS_PUBLIC_URI=wss://ws.okx.com:8443/ws/v5/public
+OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999
+OKX_DEMO_TRADING_ENABLED=0
+OKX_LIVE_ENABLED=0
+```
+
+Les requetes privees OKX sont signees avec `OK-ACCESS-*`; en demo le header
+`x-simulated-trading: 1` est ajoute. Les ordres demo restent bloques tant que
+`OKX_DEMO_TRADING_ENABLED=1` n'est pas explicite. Le live reste bloque tant que
+`OKX_ENV=live` et `OKX_LIVE_ENABLED=1` ne sont pas tous les deux presents.
+
+## Verification SL
+
+Avant tout run reel, verifier que le chemin d'execution ne peut pas retourner
+`submitted` ou `protected` sans stop confirme:
+
+```bash
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
+```
+
+Sur les donnees persistantes, chercher les positions ouvertes sans ordre de
+protection actif via les tables `futures_order`, `futures_plan_order`,
+`order_protection` et `trade_lifecycle_event`. Les events utiles a lire:
+
+- `exchange_execution.entry_submitted`
+- `exchange_execution.entry_filled`
+- `protection.confirmed`
+- `protection.failed`
+- `emergency_close.*`
+
+## Emergency Close
+
+Si `protection.failed` apparait, verifier immediatement:
+
+1. l'event `emergency_close` associe au meme `client_order_id`;
+2. la position exchange via l'adapter REST;
+3. les ordres stop stale encore ouverts;
+4. les lifecycle events lies au `decision_key`.
+
+Ne relancer un exchange reel qu'apres confirmation que la position est fermee ou
+qu'un stop reduce-only actif couvre toute la position.
+
+## Desactivation Immediate
+
+Pour couper les exchanges externes:
+
+- remettre `OKX_DEMO_TRADING_ENABLED=0`;
+- remettre `OKX_LIVE_ENABLED=0`;
+- remettre `HYPERLIQUID_MAINNET_ENABLED=0`;
+- retirer les secrets API des workers;
+- redemarrer les containers workers qui consomment les decisions trading.
+
+## Checklist Avant Mainnet
+
+- tests `tests/Exchange` et `ExchangeExecutionServiceTest` verts;
+- `lint:container --no-debug` vert;
+- `doctrine:schema:validate --skip-sync` vert;
+- review locale des payloads signer/order/cancel/protection;
+- aucun log ne contient private key, secret, passphrase ou signature complete;
+- mainnet active par flag explicite et revue manuelle;
+- taille minimale et leverage testes en environnement demo/testnet;
+- SL reduce-only confirme avant tout statut utilisateur "protected";
+- procedure emergency close testee sur rejet de protection;
+- rollback documente pour desactiver l'exchange.

--- a/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
+++ b/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Contract;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
+use PHPUnit\Framework\TestCase;
+
+abstract class ExchangeAdapterContractTestCase extends TestCase
+{
+    abstract protected function adapter(): ExchangeAdapterInterface;
+
+    abstract protected function exchange(): Exchange;
+
+    abstract protected function marketType(): MarketType;
+
+    protected function symbol(): string
+    {
+        return 'BTCUSDT';
+    }
+
+    protected function restingLimitPrice(): float
+    {
+        return 24950.0;
+    }
+
+    protected function marketOrdersFillImmediately(): bool
+    {
+        return false;
+    }
+
+    public function testAdapterIdentityAndCapabilitiesAreConsistent(): void
+    {
+        $adapter = $this->adapter();
+        $capabilities = $adapter->capabilities();
+
+        self::assertSame($this->exchange(), $adapter->exchange());
+        self::assertSame($this->marketType(), $adapter->marketType());
+        self::assertTrue($capabilities->supportsClientOrderId);
+        self::assertFalse($capabilities->supportsAttachedStopLossOnEntry && !$capabilities->supportsReduceOnly);
+        self::assertFalse($capabilities->supportsTriggerOrders && !$capabilities->supportsReduceOnly);
+    }
+
+    public function testLimitOrderCanBePlacedListedFetchedAndCancelled(): void
+    {
+        $adapter = $this->adapter();
+        $clientOrderId = $this->clientOrderId('limit');
+
+        $placed = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        ));
+
+        self::assertTrue($placed->accepted);
+        self::assertContains($placed->status, [
+            ExchangeOrderStatus::PENDING,
+            ExchangeOrderStatus::OPEN,
+        ]);
+        self::assertSame($clientOrderId, $placed->clientOrderId);
+        self::assertNotNull($placed->exchangeOrderId);
+
+        $openOrders = $adapter->getOpenOrders($this->symbol());
+        self::assertCount(1, array_filter(
+            $openOrders,
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $clientOrderId,
+        ));
+        self::assertNotNull($adapter->getOrder($this->symbol(), (string) $placed->exchangeOrderId));
+
+        $cancelled = $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $this->symbol(),
+            exchangeOrderId: $placed->exchangeOrderId,
+            clientOrderId: $clientOrderId,
+        ));
+
+        self::assertTrue($cancelled->cancelled);
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $cancelled->status);
+        self::assertCount(0, array_filter(
+            $adapter->getOpenOrders($this->symbol()),
+            static fn (ExchangeOrderDto $order): bool => $order->exchangeOrderId === $placed->exchangeOrderId,
+        ));
+    }
+
+    public function testMarketOrderCreatesPositionWhenAdapterExecutesImmediateFills(): void
+    {
+        if (!$this->marketOrdersFillImmediately()) {
+            self::markTestSkipped('Adapter does not execute immediate fills in local contract tests.');
+        }
+
+        $adapter = $this->adapter();
+        $placed = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $this->clientOrderId('market'),
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+        ));
+
+        self::assertTrue($placed->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $placed->status);
+        self::assertEqualsWithDelta(1.0, $placed->order?->filledQuantity, 0.000001);
+
+        $positions = $adapter->getOpenPositions($this->symbol());
+        self::assertCount(1, $positions);
+        self::assertSame(ExchangePositionSide::LONG, $positions[0]->side);
+        self::assertGreaterThan(0.0, $positions[0]->size);
+    }
+
+    public function testDuplicateClientOrderIdDoesNotCreateSecondActiveOrder(): void
+    {
+        $adapter = $this->adapter();
+        $clientOrderId = $this->clientOrderId('duplicate');
+
+        $first = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        ));
+        $second = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice() - 10.0,
+            postOnly: true,
+        ));
+
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertCount(1, array_filter(
+            $adapter->getOpenOrders($this->symbol()),
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $clientOrderId,
+        ));
+    }
+
+    public function testStandaloneReduceOnlyStopCanBeConfirmedWhenSupported(): void
+    {
+        $adapter = $this->adapter();
+        if (!$adapter->capabilities()->supportsTriggerOrders) {
+            self::markTestSkipped('Adapter does not advertise standalone trigger orders.');
+        }
+        if (!$this->marketOrdersFillImmediately()) {
+            self::markTestSkipped('Contract stop confirmation requires a locally filled position.');
+        }
+
+        $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $this->clientOrderId('entry'),
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+        ));
+        $stop = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $this->clientOrderId('stop'),
+            orderType: ExchangeOrderType::STOP_LOSS,
+            price: null,
+            stopPrice: 24800.0,
+            side: ExchangeOrderSide::SELL,
+            reduceOnly: true,
+            postOnly: false,
+        ));
+
+        self::assertTrue($stop->accepted);
+        self::assertTrue($stop->order?->reduceOnly);
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $stop->order?->orderType);
+
+        $confirmed = array_values(array_filter(
+            $adapter->getOpenOrders($this->symbol()),
+            static fn (ExchangeOrderDto $order): bool => $order->orderType === ExchangeOrderType::STOP_LOSS
+                && $order->reduceOnly
+                && $order->stopPrice !== null,
+        ));
+        self::assertCount(1, $confirmed);
+    }
+
+    public function testRestSnapshotProviderReportsOrdersPositionsAndFills(): void
+    {
+        $adapter = $this->adapter();
+        if (!$adapter instanceof ExchangeRestSnapshotProviderInterface) {
+            self::markTestSkipped('Adapter does not expose REST snapshot provider contract.');
+        }
+        if (!$this->marketOrdersFillImmediately()) {
+            self::markTestSkipped('Snapshot fill assertion requires local immediate fills.');
+        }
+
+        $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $this->clientOrderId('snapshot'),
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+        ));
+
+        self::assertCount(1, $adapter->getOpenPositions($this->symbol()));
+        self::assertGreaterThanOrEqual(1, \count($adapter->getFillsSnapshot($this->symbol())));
+
+        $result = $adapter->reconcile($this->symbol());
+        self::assertSame($this->exchange(), $result->exchange);
+        self::assertSame($this->marketType(), $result->marketType);
+        self::assertSame($this->symbol(), $result->symbol);
+        self::assertGreaterThanOrEqual(1, $result->positionsChecked);
+    }
+
+    protected function clientOrderId(string $suffix): string
+    {
+        return 'contract-' . $suffix;
+    }
+
+    protected function placeRequest(
+        string $clientOrderId,
+        ExchangeOrderType $orderType,
+        ?float $price,
+        bool $postOnly,
+        ?float $stopPrice = null,
+        ExchangeOrderSide $side = ExchangeOrderSide::BUY,
+        bool $reduceOnly = false,
+    ): PlaceOrderRequest {
+        return new PlaceOrderRequest(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $this->symbol(),
+            side: $side,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: $orderType,
+            timeInForce: $orderType === ExchangeOrderType::MARKET ? ExchangeTimeInForce::IOC : ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: $price,
+            stopPrice: $stopPrice,
+            reduceOnly: $reduceOnly,
+            postOnly: $postOnly,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+        );
+    }
+}

--- a/trading-app/tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
+++ b/trading-app/tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Contract;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(FakeExchangeAdapter::class)]
+#[CoversClass(FakeExchangeMatchingEngine::class)]
+#[CoversClass(FakeExchangeOrderBook::class)]
+#[CoversClass(FakeExchangeStateStore::class)]
+final class FakeExchangeAdapterContractTest extends ExchangeAdapterContractTestCase
+{
+    private FakeExchangeAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->fixedClock());
+        $this->adapter = new FakeExchangeAdapter($state, $book, $engine, $this->fixedClock());
+    }
+
+    protected function adapter(): ExchangeAdapterInterface
+    {
+        return $this->adapter;
+    }
+
+    protected function exchange(): Exchange
+    {
+        return Exchange::FAKE;
+    }
+
+    protected function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    protected function marketOrdersFillImmediately(): bool
+    {
+        return true;
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable ExchangeAdapterContractTestCase for common adapter invariants
- add FakeExchange contract coverage for limit lifecycle, immediate fills, idempotency, reduce-only stop confirmation, and REST snapshots
- add API_FIRST_RUNBOOK with FakeExchange, Hyperliquid, OKX, SL verification, emergency close, disablement, and mainnet checklist

Refs #88

## Tests
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check
- git diff --cached --check