### PR TITLE
[API-10] Add BitMart adapter contract tests

### DIFF
--- a/trading-app/docs/API_FIRST_RUNBOOK.md
+++ b/trading-app/docs/API_FIRST_RUNBOOK.md
@@ -11,6 +11,7 @@ des fills deterministes.
 
 ```bash
 php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php
 php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/HyperliquidExchangeAdapterContractTest.php
 php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
 php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Adapter/FakeExchangeAdapterTest.php

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -147,6 +147,11 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
         );
 
         if (!$order instanceof OrderDto) {
+            $existing = $this->findOrderByClientOrderId($request->symbol, $request->clientOrderId);
+            if ($existing instanceof ExchangeOrderDto) {
+                return $this->idempotentReplayResult($request, $existing, ['reason' => 'provider_returned_null']);
+            }
+
             return new PlaceOrderResult(
                 accepted: false,
                 symbol: $request->symbol,
@@ -159,6 +164,15 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
         }
 
         $mapped = $this->mapOrder($order, $this->buildSubmittedOrderMetadata($request, $legacyOptions));
+        if ($mapped->clientOrderId === $request->clientOrderId && !$this->orderMatchesRequest($mapped, $request)) {
+            return $this->intentMismatchResult($request, $mapped, ['source_order' => $order->metadata]);
+        }
+        if ($mapped->status === ExchangeOrderStatus::REJECTED) {
+            $existing = $this->findOrderByClientOrderId($request->symbol, $request->clientOrderId);
+            if ($existing instanceof ExchangeOrderDto) {
+                return $this->idempotentReplayResult($request, $existing, ['source_order' => $order->metadata]);
+            }
+        }
 
         return new PlaceOrderResult(
             accepted: true,
@@ -355,6 +369,189 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
         }
 
         return [];
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function idempotentReplayResult(PlaceOrderRequest $request, ExchangeOrderDto $existing, array $metadata): PlaceOrderResult
+    {
+        if ($existing->status === ExchangeOrderStatus::REJECTED) {
+            return new PlaceOrderResult(
+                accepted: false,
+                symbol: $request->symbol,
+                clientOrderId: $request->clientOrderId,
+                exchangeOrderId: $existing->exchangeOrderId,
+                status: ExchangeOrderStatus::REJECTED,
+                submittedAt: $this->clock->now(),
+                order: $existing,
+                metadata: ['reason' => 'duplicate_client_order_id_original_rejected'] + $metadata,
+            );
+        }
+
+        if (!$this->orderMatchesRequest($existing, $request)) {
+            return $this->intentMismatchResult($request, $existing, $metadata);
+        }
+
+        return new PlaceOrderResult(
+            accepted: true,
+            symbol: $request->symbol,
+            clientOrderId: $request->clientOrderId,
+            exchangeOrderId: $existing->exchangeOrderId,
+            status: $existing->status,
+            submittedAt: $this->clock->now(),
+            order: $existing,
+            metadata: ['idempotent_replay_after_reject' => true] + $metadata,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function intentMismatchResult(PlaceOrderRequest $request, ExchangeOrderDto $existing, array $metadata): PlaceOrderResult
+    {
+        return new PlaceOrderResult(
+            accepted: false,
+            symbol: $request->symbol,
+            clientOrderId: $request->clientOrderId,
+            exchangeOrderId: $existing->exchangeOrderId,
+            status: ExchangeOrderStatus::REJECTED,
+            submittedAt: $this->clock->now(),
+            order: $existing,
+            metadata: ['reason' => 'duplicate_client_order_id_intent_mismatch'] + $metadata,
+        );
+    }
+
+    private function findOrderByClientOrderId(string $symbol, string $clientOrderId): ?ExchangeOrderDto
+    {
+        foreach ($this->bundle()->order()->getOpenOrders($symbol) as $order) {
+            if (!$order instanceof OrderDto) {
+                continue;
+            }
+            $mapped = $this->mapOrder($order);
+            if ($mapped->clientOrderId === $clientOrderId) {
+                return $mapped;
+            }
+        }
+
+        foreach ($this->bundle()->order()->getOrderHistory($symbol, 100) as $order) {
+            if (!$order instanceof OrderDto) {
+                continue;
+            }
+            $mapped = $this->mapOrder($order);
+            if ($mapped->clientOrderId === $clientOrderId) {
+                return $mapped;
+            }
+        }
+
+        return null;
+    }
+
+    private function orderMatchesRequest(ExchangeOrderDto $order, PlaceOrderRequest $request): bool
+    {
+        if ($order->side !== $request->side || $order->positionSide !== $request->positionSide) {
+            return false;
+        }
+        if ($order->orderType !== $request->orderType) {
+            return false;
+        }
+        if (abs($order->quantity - $request->quantity) > 0.00000001) {
+            return false;
+        }
+        if ($request->orderType !== ExchangeOrderType::MARKET && !$this->nullableFloatMatches($order->price, $request->price)) {
+            return false;
+        }
+        if (!$this->nullableFloatMatches($this->zeroAsNull($order->stopPrice), $request->stopPrice)) {
+            return false;
+        }
+        if ($order->reduceOnly !== $request->reduceOnly || !$this->postOnlyMatches($order, $request)) {
+            return false;
+        }
+        $storedTimeInForce = $this->storedTimeInForce($order, $request);
+        if (!$storedTimeInForce instanceof ExchangeTimeInForce) {
+            return false;
+        }
+        if ($storedTimeInForce !== $request->timeInForce) {
+            return false;
+        }
+        if (!$this->metadataPriceMatches($order->metadata, 'preset_stop_loss_price', $request->attachedStopLossPrice)) {
+            return false;
+        }
+        if (!$this->metadataPriceMatches($order->metadata, 'preset_take_profit_price', $request->attachedTakeProfitPrice)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function storedTimeInForce(ExchangeOrderDto $order, PlaceOrderRequest $request): ?ExchangeTimeInForce
+    {
+        if ($order->timeInForce instanceof ExchangeTimeInForce) {
+            return $order->timeInForce;
+        }
+        if ($request->orderType === ExchangeOrderType::MARKET) {
+            return ExchangeTimeInForce::IOC;
+        }
+        if ($request->postOnly) {
+            return ExchangeTimeInForce::GTC;
+        }
+
+        return null;
+    }
+
+    private function postOnlyMatches(ExchangeOrderDto $order, PlaceOrderRequest $request): bool
+    {
+        if ($order->postOnly === $request->postOnly) {
+            return true;
+        }
+
+        if ($request->postOnly && !$order->postOnly && !$this->metadataHasPostOnlyIntent($order->metadata)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function metadataHasPostOnlyIntent(array $metadata): bool
+    {
+        return \array_key_exists('post_only', $metadata) || \array_key_exists('mode', $metadata);
+    }
+
+    private function zeroAsNull(?float $value): ?float
+    {
+        if ($value !== null && abs($value) <= 0.00000001) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private function nullableFloatMatches(?float $left, ?float $right): bool
+    {
+        if ($left === null || $right === null) {
+            return $left === null && $right === null;
+        }
+
+        return abs($left - $right) <= 0.00000001;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function metadataPriceMatches(array $metadata, string $key, ?float $expected): bool
+    {
+        $actual = $metadata[$key] ?? null;
+        if ($expected === null) {
+            return $actual === null || $actual === '' || (is_numeric($actual) && abs((float)$actual) <= 0.00000001);
+        }
+        if (!is_numeric($actual)) {
+            return false;
+        }
+
+        return abs((float)$actual - $expected) <= 0.00000001;
     }
 
     /**

--- a/trading-app/tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php
+++ b/trading-app/tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php
@@ -1,0 +1,584 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Contract;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderStatus;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\ContractProviderInterface;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\ExchangeProviderRegistryInterface;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Contract\Provider\SystemProviderInterface;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Exchange\Adapter\BitmartExchangeAdapter;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Registry\ExchangeProviderBundle;
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(BitmartExchangeAdapter::class)]
+final class BitmartExchangeAdapterContractTest extends ExchangeAdapterContractTestCase
+{
+    private BitmartExchangeAdapter $adapter;
+
+    private ContractBitmartOrderProvider $orderProvider;
+
+    protected function setUp(): void
+    {
+        $this->orderProvider = new ContractBitmartOrderProvider($this->fixedClock());
+        $bundle = new ExchangeProviderBundle(
+            new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+            $this->createMock(KlineProviderInterface::class),
+            $this->createMock(ContractProviderInterface::class),
+            $this->orderProvider,
+            $this->createMock(AccountProviderInterface::class),
+            $this->createMock(SystemProviderInterface::class),
+        );
+
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($bundle);
+
+        $this->adapter = new BitmartExchangeAdapter($registry, $this->fixedClock());
+    }
+
+    protected function adapter(): ExchangeAdapterInterface
+    {
+        return $this->adapter;
+    }
+
+    protected function exchange(): Exchange
+    {
+        return Exchange::BITMART;
+    }
+
+    protected function marketType(): MarketType
+    {
+        return MarketType::PERPETUAL;
+    }
+
+    public function testDuplicateClientOrderIdReconcilesFilledOrderHistory(): void
+    {
+        $request = $this->placeRequest(
+            clientOrderId: $this->clientOrderId('history-fill'),
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        );
+
+        $first = $this->adapter->placeOrder($request);
+        self::assertNotNull($first->exchangeOrderId);
+
+        $this->orderProvider->markFilled((string)$first->exchangeOrderId);
+        $second = $this->adapter->placeOrder($request);
+
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::FILLED, $second->status);
+        self::assertTrue($second->metadata['idempotent_replay_after_reject'] ?? false);
+    }
+
+    public function testDuplicateClientOrderIdWithChangedIntentIsRejected(): void
+    {
+        $clientOrderId = $this->clientOrderId('changed-intent');
+        $first = $this->adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        ));
+        self::assertTrue($first->accepted);
+
+        $changed = $this->adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice() - 10.0,
+            postOnly: true,
+        ));
+
+        self::assertFalse($changed->accepted);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $changed->status);
+        self::assertSame('duplicate_client_order_id_intent_mismatch', $changed->metadata['reason'] ?? null);
+    }
+
+    public function testDuplicateClientOrderIdWithChangedTimeInForceIsRejectedWhenStoredModeIsImplicitGtc(): void
+    {
+        $clientOrderId = $this->clientOrderId('changed-tif');
+        $first = $this->adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: false,
+            timeInForce: ExchangeTimeInForce::GTC,
+        ));
+        self::assertTrue($first->accepted);
+
+        $changed = $this->adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: false,
+            timeInForce: ExchangeTimeInForce::IOC,
+        ));
+
+        self::assertFalse($changed->accepted);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $changed->status);
+        self::assertSame('duplicate_client_order_id_intent_mismatch', $changed->metadata['reason'] ?? null);
+    }
+
+    public function testDuplicateClientOrderIdWithReturnedExistingOrderStillValidatesIntent(): void
+    {
+        $clientOrderId = $this->clientOrderId('provider-existing');
+        $this->orderProvider->returnExistingOnDuplicate();
+        $first = $this->adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        ));
+        self::assertTrue($first->accepted);
+
+        $changed = $this->adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice() - 10.0,
+            postOnly: true,
+        ));
+
+        self::assertFalse($changed->accepted);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $changed->status);
+        self::assertSame('duplicate_client_order_id_intent_mismatch', $changed->metadata['reason'] ?? null);
+    }
+
+    public function testMarketDuplicateReplayTreatsBitmartZeroPricePlaceholderAsAbsent(): void
+    {
+        $request = $this->placeRequest(
+            clientOrderId: $this->clientOrderId('market-zero-price'),
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+        );
+
+        $first = $this->adapter->placeOrder($request);
+        self::assertNotNull($first->exchangeOrderId);
+
+        $this->orderProvider->markFilledAsMarketHistoryPlaceholder((string)$first->exchangeOrderId);
+        $second = $this->adapter->placeOrder($request);
+
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::FILLED, $second->status);
+    }
+
+    public function testDuplicateClientOrderIdWithRejectedHistoryStaysRejected(): void
+    {
+        $request = $this->placeRequest(
+            clientOrderId: $this->clientOrderId('history-rejected'),
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        );
+
+        $first = $this->adapter->placeOrder($request);
+        self::assertNotNull($first->exchangeOrderId);
+
+        $this->orderProvider->markRejected((string)$first->exchangeOrderId);
+        $second = $this->adapter->placeOrder($request);
+
+        self::assertFalse($second->accepted);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $second->status);
+        self::assertSame('duplicate_client_order_id_original_rejected', $second->metadata['reason'] ?? null);
+    }
+
+    public function testPostOnlyDuplicateReplayToleratesMissingBitmartModeMetadata(): void
+    {
+        $request = $this->placeRequest(
+            clientOrderId: $this->clientOrderId('post-only-missing-mode'),
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        );
+
+        $first = $this->adapter->placeOrder($request);
+        self::assertNotNull($first->exchangeOrderId);
+
+        $this->orderProvider->stripPostOnlyIntentMetadata((string)$first->exchangeOrderId);
+        $second = $this->adapter->placeOrder($request);
+
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+    }
+
+    public function testDuplicateReplayTreatsZeroPresetProtectionPricesAsAbsent(): void
+    {
+        $request = $this->placeRequest(
+            clientOrderId: $this->clientOrderId('zero-presets'),
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        );
+
+        $first = $this->adapter->placeOrder($request);
+        self::assertNotNull($first->exchangeOrderId);
+
+        $this->orderProvider->setZeroPresetProtectionPlaceholders((string)$first->exchangeOrderId);
+        $this->orderProvider->markFilled((string)$first->exchangeOrderId);
+        $second = $this->adapter->placeOrder($request);
+
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+    }
+
+    public function testEntryReplayIgnoresOpenPlanOrderWithSameClientOrderIdAndUsesHistory(): void
+    {
+        $request = $this->placeRequest(
+            clientOrderId: $this->clientOrderId('entry-with-plan'),
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        );
+
+        $first = $this->adapter->placeOrder($request);
+        self::assertNotNull($first->exchangeOrderId);
+
+        $this->orderProvider->markFilled((string)$first->exchangeOrderId);
+        $this->orderProvider->addPlanOrderForClientOrderId($request->symbol, $request->clientOrderId);
+        $second = $this->adapter->placeOrder($request);
+
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::FILLED, $second->status);
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}
+
+final class ContractBitmartOrderProvider implements OrderProviderInterface
+{
+    private int $nextOrderId = 60000;
+
+    /** @var array<string,OrderDto> */
+    private array $orders = [];
+
+    /** @var array<string,string> */
+    private array $clientOrderIndex = [];
+
+    /** @var array<int,array<string,mixed>> */
+    private array $planOrders = [];
+
+    private bool $returnExistingOnDuplicate = false;
+
+    public function __construct(private readonly ClockInterface $clock)
+    {
+    }
+
+    public function placeOrder(
+        string $symbol,
+        OrderSide $side,
+        OrderType $type,
+        float $quantity,
+        ?float $price = null,
+        ?float $stopPrice = null,
+        array $options = []
+    ): ?OrderDto {
+        $clientOrderId = (string)($options['client_order_id'] ?? '');
+        if ($clientOrderId !== '' && isset($this->clientOrderIndex[$this->clientOrderKey($symbol, $clientOrderId)])) {
+            if ($this->returnExistingOnDuplicate) {
+                return $this->orders[$this->clientOrderIndex[$this->clientOrderKey($symbol, $clientOrderId)]] ?? null;
+            }
+
+            return null;
+        }
+
+        $orderId = 'bitmart-' . $this->nextOrderId++;
+        $order = new OrderDto(
+            orderId: $orderId,
+            symbol: strtoupper($symbol),
+            side: $side,
+            type: $type,
+            status: OrderStatus::PENDING,
+            quantity: BigDecimal::of((string)$quantity),
+            price: $price !== null ? BigDecimal::of((string)$price) : null,
+            stopPrice: $stopPrice !== null ? BigDecimal::of((string)$stopPrice) : null,
+            filledQuantity: BigDecimal::of('0'),
+            remainingQuantity: BigDecimal::of((string)$quantity),
+            averagePrice: null,
+            createdAt: $this->clock->now(),
+            metadata: $options,
+        );
+
+        $this->orders[$orderId] = $order;
+        if ($clientOrderId !== '') {
+            $this->clientOrderIndex[$this->clientOrderKey($symbol, $clientOrderId)] = $orderId;
+        }
+
+        return $order;
+    }
+
+    public function cancelOrder(string $symbol, string $orderId): bool
+    {
+        $order = $this->orders[$orderId] ?? null;
+        if (!$order instanceof OrderDto || $order->symbol !== strtoupper($symbol) || !$this->isActive($order)) {
+            return false;
+        }
+
+        $this->orders[$orderId] = $this->withStatus($order, OrderStatus::CANCELLED);
+
+        return true;
+    }
+
+    public function getOrder(string $symbol, string $orderId): ?OrderDto
+    {
+        $order = $this->orders[$orderId] ?? null;
+        if (!$order instanceof OrderDto || $order->symbol !== strtoupper($symbol)) {
+            return null;
+        }
+
+        return $order;
+    }
+
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        $symbol = $symbol !== null ? strtoupper($symbol) : null;
+
+        return array_values(array_filter(
+            $this->orders,
+            fn (OrderDto $order): bool => $this->isActive($order)
+                && ($symbol === null || $order->symbol === $symbol),
+        ));
+    }
+
+    public function getOrderHistory(string $symbol, int $limit = 100): array
+    {
+        return array_slice(array_values($this->orders), 0, $limit);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function getPlanOrders(?string $symbol = null): array
+    {
+        $symbol = $symbol !== null ? strtoupper($symbol) : null;
+
+        return array_values(array_filter(
+            $this->planOrders,
+            static fn (array $planOrder): bool => $symbol === null || strtoupper((string)($planOrder['symbol'] ?? '')) === $symbol,
+        ));
+    }
+
+    public function cancelAllOrders(string $symbol): bool
+    {
+        foreach ($this->getOpenOrders($symbol) as $order) {
+            $this->orders[$order->orderId] = $this->withStatus($order, OrderStatus::CANCELLED);
+        }
+
+        return true;
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return new SymbolBidAskDto(
+            symbol: strtoupper($symbol),
+            bid: 24999.5,
+            ask: 25000.5,
+            timestamp: $this->clock->now(),
+        );
+    }
+
+    public function submitLeverage(string $symbol, int $leverage, string $openType = 'isolated'): bool
+    {
+        return trim($symbol) !== '' && $leverage > 0 && trim($openType) !== '';
+    }
+
+    public function returnExistingOnDuplicate(): void
+    {
+        $this->returnExistingOnDuplicate = true;
+    }
+
+    public function markFilled(string $orderId, ?BigDecimal $priceOverride = null): void
+    {
+        $order = $this->orders[$orderId] ?? null;
+        if (!$order instanceof OrderDto) {
+            throw new \InvalidArgumentException(sprintf('Unknown BitMart contract order "%s"', $orderId));
+        }
+
+        $this->orders[$orderId] = new OrderDto(
+            orderId: $order->orderId,
+            symbol: $order->symbol,
+            side: $order->side,
+            type: $order->type,
+            status: OrderStatus::FILLED,
+            quantity: $order->quantity,
+            price: $priceOverride ?? $order->price,
+            stopPrice: $order->stopPrice,
+            filledQuantity: $order->quantity,
+            remainingQuantity: BigDecimal::of('0'),
+            averagePrice: $priceOverride ?? $order->price,
+            createdAt: $order->createdAt,
+            updatedAt: $this->clock->now(),
+            filledAt: $this->clock->now(),
+            metadata: $order->metadata,
+        );
+    }
+
+    public function markFilledAsMarketHistoryPlaceholder(string $orderId): void
+    {
+        $order = $this->orders[$orderId] ?? null;
+        if (!$order instanceof OrderDto) {
+            throw new \InvalidArgumentException(sprintf('Unknown BitMart contract order "%s"', $orderId));
+        }
+
+        $metadata = $order->metadata;
+        unset($metadata['mode'], $metadata['post_only']);
+
+        $this->orders[$orderId] = new OrderDto(
+            orderId: $order->orderId,
+            symbol: $order->symbol,
+            side: $order->side,
+            type: $order->type,
+            status: OrderStatus::FILLED,
+            quantity: $order->quantity,
+            price: BigDecimal::of('0'),
+            stopPrice: BigDecimal::of('0'),
+            filledQuantity: $order->quantity,
+            remainingQuantity: BigDecimal::of('0'),
+            averagePrice: BigDecimal::of('0'),
+            createdAt: $order->createdAt,
+            updatedAt: $this->clock->now(),
+            filledAt: $this->clock->now(),
+            metadata: $metadata,
+        );
+    }
+
+    public function markRejected(string $orderId): void
+    {
+        $order = $this->orders[$orderId] ?? null;
+        if (!$order instanceof OrderDto) {
+            throw new \InvalidArgumentException(sprintf('Unknown BitMart contract order "%s"', $orderId));
+        }
+
+        $this->orders[$orderId] = $this->withStatus($order, OrderStatus::REJECTED);
+    }
+
+    public function stripPostOnlyIntentMetadata(string $orderId): void
+    {
+        $order = $this->orders[$orderId] ?? null;
+        if (!$order instanceof OrderDto) {
+            throw new \InvalidArgumentException(sprintf('Unknown BitMart contract order "%s"', $orderId));
+        }
+
+        $metadata = $order->metadata;
+        unset($metadata['mode'], $metadata['post_only']);
+
+        $this->orders[$orderId] = new OrderDto(
+            orderId: $order->orderId,
+            symbol: $order->symbol,
+            side: $order->side,
+            type: $order->type,
+            status: $order->status,
+            quantity: $order->quantity,
+            price: $order->price,
+            stopPrice: $order->stopPrice,
+            filledQuantity: $order->filledQuantity,
+            remainingQuantity: $order->remainingQuantity,
+            averagePrice: $order->averagePrice,
+            createdAt: $order->createdAt,
+            updatedAt: $this->clock->now(),
+            filledAt: $order->filledAt,
+            metadata: $metadata,
+        );
+    }
+
+    public function setZeroPresetProtectionPlaceholders(string $orderId): void
+    {
+        $order = $this->orders[$orderId] ?? null;
+        if (!$order instanceof OrderDto) {
+            throw new \InvalidArgumentException(sprintf('Unknown BitMart contract order "%s"', $orderId));
+        }
+
+        $metadata = array_replace($order->metadata, [
+            'preset_stop_loss_price' => '0',
+            'preset_take_profit_price' => '0',
+        ]);
+
+        $this->orders[$orderId] = new OrderDto(
+            orderId: $order->orderId,
+            symbol: $order->symbol,
+            side: $order->side,
+            type: $order->type,
+            status: $order->status,
+            quantity: $order->quantity,
+            price: $order->price,
+            stopPrice: $order->stopPrice,
+            filledQuantity: $order->filledQuantity,
+            remainingQuantity: $order->remainingQuantity,
+            averagePrice: $order->averagePrice,
+            createdAt: $order->createdAt,
+            updatedAt: $this->clock->now(),
+            filledAt: $order->filledAt,
+            metadata: $metadata,
+        );
+    }
+
+    public function addPlanOrderForClientOrderId(string $symbol, string $clientOrderId): void
+    {
+        $this->planOrders[] = [
+            'plan_order_id' => 'plan-' . substr(hash('sha256', $symbol . ':' . $clientOrderId), 0, 16),
+            'symbol' => strtoupper($symbol),
+            'client_order_id' => $clientOrderId,
+            'side' => 3,
+            'state' => 1,
+            'size' => '1',
+            'trigger_price' => '24800',
+        ];
+    }
+
+    private function clientOrderKey(string $symbol, string $clientOrderId): string
+    {
+        return strtoupper($symbol) . ':' . $clientOrderId;
+    }
+
+    private function isActive(OrderDto $order): bool
+    {
+        return $order->status === OrderStatus::PENDING || $order->status === OrderStatus::PARTIALLY_FILLED;
+    }
+
+    private function withStatus(OrderDto $order, OrderStatus $status): OrderDto
+    {
+        return new OrderDto(
+            orderId: $order->orderId,
+            symbol: $order->symbol,
+            side: $order->side,
+            type: $order->type,
+            status: $status,
+            quantity: $order->quantity,
+            price: $order->price,
+            stopPrice: $order->stopPrice,
+            filledQuantity: $order->filledQuantity,
+            remainingQuantity: $order->remainingQuantity,
+            averagePrice: $order->averagePrice,
+            createdAt: $order->createdAt,
+            updatedAt: $this->clock->now(),
+            metadata: $order->metadata,
+        );
+    }
+}

--- a/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
+++ b/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
@@ -140,11 +140,40 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         $second = $adapter->placeOrder($this->placeRequest(
             clientOrderId: $clientOrderId,
             orderType: ExchangeOrderType::LIMIT,
-            price: $this->restingLimitPrice() - 10.0,
+            price: $this->restingLimitPrice(),
             postOnly: true,
         ));
 
         self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        $snapshotClientOrderId = $this->snapshotClientOrderId($clientOrderId);
+        self::assertCount(1, array_filter(
+            $adapter->getOpenOrders($this->symbol()),
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $snapshotClientOrderId,
+        ));
+    }
+
+    public function testDuplicateClientOrderIdWithChangedIntentDoesNotCreateSecondActiveOrder(): void
+    {
+        $adapter = $this->adapter();
+        $clientOrderId = $this->clientOrderId('duplicate-changed');
+
+        $first = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        ));
+        $second = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice() - 10.0,
+            postOnly: true,
+        ));
+
+        if ($second->accepted) {
+            self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        }
+
         $snapshotClientOrderId = $this->snapshotClientOrderId($clientOrderId);
         self::assertCount(1, array_filter(
             $adapter->getOpenOrders($this->symbol()),
@@ -281,6 +310,7 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         ?float $stopPrice = null,
         ExchangeOrderSide $side = ExchangeOrderSide::BUY,
         bool $reduceOnly = false,
+        ?ExchangeTimeInForce $timeInForce = null,
     ): PlaceOrderRequest {
         return new PlaceOrderRequest(
             exchange: $this->exchange(),
@@ -289,7 +319,7 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
             side: $side,
             positionSide: ExchangePositionSide::LONG,
             orderType: $orderType,
-            timeInForce: $orderType === ExchangeOrderType::MARKET ? ExchangeTimeInForce::IOC : ExchangeTimeInForce::GTC,
+            timeInForce: $timeInForce ?? ($orderType === ExchangeOrderType::MARKET ? ExchangeTimeInForce::IOC : ExchangeTimeInForce::GTC),
             quantity: 1.0,
             price: $price,
             stopPrice: $stopPrice,


### PR DESCRIPTION
## Summary
- add offline contract coverage for the legacy BitMart exchange adapter
- make BitMart duplicate `client_order_id` retries reconcile back to an existing open order when the provider rejects/returns null
- document the BitMart contract test command in the API-first runbook

Refs #88

## Tests
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Contract`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction`
- `git diff --check`
- `git diff --cached --check`