### PR TITLE
[API-10] Add filled replay idempotency coverage

### DIFF
--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -33,24 +33,28 @@ final readonly class FakeExchangeMatchingEngine
         $this->assertRequestContext($request);
         $this->assertRequestIntent($request);
 
-        $existing = $this->stateStore->findActiveOrderByClientOrderId($request->symbol, $request->clientOrderId);
+        $existing = $this->stateStore->getOrderByClientOrderId($request->symbol, $request->clientOrderId);
         if ($existing instanceof ExchangeOrderDto) {
+            if (!$this->orderMatchesRequest($existing, $request)) {
+                return $this->intentMismatchReplayResult($request, $existing);
+            }
+
             return new PlaceOrderResult(
-                accepted: true,
+                accepted: $this->isAcceptedReplayStatus($existing->status),
                 symbol: $existing->symbol,
                 clientOrderId: $request->clientOrderId,
                 exchangeOrderId: $existing->exchangeOrderId,
                 status: $existing->status,
                 submittedAt: $this->clock->now(),
                 order: $existing,
-                metadata: ['idempotent_replay' => true],
+                metadata: array_replace($existing->metadata, ['idempotent_replay' => true]),
             );
         }
 
         if ($request->postOnly && $this->wouldCross($request)) {
-            $order = $this->buildOrder($request, ExchangeOrderStatus::REJECTED, [
+            $order = $this->buildOrder($request, ExchangeOrderStatus::REJECTED, array_replace($this->requestMetadata($request), [
                 'reason' => 'post_only_would_cross',
-            ]);
+            ]));
             $this->stateStore->saveOrder($order);
             $this->appendEvent('order.rejected', $order, ['reason' => 'post_only_would_cross']);
 
@@ -58,9 +62,9 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         if ($this->isStandaloneProtection($request) && $this->stateStore->consumeProtectionRejectionFlag()) {
-            $order = $this->buildOrder($request, ExchangeOrderStatus::REJECTED, [
+            $order = $this->buildOrder($request, ExchangeOrderStatus::REJECTED, array_replace($this->requestMetadata($request), [
                 'reason' => 'protection_rejected_by_scenario',
-            ]);
+            ]));
             $this->stateStore->saveOrder($order);
             $this->appendEvent('protection_order.rejected', $order, ['reason' => 'protection_rejected_by_scenario']);
 
@@ -267,6 +271,23 @@ final readonly class FakeExchangeMatchingEngine
             'attached_stop_loss_price' => $request->attachedStopLossPrice,
             'attached_take_profit_price' => $request->attachedTakeProfitPrice,
         ], static fn (mixed $value): bool => $value !== null) + $request->metadata;
+    }
+
+    private function intentMismatchReplayResult(PlaceOrderRequest $request, ExchangeOrderDto $existing): PlaceOrderResult
+    {
+        return new PlaceOrderResult(
+            accepted: false,
+            symbol: $existing->symbol,
+            clientOrderId: $request->clientOrderId,
+            exchangeOrderId: $existing->exchangeOrderId,
+            status: ExchangeOrderStatus::REJECTED,
+            submittedAt: $this->clock->now(),
+            order: $existing,
+            metadata: array_replace($existing->metadata, [
+                'reason' => 'duplicate_client_order_id_intent_mismatch',
+                'idempotent_replay' => true,
+            ]),
+        );
     }
 
     private function createAttachedProtectionOrders(ExchangeOrderDto $entryOrder): ExchangeOrderDto
@@ -732,6 +753,95 @@ final readonly class FakeExchangeMatchingEngine
             ExchangeOrderStatus::OPEN,
             ExchangeOrderStatus::PARTIALLY_FILLED,
         ], true);
+    }
+
+    private function isAcceptedReplayStatus(ExchangeOrderStatus $status): bool
+    {
+        return !\in_array($status, [
+            ExchangeOrderStatus::REJECTED,
+            ExchangeOrderStatus::UNKNOWN,
+        ], true);
+    }
+
+    private function orderMatchesRequest(ExchangeOrderDto $order, PlaceOrderRequest $request): bool
+    {
+        if ($order->side !== $request->side || $order->positionSide !== $request->positionSide) {
+            return false;
+        }
+        if ($order->orderType !== $request->orderType) {
+            return false;
+        }
+        if (abs($order->quantity - $request->quantity) > 0.00000001) {
+            return false;
+        }
+        if ($request->orderType !== ExchangeOrderType::MARKET && !$this->nullableFloatMatches($order->price, $request->price)) {
+            return false;
+        }
+        if (!$this->nullableFloatMatches($order->stopPrice, $request->stopPrice)) {
+            return false;
+        }
+        if ($order->reduceOnly !== ($request->reduceOnly || $this->isStandaloneProtection($request))) {
+            return false;
+        }
+        if ($order->postOnly !== $request->postOnly || $order->timeInForce !== $request->timeInForce) {
+            return false;
+        }
+        if (!$this->metadataPriceMatches($order->metadata, 'attached_stop_loss_price', $request->attachedStopLossPrice)) {
+            return false;
+        }
+        if (!$this->metadataPriceMatches($order->metadata, 'attached_take_profit_price', $request->attachedTakeProfitPrice)) {
+            return false;
+        }
+        if (\array_key_exists('leverage', $order->metadata) && !$this->metadataFloatMatches($order->metadata, 'leverage', $request->leverage)) {
+            return false;
+        }
+        $storedMarginMode = $order->metadata['margin_mode'] ?? null;
+        if ($storedMarginMode !== null && $storedMarginMode !== '' && $storedMarginMode !== $request->marginMode) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function nullableFloatMatches(?float $left, ?float $right): bool
+    {
+        if ($left === null || $right === null) {
+            return $left === null && $right === null;
+        }
+
+        return abs($left - $right) <= 0.00000001;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function metadataPriceMatches(array $metadata, string $key, ?float $expected): bool
+    {
+        $actual = $metadata[$key] ?? null;
+        if ($expected === null) {
+            return $actual === null || $actual === '' || (is_numeric($actual) && abs((float)$actual) <= 0.00000001);
+        }
+        if (!is_numeric($actual)) {
+            return false;
+        }
+
+        return abs((float)$actual - $expected) <= 0.00000001;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function metadataFloatMatches(array $metadata, string $key, ?float $expected): bool
+    {
+        $actual = $metadata[$key] ?? null;
+        if ($expected === null) {
+            return $actual === null || $actual === '' || (is_numeric($actual) && abs((float)$actual) <= 0.00000001);
+        }
+        if (!is_numeric($actual)) {
+            return false;
+        }
+
+        return abs((float)$actual - $expected) <= 0.00000001;
     }
 
     /**

--- a/trading-app/src/TradeEntry/Execution/ExchangeExecutionService.php
+++ b/trading-app/src/TradeEntry/Execution/ExchangeExecutionService.php
@@ -363,10 +363,14 @@ final class ExchangeExecutionService
 
     private function entryFilled(PlaceOrderResult $result): bool
     {
-        return \in_array($result->status, [
+        if (\in_array($result->status, [
             ExchangeOrderStatus::FILLED,
             ExchangeOrderStatus::PARTIALLY_FILLED,
-        ], true);
+        ], true)) {
+            return true;
+        }
+
+        return ($result->order?->filledQuantity ?? 0.0) > 0.00000001;
     }
 
     private function entryActive(PlaceOrderResult $result): bool

--- a/trading-app/src/TradeEntry/Execution/ProtectionEnforcer.php
+++ b/trading-app/src/TradeEntry/Execution/ProtectionEnforcer.php
@@ -410,10 +410,14 @@ final class ProtectionEnforcer
 
     private function entryFilled(PlaceOrderResult $result): bool
     {
-        return \in_array($result->status, [
+        if (\in_array($result->status, [
             ExchangeOrderStatus::FILLED,
             ExchangeOrderStatus::PARTIALLY_FILLED,
-        ], true);
+        ], true)) {
+            return true;
+        }
+
+        return ($result->order?->filledQuantity ?? 0.0) > 0.00000001;
     }
 
     private function activeOrderStatus(ExchangeOrderStatus $status): bool

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
@@ -8,6 +8,7 @@ use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Exchange\Adapter\FakeExchangeAdapter;
 use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\ExchangeOrderDto;
 use App\Exchange\Dto\PlaceOrderRequest;
 use App\Exchange\Enum\ExchangeOrderSide;
 use App\Exchange\Enum\ExchangeOrderStatus;
@@ -332,6 +333,143 @@ final class FakeExchangeAdapterTest extends TestCase
         self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
         self::assertTrue($second->metadata['idempotent_replay'] ?? false);
         self::assertCount(1, $this->adapter->getOpenOrders('BTCUSDT'));
+    }
+
+    public function testFilledClientOrderIdReplayDoesNotCreateSecondEntry(): void
+    {
+        $first = $this->adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'cid-filled',
+            postOnly: false,
+        ));
+        $second = $this->adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'cid-filled',
+            postOnly: false,
+        ));
+
+        self::assertTrue($first->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $first->status);
+
+        $entryOrders = array_filter(
+            $this->adapter->getOrdersSnapshot('BTCUSDT'),
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === 'cid-filled' && !$order->reduceOnly,
+        );
+
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::FILLED, $second->status);
+        self::assertTrue($second->metadata['idempotent_replay'] ?? false);
+        self::assertCount(1, $entryOrders);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertEqualsWithDelta(1.0, $this->adapter->getOpenPositions('BTCUSDT')[0]->size, 0.000001);
+    }
+
+    public function testRejectedClientOrderIdReplayPreservesTerminalFailure(): void
+    {
+        $first = $this->adapter->placeOrder($this->request(
+            price: 26000.0,
+            clientOrderId: 'cid-rejected',
+            postOnly: true,
+        ));
+        $second = $this->adapter->placeOrder($this->request(
+            price: 26000.0,
+            clientOrderId: 'cid-rejected',
+            postOnly: true,
+        ));
+
+        self::assertFalse($first->accepted);
+        self::assertFalse($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $second->status);
+        self::assertSame('post_only_would_cross', $second->metadata['reason'] ?? null);
+        self::assertTrue($second->metadata['idempotent_replay'] ?? false);
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+    }
+
+    public function testFilledClientOrderIdReplayRejectsChangedIntent(): void
+    {
+        $first = $this->adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'cid-filled-changed',
+            postOnly: false,
+            attachedStopLossPrice: 24800.0,
+        ));
+        $changed = $this->adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'cid-filled-changed',
+            postOnly: false,
+            attachedStopLossPrice: 24700.0,
+        ));
+
+        self::assertTrue($first->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $first->status);
+        self::assertFalse($changed->accepted);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $changed->status);
+        self::assertSame('duplicate_client_order_id_intent_mismatch', $changed->metadata['reason'] ?? null);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(1, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertEqualsWithDelta(24800.0, $this->adapter->getOpenOrders('BTCUSDT')[0]->stopPrice, 0.000001);
+    }
+
+    public function testExpiredClientOrderIdReplayPreservesAcceptedTerminalStatus(): void
+    {
+        $first = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-expired',
+            postOnly: false,
+            timeInForce: ExchangeTimeInForce::IOC,
+        ));
+        $second = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-expired',
+            postOnly: false,
+            timeInForce: ExchangeTimeInForce::IOC,
+        ));
+
+        self::assertTrue($first->accepted);
+        self::assertSame(ExchangeOrderStatus::EXPIRED, $first->status);
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::EXPIRED, $second->status);
+        self::assertTrue($second->metadata['idempotent_replay'] ?? false);
+    }
+
+    public function testCancelledPartialClientOrderIdReplayPreservesFilledSemantics(): void
+    {
+        $first = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-partial-cancelled',
+            postOnly: true,
+        ));
+        self::assertNotNull($first->exchangeOrderId);
+
+        $this->scenario->fillOrder($first->exchangeOrderId, 0.4, 24950.0);
+        $this->adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: $first->exchangeOrderId,
+            clientOrderId: 'cid-partial-cancelled',
+        ));
+
+        $second = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-partial-cancelled',
+            postOnly: true,
+        ));
+
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $second->status);
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $second->order?->status);
+        self::assertEqualsWithDelta(0.4, $second->order?->filledQuantity, 0.000001);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertEqualsWithDelta(0.4, $this->adapter->getOpenPositions('BTCUSDT')[0]->size, 0.000001);
     }
 
     public function testCrossingLimitFillsAtBookPriceInsteadOfLimitPrice(): void

--- a/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
+++ b/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
@@ -126,6 +126,47 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         self::assertGreaterThan(0.0, $positions[0]->size);
     }
 
+    public function testFilledClientOrderIdReplayDoesNotCreateSecondPositionWhenAdapterExecutesImmediateFills(): void
+    {
+        if (!$this->marketOrdersFillImmediately()) {
+            self::markTestSkipped('Adapter does not execute immediate fills in local contract tests.');
+        }
+
+        $adapter = $this->adapter();
+        $clientOrderId = $this->clientOrderId('filled-replay');
+        $first = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+        ));
+        $second = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $clientOrderId,
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+        ));
+
+        self::assertTrue($first->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $first->status);
+        self::assertTrue($second->accepted);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::FILLED, $second->status);
+
+        $positions = $adapter->getOpenPositions($this->symbol());
+        self::assertCount(1, $positions);
+        self::assertEqualsWithDelta(1.0, $positions[0]->size, 0.000001);
+
+        if ($adapter instanceof ExchangeRestSnapshotProviderInterface) {
+            $snapshotClientOrderId = $this->snapshotClientOrderId($clientOrderId);
+            self::assertCount(1, array_filter(
+                $adapter->getOrdersSnapshot($this->symbol()),
+                static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $snapshotClientOrderId
+                    && !$order->reduceOnly,
+            ));
+        }
+    }
+
     public function testDuplicateClientOrderIdDoesNotCreateSecondActiveOrder(): void
     {
         $adapter = $this->adapter();

--- a/trading-app/tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
+++ b/trading-app/tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
@@ -81,6 +81,67 @@ final class ExchangeExecutionServiceTest extends TestCase
         self::assertEqualsWithDelta(24800.0, $stopOrders[0]->stopPrice, 0.000001);
     }
 
+    public function testSameDecisionKeyTwiceReplaysFilledEntryWithoutOpeningSecondPosition(): void
+    {
+        $first = $this->service()->execute($this->plan(orderType: 'market'), 'decision-idempotent');
+        $second = $this->service()->execute($this->plan(orderType: 'market'), 'decision-idempotent');
+
+        $entryOrders = array_filter(
+            $this->adapter->getOrdersSnapshot('BTCUSDT'),
+            static fn (ExchangeOrderDto $order): bool => $order->clientOrderId === $first->clientOrderId && !$order->reduceOnly,
+        );
+
+        self::assertSame($first->clientOrderId, $second->clientOrderId);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $first->status);
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $second->status);
+        self::assertTrue($second->raw['order']['metadata']['idempotent_replay'] ?? false);
+        self::assertCount(1, $entryOrders);
+        self::assertCount(1, $this->stopLossOrders($this->adapter));
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertEqualsWithDelta(1.0, $this->adapter->getOpenPositions('BTCUSDT')[0]->size, 0.000001);
+    }
+
+    public function testSameDecisionKeyWithChangedStopRejectsDuplicateIntentWithoutEmergencyClose(): void
+    {
+        $first = $this->service()->execute($this->plan(orderType: 'market'), 'decision-changed-intent');
+        $second = $this->service()->execute(
+            $this->plan(orderType: 'market', stop: 24700.0),
+            'decision-changed-intent',
+        );
+
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $first->status);
+        self::assertSame(ExecutionResult::STATUS_ERROR, $second->status);
+        self::assertSame('entry_rejected_exchange', $second->raw['reason']);
+        self::assertSame('duplicate_client_order_id_intent_mismatch', $second->raw['order']['metadata']['reason'] ?? null);
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(1, $this->stopLossOrders($this->adapter));
+        self::assertEqualsWithDelta(24800.0, $this->stopLossOrders($this->adapter)[0]->stopPrice, 0.000001);
+    }
+
+    public function testSameDecisionKeyReplaysCancelledPartialEntryAsProtectedFill(): void
+    {
+        $adapter = new PartialFillOnEntryAdapter($this->adapter);
+        $first = $this->service($adapter)->execute(
+            $this->plan(orderType: 'limit', entry: 24950.0),
+            'decision-partial-replay',
+        );
+        $second = $this->service($adapter)->execute(
+            $this->plan(orderType: 'limit', entry: 24950.0),
+            'decision-partial-replay',
+        );
+
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $first->status);
+        self::assertSame(ExecutionResult::STATUS_SUBMITTED_PROTECTED, $second->status);
+        self::assertSame($first->clientOrderId, $second->clientOrderId);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::CANCELLED->value, $second->raw['order']['status']);
+        self::assertEqualsWithDelta(0.4, $second->raw['order']['order']['filled_quantity'], 0.000001);
+        self::assertCount(1, $this->stopLossOrders($this->adapter));
+        self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertEqualsWithDelta(0.4, $this->adapter->getOpenPositions('BTCUSDT')[0]->size, 0.000001);
+    }
+
     public function testBitmartMarketEntryWithoutSeparateProtectionIsRejectedBeforeSubmit(): void
     {
         $adapter = new BitmartMarketRejectAdapter();
@@ -391,6 +452,8 @@ YAML);
     private function plan(
         string $orderType,
         float $entry = 25000.0,
+        float $stop = 24800.0,
+        float $takeProfit = 25200.0,
         int $orderMode = 1,
         ?ExchangeContext $exchangeContext = null,
         int $size = 1,
@@ -405,8 +468,8 @@ YAML);
             openType: 'isolated',
             orderMode: $orderMode,
             entry: $entry,
-            stop: 24800.0,
-            takeProfit: 25200.0,
+            stop: $stop,
+            takeProfit: $takeProfit,
             size: $size,
             leverage: $leverage,
             pricePrecision: 2,


### PR DESCRIPTION
Refs #88

Summary:
- replay FakeExchange clientOrderId matches even after a filled terminal order, preserving terminal failures without creating a second entry
- add shared contract coverage for filled clientOrderId replay on immediate-fill adapters
- add ExchangeExecutionService coverage for the same decision key replaying a filled entry without duplicating position or stop protection

Tests:
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check
- git diff --cached --check