### PR TITLE
[API-09] Add OKX private event normalizer

### DIFF
--- a/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/OkxExchangeAdapter.php
@@ -25,6 +25,7 @@ use App\Exchange\Enum\ExchangePositionSide;
 use App\Exchange\Enum\ExchangeTimeInForce;
 use App\Exchange\Okx\OkxActionFactory;
 use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Okx\OkxFillId;
 use App\Exchange\Okx\OkxInstrumentResolver;
 use App\Exchange\Okx\OkxRestClientInterface;
 use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
@@ -358,7 +359,7 @@ final readonly class OkxExchangeAdapter implements ExchangeAdapterInterface, Exc
                 symbol: $this->instruments->symbol((string)($row['instId'] ?? '')),
                 exchangeOrderId: (string)($row['ordId'] ?? ''),
                 clientOrderId: isset($row['clOrdId']) ? (string) $row['clOrdId'] : null,
-                fillId: isset($row['tradeId']) ? (string) $row['tradeId'] : null,
+                fillId: OkxFillId::fromTradeId($row['instId'] ?? '', $row['tradeId'] ?? null),
                 side: $this->orderSide($row['side'] ?? null),
                 positionSide: $this->nullablePositionSide($row['posSide'] ?? null),
                 quantity: $this->float($row['fillSz'] ?? null),

--- a/trading-app/src/Exchange/Okx/OkxExchangeEventNormalizer.php
+++ b/trading-app/src/Exchange/Okx/OkxExchangeEventNormalizer.php
@@ -1,0 +1,646 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Okx;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Event\ExchangeEventInterface;
+use App\Exchange\Event\ExchangeEventNormalizerInterface;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Exchange\Event\ExchangeOrderCancelled;
+use App\Exchange\Event\ExchangeOrderCreated;
+use App\Exchange\Event\ExchangeOrderFilled;
+use App\Exchange\Event\ExchangeOrderPartiallyFilled;
+use App\Exchange\Event\ExchangeOrderRejected;
+use App\Exchange\Event\ExchangeOrderUpdated;
+use App\Exchange\Event\ExchangePositionClosed;
+use App\Exchange\Event\ExchangePositionUpdated;
+use App\Exchange\Event\ExchangeProtectionOrderCreated;
+use App\Exchange\Event\ExchangeProtectionOrderRejected;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.exchange_event_normalizer')]
+final readonly class OkxExchangeEventNormalizer implements ExchangeEventNormalizerInterface
+{
+    public function __construct(
+        private OkxInstrumentResolver $instruments,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function supports(mixed $event): bool
+    {
+        if (!\is_array($event) || !\is_array($event['data'] ?? null)) {
+            return false;
+        }
+
+        return $this->isSwapEvent($event)
+            && \in_array($this->channel($event), ['orders', 'orders-algo', 'fills', 'positions'], true);
+    }
+
+    /**
+     * @return ExchangeEventInterface[]
+     */
+    public function normalize(mixed $event): array
+    {
+        if (!$this->supports($event)) {
+            return [];
+        }
+
+        /** @var array<string,mixed> $event */
+        $normalized = [];
+        $channel = $this->channel($event);
+        foreach ($this->dataRows($event) as $row) {
+            array_push($normalized, ...match ($channel) {
+                'orders', 'orders-algo' => $this->orderEvents($row, $channel),
+                'fills' => $this->fillEvents($row),
+                'positions' => $this->positionEvents($row),
+                default => [],
+            });
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return ExchangeEventInterface[]
+     */
+    private function orderEvents(array $row, string $channel): array
+    {
+        $preferAlgoId = $channel === 'orders-algo';
+        $order = $this->orderFromRow($row, $preferAlgoId);
+        if (!$order instanceof ExchangeOrderDto) {
+            return [];
+        }
+
+        $occurredAt = $this->time($row['uTime'] ?? $row['fillTime'] ?? $row['cTime'] ?? null);
+        $events = match ($order->status) {
+            ExchangeOrderStatus::OPEN, ExchangeOrderStatus::PENDING => [
+                $this->isProtectionOrder($order, $row)
+                    ? new ExchangeProtectionOrderCreated($order, $occurredAt, $row)
+                    : new ExchangeOrderCreated($order, $occurredAt, $row),
+            ],
+            ExchangeOrderStatus::PARTIALLY_FILLED => [
+                new ExchangeOrderPartiallyFilled($order, $occurredAt, $row),
+            ],
+            ExchangeOrderStatus::FILLED => [
+                new ExchangeOrderFilled($order, $occurredAt, $row),
+            ],
+            ExchangeOrderStatus::CANCELLED, ExchangeOrderStatus::EXPIRED => [
+                new ExchangeOrderCancelled($order, $occurredAt, $row),
+            ],
+            ExchangeOrderStatus::REJECTED => [
+                $this->isProtectionOrder($order, $row)
+                    ? new ExchangeProtectionOrderRejected($order, $occurredAt, $row)
+                    : new ExchangeOrderRejected($order, $occurredAt, $row),
+            ],
+            default => [
+                new ExchangeOrderUpdated($order, $occurredAt, $row),
+            ],
+        };
+
+        $fill = $this->fillFromRow($row, 'okx_ws_orders', $preferAlgoId);
+        if ($fill instanceof ExchangeFillDto) {
+            $events[] = new ExchangeFillReceived($fill, $row);
+        }
+
+        return $events;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return ExchangeEventInterface[]
+     */
+    private function fillEvents(array $row): array
+    {
+        $fill = $this->fillFromRow($row, 'okx_ws_fills');
+
+        return $fill instanceof ExchangeFillDto ? [new ExchangeFillReceived($fill, $row)] : [];
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return ExchangeEventInterface[]
+     */
+    private function positionEvents(array $row): array
+    {
+        if ($this->isNetModeZeroPosition($row)) {
+            $symbol = $this->symbol($row);
+            if ($symbol === null) {
+                return [];
+            }
+
+            $occurredAt = $this->time($row['uTime'] ?? null);
+
+            return [
+                $this->positionClosedEvent($symbol, ExchangePositionSide::LONG, $occurredAt, $row),
+                $this->positionClosedEvent($symbol, ExchangePositionSide::SHORT, $occurredAt, $row),
+            ];
+        }
+
+        $position = $this->positionFromRow($row);
+        if (!$position instanceof ExchangePositionDto) {
+            return [];
+        }
+
+        $occurredAt = $position->updatedAt ?? $this->clock->now();
+        if ($position->size <= 0.00000001) {
+            return [$this->positionClosedEvent($position->symbol, $position->side, $occurredAt, $row)];
+        }
+
+        return [new ExchangePositionUpdated(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: $position->symbol,
+            side: $position->side,
+            size: $position->size,
+            position: $position,
+            occurredAt: $occurredAt,
+            payload: $row,
+        )];
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderFromRow(array $row, bool $preferAlgoId): ?ExchangeOrderDto
+    {
+        if (!$this->isSwapRow($row)) {
+            return null;
+        }
+
+        $symbol = $this->symbol($row);
+        if ($symbol === null) {
+            return null;
+        }
+
+        $exchangeOrderId = $this->orderId($row, $preferAlgoId);
+        $clientOrderId = $this->clientOrderId($row, $preferAlgoId);
+        if ($exchangeOrderId === '' && ($clientOrderId === null || $clientOrderId === '')) {
+            return null;
+        }
+
+        $status = $this->orderStatus($row['state'] ?? null);
+        $quantity = $this->float($row['sz'] ?? null);
+        $filled = $this->orderFilledQuantity($row, $quantity, $status);
+        $orderType = $this->orderType($row);
+        $reduceOnly = $this->bool($row['reduceOnly'] ?? false);
+
+        return new ExchangeOrderDto(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            exchangeOrderId: $exchangeOrderId !== '' ? $exchangeOrderId : (string) $clientOrderId,
+            clientOrderId: $clientOrderId,
+            side: $this->orderSide($row['side'] ?? null),
+            positionSide: $this->nullablePositionSide($row['posSide'] ?? null, $row['side'] ?? null, $reduceOnly),
+            orderType: $orderType,
+            status: $status,
+            quantity: $quantity,
+            filledQuantity: $filled,
+            remainingQuantity: max(0.0, $quantity - $filled),
+            price: $this->orderPrice($row, $orderType),
+            averagePrice: $this->floatOrNull($row['avgPx'] ?? null),
+            stopPrice: $this->stopPrice($row, $orderType),
+            reduceOnly: $reduceOnly,
+            postOnly: strtolower((string) ($row['ordType'] ?? '')) === 'post_only',
+            timeInForce: $this->timeInForce($row['ordType'] ?? null),
+            createdAt: $this->time($row['cTime'] ?? null),
+            updatedAt: $this->timeOrNull($row['uTime'] ?? null),
+            metadata: ['source' => 'okx_ws_orders'] + $row,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function fillFromRow(array $row, string $source, bool $preferAlgoId = false): ?ExchangeFillDto
+    {
+        if (!$this->isSwapRow($row)) {
+            return null;
+        }
+
+        $symbol = $this->symbol($row);
+        $quantity = $this->fillQuantity($row);
+        $price = $this->fillPrice($row);
+        $exchangeOrderId = $this->orderId($row, $preferAlgoId);
+        $fillId = OkxFillId::fromTradeId($row['instId'] ?? '', $row['tradeId'] ?? null);
+        if ($symbol === null || $fillId === null || $quantity <= 0.0 || $price <= 0.0 || $exchangeOrderId === '') {
+            return null;
+        }
+
+        $filledAt = $this->time($row['fillTime'] ?? $row['ts'] ?? $row['uTime'] ?? null);
+        $fee = $this->hasValue($row['fillFee'] ?? null) ? $row['fillFee'] : ($row['fee'] ?? null);
+        $feeCurrency = $this->hasValue($row['fillFeeCcy'] ?? null)
+            ? (string) $row['fillFeeCcy']
+            : ($this->hasValue($row['feeCcy'] ?? null) ? (string) $row['feeCcy'] : null);
+        $reduceOnly = $this->bool($row['reduceOnly'] ?? false);
+
+        return new ExchangeFillDto(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            exchangeOrderId: $exchangeOrderId,
+            clientOrderId: $this->clientOrderId($row, $preferAlgoId),
+            fillId: $fillId,
+            side: $this->orderSide($row['side'] ?? null),
+            positionSide: $this->nullablePositionSide($row['posSide'] ?? null, $row['side'] ?? null, $reduceOnly),
+            quantity: $quantity,
+            price: $price,
+            fee: $this->floatOrNull($fee),
+            feeCurrency: $feeCurrency,
+            filledAt: $filledAt,
+            metadata: ['source' => $source] + $row,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function positionFromRow(array $row): ?ExchangePositionDto
+    {
+        if (!$this->isSwapRow($row)) {
+            return null;
+        }
+
+        $symbol = $this->symbol($row);
+        if ($symbol === null) {
+            return null;
+        }
+
+        $size = $this->float($row['pos'] ?? null);
+        $side = $this->positionSide($row['posSide'] ?? null, $size);
+        if (!$side instanceof ExchangePositionSide) {
+            return null;
+        }
+
+        return new ExchangePositionDto(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            side: $side,
+            size: abs($size),
+            entryPrice: $this->float($row['avgPx'] ?? null),
+            markPrice: $this->floatOrNull($row['markPx'] ?? null),
+            unrealizedPnl: $this->floatOrNull($row['upl'] ?? null),
+            realizedPnl: $this->floatOrNull($row['realizedPnl'] ?? null),
+            margin: $this->floatOrNull($row['margin'] ?? $row['imr'] ?? null),
+            leverage: $this->floatOrNull($row['lever'] ?? null),
+            updatedAt: $this->timeOrNull($row['uTime'] ?? null),
+            metadata: ['source' => 'okx_ws_positions'] + $row,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function isProtectionOrder(ExchangeOrderDto $order, array $row): bool
+    {
+        if (\in_array($order->orderType, [ExchangeOrderType::STOP_LOSS, ExchangeOrderType::TAKE_PROFIT], true)) {
+            return true;
+        }
+        if ($order->orderType === ExchangeOrderType::TRIGGER && $order->reduceOnly) {
+            return true;
+        }
+
+        return strtolower((string) ($row['ordType'] ?? '')) === 'conditional';
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderType(array $row): ExchangeOrderType
+    {
+        if ($this->hasValue($row['tpTriggerPx'] ?? null)) {
+            return ExchangeOrderType::TAKE_PROFIT;
+        }
+        if ($this->hasValue($row['slTriggerPx'] ?? null)) {
+            return ExchangeOrderType::STOP_LOSS;
+        }
+        if (strtolower((string) ($row['ordType'] ?? '')) === 'conditional') {
+            return ExchangeOrderType::TRIGGER;
+        }
+        if (strtolower((string) ($row['ordType'] ?? '')) === 'trigger') {
+            return ExchangeOrderType::TRIGGER;
+        }
+
+        if (strtolower((string) ($row['ordType'] ?? '')) === 'optimal_limit_ioc') {
+            return ExchangeOrderType::MARKET;
+        }
+
+        return strtolower((string) ($row['ordType'] ?? '')) === 'market'
+            ? ExchangeOrderType::MARKET
+            : ExchangeOrderType::LIMIT;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function stopPrice(array $row, ExchangeOrderType $orderType): ?float
+    {
+        if ($orderType === ExchangeOrderType::TAKE_PROFIT) {
+            return $this->floatOrNull($row['tpTriggerPx'] ?? null);
+        }
+        if ($orderType === ExchangeOrderType::STOP_LOSS) {
+            return $this->floatOrNull($row['slTriggerPx'] ?? null);
+        }
+        if ($orderType === ExchangeOrderType::TRIGGER) {
+            return $this->floatOrNull($row['triggerPx'] ?? null);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderPrice(array $row, ExchangeOrderType $orderType): ?float
+    {
+        $candidate = match ($orderType) {
+            ExchangeOrderType::TAKE_PROFIT => $row['tpOrdPx'] ?? null,
+            ExchangeOrderType::STOP_LOSS => $row['slOrdPx'] ?? null,
+            ExchangeOrderType::TRIGGER => $row['ordPx'] ?? null,
+            default => $row['px'] ?? null,
+        };
+
+        $price = $this->floatOrNull($candidate);
+        if ($price !== null && $price > 0.0) {
+            return $price;
+        }
+
+        return $this->floatOrNull($row['px'] ?? null);
+    }
+
+    private function orderSide(mixed $side): ExchangeOrderSide
+    {
+        return strtolower((string) $side) === 'sell' ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY;
+    }
+
+    private function nullablePositionSide(
+        mixed $side,
+        mixed $orderSide = null,
+        bool $reduceOnly = false,
+    ): ?ExchangePositionSide
+    {
+        $positionSide = strtolower((string) $side);
+        if ($positionSide === 'long') {
+            return ExchangePositionSide::LONG;
+        }
+        if ($positionSide === 'short') {
+            return ExchangePositionSide::SHORT;
+        }
+        if ($positionSide !== 'net') {
+            return null;
+        }
+
+        $isSell = strtolower((string) $orderSide) === 'sell';
+        if ($reduceOnly) {
+            return $isSell ? ExchangePositionSide::LONG : ExchangePositionSide::SHORT;
+        }
+
+        return null;
+    }
+
+    private function positionSide(mixed $side, float $size): ?ExchangePositionSide
+    {
+        return match (strtolower((string) $side)) {
+            'short' => ExchangePositionSide::SHORT,
+            'long' => ExchangePositionSide::LONG,
+            default => $size < -0.00000001
+                ? ExchangePositionSide::SHORT
+                : ($size > 0.00000001 ? ExchangePositionSide::LONG : null),
+        };
+    }
+
+    private function timeInForce(mixed $ordType): ExchangeTimeInForce
+    {
+        return match (strtolower((string) $ordType)) {
+            'ioc', 'optimal_limit_ioc' => ExchangeTimeInForce::IOC,
+            'fok' => ExchangeTimeInForce::FOK,
+            default => ExchangeTimeInForce::GTC,
+        };
+    }
+
+    private function orderStatus(mixed $state): ExchangeOrderStatus
+    {
+        return match (strtolower((string) $state)) {
+            'filled' => ExchangeOrderStatus::FILLED,
+            'partially_filled' => ExchangeOrderStatus::PARTIALLY_FILLED,
+            'canceled', 'cancelled', 'mmp_canceled' => ExchangeOrderStatus::CANCELLED,
+            'rejected', 'order_failed', 'partially_failed' => ExchangeOrderStatus::REJECTED,
+            'effective', 'partially_effective' => ExchangeOrderStatus::UNKNOWN,
+            'live' => ExchangeOrderStatus::OPEN,
+            default => ExchangeOrderStatus::PENDING,
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderId(array $row, bool $preferAlgoId = false): string
+    {
+        if ($preferAlgoId && $this->hasValue($row['algoId'] ?? null)) {
+            return 'algo:' . (string) $row['algoId'];
+        }
+        if ($this->hasValue($row['ordId'] ?? null)) {
+            return (string) $row['ordId'];
+        }
+        if ($this->hasValue($row['algoId'] ?? null)) {
+            return 'algo:' . (string) $row['algoId'];
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function clientOrderId(array $row, bool $preferAlgoId = false): ?string
+    {
+        if ($preferAlgoId && $this->hasValue($row['algoClOrdId'] ?? null)) {
+            return (string) $row['algoClOrdId'];
+        }
+        if ($this->hasValue($row['clOrdId'] ?? null)) {
+            return (string) $row['clOrdId'];
+        }
+        if ($this->hasValue($row['algoClOrdId'] ?? null)) {
+            return (string) $row['algoClOrdId'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function symbol(array $row): ?string
+    {
+        if (!$this->hasValue($row['instId'] ?? null)) {
+            return null;
+        }
+
+        return $this->instruments->symbol((string) $row['instId']);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function isSwapRow(array $row): bool
+    {
+        if (isset($row['instType'])) {
+            return strtoupper((string) $row['instType']) === 'SWAP';
+        }
+
+        return $this->hasValue($row['instId'] ?? null)
+            && str_ends_with(strtoupper((string) $row['instId']), '-SWAP');
+    }
+
+    /**
+     * @param array<string,mixed> $event
+     */
+    private function isSwapEvent(array $event): bool
+    {
+        if (!\is_array($event['arg'] ?? null) || !isset($event['arg']['instType'])) {
+            return true;
+        }
+
+        return \in_array(strtoupper((string) $event['arg']['instType']), ['SWAP', 'ANY'], true);
+    }
+
+    /**
+     * @param array<string,mixed> $event
+     * @return list<array<string,mixed>>
+     */
+    private function dataRows(array $event): array
+    {
+        $data = $event['data'] ?? [];
+        if (!\is_array($data)) {
+            return [];
+        }
+
+        return array_values(array_filter($data, \is_array(...)));
+    }
+
+    /**
+     * @param array<string,mixed> $event
+     */
+    private function channel(array $event): string
+    {
+        return \is_array($event['arg'] ?? null) ? (string) ($event['arg']['channel'] ?? '') : '';
+    }
+
+    private function time(mixed $milliseconds): \DateTimeImmutable
+    {
+        return $this->timeOrNull($milliseconds) ?? $this->clock->now();
+    }
+
+    private function timeOrNull(mixed $milliseconds): ?\DateTimeImmutable
+    {
+        if (!is_numeric($milliseconds)) {
+            return null;
+        }
+
+        $milliseconds = (int) floor((float) $milliseconds);
+        $seconds = intdiv($milliseconds, 1000);
+        $microseconds = ($milliseconds % 1000) * 1000;
+        $time = \DateTimeImmutable::createFromFormat(
+            'U.u',
+            sprintf('%d.%06d', $seconds, $microseconds),
+            new \DateTimeZone('UTC'),
+        );
+
+        return $time instanceof \DateTimeImmutable ? $time->setTimezone(new \DateTimeZone('UTC')) : null;
+    }
+
+    private function bool(mixed $value): bool
+    {
+        return \filter_var($value, \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE) ?? (bool) $value;
+    }
+
+    private function float(mixed $value): float
+    {
+        return is_numeric($value) ? (float) $value : 0.0;
+    }
+
+    private function floatOrNull(mixed $value): ?float
+    {
+        return is_numeric($value) ? (float) $value : null;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function fillQuantity(array $row): float
+    {
+        return $this->float($row['fillSz'] ?? null);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function fillPrice(array $row): float
+    {
+        return $this->float($row['fillPx'] ?? null);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderFilledQuantity(array $row, float $quantity, ExchangeOrderStatus $status): float
+    {
+        $filled = $this->float($row['accFillSz'] ?? null);
+        if ($filled > 0.0 || $status !== ExchangeOrderStatus::FILLED) {
+            return $filled;
+        }
+
+        return $quantity;
+    }
+
+    private function hasValue(mixed $value): bool
+    {
+        return trim((string) $value) !== '';
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function isNetModeZeroPosition(array $row): bool
+    {
+        return strtolower((string) ($row['posSide'] ?? '')) === 'net'
+            && abs($this->float($row['pos'] ?? null)) <= 0.00000001;
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    private function positionClosedEvent(
+        string $symbol,
+        ExchangePositionSide $side,
+        \DateTimeImmutable $occurredAt,
+        array $payload,
+    ): ExchangePositionClosed {
+        return new ExchangePositionClosed(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            side: $side,
+            size: 0.0,
+            position: null,
+            occurredAt: $occurredAt,
+            payload: $payload,
+        );
+    }
+
+}

--- a/trading-app/src/Exchange/Okx/OkxFillId.php
+++ b/trading-app/src/Exchange/Okx/OkxFillId.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Okx;
+
+final class OkxFillId
+{
+    public static function fromTradeId(mixed $instId, mixed $tradeId): ?string
+    {
+        $tradeId = trim((string) $tradeId);
+        if ($tradeId === '') {
+            return null;
+        }
+
+        return 'okx-fill-' . substr(hash('sha256', strtoupper(trim((string) $instId)) . ':' . $tradeId), 0, 32);
+    }
+}

--- a/trading-app/src/Exchange/Okx/README.md
+++ b/trading-app/src/Exchange/Okx/README.md
@@ -12,7 +12,7 @@ API-first OKX demo integration slice for SWAP instruments.
 - REST private calls are signed with `OK-ACCESS-*` headers. Demo calls include `x-simulated-trading: 1`.
 - Internal symbols are normalized as SWAP instruments, for example `BTCUSDT` to `BTC-USDT-SWAP`.
 - Entry orders use `/api/v5/trade/order`; standalone stop-loss/take-profit protection uses `/api/v5/trade/order-algo` conditional orders.
-- WebSocket private ingestion is intentionally not implemented in this slice.
+- WebSocket private payload normalization is available for `orders`, `fills`, and `positions` messages. A real OKX private WS client is not implemented yet, so the adapter still does not advertise private WS support.
 
 Environment:
 

--- a/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/OkxExchangeAdapterTest.php
@@ -16,6 +16,7 @@ use App\Exchange\Enum\ExchangePositionSide;
 use App\Exchange\Enum\ExchangeTimeInForce;
 use App\Exchange\Okx\OkxActionFactory;
 use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Okx\OkxFillId;
 use App\Exchange\Okx\OkxInstrumentResolver;
 use App\Exchange\Okx\OkxRestClientInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -26,6 +27,7 @@ use Psr\Clock\ClockInterface;
 #[CoversClass(OkxActionFactory::class)]
 #[CoversClass(OkxInstrumentResolver::class)]
 #[CoversClass(OkxConfig::class)]
+#[CoversClass(OkxFillId::class)]
 final class OkxExchangeAdapterTest extends TestCase
 {
     public function testCapabilitiesAdvertiseDemoAndProtectionBoundaries(): void
@@ -123,7 +125,7 @@ final class OkxExchangeAdapterTest extends TestCase
         self::assertSame(ExchangePositionSide::LONG, $positions[0]->side);
         self::assertSame(0.2, $positions[0]->size);
         self::assertCount(1, $fills);
-        self::assertSame('fill-1', $fills[0]->fillId);
+        self::assertSame(OkxFillId::fromTradeId('BTC-USDT-SWAP', 'fill-1'), $fills[0]->fillId);
         self::assertSame(ExchangeOrderSide::BUY, $fills[0]->side);
     }
 

--- a/trading-app/tests/Exchange/Okx/OkxExchangeEventNormalizerTest.php
+++ b/trading-app/tests/Exchange/Okx/OkxExchangeEventNormalizerTest.php
@@ -1,0 +1,896 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Okx;
+
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Exchange\Event\ExchangeOrderCancelled;
+use App\Exchange\Event\ExchangeOrderCreated;
+use App\Exchange\Event\ExchangeOrderFilled;
+use App\Exchange\Event\ExchangeOrderPartiallyFilled;
+use App\Exchange\Event\ExchangeOrderUpdated;
+use App\Exchange\Event\ExchangePositionClosed;
+use App\Exchange\Event\ExchangePositionUpdated;
+use App\Exchange\Event\ExchangeProtectionOrderCreated;
+use App\Exchange\Event\ExchangeProtectionOrderRejected;
+use App\Exchange\Okx\OkxExchangeEventNormalizer;
+use App\Exchange\Okx\OkxFillId;
+use App\Exchange\Okx\OkxInstrumentResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(OkxExchangeEventNormalizer::class)]
+#[CoversClass(OkxFillId::class)]
+#[CoversClass(OkxInstrumentResolver::class)]
+#[CoversClass(ExchangeOrderCreated::class)]
+#[CoversClass(ExchangeOrderPartiallyFilled::class)]
+#[CoversClass(ExchangeOrderFilled::class)]
+#[CoversClass(ExchangeOrderUpdated::class)]
+#[CoversClass(ExchangeFillReceived::class)]
+#[CoversClass(ExchangeProtectionOrderCreated::class)]
+#[CoversClass(ExchangeProtectionOrderRejected::class)]
+#[CoversClass(ExchangePositionUpdated::class)]
+#[CoversClass(ExchangePositionClosed::class)]
+final class OkxExchangeEventNormalizerTest extends TestCase
+{
+    private OkxExchangeEventNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new OkxExchangeEventNormalizer(new OkxInstrumentResolver(), $this->fixedClock());
+    }
+
+    public function testNormalizesOrderPartialFillIntoOrderAndFillEvents(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '0.2',
+                'avgPx' => '25010',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXENTRY',
+                'fee' => '-0.05',
+                'feeCcy' => 'USDT',
+                'fillFee' => '-0.02',
+                'fillFeeCcy' => 'USDT',
+                'fillPx' => '25010',
+                'fillSz' => '0.2',
+                'fillTime' => '1767225601123',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => '12345',
+                'ordType' => 'limit',
+                'posSide' => 'long',
+                'px' => '25000',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'partially_filled',
+                'sz' => '1',
+                'tradeId' => 'fill-1',
+                'uTime' => '1767225601123',
+            ]],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangeOrderPartiallyFilled::class, $events[0]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[1]);
+        self::assertSame('exchange.order.partially_filled', $events[0]->eventType());
+        self::assertSame('BTCUSDT', $events[0]->order()->symbol);
+        self::assertSame(ExchangeOrderStatus::PARTIALLY_FILLED, $events[0]->order()->status);
+        self::assertEqualsWithDelta(0.2, $events[0]->order()->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.8, $events[0]->order()->remainingQuantity, 0.000001);
+        self::assertSame('1767225601.123000', $events[0]->occurredAt()->format('U.u'));
+        self::assertSame($this->okxFillId('BTC-USDT-SWAP', 'fill-1'), $events[1]->fill()->fillId);
+        self::assertSame(ExchangeOrderSide::BUY, $events[1]->fill()->side);
+        self::assertEqualsWithDelta(25010.0, $events[1]->fill()->price, 0.000001);
+        self::assertEqualsWithDelta(-0.02, $events[1]->fill()->fee, 0.000001);
+        self::assertSame('USDT', $events[1]->fill()->feeCurrency);
+        self::assertSame('1767225601.123000', $events[1]->fill()->filledAt->format('U.u'));
+    }
+
+    public function testNormalizesStopLossAlgoLiveAsProtectionCreated(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            'data' => [[
+                'algoClOrdId' => 'OKXSL',
+                'algoId' => '90001',
+                'cTime' => '1767225600000',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordType' => 'conditional',
+                'posSide' => 'long',
+                'reduceOnly' => 'true',
+                'side' => 'sell',
+                'slOrdPx' => '-1',
+                'slTriggerPx' => '24800',
+                'state' => 'live',
+                'sz' => '0.01',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeProtectionOrderCreated::class, $events[0]);
+        self::assertSame('algo:90001', $events[0]->order()->exchangeOrderId);
+        self::assertSame('OKXSL', $events[0]->order()->clientOrderId);
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $events[0]->order()->orderType);
+        self::assertSame(ExchangePositionSide::LONG, $events[0]->order()->positionSide);
+        self::assertTrue($events[0]->order()->reduceOnly);
+        self::assertEqualsWithDelta(24800.0, $events[0]->order()->stopPrice, 0.000001);
+    }
+
+    public function testNormalizesFailedAlgoOrderAsProtectionRejected(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            'data' => [[
+                'algoClOrdId' => 'OKXSL',
+                'algoId' => '90002',
+                'cTime' => '1767225600000',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordType' => 'conditional',
+                'posSide' => 'long',
+                'reduceOnly' => 'true',
+                'side' => 'sell',
+                'slOrdPx' => '-1',
+                'slTriggerPx' => '24800',
+                'state' => 'order_failed',
+                'sz' => '0.01',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeProtectionOrderRejected::class, $events[0]);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $events[0]->order()->status);
+        self::assertSame('algo:90002', $events[0]->order()->exchangeOrderId);
+    }
+
+    public function testNormalizesPartiallyFailedAlgoOrderAsProtectionRejected(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            'data' => [[
+                'algoClOrdId' => 'OKXSL',
+                'algoId' => '90006',
+                'cTime' => '1767225600000',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordType' => 'conditional',
+                'posSide' => 'long',
+                'reduceOnly' => 'true',
+                'side' => 'sell',
+                'slOrdPx' => '-1',
+                'slTriggerPx' => '24800',
+                'state' => 'partially_failed',
+                'sz' => '0.01',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeProtectionOrderRejected::class, $events[0]);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $events[0]->order()->status);
+        self::assertSame('algo:90006', $events[0]->order()->exchangeOrderId);
+    }
+
+    public function testNormalizesEffectiveAlgoOrderAsTerminalNonFillEvent(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            'data' => [[
+                'algoClOrdId' => 'OKXSL',
+                'algoId' => '90003',
+                'cTime' => '1767225600000',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordType' => 'conditional',
+                'posSide' => 'long',
+                'reduceOnly' => 'true',
+                'side' => 'sell',
+                'slOrdPx' => '-1',
+                'slTriggerPx' => '24800',
+                'state' => 'effective',
+                'sz' => '0.01',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderUpdated::class, $events[0]);
+        self::assertSame(ExchangeOrderStatus::UNKNOWN, $events[0]->order()->status);
+        self::assertSame('algo:90003', $events[0]->order()->exchangeOrderId);
+        self::assertEqualsWithDelta(0.0, $events[0]->order()->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.01, $events[0]->order()->remainingQuantity, 0.000001);
+    }
+
+    public function testNormalizesAlgoLimitExecutionPrice(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            'data' => [[
+                'algoClOrdId' => 'OKXTP',
+                'algoId' => '90007',
+                'cTime' => '1767225600000',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordType' => 'conditional',
+                'posSide' => 'long',
+                'reduceOnly' => 'true',
+                'side' => 'sell',
+                'state' => 'live',
+                'sz' => '0.01',
+                'tpOrdPx' => '25550',
+                'tpTriggerPx' => '25500',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeProtectionOrderCreated::class, $events[0]);
+        self::assertSame(ExchangeOrderType::TAKE_PROFIT, $events[0]->order()->orderType);
+        self::assertEqualsWithDelta(25550.0, $events[0]->order()->price, 0.000001);
+        self::assertEqualsWithDelta(25500.0, $events[0]->order()->stopPrice, 0.000001);
+    }
+
+    public function testNormalizesPartiallyEffectiveAlgoOrderAsUpdate(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            'data' => [[
+                'actualSz' => '0.005',
+                'algoClOrdId' => 'OKXSL',
+                'algoId' => '90005',
+                'cTime' => '1767225600000',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordType' => 'conditional',
+                'posSide' => 'long',
+                'reduceOnly' => 'true',
+                'side' => 'sell',
+                'slOrdPx' => '-1',
+                'slTriggerPx' => '24800',
+                'state' => 'partially_effective',
+                'sz' => '0.01',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderUpdated::class, $events[0]);
+        self::assertSame(ExchangeOrderStatus::UNKNOWN, $events[0]->order()->status);
+        self::assertSame('algo:90005', $events[0]->order()->exchangeOrderId);
+    }
+
+    public function testNormalOrderChannelPrefersChildOrderIdsWhenAlgoFieldsArePresent(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '0.3',
+                'algoClOrdId' => 'PARENT-CID',
+                'algoId' => 'parent-algo',
+                'avgPx' => '25005',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'CHILD-CID',
+                'fillPx' => '25005',
+                'fillSz' => '0.3',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => 'child-order',
+                'ordType' => 'market',
+                'posSide' => 'long',
+                'side' => 'buy',
+                'state' => 'filled',
+                'sz' => '0.3',
+                'tradeId' => 'child-fill',
+                'uTime' => '1767225601123',
+            ]],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[0]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[1]);
+        self::assertSame('child-order', $events[0]->order()->exchangeOrderId);
+        self::assertSame('CHILD-CID', $events[0]->order()->clientOrderId);
+        self::assertSame('child-order', $events[1]->fill()->exchangeOrderId);
+        self::assertSame('CHILD-CID', $events[1]->fill()->clientOrderId);
+    }
+
+    public function testNormalizesTriggerAlgoOrderType(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            'data' => [[
+                'algoClOrdId' => 'OKXTRIGGER',
+                'algoId' => '90004',
+                'cTime' => '1767225600000',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordPx' => '-1',
+                'ordType' => 'trigger',
+                'posSide' => 'short',
+                'reduceOnly' => 'true',
+                'side' => 'buy',
+                'state' => 'live',
+                'sz' => '0.01',
+                'triggerPx' => '25200',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeProtectionOrderCreated::class, $events[0]);
+        self::assertSame('algo:90004', $events[0]->order()->exchangeOrderId);
+        self::assertSame(ExchangeOrderType::TRIGGER, $events[0]->order()->orderType);
+        self::assertSame(ExchangePositionSide::SHORT, $events[0]->order()->positionSide);
+        self::assertEqualsWithDelta(25200.0, $events[0]->order()->stopPrice, 0.000001);
+    }
+
+    public function testNormalizesOptimalLimitIocAsMarketIoc(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '0',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXIOC',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => 'ioc-order',
+                'ordType' => 'optimal_limit_ioc',
+                'posSide' => 'long',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'live',
+                'sz' => '1',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderCreated::class, $events[0]);
+        self::assertSame(ExchangeOrderType::MARKET, $events[0]->order()->orderType);
+        self::assertSame(ExchangeTimeInForce::IOC, $events[0]->order()->timeInForce);
+    }
+
+    public function testCanceledIocWithTradeIdEmitsCancelAndFillEvents(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '0.4',
+                'avgPx' => '25005.5',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXIOC',
+                'fillFee' => '-0.01',
+                'fillFeeCcy' => 'USDT',
+                'fillPx' => '25005.5',
+                'fillSz' => '0.4',
+                'fillTime' => '1767225603123',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => 'ioc-order',
+                'ordType' => 'optimal_limit_ioc',
+                'posSide' => 'long',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'canceled',
+                'sz' => '1',
+                'tradeId' => 'ioc-fill',
+                'uTime' => '1767225604000',
+            ]],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangeOrderCancelled::class, $events[0]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[1]);
+        self::assertEqualsWithDelta(0.4, $events[0]->order()->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $events[0]->order()->remainingQuantity, 0.000001);
+        self::assertSame($this->okxFillId('BTC-USDT-SWAP', 'ioc-fill'), $events[1]->fill()->fillId);
+        self::assertEqualsWithDelta(0.4, $events[1]->fill()->quantity, 0.000001);
+    }
+
+    public function testFilledSwapMarketOrderWithoutTradeIdDoesNotEmitSyntheticFill(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '1',
+                'avgPx' => '25005.5',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXMARKET',
+                'fillPx' => '',
+                'fillSz' => '0',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => '12347',
+                'ordType' => 'market',
+                'posSide' => 'long',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'filled',
+                'sz' => '1',
+                'uTime' => '1767225603000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[0]);
+        self::assertEqualsWithDelta(1.0, $events[0]->order()->filledQuantity, 0.000001);
+    }
+
+    public function testFilledLimitOrderWithoutIncrementalFillDoesNotEmitCumulativeFill(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '1',
+                'avgPx' => '25005.5',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXLIMIT',
+                'fillPx' => '',
+                'fillSz' => '0',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => 'limit-filled-order',
+                'ordType' => 'limit',
+                'posSide' => 'long',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'filled',
+                'sz' => '1',
+                'uTime' => '1767225603000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[0]);
+        self::assertEqualsWithDelta(1.0, $events[0]->order()->filledQuantity, 0.000001);
+    }
+
+    public function testFilledMarketAmendWithoutIncrementalFillDoesNotEmitCumulativeFill(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '1',
+                'avgPx' => '25005.5',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXMARKET',
+                'fillPx' => '',
+                'fillSz' => '0',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => 'market-amend-order',
+                'ordType' => 'market',
+                'posSide' => 'long',
+                'reduceOnly' => 'false',
+                'reqId' => 'amend-1',
+                'side' => 'buy',
+                'state' => 'filled',
+                'sz' => '1',
+                'uTime' => '1767225603000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[0]);
+        self::assertEqualsWithDelta(1.0, $events[0]->order()->filledQuantity, 0.000001);
+    }
+
+    public function testDuplicateFilledSwapMessagesWithoutTradeIdDoNotEmitSyntheticFills(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [
+                [
+                    'accFillSz' => '1',
+                    'avgPx' => '25005.5',
+                    'clOrdId' => 'OKXMARKET',
+                    'fillPx' => '',
+                    'fillSz' => '0',
+                    'instId' => 'BTC-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'ordId' => 'duplicate-filled-order',
+                    'ordType' => 'market',
+                    'posSide' => 'long',
+                    'side' => 'buy',
+                    'state' => 'filled',
+                    'sz' => '1',
+                    'uTime' => '1767225603000',
+                ],
+                [
+                    'accFillSz' => '1',
+                    'avgPx' => '25005.5',
+                    'clOrdId' => 'OKXMARKET',
+                    'fillPx' => '',
+                    'fillSz' => '0',
+                    'instId' => 'BTC-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'ordId' => 'duplicate-filled-order',
+                    'ordType' => 'market',
+                    'posSide' => 'long',
+                    'side' => 'buy',
+                    'state' => 'filled',
+                    'sz' => '1',
+                    'uTime' => '1767225603999',
+                ],
+            ],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[0]);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[1]);
+    }
+
+    public function testNormalizesNetModeReduceOnlyOrderSides(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [
+                [
+                    'accFillSz' => '0.1',
+                    'avgPx' => '25000',
+                    'clOrdId' => 'CLOSE-LONG',
+                    'fillPx' => '25000',
+                    'fillSz' => '0.1',
+                    'instId' => 'BTC-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'ordId' => 'close-long',
+                    'ordType' => 'market',
+                    'posSide' => 'net',
+                    'reduceOnly' => 'true',
+                    'side' => 'sell',
+                    'state' => 'filled',
+                    'sz' => '0.1',
+                    'tradeId' => 'close-long-fill',
+                    'uTime' => '1767225600000',
+                ],
+                [
+                    'accFillSz' => '0.2',
+                    'avgPx' => '25100',
+                    'clOrdId' => 'CLOSE-SHORT',
+                    'fillPx' => '25100',
+                    'fillSz' => '0.2',
+                    'instId' => 'BTC-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'ordId' => 'close-short',
+                    'ordType' => 'market',
+                    'posSide' => 'net',
+                    'reduceOnly' => 'true',
+                    'side' => 'buy',
+                    'state' => 'filled',
+                    'sz' => '0.2',
+                    'tradeId' => 'close-short-fill',
+                    'uTime' => '1767225601000',
+                ],
+            ],
+        ]);
+
+        self::assertCount(4, $events);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[0]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[1]);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[2]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[3]);
+        self::assertSame(ExchangePositionSide::LONG, $events[0]->order()->positionSide);
+        self::assertSame(ExchangePositionSide::LONG, $events[1]->fill()->positionSide);
+        self::assertSame(ExchangePositionSide::SHORT, $events[2]->order()->positionSide);
+        self::assertSame(ExchangePositionSide::SHORT, $events[3]->fill()->positionSide);
+    }
+
+    public function testNetModeNonReduceOnlyOrderLeavesPositionSideUnknown(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '0.1',
+                'avgPx' => '25000',
+                'clOrdId' => 'NET-BUY',
+                'fillPx' => '25000',
+                'fillSz' => '0.1',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => 'net-buy-order',
+                'ordType' => 'market',
+                'posSide' => 'net',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'filled',
+                'sz' => '0.1',
+                'tradeId' => 'net-buy-fill',
+                'uTime' => '1767225600000',
+            ]],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangeOrderFilled::class, $events[0]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[1]);
+        self::assertNull($events[0]->order()->positionSide);
+        self::assertNull($events[1]->fill()->positionSide);
+    }
+
+    public function testNormalizesCancelledOrder(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '0',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXCANCEL',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => '12346',
+                'ordType' => 'post_only',
+                'posSide' => 'long',
+                'px' => '25000',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'canceled',
+                'sz' => '1',
+                'uTime' => '1767225602000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderCancelled::class, $events[0]);
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $events[0]->order()->status);
+        self::assertTrue($events[0]->order()->postOnly);
+    }
+
+    public function testNormalizesMmpCanceledOrderAsCancelled(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'SWAP'],
+            'data' => [[
+                'accFillSz' => '0',
+                'cTime' => '1767225600000',
+                'clOrdId' => 'OKXMMP',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => '12349',
+                'ordType' => 'limit',
+                'posSide' => 'long',
+                'px' => '25000',
+                'reduceOnly' => 'false',
+                'side' => 'buy',
+                'state' => 'mmp_canceled',
+                'sz' => '1',
+                'uTime' => '1767225602000',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeOrderCancelled::class, $events[0]);
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $events[0]->order()->status);
+    }
+
+    public function testNormalizesFillsChannel(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'fills', 'instType' => 'SWAP'],
+            'data' => [[
+                'clOrdId' => 'OKXENTRY',
+                'fee' => '-0.01',
+                'feeCcy' => 'USDT',
+                'fillPx' => '25000.5',
+                'fillSz' => '0.1',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'ordId' => '12345',
+                'posSide' => 'long',
+                'side' => 'buy',
+                'tradeId' => 'trade-1',
+                'ts' => '1767225603123',
+            ]],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[0]);
+        self::assertSame($this->okxFillId('BTC-USDT-SWAP', 'trade-1'), $events[0]->fill()->fillId);
+        self::assertSame('BTCUSDT', $events[0]->fill()->symbol);
+        self::assertEqualsWithDelta(0.1, $events[0]->fill()->quantity, 0.000001);
+        self::assertSame('1767225603.123000', $events[0]->fill()->filledAt->format('U.u'));
+        self::assertSame('okx_ws_fills', $events[0]->fill()->metadata['source'] ?? null);
+    }
+
+    public function testOkxTradeFillIdsIncludeInstrument(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'fills', 'instType' => 'ANY'],
+            'data' => [
+                [
+                    'fillPx' => '25000.5',
+                    'fillSz' => '0.1',
+                    'instId' => 'BTC-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'ordId' => 'btc-order',
+                    'side' => 'buy',
+                    'tradeId' => 'duplicate-trade-id',
+                    'ts' => '1767225603000',
+                ],
+                [
+                    'fillPx' => '3500.5',
+                    'fillSz' => '0.2',
+                    'instId' => 'ETH-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'ordId' => 'eth-order',
+                    'side' => 'buy',
+                    'tradeId' => 'duplicate-trade-id',
+                    'ts' => '1767225603000',
+                ],
+            ],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[0]);
+        self::assertInstanceOf(ExchangeFillReceived::class, $events[1]);
+        self::assertSame($this->okxFillId('BTC-USDT-SWAP', 'duplicate-trade-id'), $events[0]->fill()->fillId);
+        self::assertSame($this->okxFillId('ETH-USDT-SWAP', 'duplicate-trade-id'), $events[1]->fill()->fillId);
+        self::assertNotSame($events[0]->fill()->fillId, $events[1]->fill()->fillId);
+    }
+
+    public function testNormalizesPositionUpdateAndCloseEvents(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'positions', 'instType' => 'SWAP'],
+            'data' => [
+                [
+                    'avgPx' => '25000',
+                    'instId' => 'BTC-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'lever' => '3',
+                    'markPx' => '25100',
+                    'margin' => '100',
+                    'pos' => '0.5',
+                    'posSide' => 'long',
+                    'realizedPnl' => '0',
+                    'uTime' => '1767225604000',
+                    'upl' => '50',
+                ],
+                [
+                    'avgPx' => '0',
+                    'instId' => 'ETH-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'pos' => '0',
+                    'posSide' => 'short',
+                    'uTime' => '1767225605000',
+                ],
+            ],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangePositionUpdated::class, $events[0]);
+        self::assertSame('BTCUSDT', $events[0]->symbol());
+        self::assertSame(ExchangePositionSide::LONG, $events[0]->side());
+        self::assertEqualsWithDelta(0.5, $events[0]->size(), 0.000001);
+        self::assertInstanceOf(ExchangePositionClosed::class, $events[1]);
+        self::assertSame('ETHUSDT', $events[1]->symbol());
+        self::assertSame(ExchangePositionSide::SHORT, $events[1]->side());
+        self::assertEqualsWithDelta(0.0, $events[1]->size(), 0.000001);
+    }
+
+    public function testNormalizesNetModeZeroPositionCloseForBothSides(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'positions', 'instType' => 'SWAP'],
+            'data' => [[
+                'avgPx' => '0',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'pos' => '0',
+                'posSide' => 'net',
+                'uTime' => '1767225605000',
+            ]],
+        ]);
+
+        self::assertCount(2, $events);
+        self::assertInstanceOf(ExchangePositionClosed::class, $events[0]);
+        self::assertInstanceOf(ExchangePositionClosed::class, $events[1]);
+        self::assertSame([ExchangePositionSide::LONG, ExchangePositionSide::SHORT], [
+            $events[0]->side(),
+            $events[1]->side(),
+        ]);
+    }
+
+    public function testIgnoresAmbiguousZeroPositionWithoutSide(): void
+    {
+        self::assertSame([], $this->normalizer->normalize([
+            'arg' => ['channel' => 'positions', 'instType' => 'SWAP'],
+            'data' => [[
+                'avgPx' => '0',
+                'instId' => 'BTC-USDT-SWAP',
+                'instType' => 'SWAP',
+                'pos' => '0',
+                'posSide' => '',
+                'uTime' => '1767225605000',
+            ]],
+        ]));
+    }
+
+    public function testIgnoresUnsupportedChannelsAndNonSwapRows(): void
+    {
+        self::assertFalse($this->normalizer->supports(['arg' => ['channel' => 'tickers'], 'data' => []]));
+        self::assertFalse($this->normalizer->supports([
+            'arg' => ['channel' => 'orders', 'instType' => 'SPOT'],
+            'data' => [['instId' => 'BTC-USDT']],
+        ]));
+        self::assertSame([], $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders'],
+            'data' => [[
+                'instId' => 'BTC-USDT',
+                'instType' => 'SPOT',
+                'ordId' => 'spot-order',
+                'side' => 'buy',
+                'state' => 'live',
+                'sz' => '1',
+            ]],
+        ]));
+    }
+
+    public function testAcceptsAnyInstTypeSubscriptionsAndFiltersRows(): void
+    {
+        $events = $this->normalizer->normalize([
+            'arg' => ['channel' => 'orders', 'instType' => 'ANY'],
+            'data' => [
+                [
+                    'accFillSz' => '0',
+                    'clOrdId' => 'OKXSWAP',
+                    'instId' => 'BTC-USDT-SWAP',
+                    'instType' => 'SWAP',
+                    'ordId' => '12348',
+                    'ordType' => 'limit',
+                    'posSide' => 'long',
+                    'px' => '25000',
+                    'reduceOnly' => 'false',
+                    'side' => 'buy',
+                    'state' => 'live',
+                    'sz' => '1',
+                    'uTime' => '1767225604000',
+                ],
+                [
+                    'instId' => 'BTC-USDT',
+                    'instType' => 'SPOT',
+                    'ordId' => 'spot-order',
+                    'side' => 'buy',
+                    'state' => 'live',
+                    'sz' => '1',
+                ],
+                [
+                    'instId' => 'ETH-USDT',
+                    'ordId' => 'spot-without-inst-type',
+                    'side' => 'buy',
+                    'state' => 'live',
+                    'sz' => '1',
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $events);
+        self::assertSame('BTCUSDT', $events[0]->symbol());
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+
+    private function okxFillId(string $instId, string $tradeId): string
+    {
+        return OkxFillId::fromTradeId($instId, $tradeId) ?? '';
+    }
+}


### PR DESCRIPTION
## Summary
- add an OKX exchange event normalizer for private WS-style orders, fills, and positions payloads
- map order lifecycle, fill, protection, position update, and position close events into common exchange events
- keep private WS capability disabled until a real OKX WS client is implemented

Refs #87

## Tests
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange/Okx tests/Exchange/Adapter/OkxExchangeAdapterTest.php tests/Exchange/Contract/OkxExchangeAdapterContractTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check