### PR TITLE
[API-09] Add OKX protection rejection coverage

### DIFF
--- a/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
@@ -164,7 +164,7 @@ final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, Exc
             ? $this->client->privatePost('/api/v5/trade/order-algo', $this->actions->algoOrder($instId, $request))
             : $this->client->privatePost('/api/v5/trade/order', $this->actions->order($instId, $request));
         $status = $this->responseStatus($response);
-        $exchangeOrderId = $this->responseOrderId($response, $isAlgo) ?? $request->clientOrderId;
+        $responseOrderId = $this->responseOrderId($response, $isAlgo);
         $accepted = $status !== ExchangeOrderStatus::REJECTED;
         if (!$accepted) {
             $existing = $this->findOpenOrderByClientOrderId($request->symbol, $this->actions->clientOrderId($request->clientOrderId));
@@ -184,6 +184,7 @@ final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, Exc
                 );
             }
         }
+        $exchangeOrderId = $accepted ? ($responseOrderId ?? $request->clientOrderId) : null;
 
         return new PlaceOrderResult(
             accepted: $accepted,
@@ -196,7 +197,7 @@ final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, Exc
                 exchange: $this->exchange(),
                 marketType: $this->marketType(),
                 symbol: strtoupper($request->symbol),
-                exchangeOrderId: $exchangeOrderId,
+                exchangeOrderId: $exchangeOrderId ?? $request->clientOrderId,
                 clientOrderId: $request->clientOrderId,
                 side: $request->side,
                 positionSide: $request->positionSide,

--- a/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
@@ -87,6 +87,25 @@ final class OkxExchangeAdapterTest extends TestCase
         self::assertEqualsWithDelta(24800.0, $stopOrders[0]->stopPrice, 0.000001);
     }
 
+    public function testRejectedStopLossAlgoDoesNotExposeConfirmedExchangeOrderId(): void
+    {
+        $client = new FakeOkxClient();
+        $client->rejectNextAlgoOrder = true;
+        $adapter = $this->adapter($client);
+
+        $result = $adapter->placeOrder($this->stopLossRequest());
+
+        self::assertFalse($result->accepted);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $result->order?->status);
+        self::assertSame('cid-okx-sl', $result->order?->exchangeOrderId);
+        self::assertSame('/api/v5/trade/order-algo', $client->lastPostPath);
+        self::assertSame('true', $client->lastPostBody['reduceOnly'] ?? null);
+        self::assertSame('51008', $result->metadata['data'][0]['sCode'] ?? null);
+        self::assertSame('insufficient margin for protection', $result->metadata['data'][0]['sMsg'] ?? null);
+    }
+
     public function testMapsRestSnapshots(): void
     {
         $adapter = $this->adapter();
@@ -250,6 +269,8 @@ final class FakeOkxClient implements OkxRestClientInterface
 {
     public ?string $lastPostPath = null;
 
+    public bool $rejectNextAlgoOrder = false;
+
     /** @var array<mixed> */
     public array $lastPostBody = [];
 
@@ -349,12 +370,31 @@ final class FakeOkxClient implements OkxRestClientInterface
                 'clOrdId' => (string)($body['clOrdId'] ?? ''),
                 'sCode' => '0',
             ]]],
-            '/api/v5/trade/order-algo' => ['code' => '0', 'data' => [[
-                'algoId' => '90001',
-                'algoClOrdId' => (string)($body['algoClOrdId'] ?? ''),
-                'sCode' => '0',
-            ]]],
+            '/api/v5/trade/order-algo' => $this->algoOrderResponse($body),
             default => ['code' => '0', 'data' => [['sCode' => '0']]],
         };
+    }
+
+    /**
+     * @param array<string,mixed> $body
+     * @return array<string,mixed>
+     */
+    private function algoOrderResponse(array $body): array
+    {
+        if ($this->rejectNextAlgoOrder) {
+            $this->rejectNextAlgoOrder = false;
+
+            return ['code' => '0', 'data' => [[
+                'algoClOrdId' => (string)($body['algoClOrdId'] ?? ''),
+                'sCode' => '51008',
+                'sMsg' => 'insufficient margin for protection',
+            ]]];
+        }
+
+        return ['code' => '0', 'data' => [[
+            'algoId' => '90001',
+            'algoClOrdId' => (string)($body['algoClOrdId'] ?? ''),
+            'sCode' => '0',
+        ]]];
     }
 }


### PR DESCRIPTION
## Summary
- keep rejected OKX order/algo responses from exposing a confirmed exchangeOrderId when OKX returns no ordId/algoId
- add adapter coverage for rejected reduce-only stop-loss algo submissions
- keep the local rejected order payload available for diagnostics while the public submit result stays rejected

Refs #87

## Tests
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Adapter/OkxExchangeAdapterTest.php tests/Exchange/Contract/OkxExchangeAdapterContractTest.php tests/Exchange/Okx
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check
- git diff --cached --check