### PR TITLE
[API-08] Guard Hyperliquid private WS capability

### DIFF
--- a/trading-app/src/Exchange/Adapter/HyperliquidExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/HyperliquidExchangeAdapter.php
@@ -59,7 +59,7 @@ final readonly class HyperliquidExchangeAdapter implements ExchangeAdapterInterf
     {
         return new ExchangeCapabilities(
             supportsTestnet: true,
-            supportsWebSocketPrivate: true,
+            supportsWebSocketPrivate: false,
             supportsClientOrderId: true,
             supportsCancelByClientOrderId: true,
             supportsPostOnly: true,

--- a/trading-app/src/Exchange/Hyperliquid/README.md
+++ b/trading-app/src/Exchange/Hyperliquid/README.md
@@ -11,6 +11,7 @@ First API-first Hyperliquid integration slice.
 - Trading actions are built in official `/exchange` wire format (`order`, `cancel`, `cancelByCloid`, `updateLeverage`).
 - Market orders are sent as IOC limit orders with a 5% slippage cap derived from the current L2 top. Stop-loss/take-profit trigger market orders use the same 5% cap around `stopPrice`.
 - Internal app client order IDs are deterministically mapped to Hyperliquid Cloid values (`0x` + 128-bit hex) before they reach `/exchange`.
+- Private WebSocket support is not advertised yet; keep reconciliation on REST snapshots until a Hyperliquid WS client and normalizer are added.
 - Live signing is intentionally not enabled by the default REST client. Inject a signed `HyperliquidRestClientInterface` implementation before sending real testnet orders.
 
 Environment:

--- a/trading-app/tests/Exchange/Adapter/HyperliquidExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/HyperliquidExchangeAdapterTest.php
@@ -33,6 +33,7 @@ final class HyperliquidExchangeAdapterTest extends TestCase
         $capabilities = $this->adapter()->capabilities();
 
         self::assertTrue($capabilities->supportsTestnet);
+        self::assertFalse($capabilities->supportsWebSocketPrivate);
         self::assertTrue($capabilities->supportsClientOrderId);
         self::assertTrue($capabilities->supportsCancelByClientOrderId);
         self::assertFalse($capabilities->supportsAttachedStopLossOnEntry);


### PR DESCRIPTION
## Summary
- stop advertising Hyperliquid private WebSocket support until a real WS client/normalizer exists
- lock the capability in adapter tests
- document REST snapshot reconciliation as the current Hyperliquid path

Refs #86

## Tests
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Adapter/HyperliquidExchangeAdapterTest.php tests/Exchange/Contract/HyperliquidExchangeAdapterContractTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check
- git diff --cached --check