### PR TITLE
[API-09] Add OKX REST client safety coverage

### DIFF
--- a/trading-app/src/Exchange/Okx/README.md
+++ b/trading-app/src/Exchange/Okx/README.md
@@ -27,3 +27,9 @@ OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999
 OKX_DEMO_TRADING_ENABLED=0
 OKX_LIVE_ENABLED=0
 ```
+
+Local safety checks:
+
+```bash
+./vendor/bin/phpunit tests/Exchange/Okx/OkxRestClientTest.php tests/Exchange/Adapter/OkxExchangeAdapterTest.php tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
+```

--- a/trading-app/tests/Exchange/Okx/OkxRestClientTest.php
+++ b/trading-app/tests/Exchange/Okx/OkxRestClientTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Okx;
+
+use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Okx\OkxRestClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+#[CoversClass(OkxRestClient::class)]
+#[CoversClass(OkxConfig::class)]
+final class OkxRestClientTest extends TestCase
+{
+    public function testDemoPrivateGetSignsRequestAndAddsSimulatedTradingHeader(): void
+    {
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            return new MockResponse('{"code":"0","data":[]}');
+        });
+        $client = new OkxRestClient(
+            $http,
+            new OkxConfig(
+                environment: 'demo',
+                apiKey: 'test-key',
+                apiSecret: 'test-secret',
+                apiPassphrase: 'test-passphrase',
+            ),
+            $this->fixedClock(),
+        );
+
+        $client->privateGet('/api/v5/account/balance', ['ccy' => 'USDT']);
+
+        self::assertIsArray($captured);
+        self::assertSame('GET', $captured['method']);
+        self::assertSame('https://www.okx.com/api/v5/account/balance?ccy=USDT', $captured['url']);
+        self::assertSame('test-key', $this->header($captured['options'], 'OK-ACCESS-KEY'));
+        self::assertSame('test-passphrase', $this->header($captured['options'], 'OK-ACCESS-PASSPHRASE'));
+        self::assertSame('2026-01-01T00:00:00.000Z', $this->header($captured['options'], 'OK-ACCESS-TIMESTAMP'));
+        self::assertSame('1', $this->header($captured['options'], 'x-simulated-trading'));
+        self::assertSame(
+            base64_encode(hash_hmac(
+                'sha256',
+                '2026-01-01T00:00:00.000ZGET/api/v5/account/balance?ccy=USDT',
+                'test-secret',
+                true,
+            )),
+            $this->header($captured['options'], 'OK-ACCESS-SIGN'),
+        );
+    }
+
+    public function testDemoPrivatePostRequiresExplicitTradingFlagBeforeHttpCall(): void
+    {
+        $requests = 0;
+        $http = new MockHttpClient(function () use (&$requests): MockResponse {
+            ++$requests;
+
+            return new MockResponse('{"code":"0","data":[]}');
+        });
+        $client = new OkxRestClient(
+            $http,
+            new OkxConfig(
+                environment: 'demo',
+                apiKey: 'test-key',
+                apiSecret: 'test-secret',
+                apiPassphrase: 'test-passphrase',
+            ),
+            $this->fixedClock(),
+        );
+
+        try {
+            $client->privatePost('/api/v5/trade/order', ['instId' => 'BTC-USDT-SWAP']);
+            self::fail('Expected demo trading guard to reject the private POST.');
+        } catch (\RuntimeException $e) {
+            self::assertStringContainsString('demo trading is disabled', $e->getMessage());
+        }
+
+        self::assertSame(0, $requests);
+    }
+
+    public function testDemoPrivatePostSignsBodyAndAddsSimulatedTradingHeaderWhenEnabled(): void
+    {
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = ['method' => $method, 'url' => $url, 'options' => $options];
+
+            return new MockResponse('{"code":"0","data":[]}');
+        });
+        $client = new OkxRestClient(
+            $http,
+            new OkxConfig(
+                environment: 'demo',
+                apiKey: 'test-key',
+                apiSecret: 'test-secret',
+                apiPassphrase: 'test-passphrase',
+                demoTradingEnabled: true,
+            ),
+            $this->fixedClock(),
+        );
+        $body = ['instId' => 'BTC-USDT-SWAP', 'side' => 'buy'];
+
+        $client->privatePost('/api/v5/trade/order', $body);
+
+        self::assertIsArray($captured);
+        self::assertSame('POST', $captured['method']);
+        self::assertSame('https://www.okx.com/api/v5/trade/order', $captured['url']);
+        self::assertSame('{"instId":"BTC-USDT-SWAP","side":"buy"}', $captured['options']['body'] ?? null);
+        self::assertSame('1', $this->header($captured['options'], 'x-simulated-trading'));
+        self::assertSame(
+            base64_encode(hash_hmac(
+                'sha256',
+                '2026-01-01T00:00:00.000ZPOST/api/v5/trade/order{"instId":"BTC-USDT-SWAP","side":"buy"}',
+                'test-secret',
+                true,
+            )),
+            $this->header($captured['options'], 'OK-ACCESS-SIGN'),
+        );
+    }
+
+    public function testLivePrivateGetRequiresExplicitLiveFlagBeforeHttpCall(): void
+    {
+        $requests = 0;
+        $http = new MockHttpClient(function () use (&$requests): MockResponse {
+            ++$requests;
+
+            return new MockResponse('{"code":"0","data":[]}');
+        });
+        $client = new OkxRestClient(
+            $http,
+            new OkxConfig(
+                environment: 'live',
+                apiKey: 'test-key',
+                apiSecret: 'test-secret',
+                apiPassphrase: 'test-passphrase',
+            ),
+            $this->fixedClock(),
+        );
+
+        try {
+            $client->privateGet('/api/v5/account/balance');
+            self::fail('Expected live guard to reject the private GET.');
+        } catch (\RuntimeException $e) {
+            self::assertStringContainsString('live trading is disabled', $e->getMessage());
+        }
+
+        self::assertSame(0, $requests);
+    }
+
+    public function testLivePrivatePostRequiresExplicitLiveFlagBeforeHttpCall(): void
+    {
+        $requests = 0;
+        $http = new MockHttpClient(function () use (&$requests): MockResponse {
+            ++$requests;
+
+            return new MockResponse('{"code":"0","data":[]}');
+        });
+        $client = new OkxRestClient(
+            $http,
+            new OkxConfig(
+                environment: 'live',
+                apiKey: 'test-key',
+                apiSecret: 'test-secret',
+                apiPassphrase: 'test-passphrase',
+            ),
+            $this->fixedClock(),
+        );
+
+        try {
+            $client->privatePost('/api/v5/trade/order', ['instId' => 'BTC-USDT-SWAP']);
+            self::fail('Expected live guard to reject the private POST.');
+        } catch (\RuntimeException $e) {
+            self::assertStringContainsString('live trading is disabled', $e->getMessage());
+        }
+
+        self::assertSame(0, $requests);
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     */
+    private function header(array $options, string $name): ?string
+    {
+        $needle = strtolower($name);
+        foreach (($options['headers'] ?? []) as $key => $value) {
+            if (\is_string($key) && strtolower($key) === $needle) {
+                return \is_array($value) ? (string)($value[0] ?? '') : (string)$value;
+            }
+            if (\is_string($value) && str_starts_with(strtolower($value), $needle . ':')) {
+                return trim(substr($value, strlen($name) + 1));
+            }
+        }
+
+        return null;
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}


### PR DESCRIPTION
Refs #87

Summary:
- adds unit coverage for OKX private REST request signing in demo mode
- verifies demo private GET sends `x-simulated-trading: 1` and deterministic `OK-ACCESS-*` headers
- verifies demo private POST is blocked until `OKX_DEMO_TRADING_ENABLED=1` before any HTTP call
- verifies live private GET is blocked until `OKX_LIVE_ENABLED=1` before any HTTP call
- documents the local OKX safety test command

Tests:
- php -d error_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit tests/Exchange/Okx/OkxRestClientTest.php
- php -d error_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit tests/Exchange/Okx/OkxRestClientTest.php tests/Exchange/Adapter/OkxExchangeAdapterTest.php tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
- php -d error_reporting="E_ALL & ~E_DEPRECATED" ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting="E_ALL & ~E_DEPRECATED" bin/console lint:container --no-debug
- php -d error_reporting="E_ALL & ~E_DEPRECATED" bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check
- git diff --cached --check