### PR TITLE
[MtfValidator] Add ConditionRegistry fallback observability

### DIFF
--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -50,6 +50,7 @@ parameters:
     env(OKX_WS_PRIVATE_URI): ''
     env(OKX_DEMO_TRADING_ENABLED): '0'
     env(OKX_LIVE_ENABLED): '0'
+    env(MTF_VALIDATION_FALLBACK_ALERT_THRESHOLD): '1'
     app.trade_entry_default_mode: 'scalper_micro'
 
     # Configuration TradeEntry - Valeurs par défaut (déplacées dans services_trade_entry.yaml)
@@ -314,6 +315,10 @@ services:
     App\MtfValidator\ConditionLoader\TimeframeEvaluator:
         arguments:
             $registry: '@App\MtfValidator\ConditionLoader\ConditionRegistry'
+
+    App\MtfValidator\Service\TimeframeValidationService:
+        arguments:
+            $mtfLogger: '@monolog.logger.mtf'
 
     # Execution selector (decide 15m/5m/1m)
     App\MtfValidator\Execution\ExecutionSelector:

--- a/trading-app/src/Indicator/Condition/GetFalseCondition.php
+++ b/trading-app/src/Indicator/Condition/GetFalseCondition.php
@@ -7,9 +7,9 @@ use App\Indicator\Attribute\AsIndicatorCondition;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
-#[AsIndicatorCondition(timeframes: ['15m','5m','1m','1h','4h'], name: ExpectedRMultipleLtCondition::NAME)]
+#[AsIndicatorCondition(timeframes: ['15m','5m','1m','1h','4h'], name: GetFalseCondition::NAME)]
 #[AutoconfigureTag('app.indicator.condition')]
-#[AsTaggedItem(index: ExpectedRMultipleLtCondition::NAME)]
+#[AsTaggedItem(index: GetFalseCondition::NAME)]
 class GetFalseCondition extends AbstractCondition
 {
     const NAME = 'get_false';

--- a/trading-app/src/MtfValidator/README.md
+++ b/trading-app/src/MtfValidator/README.md
@@ -74,6 +74,11 @@ RunnerController / mtf:run
 - Interprète le YAML (rules, filters, `filters_mandatory`).
 - Peut basculer sur le moteur ConditionRegistry compilé si disponible.
 - Retourne un `TimeframeDecisionDto` pour chaque TF inspecté (`valid`, `signal`, `invalidReason`, conditions passées/échouées).
+- Si le moteur ConditionRegistry échoue et que le fallback YAML est utilisé, le compteur
+  `mtf.validation.engine.fallback_count` est incrémenté via `MtfValidationEngineMetrics`.
+  Le seuil d'alerte est configurable avec `MTF_VALIDATION_FALLBACK_ALERT_THRESHOLD`
+  (défaut `1`). Le fallback est aussi ajouté dans `TimeframeDecisionDto.extra.validation_engine_fallback`
+  pour faciliter l'audit d'un run.
 
 ### 3.4 `TradingDecisionHandler`
 - Reçoit un `SymbolResultDto`.
@@ -116,6 +121,12 @@ Les repositories `MtfSwitchRepository`, `MtfLockRepository`, `MtfAuditRepository
 - **Tests PHPUnit**
   - `tests/MtfValidator/Service/*` : tests unitaires/métier.
   - `tests/MtfValidator/Integration/*` : autowiring, pipeline complet.
+- **Validation YAML / ConditionRegistry**
+  - `bin/console app:validate:mtf-config --mode=all` vérifie que les références YAML
+    pointent vers des règles ou conditions disponibles dans le registry.
+  - Surveiller les logs `monolog.logger.mtf` pour le metric
+    `mtf.validation.engine.fallback_count`; tout fallback indique une dérive possible
+    entre YAML, conditions taguées `AsIndicatorCondition` et moteur compilé.
 - **Endpoints REST (`MtfController`)**
   - `/mtf/status`, `/mtf/lock/status`, `/mtf/audit`, `/mtf/sync-contracts` fournissent des diagnostics runtime.
 

--- a/trading-app/src/MtfValidator/Service/MtfValidationEngineMetrics.php
+++ b/trading-app/src/MtfValidator/Service/MtfValidationEngineMetrics.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MtfValidator\Service;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final class MtfValidationEngineMetrics
+{
+    public const CONDITION_REGISTRY_FALLBACK_COUNT = 'mtf.validation.engine.fallback_count';
+
+    /** @var array<string,int> */
+    private array $counters = [
+        self::CONDITION_REGISTRY_FALLBACK_COUNT => 0,
+    ];
+
+    public function __construct(
+        #[Autowire(service: 'monolog.logger.mtf')]
+        private readonly LoggerInterface $mtfLogger,
+        #[Autowire('%env(int:MTF_VALIDATION_FALLBACK_ALERT_THRESHOLD)%')]
+        private readonly int $fallbackAlertThreshold = 1,
+    ) {
+    }
+
+    public function recordConditionRegistryFallback(
+        string $symbol,
+        string $timeframe,
+        string $phase,
+        ?string $mode,
+        \Throwable $error,
+    ): int {
+        $count = $this->increment(self::CONDITION_REGISTRY_FALLBACK_COUNT);
+        $threshold = max(1, $this->fallbackAlertThreshold);
+        $context = [
+            'metric' => self::CONDITION_REGISTRY_FALLBACK_COUNT,
+            'fallback_count' => $count,
+            'alert_threshold' => $threshold,
+            'symbol' => $symbol,
+            'timeframe' => $timeframe,
+            'phase' => $phase,
+            'mode' => $mode,
+            'source_engine' => 'condition_registry',
+            'fallback_engine' => 'yaml',
+            'exception' => $error::class,
+            'error' => $error->getMessage(),
+        ];
+
+        $this->mtfLogger->warning('[MTF] Validation engine fallback recorded', $context);
+
+        if ($count >= $threshold) {
+            $this->mtfLogger->critical('[MTF] Validation engine fallback threshold reached', $context + [
+                'alert' => self::CONDITION_REGISTRY_FALLBACK_COUNT,
+            ]);
+        }
+
+        return $count;
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    public function snapshot(): array
+    {
+        return $this->counters;
+    }
+
+    public function reset(): void
+    {
+        foreach ($this->counters as $metric => $_) {
+            $this->counters[$metric] = 0;
+        }
+    }
+
+    private function increment(string $metric): int
+    {
+        if (!isset($this->counters[$metric])) {
+            $this->counters[$metric] = 0;
+        }
+
+        return ++$this->counters[$metric];
+    }
+}

--- a/trading-app/src/MtfValidator/Service/TimeframeValidationService.php
+++ b/trading-app/src/MtfValidator/Service/TimeframeValidationService.php
@@ -27,6 +27,7 @@ final class TimeframeValidationService
         private readonly ?IndicatorEngineInterface $indicatorEngine = null,
         private readonly ?KlineProviderInterface $klineProvider = null,
         private readonly ?MainProviderInterface $mainProvider = null,
+        private readonly ?MtfValidationEngineMetrics $validationEngineMetrics = null,
     ) {
     }
 
@@ -67,6 +68,7 @@ final class TimeframeValidationService
 
         $decision = null;
         $engine = 'yaml';
+        $fallbackContext = null;
 
         // Si l'engine ConditionRegistry est disponible, on l'utilise en priorité.
         if ($this->canUseConditionRegistryEngine()) {
@@ -89,7 +91,22 @@ final class TimeframeValidationService
                         'error'     => $e->getMessage(),
                     ]);
                 }
-                // Fallback silencieux vers l'ancien moteur YAML.
+
+                $fallbackCount = $this->validationEngineMetrics?->recordConditionRegistryFallback(
+                    symbol: $symbol,
+                    timeframe: $timeframe,
+                    phase: $phase,
+                    mode: $mode,
+                    error: $e,
+                );
+                $fallbackContext = [
+                    'metric' => MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT,
+                    'fallback_count' => $fallbackCount,
+                    'source_engine' => 'condition_registry',
+                    'fallback_engine' => 'yaml',
+                    'exception' => $e::class,
+                    'error' => $e->getMessage(),
+                ];
             }
         }
 
@@ -105,11 +122,34 @@ final class TimeframeValidationService
                 rulesConfig: $rulesConfig,
             );
             $engine = 'yaml';
+
+            if ($fallbackContext !== null) {
+                $decision = $this->withValidationEngineFallback($decision, $fallbackContext);
+            }
         }
 
         $this->logInvalidContextTimeframe($symbol, $timeframe, $phase, $mode, $decision, $engine);
 
         return $decision;
+    }
+
+    /**
+     * @param array<string,mixed> $fallbackContext
+     */
+    private function withValidationEngineFallback(
+        TimeframeDecisionDto $decision,
+        array $fallbackContext,
+    ): TimeframeDecisionDto {
+        return new TimeframeDecisionDto(
+            timeframe: $decision->timeframe,
+            phase: $decision->phase,
+            signal: $decision->signal,
+            valid: $decision->valid,
+            invalidReason: $decision->invalidReason,
+            rulesPassed: $decision->rulesPassed,
+            rulesFailed: $decision->rulesFailed,
+            extra: $decision->extra + ['validation_engine_fallback' => $fallbackContext],
+        );
     }
 
     /**

--- a/trading-app/src/MtfValidator/Validator/ValidationsYamlValidator.php
+++ b/trading-app/src/MtfValidator/Validator/ValidationsYamlValidator.php
@@ -16,6 +16,7 @@ final class ValidationsYamlValidator
     private array $definedRules = [];
     private array $availableConditions = [];
     private array $visitedRules = []; // Pour détecter les références circulaires
+    private array $reportedCycles = [];
 
     public function __construct(
         private readonly MtfValidationConfig $config,
@@ -36,6 +37,7 @@ final class ValidationsYamlValidator
         $rules = $this->config->getRules();
         $this->definedRules = array_keys($rules);
         $this->validateRules($rules, $result);
+        $this->validateRuleReferenceCycles($rules, $result);
 
         // 3. Valider execution_selector
         if (isset($config['execution_selector'])) {
@@ -385,6 +387,103 @@ final class ValidationsYamlValidator
         ));
     }
 
+    /**
+     * @param array<string,mixed> $rules
+     */
+    private function validateRuleReferenceCycles(array $rules, ValidationResult $result): void
+    {
+        $checked = [];
+        $this->reportedCycles = [];
+
+        foreach (array_keys($rules) as $ruleName) {
+            $this->detectRuleCycle((string) $ruleName, $rules, [], $checked, $result);
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $rules
+     * @param string[] $stack
+     * @param array<string,bool> $checked
+     */
+    private function detectRuleCycle(
+        string $ruleName,
+        array $rules,
+        array $stack,
+        array &$checked,
+        ValidationResult $result,
+    ): void {
+        if (isset($checked[$ruleName])) {
+            return;
+        }
+
+        $cycleIndex = array_search($ruleName, $stack, true);
+        if ($cycleIndex !== false) {
+            $cycle = array_slice($stack, (int) $cycleIndex);
+            $cycle[] = $ruleName;
+            $cycleKey = implode('>', $cycle);
+            if (!isset($this->reportedCycles[$cycleKey])) {
+                $this->reportedCycles[$cycleKey] = true;
+                $result->addError(new ValidationError(
+                    'circular_reference',
+                    sprintf("Référence circulaire détectée: %s", implode(' -> ', $cycle)),
+                    sprintf('mtf_validation.rules.%s', $ruleName),
+                    $ruleName,
+                    ['cycle' => $cycle],
+                ));
+            }
+            return;
+        }
+
+        $stack[] = $ruleName;
+        foreach ($this->extractRuleReferences($rules[$ruleName] ?? null, $ruleName) as $reference) {
+            if (array_key_exists($reference, $rules)) {
+                $this->detectRuleCycle($reference, $rules, $stack, $checked, $result);
+            }
+        }
+
+        $checked[$ruleName] = true;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function extractRuleReferences(mixed $spec, ?string $ownerRule = null): array
+    {
+        if (\is_string($spec)) {
+            if ($ownerRule === $spec && \in_array($spec, $this->availableConditions, true)) {
+                return [];
+            }
+
+            return [$spec];
+        }
+
+        if (!\is_array($spec)) {
+            return [];
+        }
+
+        $references = [];
+        foreach (['any_of', 'all_of'] as $logicalKey) {
+            if (isset($spec[$logicalKey]) && \is_array($spec[$logicalKey])) {
+                foreach ($spec[$logicalKey] as $item) {
+                    array_push($references, ...$this->extractRuleReferences($item, $ownerRule));
+                }
+            }
+        }
+
+        if (\count($spec) === 1) {
+            $key = array_key_first($spec);
+            if (\is_string($key) && !\in_array($key, ['any_of', 'all_of'], true)) {
+                if ($ownerRule === $key && \in_array($key, $this->availableConditions, true)) {
+                    return array_values(array_unique($references));
+                }
+
+                $references[] = $key;
+            }
+        }
+
+        return array_values(array_unique($references));
+    }
+
     private function validateExecutionSelector(array $selector, ValidationResult $result): void
     {
         // Vérifier si le nouveau format per_timeframe est utilisé
@@ -412,6 +511,11 @@ final class ValidationsYamlValidator
                 continue;
             }
 
+            if ($groupName === 'allow_1m_only_for') {
+                $this->validateAllow1mOnlyFor($items, $result);
+                continue;
+            }
+
             if (!is_array($items)) {
                 $result->addError(new ValidationError(
                     'invalid_type',
@@ -426,6 +530,47 @@ final class ValidationsYamlValidator
                 $itemPath = "mtf_validation.execution_selector.{$groupName}[{$index}]";
                 $this->validateExecutionSelectorItem($item, $itemPath, $result);
             }
+        }
+    }
+
+    private function validateAllow1mOnlyFor(mixed $config, ValidationResult $result): void
+    {
+        $path = 'mtf_validation.execution_selector.allow_1m_only_for';
+        if (!\is_array($config)) {
+            $result->addError(new ValidationError(
+                'invalid_type',
+                'allow_1m_only_for doit être un tableau',
+                $path,
+                null,
+                ['type' => gettype($config)],
+            ));
+            return;
+        }
+
+        if (isset($config['enabled']) && !\is_bool($config['enabled'])) {
+            $result->addError(new ValidationError(
+                'invalid_type',
+                'allow_1m_only_for.enabled doit être booléen',
+                "{$path}.enabled",
+                null,
+                ['type' => gettype($config['enabled'])],
+            ));
+        }
+
+        $conditions = $config['conditions'] ?? [];
+        if (!\is_array($conditions)) {
+            $result->addError(new ValidationError(
+                'invalid_type',
+                'allow_1m_only_for.conditions doit être un tableau',
+                "{$path}.conditions",
+                null,
+                ['type' => gettype($conditions)],
+            ));
+            return;
+        }
+
+        foreach ($conditions as $index => $condition) {
+            $this->validateExecutionSelectorItem($condition, "{$path}.conditions[{$index}]", $result);
         }
     }
 
@@ -897,4 +1042,3 @@ final class ValidationsYamlValidator
         }
     }
 }
-

--- a/trading-app/tests/MtfValidator/Service/MtfValidationEngineMetricsTest.php
+++ b/trading-app/tests/MtfValidator/Service/MtfValidationEngineMetricsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfValidator\Service;
+
+use App\MtfValidator\Service\MtfValidationEngineMetrics;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+
+#[CoversClass(MtfValidationEngineMetrics::class)]
+final class MtfValidationEngineMetricsTest extends TestCase
+{
+    public function testRecordsFallbackCounterAndAlertsAtThreshold(): void
+    {
+        $logger = new class extends AbstractLogger {
+            /** @var array<int,array{level:mixed,message:string,context:array<string,mixed>}> */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [
+                    'level' => $level,
+                    'message' => (string) $message,
+                    'context' => $context,
+                ];
+            }
+        };
+        $metrics = new MtfValidationEngineMetrics($logger, fallbackAlertThreshold: 2);
+
+        self::assertSame(1, $metrics->recordConditionRegistryFallback(
+            symbol: 'BTCUSDT',
+            timeframe: '5m',
+            phase: 'context',
+            mode: 'scalper',
+            error: new \RuntimeException('first failure'),
+        ));
+        self::assertSame(2, $metrics->recordConditionRegistryFallback(
+            symbol: 'ETHUSDT',
+            timeframe: '1m',
+            phase: 'execution',
+            mode: 'scalper',
+            error: new \LogicException('second failure'),
+        ));
+
+        self::assertSame(2, $metrics->snapshot()[MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT]);
+        self::assertCount(2, array_filter(
+            $logger->records,
+            static fn (array $record): bool => $record['level'] === 'warning'
+                && ($record['context']['metric'] ?? null) === MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT,
+        ));
+        self::assertCount(1, array_filter(
+            $logger->records,
+            static fn (array $record): bool => $record['level'] === 'critical'
+                && ($record['context']['alert'] ?? null) === MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT,
+        ));
+
+        $metrics->reset();
+        self::assertSame(0, $metrics->snapshot()[MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT]);
+    }
+}

--- a/trading-app/tests/MtfValidator/Service/TimeframeValidationServiceFallbackTest.php
+++ b/trading-app/tests/MtfValidator/Service/TimeframeValidationServiceFallbackTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfValidator\Service;
+
+use App\Common\Enum\Timeframe;
+use App\Contract\Indicator\IndicatorEngineInterface;
+use App\Contract\Provider\KlineProviderInterface;
+use App\MtfValidator\ConditionLoader\ConditionRegistry as MtfConditionRegistry;
+use App\MtfValidator\ConditionLoader\TimeframeEvaluator as MtfTimeframeEvaluator;
+use App\MtfValidator\Service\MtfValidationEngineMetrics;
+use App\MtfValidator\Service\Rule\TimeframeRuleEvaluator;
+use App\MtfValidator\Service\Rule\YamlRuleEngine;
+use App\MtfValidator\Service\TimeframeValidationService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+
+#[CoversClass(TimeframeValidationService::class)]
+#[CoversClass(MtfValidationEngineMetrics::class)]
+final class TimeframeValidationServiceFallbackTest extends TestCase
+{
+    public function testConditionRegistryFailureIsCountedLoggedAndExposedOnYamlFallbackDecision(): void
+    {
+        $ruleEngine = new YamlRuleEngine();
+        $logger = new class extends AbstractLogger {
+            /** @var array<int,array{level:mixed,message:string,context:array<string,mixed>}> */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [
+                    'level' => $level,
+                    'message' => (string) $message,
+                    'context' => $context,
+                ];
+            }
+        };
+        $metrics = new MtfValidationEngineMetrics($logger, fallbackAlertThreshold: 1);
+
+        $conditionRegistry = $this->createMock(MtfConditionRegistry::class);
+        $conditionRegistry
+            ->expects(self::once())
+            ->method('load');
+
+        $conditionEvaluator = $this->createMock(MtfTimeframeEvaluator::class);
+        $conditionEvaluator
+            ->expects(self::once())
+            ->method('evaluate')
+            ->with('5m', ['rsi' => 65.0, 'macd_hist' => 0.0012])
+            ->willThrowException(new \RuntimeException('compiled condition drift'));
+
+        $indicatorEngine = $this->createMock(IndicatorEngineInterface::class);
+        $indicatorEngine
+            ->expects(self::once())
+            ->method('buildContext')
+            ->willReturn(['rsi' => 65.0, 'macd_hist' => 0.0012]);
+
+        $klineProvider = $this->createMock(KlineProviderInterface::class);
+        $klineProvider
+            ->expects(self::once())
+            ->method('getKlines')
+            ->with('BTCUSDT', Timeframe::TF_5M, 250)
+            ->willReturn([['open' => 1, 'high' => 1, 'low' => 1, 'close' => 1, 'volume' => 1]]);
+
+        $service = new TimeframeValidationService(
+            new TimeframeRuleEvaluator($ruleEngine),
+            $ruleEngine,
+            $logger,
+            $conditionEvaluator,
+            $conditionRegistry,
+            $indicatorEngine,
+            $klineProvider,
+            null,
+            $metrics,
+        );
+
+        $decision = $service->validateTimeframe(
+            symbol: 'BTCUSDT',
+            timeframe: '5m',
+            phase: 'context',
+            mode: 'scalper',
+            mtfConfig: $this->mtfConfig(),
+            indicators: ['rsi' => 65.0, 'macd_hist' => 0.0012],
+        );
+
+        self::assertTrue($decision->valid);
+        self::assertSame('long', $decision->signal);
+        self::assertSame(
+            1,
+            $metrics->snapshot()[MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT],
+        );
+        self::assertSame(
+            MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT,
+            $decision->extra['validation_engine_fallback']['metric'] ?? null,
+        );
+        self::assertSame(1, $decision->extra['validation_engine_fallback']['fallback_count'] ?? null);
+        self::assertSame('compiled condition drift', $decision->extra['validation_engine_fallback']['error'] ?? null);
+        self::assertNotEmpty(array_filter(
+            $logger->records,
+            static fn (array $record): bool => $record['level'] === 'critical'
+                && ($record['context']['alert'] ?? null) === MtfValidationEngineMetrics::CONDITION_REGISTRY_FALLBACK_COUNT,
+        ));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function mtfConfig(): array
+    {
+        return [
+            'rules' => [
+                'rsi_lt_70' => [
+                    'field' => 'rsi',
+                    'lt' => 70.0,
+                ],
+                'macd_hist_gt_eps' => [
+                    'op' => '>',
+                    'left' => 'macd_hist',
+                    'right' => 0.0,
+                    'eps' => 0.000001,
+                ],
+            ],
+            'validation' => [
+                'timeframe' => [
+                    '5m' => [
+                        'long' => [
+                            [
+                                'all_of' => [
+                                    'rsi_lt_70',
+                                    'macd_hist_gt_eps',
+                                ],
+                            ],
+                        ],
+                        'short' => [],
+                    ],
+                ],
+            ],
+            'filters_mandatory' => [],
+        ];
+    }
+}

--- a/trading-app/tests/MtfValidator/Service/TimeframeValidationServiceScalperTest.php
+++ b/trading-app/tests/MtfValidator/Service/TimeframeValidationServiceScalperTest.php
@@ -8,9 +8,14 @@ use App\MtfValidator\Service\Rule\TimeframeRuleEvaluator;
 use App\MtfValidator\Service\Rule\YamlRuleEngine;
 use App\MtfValidator\Service\TimeframeValidationService;
 use App\Contract\MtfValidator\Dto\TimeframeDecisionDto;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
+#[CoversClass(TimeframeValidationService::class)]
+#[CoversClass(TimeframeRuleEvaluator::class)]
+#[CoversClass(YamlRuleEngine::class)]
+#[CoversClass(TimeframeDecisionDto::class)]
 final class TimeframeValidationServiceScalperTest extends TestCase
 {
     private TimeframeValidationService $service;
@@ -97,9 +102,9 @@ final class TimeframeValidationServiceScalperTest extends TestCase
 
         self::assertInstanceOf(TimeframeDecisionDto::class, $decision);
         self::assertSame('5m', $decision->timeframe);
-        self::assertSame('VALID', $decision->status);
-        self::assertSame('LONG', $decision->side);
-        self::assertNull($decision->reason);
+        self::assertTrue($decision->valid);
+        self::assertSame('long', $decision->signal);
+        self::assertNull($decision->invalidReason);
     }
 
     public function testScalper5mLong_FailsWhenRsiTooHigh(): void
@@ -164,8 +169,8 @@ final class TimeframeValidationServiceScalperTest extends TestCase
         );
 
         self::assertSame('5m', $decision->timeframe);
-        self::assertSame('INVALID', $decision->status);
-        self::assertNull($decision->side);
-        self::assertSame('NO_LONG_NO_SHORT', $decision->reason);
+        self::assertFalse($decision->valid);
+        self::assertSame('invalid', $decision->signal);
+        self::assertSame('NO_LONG_NO_SHORT', $decision->invalidReason);
     }
 }

--- a/trading-app/tests/MtfValidator/Validator/ValidationsYamlValidatorTest.php
+++ b/trading-app/tests/MtfValidator/Validator/ValidationsYamlValidatorTest.php
@@ -6,10 +6,16 @@ namespace App\Tests\MtfValidator\Validator;
 
 use App\Config\MtfValidationConfig;
 use App\MtfValidator\ConditionLoader\ConditionRegistry;
+use App\MtfValidator\Validator\ValidationError;
+use App\MtfValidator\Validator\ValidationResult;
 use App\MtfValidator\Validator\ValidationsYamlValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(ValidationsYamlValidator::class)]
+#[CoversClass(ValidationResult::class)]
+#[CoversClass(ValidationError::class)]
 class ValidationsYamlValidatorTest extends TestCase
 {
     private MtfValidationConfig $config;
@@ -236,6 +242,62 @@ class ValidationsYamlValidatorTest extends TestCase
         $this->assertFalse($result->hasErrors());
     }
 
+    public function testValidateRuleDelegatingToHomonymousPhpConditionIsNotCircular(): void
+    {
+        $rules = [
+            'near_vwap' => ['near_vwap' => true],
+        ];
+        $config = [
+            'rules' => $rules,
+            'validation' => [
+                'timeframe' => [
+                    '5m' => [
+                        'long' => [
+                            ['all_of' => ['near_vwap']],
+                        ],
+                        'short' => [],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->config->method('getConfig')->willReturn($config);
+        $this->config->method('getRules')->willReturn($rules);
+        $this->config->method('getValidation')->willReturn($config['validation']);
+        $this->registry->method('names')->willReturn(['near_vwap']);
+
+        $validator = new ValidationsYamlValidator($this->config, $this->registry);
+        $result = $validator->validate();
+
+        $this->assertFalse($result->hasErrors());
+    }
+
+    public function testValidateAllow1mOnlyForCurrentFormat(): void
+    {
+        $config = [
+            'rules' => [],
+            'execution_selector' => [
+                'allow_1m_only_for' => [
+                    'enabled' => false,
+                    'conditions' => [
+                        ['scalping' => true],
+                    ],
+                ],
+            ],
+            'validation' => [],
+        ];
+
+        $this->config->method('getConfig')->willReturn($config);
+        $this->config->method('getRules')->willReturn([]);
+        $this->config->method('getValidation')->willReturn([]);
+        $this->registry->method('names')->willReturn(['scalping']);
+
+        $validator = new ValidationsYamlValidator($this->config, $this->registry);
+        $result = $validator->validate();
+
+        $this->assertFalse($result->hasErrors());
+    }
+
     public function testValidateExecutionSelectorInvalidValueType(): void
     {
         $config = [
@@ -262,4 +324,3 @@ class ValidationsYamlValidatorTest extends TestCase
         $this->assertNotEmpty(array_filter($errorMessages, fn($m) => str_contains($m, 'numérique') || str_contains($m, 'booléen')));
     }
 }
-


### PR DESCRIPTION
Closes #78

## Summary
- Add `MtfValidationEngineMetrics` to count and alert on ConditionRegistry -> YAML validation fallbacks via `mtf.validation.engine.fallback_count`.
- Attach fallback audit details to `TimeframeDecisionDto.extra.validation_engine_fallback`.
- Strengthen MTF YAML validation for rule-reference cycles and current `allow_1m_only_for` format, and fix the `get_false` condition registry name.
- Document the fallback metric and config validation workflow.

## Tests
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/MtfValidator/Service/MtfValidationEngineMetricsTest.php tests/MtfValidator/Service/TimeframeValidationServiceFallbackTest.php tests/MtfValidator/Service/TimeframeValidationServiceScalperTest.php tests/MtfValidator/Validator/ValidationsYamlValidatorTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console app:validate:mtf-config --mode=all` (0 errors, 1 existing warning: `filters_mandatory est vide`)
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction`
- `git diff --check`
- `git diff --cached --check`