### PR TITLE
[API-10] Add external adapter contract tests

### DIFF
--- a/trading-app/docs/API_FIRST_RUNBOOK.md
+++ b/trading-app/docs/API_FIRST_RUNBOOK.md
@@ -11,6 +11,8 @@ des fills deterministes.
 
 ```bash
 php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/HyperliquidExchangeAdapterContractTest.php
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
 php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Adapter/FakeExchangeAdapterTest.php
 ```
 
@@ -26,6 +28,8 @@ fichier `var/fake_exchange_state.dat` ou reconstruire le service
 - placement, listing, lookup et cancel d'un limit order;
 - fill market local et creation de position quand l'adapter le permet;
 - idempotence par `clientOrderId`;
+- placement, listing et cancel d'un stop reduce-only separe quand
+  `supportsTriggerOrders=true`;
 - confirmation d'un stop reduce-only separe quand `supportsTriggerOrders=true`;
 - snapshots REST positions/fills quand l'adapter implemente
   `ExchangeRestSnapshotProviderInterface`.

--- a/trading-app/src/Exchange/Adapter/HyperliquidExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/HyperliquidExchangeAdapter.php
@@ -161,6 +161,24 @@ final readonly class HyperliquidExchangeAdapter implements ExchangeAdapterInterf
         $status = $this->extractOrderStatus($response);
         $exchangeOrderId = $this->extractOrderId($response) ?? $request->clientOrderId;
         $accepted = $status !== ExchangeOrderStatus::REJECTED;
+        if (!$accepted) {
+            $existing = $this->findOpenOrderByClientOrderId($request->symbol, $this->actions->cloid($request->clientOrderId));
+            if ($existing instanceof ExchangeOrderDto) {
+                return new PlaceOrderResult(
+                    accepted: true,
+                    symbol: $request->symbol,
+                    clientOrderId: $request->clientOrderId,
+                    exchangeOrderId: $existing->exchangeOrderId,
+                    status: $existing->status,
+                    submittedAt: $this->clock->now(),
+                    order: $existing,
+                    metadata: [
+                        'idempotent_replay_after_reject' => true,
+                        'source_response' => $response,
+                    ],
+                );
+            }
+        }
 
         return new PlaceOrderResult(
             accepted: $accepted,
@@ -524,6 +542,17 @@ final readonly class HyperliquidExchangeAdapter implements ExchangeAdapterInterf
         }
 
         return $this->clock->now();
+    }
+
+    private function findOpenOrderByClientOrderId(string $symbol, string $clientOrderId): ?ExchangeOrderDto
+    {
+        foreach ($this->getOpenOrders($symbol) as $order) {
+            if ($order->clientOrderId === $clientOrderId) {
+                return $order;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
@@ -166,6 +166,24 @@ final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, Exc
         $status = $this->responseStatus($response);
         $exchangeOrderId = $this->responseOrderId($response, $isAlgo) ?? $request->clientOrderId;
         $accepted = $status !== ExchangeOrderStatus::REJECTED;
+        if (!$accepted) {
+            $existing = $this->findOpenOrderByClientOrderId($request->symbol, $this->actions->clientOrderId($request->clientOrderId));
+            if ($existing instanceof ExchangeOrderDto) {
+                return new PlaceOrderResult(
+                    accepted: true,
+                    symbol: $request->symbol,
+                    clientOrderId: $request->clientOrderId,
+                    exchangeOrderId: $existing->exchangeOrderId,
+                    status: $existing->status,
+                    submittedAt: $this->clock->now(),
+                    order: $existing,
+                    metadata: [
+                        'idempotent_replay_after_reject' => true,
+                        'source_response' => $response,
+                    ],
+                );
+            }
+        }
 
         return new PlaceOrderResult(
             accepted: $accepted,
@@ -205,7 +223,7 @@ final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, Exc
         $this->assertContext($request->exchange, $request->marketType);
         $this->config->assertTradingConfigured();
         $instId = $this->instruments->instId($request->symbol);
-        $isAlgo = $request->exchangeOrderId !== null && str_starts_with($request->exchangeOrderId, 'algo:');
+        $isAlgo = $this->isAlgoCancelRequest($instId, $request);
         $response = $isAlgo
             ? $this->client->privatePost('/api/v5/trade/cancel-algos', [$this->actions->cancelAlgo($instId, $request)])
             : $this->client->privatePost('/api/v5/trade/cancel-order', $this->actions->cancelOrder($instId, $request));
@@ -226,6 +244,44 @@ final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, Exc
     {
         foreach ($this->getOpenOrders($symbol) as $order) {
             if ($order->exchangeOrderId === $exchangeOrderId || $order->clientOrderId === $exchangeOrderId) {
+                return $order;
+            }
+        }
+
+        return null;
+    }
+
+    private function isAlgoCancelRequest(string $instId, CancelOrderRequest $request): bool
+    {
+        if ($request->exchangeOrderId !== null && str_starts_with($request->exchangeOrderId, 'algo:')) {
+            return true;
+        }
+        if ($request->exchangeOrderId !== null && trim($request->exchangeOrderId) !== '') {
+            return false;
+        }
+        if ($request->clientOrderId === null || trim($request->clientOrderId) === '') {
+            return false;
+        }
+
+        $clientOrderId = $this->actions->clientOrderId($request->clientOrderId);
+        $query = [
+            'instType' => 'SWAP',
+            'instId' => $instId,
+            'ordType' => 'conditional',
+        ];
+        foreach ($this->dataRows($this->client->privateGet('/api/v5/trade/orders-algo-pending', $query)) as $row) {
+            if ((string)($row['algoClOrdId'] ?? '') === $clientOrderId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function findOpenOrderByClientOrderId(string $symbol, string $clientOrderId): ?ExchangeOrderDto
+    {
+        foreach ($this->getOpenOrders($symbol) as $order) {
+            if ($order->clientOrderId === $clientOrderId) {
                 return $order;
             }
         }

--- a/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
@@ -134,6 +134,17 @@ final class OkxExchangeAdapterTest extends TestCase
         self::assertTrue($algo->cancelled);
         self::assertSame('/api/v5/trade/cancel-algos', $client->lastPostPath);
         self::assertSame('90001', $client->lastPostBody[0]['algoId'] ?? null);
+
+        $algoByClientId = $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: null,
+            clientOrderId: 'OKXSL',
+        ));
+        self::assertTrue($algoByClientId->cancelled);
+        self::assertSame('/api/v5/trade/cancel-algos', $client->lastPostPath);
+        self::assertSame('OKXSL', $client->lastPostBody[0]['algoClOrdId'] ?? null);
     }
 
     public function testLiveAndDemoTradingAreDisabledByDefault(): void

--- a/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
+++ b/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
@@ -41,6 +41,11 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         return false;
     }
 
+    protected function snapshotClientOrderId(string $clientOrderId): string
+    {
+        return $clientOrderId;
+    }
+
     public function testAdapterIdentityAndCapabilitiesAreConsistent(): void
     {
         $adapter = $this->adapter();
@@ -74,9 +79,10 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         self::assertNotNull($placed->exchangeOrderId);
 
         $openOrders = $adapter->getOpenOrders($this->symbol());
+        $snapshotClientOrderId = $this->snapshotClientOrderId($clientOrderId);
         self::assertCount(1, array_filter(
             $openOrders,
-            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $clientOrderId,
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $snapshotClientOrderId,
         ));
         self::assertNotNull($adapter->getOrder($this->symbol(), (string) $placed->exchangeOrderId));
 
@@ -139,9 +145,60 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         ));
 
         self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        $snapshotClientOrderId = $this->snapshotClientOrderId($clientOrderId);
         self::assertCount(1, array_filter(
             $adapter->getOpenOrders($this->symbol()),
-            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $clientOrderId,
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $snapshotClientOrderId,
+        ));
+    }
+
+    public function testStandaloneReduceOnlyStopCanBePlacedListedAndCancelledWhenSupported(): void
+    {
+        $adapter = $this->adapter();
+        if (!$adapter->capabilities()->supportsTriggerOrders) {
+            self::markTestSkipped('Adapter does not advertise standalone trigger orders.');
+        }
+
+        $clientOrderId = $this->clientOrderId('stop-listed');
+        $stop = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::STOP_LOSS,
+            price: null,
+            stopPrice: 24800.0,
+            side: ExchangeOrderSide::SELL,
+            reduceOnly: true,
+            postOnly: false,
+        ));
+
+        self::assertTrue($stop->accepted);
+        self::assertSame($clientOrderId, $stop->clientOrderId);
+        self::assertNotNull($stop->exchangeOrderId);
+
+        $snapshotClientOrderId = $this->snapshotClientOrderId($clientOrderId);
+        $listedStops = array_values(array_filter(
+            $adapter->getOpenOrders($this->symbol()),
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $snapshotClientOrderId
+                && $order->orderType === ExchangeOrderType::STOP_LOSS
+                && $order->reduceOnly
+                && $order->stopPrice !== null,
+        ));
+
+        self::assertCount(1, $listedStops);
+        self::assertSame($stop->exchangeOrderId, $listedStops[0]->exchangeOrderId);
+        self::assertEqualsWithDelta(24800.0, $listedStops[0]->stopPrice, 0.000001);
+
+        $cancelled = $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $this->symbol(),
+            exchangeOrderId: $adapter->capabilities()->supportsCancelByClientOrderId ? null : $stop->exchangeOrderId,
+            clientOrderId: $clientOrderId,
+        ));
+
+        self::assertTrue($cancelled->cancelled);
+        self::assertCount(0, array_filter(
+            $adapter->getOpenOrders($this->symbol()),
+            static fn (ExchangeOrderDto $order): bool => $order->exchangeOrderId === $stop->exchangeOrderId,
         ));
     }
 

--- a/trading-app/tests/Exchange/Contract/HyperliquidExchangeAdapterContractTest.php
+++ b/trading-app/tests/Exchange/Contract/HyperliquidExchangeAdapterContractTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Contract;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\HyperliquidExchangeAdapter;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Hyperliquid\HyperliquidActionFactory;
+use App\Exchange\Hyperliquid\HyperliquidAssetResolver;
+use App\Exchange\Hyperliquid\HyperliquidConfig;
+use App\Exchange\Hyperliquid\HyperliquidRestClientInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(HyperliquidExchangeAdapter::class)]
+#[CoversClass(HyperliquidActionFactory::class)]
+#[CoversClass(HyperliquidAssetResolver::class)]
+#[CoversClass(HyperliquidConfig::class)]
+final class HyperliquidExchangeAdapterContractTest extends ExchangeAdapterContractTestCase
+{
+    private HyperliquidExchangeAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        $client = new ContractHyperliquidClient();
+        $actions = new HyperliquidActionFactory();
+        $this->adapter = new HyperliquidExchangeAdapter(
+            $client,
+            new HyperliquidAssetResolver($client),
+            $actions,
+            new HyperliquidConfig(
+                environment: 'testnet',
+                accountAddress: '0x0000000000000000000000000000000000000001',
+                privateKey: 'test-private-key',
+            ),
+            $this->fixedClock(),
+        );
+    }
+
+    protected function adapter(): ExchangeAdapterInterface
+    {
+        return $this->adapter;
+    }
+
+    protected function exchange(): Exchange
+    {
+        return Exchange::HYPERLIQUID;
+    }
+
+    protected function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    protected function symbol(): string
+    {
+        return 'BTCUSDC';
+    }
+
+    protected function snapshotClientOrderId(string $clientOrderId): string
+    {
+        return (new HyperliquidActionFactory())->cloid($clientOrderId);
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}
+
+final class ContractHyperliquidClient implements HyperliquidRestClientInterface
+{
+    private int $nextOrderId = 90000;
+
+    /** @var array<string,array<string,mixed>> */
+    private array $orders = [];
+
+    /** @var array<string,string> */
+    private array $cloidIndex = [];
+
+    public function info(array $request): array
+    {
+        return match ($request['type'] ?? null) {
+            'meta' => ['universe' => [['name' => 'BTC']]],
+            'l2Book' => ['levels' => [
+                [['px' => '24999.5', 'sz' => '1']],
+                [['px' => '25000.5', 'sz' => '1']],
+            ]],
+            'clearinghouseState' => [
+                'withdrawable' => '1000',
+                'marginSummary' => ['accountValue' => '1000'],
+                'assetPositions' => [],
+            ],
+            'frontendOpenOrders', 'openOrders' => array_values($this->orders),
+            'userFills' => [],
+            default => [],
+        };
+    }
+
+    public function exchange(array $action): array
+    {
+        return match ($action['type'] ?? null) {
+            'order' => $this->placeOrder($action),
+            'cancel' => $this->cancelByOrderId($action),
+            'cancelByCloid' => $this->cancelByCloid($action),
+            'updateLeverage' => $this->okStatus(),
+            default => ['status' => 'err', 'response' => ['error' => 'unsupported action']],
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $action
+     * @return array<string,mixed>
+     */
+    private function placeOrder(array $action): array
+    {
+        $order = $action['orders'][0] ?? [];
+        if (!\is_array($order)) {
+            return ['status' => 'err', 'response' => ['error' => 'missing order']];
+        }
+
+        $cloid = (string)($order['c'] ?? '');
+        if (isset($this->cloidIndex[$cloid])) {
+            return [
+                'status' => 'ok',
+                'response' => [
+                    'type' => 'order',
+                    'data' => ['statuses' => [['error' => 'Duplicate client order ID']]],
+                ],
+            ];
+        }
+
+        $orderId = (string)$this->nextOrderId++;
+        $coin = ((int)($order['a'] ?? 0)) === 0 ? 'BTC' : 'UNKNOWN';
+        $isTrigger = isset($order['t']['trigger']) && \is_array($order['t']['trigger']);
+        $trigger = $isTrigger ? $order['t']['trigger'] : [];
+        $limit = isset($order['t']['limit']) && \is_array($order['t']['limit']) ? $order['t']['limit'] : [];
+
+        $this->orders[$orderId] = [
+            'coin' => $coin,
+            'oid' => (int)$orderId,
+            'cloid' => $cloid,
+            'side' => ($order['b'] ?? false) === true ? 'B' : 'A',
+            'sz' => (string)($order['s'] ?? '0'),
+            'origSz' => (string)($order['s'] ?? '0'),
+            'limitPx' => (string)($order['p'] ?? '0'),
+            'orderType' => $isTrigger ? 'Stop Market' : 'Limit',
+            'tif' => (string)($limit['tif'] ?? 'Gtc'),
+            'isTrigger' => $isTrigger,
+            'reduceOnly' => (bool)($order['r'] ?? false),
+            'triggerPx' => $isTrigger ? (string)($trigger['triggerPx'] ?? '') : null,
+            'triggerCondition' => $isTrigger && ($trigger['tpsl'] ?? '') === 'tp' ? 'Take Profit' : 'Stop Loss',
+            'timestamp' => 1767225600000,
+        ];
+        $this->cloidIndex[$cloid] = $orderId;
+
+        return $this->restingStatus($orderId);
+    }
+
+    /**
+     * @param array<string,mixed> $action
+     * @return array<string,mixed>
+     */
+    private function cancelByOrderId(array $action): array
+    {
+        foreach (($action['cancels'] ?? []) as $cancel) {
+            if (!\is_array($cancel)) {
+                continue;
+            }
+            $orderId = (string)($cancel['o'] ?? '');
+            if (isset($this->orders[$orderId])) {
+                unset($this->cloidIndex[(string)$this->orders[$orderId]['cloid']], $this->orders[$orderId]);
+            }
+        }
+
+        return $this->okStatus();
+    }
+
+    /**
+     * @param array<string,mixed> $action
+     * @return array<string,mixed>
+     */
+    private function cancelByCloid(array $action): array
+    {
+        foreach (($action['cancels'] ?? []) as $cancel) {
+            if (!\is_array($cancel)) {
+                continue;
+            }
+            $cloid = (string)($cancel['cloid'] ?? '');
+            $orderId = $this->cloidIndex[$cloid] ?? null;
+            if ($orderId !== null) {
+                unset($this->orders[$orderId], $this->cloidIndex[$cloid]);
+            }
+        }
+
+        return $this->okStatus();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function restingStatus(string $orderId): array
+    {
+        return [
+            'status' => 'ok',
+            'response' => [
+                'type' => 'order',
+                'data' => ['statuses' => [['resting' => ['oid' => (int)$orderId]]]],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function okStatus(): array
+    {
+        return [
+            'status' => 'ok',
+            'response' => ['type' => 'default', 'data' => ['statuses' => [['success' => true]]]],
+        ];
+    }
+}

--- a/trading-app/tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
+++ b/trading-app/tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
@@ -1,0 +1,318 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Contract;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\OkxExchangeAdapter;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Okx\OkxActionFactory;
+use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Okx\OkxInstrumentResolver;
+use App\Exchange\Okx\OkxRestClientInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(OkxExchangeAdapter::class)]
+#[CoversClass(OkxActionFactory::class)]
+#[CoversClass(OkxConfig::class)]
+#[CoversClass(OkxInstrumentResolver::class)]
+final class OkxExchangeAdapterContractTest extends ExchangeAdapterContractTestCase
+{
+    private OkxExchangeAdapter $adapter;
+
+    protected function setUp(): void
+    {
+        $this->adapter = new OkxExchangeAdapter(
+            new ContractOkxClient(),
+            new OkxInstrumentResolver(),
+            new OkxActionFactory(),
+            new OkxConfig(
+                environment: 'demo',
+                apiKey: 'test-key',
+                apiSecret: 'test-secret',
+                apiPassphrase: 'test-passphrase',
+                demoTradingEnabled: true,
+            ),
+            $this->fixedClock(),
+        );
+    }
+
+    protected function adapter(): ExchangeAdapterInterface
+    {
+        return $this->adapter;
+    }
+
+    protected function exchange(): Exchange
+    {
+        return Exchange::OKX;
+    }
+
+    protected function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    protected function snapshotClientOrderId(string $clientOrderId): string
+    {
+        return (new OkxActionFactory())->clientOrderId($clientOrderId);
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}
+
+final class ContractOkxClient implements OkxRestClientInterface
+{
+    private int $nextOrderId = 70000;
+
+    private int $nextAlgoId = 80000;
+
+    /** @var array<string,array<string,mixed>> */
+    private array $orders = [];
+
+    /** @var array<string,array<string,mixed>> */
+    private array $algoOrders = [];
+
+    /** @var array<string,string> */
+    private array $clientOrderIndex = [];
+
+    /** @var array<string,string> */
+    private array $algoClientOrderIndex = [];
+
+    public function publicGet(string $path, array $query = []): array
+    {
+        if ($path === '/api/v5/market/books') {
+            return ['code' => '0', 'data' => [[
+                'bids' => [['24999.5', '1']],
+                'asks' => [['25000.5', '1']],
+            ]]];
+        }
+
+        return ['code' => '0', 'data' => []];
+    }
+
+    public function privateGet(string $path, array $query = []): array
+    {
+        return match ($path) {
+            '/api/v5/account/balance' => ['code' => '0', 'data' => [[
+                'details' => [[
+                    'ccy' => 'USDT',
+                    'availEq' => '1000',
+                    'eq' => '1000',
+                    'upl' => '0',
+                ]],
+            ]]],
+            '/api/v5/account/positions' => ['code' => '0', 'data' => []],
+            '/api/v5/trade/orders-pending' => ['code' => '0', 'data' => $this->filterByInstId($this->orders, $query)],
+            '/api/v5/trade/orders-algo-pending' => ['code' => '0', 'data' => $this->filterByInstId($this->algoOrders, $query)],
+            '/api/v5/trade/fills' => ['code' => '0', 'data' => []],
+            default => ['code' => '0', 'data' => []],
+        };
+    }
+
+    public function privatePost(string $path, array $body = []): array
+    {
+        return match ($path) {
+            '/api/v5/trade/order' => $this->placeOrder($body),
+            '/api/v5/trade/order-algo' => $this->placeAlgoOrder($body),
+            '/api/v5/trade/cancel-order' => $this->cancelOrder($body),
+            '/api/v5/trade/cancel-algos' => $this->cancelAlgoOrder($body),
+            '/api/v5/account/set-leverage' => $this->okResponse(),
+            default => ['code' => '1', 'data' => [['sCode' => '1', 'sMsg' => 'unsupported path']]],
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
+    private function placeOrder(array $body): array
+    {
+        $clientOrderId = (string)($body['clOrdId'] ?? '');
+        if (isset($this->clientOrderIndex[$clientOrderId])) {
+            return $this->duplicateClientOrderResponse();
+        }
+        $instId = (string)($body['instId'] ?? '');
+        if ($instId === '') {
+            return $this->missingInstrumentResponse();
+        }
+
+        $orderId = (string)$this->nextOrderId++;
+        $this->orders[$orderId] = [
+            'instId' => $instId,
+            'ordId' => $orderId,
+            'clOrdId' => $clientOrderId,
+            'side' => (string)($body['side'] ?? 'buy'),
+            'posSide' => (string)($body['posSide'] ?? 'long'),
+            'ordType' => (string)($body['ordType'] ?? 'limit'),
+            'state' => 'live',
+            'sz' => (string)($body['sz'] ?? '0'),
+            'accFillSz' => '0',
+            'px' => (string)($body['px'] ?? ''),
+            'reduceOnly' => (string)($body['reduceOnly'] ?? 'false'),
+            'cTime' => '1767225600000',
+            'uTime' => '1767225600000',
+        ];
+        $this->clientOrderIndex[$clientOrderId] = $orderId;
+
+        return $this->orderResponse($orderId, $clientOrderId);
+    }
+
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
+    private function placeAlgoOrder(array $body): array
+    {
+        $clientOrderId = (string)($body['algoClOrdId'] ?? '');
+        if (isset($this->algoClientOrderIndex[$clientOrderId])) {
+            return $this->duplicateClientOrderResponse();
+        }
+        $instId = (string)($body['instId'] ?? '');
+        if ($instId === '') {
+            return $this->missingInstrumentResponse();
+        }
+
+        $algoId = (string)$this->nextAlgoId++;
+        $this->algoOrders[$algoId] = [
+            'instId' => $instId,
+            'algoId' => $algoId,
+            'algoClOrdId' => $clientOrderId,
+            'side' => (string)($body['side'] ?? 'sell'),
+            'posSide' => (string)($body['posSide'] ?? 'long'),
+            'ordType' => (string)($body['ordType'] ?? 'conditional'),
+            'state' => 'live',
+            'sz' => (string)($body['sz'] ?? '0'),
+            'slTriggerPx' => (string)($body['slTriggerPx'] ?? ''),
+            'slOrdPx' => (string)($body['slOrdPx'] ?? ''),
+            'tpTriggerPx' => (string)($body['tpTriggerPx'] ?? ''),
+            'tpOrdPx' => (string)($body['tpOrdPx'] ?? ''),
+            'reduceOnly' => (string)($body['reduceOnly'] ?? 'false'),
+            'cTime' => '1767225600000',
+            'uTime' => '1767225600000',
+        ];
+        $this->algoClientOrderIndex[$clientOrderId] = $algoId;
+
+        return $this->algoResponse($algoId, $clientOrderId);
+    }
+
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
+    private function cancelOrder(array $body): array
+    {
+        $orderId = isset($body['ordId']) ? (string)$body['ordId'] : null;
+        if ($orderId === null && isset($body['clOrdId'])) {
+            $orderId = $this->clientOrderIndex[(string)$body['clOrdId']] ?? null;
+        }
+        if ($orderId !== null && isset($this->orders[$orderId])) {
+            unset($this->clientOrderIndex[(string)$this->orders[$orderId]['clOrdId']], $this->orders[$orderId]);
+        }
+
+        return $this->okResponse();
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $body
+     * @return array<string,mixed>
+     */
+    private function cancelAlgoOrder(array $body): array
+    {
+        $cancel = $body[0] ?? [];
+        if (!\is_array($cancel)) {
+            return $this->okResponse();
+        }
+
+        $algoId = isset($cancel['algoId']) ? (string)$cancel['algoId'] : null;
+        if ($algoId === null && isset($cancel['algoClOrdId'])) {
+            $algoId = $this->algoClientOrderIndex[(string)$cancel['algoClOrdId']] ?? null;
+        }
+        if ($algoId !== null && isset($this->algoOrders[$algoId])) {
+            unset($this->algoClientOrderIndex[(string)$this->algoOrders[$algoId]['algoClOrdId']], $this->algoOrders[$algoId]);
+        }
+
+        return $this->okResponse();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function orderResponse(string $orderId, string $clientOrderId): array
+    {
+        return ['code' => '0', 'data' => [[
+            'ordId' => $orderId,
+            'clOrdId' => $clientOrderId,
+            'sCode' => '0',
+        ]]];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function algoResponse(string $algoId, string $clientOrderId): array
+    {
+        return ['code' => '0', 'data' => [[
+            'algoId' => $algoId,
+            'algoClOrdId' => $clientOrderId,
+            'sCode' => '0',
+        ]]];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function okResponse(): array
+    {
+        return ['code' => '0', 'data' => [['sCode' => '0']]];
+    }
+
+    /**
+     * @param array<string,array<string,mixed>> $rows
+     * @return array<int,array<string,mixed>>
+     */
+    private function filterByInstId(array $rows, array $query): array
+    {
+        $instId = isset($query['instId']) ? (string)$query['instId'] : '';
+        if ($instId === '') {
+            return array_values($rows);
+        }
+
+        return array_values(array_filter(
+            $rows,
+            static fn (array $row): bool => (string)($row['instId'] ?? '') === $instId,
+        ));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function duplicateClientOrderResponse(): array
+    {
+        return ['code' => '0', 'data' => [[
+            'sCode' => '51000',
+            'sMsg' => 'duplicate client order id',
+        ]]];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function missingInstrumentResponse(): array
+    {
+        return ['code' => '0', 'data' => [[
+            'sCode' => '51000',
+            'sMsg' => 'instId is required',
+        ]]];
+    }
+}


### PR DESCRIPTION
## Summary
- extend `ExchangeAdapterContractTestCase` with a standalone reduce-only stop listing/cancel invariant
- add offline contract coverage for Hyperliquid and OKX adapters with stateful fake REST clients
- document targeted contract commands in the API-first runbook

Refs #88

## Tests
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction`
- `git diff --check`
- `git diff --cached --check`