### PR TITLE
[API-10] Add position lifecycle contract coverage

### DIFF
--- a/trading-app/docs/API_FIRST_RUNBOOK.md
+++ b/trading-app/docs/API_FIRST_RUNBOOK.md
@@ -34,6 +34,10 @@ avec `OrderPlanModel::exchangeContext`.
 - identite exchange/marketType et coherence des capabilities;
 - placement, listing, lookup et cancel d'un limit order;
 - fill market local et creation de position quand l'adapter le permet;
+- partial fill local et mise a jour de la position quand l'adapter expose un
+  hook de fill deterministe;
+- close reduce-only local et disparition de la position quand l'adapter execute
+  les market orders immediatement;
 - idempotence par `clientOrderId`, y compris replay d'un ordre deja fill;
 - placement, listing et cancel d'un stop reduce-only separe quand
   `supportsTriggerOrders=true`;

--- a/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
+++ b/trading-app/tests/Exchange/Contract/ExchangeAdapterContractTestCase.php
@@ -41,6 +41,16 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         return false;
     }
 
+    protected function supportsLocalFillHook(): bool
+    {
+        return false;
+    }
+
+    protected function fillOrderForContract(string $exchangeOrderId, ?float $quantity = null, ?float $price = null): ?ExchangeOrderDto
+    {
+        return null;
+    }
+
     protected function snapshotClientOrderId(string $clientOrderId): string
     {
         return $clientOrderId;
@@ -124,6 +134,75 @@ abstract class ExchangeAdapterContractTestCase extends TestCase
         self::assertCount(1, $positions);
         self::assertSame(ExchangePositionSide::LONG, $positions[0]->side);
         self::assertGreaterThan(0.0, $positions[0]->size);
+    }
+
+    public function testPartialFillUpdatesPositionWhenAdapterExposesLocalFillHook(): void
+    {
+        if (!$this->supportsLocalFillHook()) {
+            self::markTestSkipped('Adapter does not expose a local fill hook for contract tests.');
+        }
+
+        $adapter = $this->adapter();
+        $placed = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $this->clientOrderId('partial-position'),
+            orderType: ExchangeOrderType::LIMIT,
+            price: $this->restingLimitPrice(),
+            postOnly: true,
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+
+        $partial = $this->fillOrderForContract($placed->exchangeOrderId, 0.4, $this->restingLimitPrice());
+
+        self::assertSame(ExchangeOrderStatus::PARTIALLY_FILLED, $partial?->status);
+        self::assertEqualsWithDelta(0.4, $partial?->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $partial?->remainingQuantity, 0.000001);
+
+        $positions = $adapter->getOpenPositions($this->symbol());
+        self::assertCount(1, $positions);
+        self::assertSame(ExchangePositionSide::LONG, $positions[0]->side);
+        self::assertEqualsWithDelta(0.4, $positions[0]->size, 0.000001);
+
+        $filled = $this->fillOrderForContract($placed->exchangeOrderId, null, $this->restingLimitPrice());
+        self::assertSame(ExchangeOrderStatus::FILLED, $filled?->status);
+        $filledPositions = $adapter->getOpenPositions($this->symbol());
+        self::assertCount(1, $filledPositions);
+        self::assertSame(ExchangePositionSide::LONG, $filledPositions[0]->side);
+        self::assertEqualsWithDelta(1.0, $filledPositions[0]->size, 0.000001);
+    }
+
+    public function testReduceOnlyMarketOrderClosesPositionWhenAdapterExecutesImmediateFills(): void
+    {
+        $adapter = $this->adapter();
+        if (!$this->marketOrdersFillImmediately()) {
+            self::markTestSkipped('Adapter does not execute immediate fills in local contract tests.');
+        }
+        if (!$adapter->capabilities()->supportsReduceOnly) {
+            self::markTestSkipped('Adapter does not advertise reduce-only orders.');
+        }
+
+        $entry = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $this->clientOrderId('close-entry'),
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+        ));
+        self::assertSame(ExchangeOrderStatus::FILLED, $entry->status);
+        self::assertCount(1, $adapter->getOpenPositions($this->symbol()));
+
+        $close = $adapter->placeOrder($this->placeRequest(
+            clientOrderId: $this->clientOrderId('close-reduce'),
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            side: ExchangeOrderSide::SELL,
+            reduceOnly: true,
+            postOnly: false,
+        ));
+
+        self::assertTrue($close->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $close->status);
+        self::assertTrue($close->order?->reduceOnly);
+        self::assertEqualsWithDelta(1.0, $close->order?->filledQuantity, 0.000001);
+        self::assertCount(0, $adapter->getOpenPositions($this->symbol()));
     }
 
     public function testFilledClientOrderIdReplayDoesNotCreateSecondPositionWhenAdapterExecutesImmediateFills(): void

--- a/trading-app/tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
+++ b/trading-app/tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
@@ -8,8 +8,10 @@ use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Exchange\Adapter\FakeExchangeAdapter;
 use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Dto\ExchangeOrderDto;
 use App\Exchange\Fake\FakeExchangeMatchingEngine;
 use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeScenarioService;
 use App\Exchange\Fake\FakeExchangeStateStore;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Psr\Clock\ClockInterface;
@@ -17,10 +19,13 @@ use Psr\Clock\ClockInterface;
 #[CoversClass(FakeExchangeAdapter::class)]
 #[CoversClass(FakeExchangeMatchingEngine::class)]
 #[CoversClass(FakeExchangeOrderBook::class)]
+#[CoversClass(FakeExchangeScenarioService::class)]
 #[CoversClass(FakeExchangeStateStore::class)]
 final class FakeExchangeAdapterContractTest extends ExchangeAdapterContractTestCase
 {
     private FakeExchangeAdapter $adapter;
+
+    private FakeExchangeScenarioService $scenario;
 
     protected function setUp(): void
     {
@@ -28,6 +33,7 @@ final class FakeExchangeAdapterContractTest extends ExchangeAdapterContractTestC
         $book = new FakeExchangeOrderBook($state);
         $engine = new FakeExchangeMatchingEngine($state, $book, $this->fixedClock());
         $this->adapter = new FakeExchangeAdapter($state, $book, $engine, $this->fixedClock());
+        $this->scenario = new FakeExchangeScenarioService($state, $book, $engine);
     }
 
     protected function adapter(): ExchangeAdapterInterface
@@ -48,6 +54,16 @@ final class FakeExchangeAdapterContractTest extends ExchangeAdapterContractTestC
     protected function marketOrdersFillImmediately(): bool
     {
         return true;
+    }
+
+    protected function supportsLocalFillHook(): bool
+    {
+        return true;
+    }
+
+    protected function fillOrderForContract(string $exchangeOrderId, ?float $quantity = null, ?float $price = null): ?ExchangeOrderDto
+    {
+        return $this->scenario->fillOrder($exchangeOrderId, $quantity, $price);
     }
 
     private function fixedClock(): ClockInterface


### PR DESCRIPTION
Refs #88

Summary:
- adds common adapter contract coverage for partial fills updating local positions when an adapter exposes a deterministic fill hook
- adds common adapter contract coverage for reduce-only market closes when an adapter executes immediate fills locally
- wires the local fill hook for FakeExchange contract tests
- updates the API-first runbook contract-test inventory

Tests:
- php -d error_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit tests/Exchange/Contract/FakeExchangeAdapterContractTest.php
- php -d error_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php tests/Exchange/Contract/HyperliquidExchangeAdapterContractTest.php tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
- php -d error_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting="E_ALL & ~E_DEPRECATED" bin/console lint:container --no-debug
- php -d error_reporting="E_ALL & ~E_DEPRECATED" bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check
- git diff --cached --check