### PR TITLE
[indicateurs] Exclude open candles from indicator windows

### DIFF
--- a/trading-app/src/Common/Dto/IndicatorSnapshotDto.php
+++ b/trading-app/src/Common/Dto/IndicatorSnapshotDto.php
@@ -32,6 +32,7 @@ final readonly class IndicatorSnapshotDto
         public ?string $runId = null,
         public ?float $adx = null,
         public ?float $close = null,
+        public ?\DateTimeImmutable $updatedAt = null,
     ) {
     }
 
@@ -60,6 +61,7 @@ final readonly class IndicatorSnapshotDto
             'run_id' => $this->runId,
             'adx' => $this->adx,
             'close' => $this->close,
+            'updated_at' => $this->updatedAt?->format('Y-m-d H:i:s'),
         ];
     }
 
@@ -88,7 +90,25 @@ final readonly class IndicatorSnapshotDto
             runId: $data['run_id'] ?? null,
             adx: isset($data['adx']) && is_numeric($data['adx']) ? (float)$data['adx'] : null,
             close: isset($data['close']) && is_numeric($data['close']) ? (float)$data['close'] : null,
+            updatedAt: self::nullableDateTime($data['updated_at'] ?? null),
         );
+    }
+
+    private static function nullableDateTime(mixed $value): ?\DateTimeImmutable
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return $value->setTimezone(new \DateTimeZone('UTC'));
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return \DateTimeImmutable::createFromInterface($value)->setTimezone(new \DateTimeZone('UTC'));
+        }
+
+        if (\is_string($value) && $value !== '') {
+            return new \DateTimeImmutable($value, new \DateTimeZone('UTC'));
+        }
+
+        return null;
     }
 
     public function isMacdBullish(): bool
@@ -127,7 +147,7 @@ final readonly class IndicatorSnapshotDto
         return $price->minus($this->ma21)->abs();
     }
 
-    public function isPriceNearMa21(BigDecimal $price, BigDecimal $atrMultiplier = null): bool
+    public function isPriceNearMa21(BigDecimal $price, ?BigDecimal $atrMultiplier = null): bool
     {
         if ($this->ma21 === null || $this->atr === null) {
             return false;
@@ -140,4 +160,3 @@ final readonly class IndicatorSnapshotDto
         return $distance !== null && $distance->isLessThanOrEqualTo($maxDistance);
     }
 }
-

--- a/trading-app/src/Indicator/Provider/IndicatorProviderService.php
+++ b/trading-app/src/Indicator/Provider/IndicatorProviderService.php
@@ -34,6 +34,9 @@ use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 #[AsAlias(id: IndicatorProviderInterface::class)]
 final class IndicatorProviderService implements IndicatorProviderInterface
     {
+        private const INDICATOR_WINDOW_SIZE = 250;
+        private const CONDITION_WINDOW_SIZE = 150;
+
         private array $atrList = [];
         /** @var array<string,array{dto: ListIndicatorDto,last_kline_time: \DateTimeInterface}> */
         private array $listPivot = [];
@@ -127,24 +130,34 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             ?ExchangeContext $context = null,
         ): IndicatorSnapshotDto
         {
+            return $this->getSnapshotAt($symbol, $timeframe, $context, $this->clock->now());
+        }
+
+        private function getSnapshotAt(
+            string $symbol,
+            string $timeframe,
+            ?ExchangeContext $context,
+            \DateTimeInterface $at,
+        ): IndicatorSnapshotDto
+        {
             $context = ExchangeContext::resolve($context);
             $tf = Timeframe::from($timeframe);
+            $now = $this->toUtcImmutable($at);
             $existing = $this->getSnapshotFromDatabaseOnly($symbol, $tf->value, $context);
             if ($existing instanceof IndicatorSnapshotDto) {
-                $now = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'));
                 if (!$this->isSnapshotStale($existing, $now, $tf)) {
                     return $existing;
                 }
             }
 
-            $klines = $this->klineProvider->getKlines($symbol, $tf, 251, $context);
+            $klines = $this->fetchClosedKlines($symbol, $tf, self::INDICATOR_WINDOW_SIZE, $now, $context);
             if (empty($klines)) {
                 throw new \RuntimeException("Aucune kline pour $symbol/$timeframe");
             }
 
             $klinesCount = count($klines);
-            if ($klinesCount < 249) {
-                throw new NotEnoughKlinesException($symbol, $timeframe, 249, $klinesCount);
+            if ($klinesCount < self::INDICATOR_WINDOW_SIZE) {
+                throw new NotEnoughKlinesException($symbol, $timeframe, self::INDICATOR_WINDOW_SIZE, $klinesCount);
             }
 
             // Normalize arrays for calculation
@@ -200,7 +213,8 @@ final class IndicatorProviderService implements IndicatorProviderInterface
                 ma9: $ma9 !== null ? \Brick\Math\BigDecimal::of((string)$ma9) : null,
                 ma21: $ma21 !== null ? \Brick\Math\BigDecimal::of((string)$ma21) : null,
                 meta: ['key' => $symbol . '-' . $tf->value],
-                source: 'PHP'
+                source: 'PHP',
+                updatedAt: $now,
             );
 
             $this->saveIndicatorSnapshot($snapshot, $context);
@@ -402,7 +416,13 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             $timeframeEnum = Timeframe::from($timeframe);
 
             // 2️⃣ Récupère les klines normalisées
-            $klines = $this->klineProvider->getKlines($symbol, $timeframeEnum, 150, $context);
+            $klines = $this->fetchClosedKlines(
+                $symbol,
+                $timeframeEnum,
+                self::CONDITION_WINDOW_SIZE,
+                $this->clock->now(),
+                $context,
+            );
 
             // 2️⃣ Convertit les klines en format array pour le contexte
             $klinesArray = [];
@@ -464,8 +484,14 @@ final class IndicatorProviderService implements IndicatorProviderInterface
 
             try {
                 $tfEnum = Timeframe::from((string)$tf);
-                $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 250, $context);
-                if (empty($klines)) {
+                $klines = $this->fetchClosedKlines(
+                    (string)$symbol,
+                    $tfEnum,
+                    self::INDICATOR_WINDOW_SIZE,
+                    $this->clock->now(),
+                    $context,
+                );
+                if (count($klines) < self::INDICATOR_WINDOW_SIZE) {
                     return null;
                 }
 
@@ -516,8 +542,14 @@ final class IndicatorProviderService implements IndicatorProviderInterface
                 }
 
                 try {
-                    $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 250, $context);
-                    if (empty($klines)) {
+                    $klines = $this->fetchClosedKlines(
+                        (string)$symbol,
+                        $tfEnum,
+                        self::INDICATOR_WINDOW_SIZE,
+                        $this->clock->now(),
+                        $context,
+                    );
+                    if (count($klines) < self::INDICATOR_WINDOW_SIZE) {
                         return null;
                     }
 
@@ -567,10 +599,7 @@ final class IndicatorProviderService implements IndicatorProviderInterface
                 return false;
             }
 
-            $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
-            $maxAge = $now->getTimestamp() - $timeframe->getStepInSeconds();
-
-            return $lastTime->getTimestamp() >= $maxAge;
+            return $this->isClosedKlineFresh($lastTime, $this->clock->now(), $timeframe);
         }
 
         /**
@@ -622,17 +651,23 @@ final class IndicatorProviderService implements IndicatorProviderInterface
 
                 // 1️⃣ si rien en DB → on calcule à partir des klines
                 if ($snapshot === null || $this->isSnapshotStale($snapshot, $at, Timeframe::from((string)$tf))) {
-                    $snapshot = $this->getSnapshot($symbol, (string)$tf, $context);
+                    $snapshot = $this->getSnapshotAt($symbol, (string)$tf, $context, $at);
                 }
 
                 // 2️⃣ mapping vers le format attendu par le MTF
                 $tfEnum = Timeframe::from((string)$tf);
-                $klines = $this->klineProvider->getKlines((string)$symbol, $tfEnum, 251, $context);
+                $klines = $this->fetchClosedKlines(
+                    (string)$symbol,
+                    $tfEnum,
+                    self::INDICATOR_WINDOW_SIZE,
+                    $at,
+                    $context,
+                );
 
                 $klinesCount = count($klines);
-                if ($klinesCount < 249) {
+                if ($klinesCount < self::INDICATOR_WINDOW_SIZE) {
                     //dd($symbol, $tf, $klinesCount);
-                    throw new NotEnoughKlinesException((string)$symbol, (string)$tf, 249, $klinesCount);
+                    throw new NotEnoughKlinesException((string)$symbol, (string)$tf, self::INDICATOR_WINDOW_SIZE, $klinesCount);
                 }
 
                 $closes = [];
@@ -717,6 +752,7 @@ final class IndicatorProviderService implements IndicatorProviderInterface
             'symbol'     => $entity->getSymbol(),
             'timeframe'  => $entity->getTimeframe()->value,
             'kline_time' => $entity->getKlineTime()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+            'updated_at' => $entity->getUpdatedAt()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
         ]);
 
         return IndicatorSnapshotDto::fromArray($data);
@@ -729,13 +765,108 @@ final class IndicatorProviderService implements IndicatorProviderInterface
         \DateTimeInterface $at,
         Timeframe $tf
     ): bool {
-        // On considère le snapshot périmé s'il est plus vieux qu'un "step" de TF
-        $snapshotTs = $snapshot->klineTime->getTimestamp();
-        $atTs = $at->getTimestamp();
+        if (!$this->isClosedKlineFresh($snapshot->klineTime, $at, $tf)) {
+            return true;
+        }
 
-        return ($atTs - $snapshotTs) > $tf->getStepInSeconds();
+        return !$this->wasSnapshotWrittenAfterCandleClose($snapshot, $tf);
     }
 
+    /**
+     * @return array<int,mixed>
+     */
+    private function fetchClosedKlines(
+        string $symbol,
+        Timeframe $timeframe,
+        int $windowSize,
+        \DateTimeInterface $at,
+        ?ExchangeContext $context,
+    ): array {
+        $klines = $this->klineProvider->getKlines($symbol, $timeframe, $windowSize + 1, $context);
 
+        return $this->closedKlineWindow($klines, $timeframe, $at, $windowSize);
+    }
+
+    /**
+     * @param array<int,mixed> $klines
+     * @return array<int,mixed>
+     */
+    private function closedKlineWindow(
+        array $klines,
+        Timeframe $timeframe,
+        \DateTimeInterface $at,
+        int $windowSize,
+    ): array {
+        $lastClosedOpenTs = $this->lastClosedKlineOpenTime($at, $timeframe)->getTimestamp();
+        $closed = [];
+        $hasOpenTime = false;
+
+        foreach ($klines as $kline) {
+            $openTime = $this->extractKlineOpenTime($kline);
+            if ($openTime === null) {
+                continue;
+            }
+
+            $hasOpenTime = true;
+            $openTs = $this->toUtcImmutable($openTime)->getTimestamp();
+            if ($openTs <= $lastClosedOpenTs) {
+                $closed[] = [
+                    'open_ts' => $openTs,
+                    'kline' => $kline,
+                ];
+            }
+        }
+
+        if (!$hasOpenTime) {
+            return \array_slice(\array_slice($klines, 0, max(0, \count($klines) - 1)), -$windowSize);
+        }
+
+        \usort(
+            $closed,
+            static fn (array $a, array $b): int => $a['open_ts'] <=> $b['open_ts'],
+        );
+
+        return \array_map(
+            static fn (array $row): mixed => $row['kline'],
+            \array_slice($closed, -$windowSize),
+        );
+    }
+
+    private function isClosedKlineFresh(
+        \DateTimeInterface $klineOpenTime,
+        \DateTimeInterface $at,
+        Timeframe $timeframe,
+    ): bool {
+        return $this->toUtcImmutable($klineOpenTime)->getTimestamp()
+            === $this->lastClosedKlineOpenTime($at, $timeframe)->getTimestamp();
+    }
+
+    private function wasSnapshotWrittenAfterCandleClose(IndicatorSnapshotDto $snapshot, Timeframe $timeframe): bool
+    {
+        if (!$snapshot->updatedAt instanceof \DateTimeInterface) {
+            return true;
+        }
+
+        $snapshotWrittenTs = $this->toUtcImmutable($snapshot->updatedAt)->getTimestamp();
+        $candleCloseTs = $this->toUtcImmutable($snapshot->klineTime)->getTimestamp()
+            + $timeframe->getStepInSeconds();
+
+        return $snapshotWrittenTs >= $candleCloseTs;
+    }
+
+    private function lastClosedKlineOpenTime(\DateTimeInterface $at, Timeframe $timeframe): \DateTimeImmutable
+    {
+        $atTs = $this->toUtcImmutable($at)->getTimestamp();
+        $step = $timeframe->getStepInSeconds();
+        $currentOpenTs = intdiv($atTs, $step) * $step;
+
+        return (new \DateTimeImmutable('@' . ($currentOpenTs - $step)))
+            ->setTimezone(new \DateTimeZone('UTC'));
+    }
+
+    private function toUtcImmutable(\DateTimeInterface $dateTime): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromInterface($dateTime)->setTimezone(new \DateTimeZone('UTC'));
+    }
 
 }

--- a/trading-app/src/MtfValidator/Service/TimeframeValidationService.php
+++ b/trading-app/src/MtfValidator/Service/TimeframeValidationService.php
@@ -13,11 +13,14 @@ use App\MtfValidator\ConditionLoader\ConditionRegistry as MtfConditionRegistry;
 use App\MtfValidator\ConditionLoader\TimeframeEvaluator as MtfTimeframeEvaluator;
 use App\MtfValidator\Service\Rule\TimeframeRuleEvaluator;
 use App\MtfValidator\Service\Rule\YamlRuleEngine;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class TimeframeValidationService
 {
+    private const CONDITION_REGISTRY_KLINE_WINDOW_SIZE = 250;
+
     public function __construct(
         private readonly TimeframeRuleEvaluator $tfEvaluator,
         private readonly YamlRuleEngine $ruleEngine,
@@ -28,6 +31,7 @@ final class TimeframeValidationService
         private readonly ?KlineProviderInterface $klineProvider = null,
         private readonly ?MainProviderInterface $mainProvider = null,
         private readonly ?MtfValidationEngineMetrics $validationEngineMetrics = null,
+        private readonly ?ClockInterface $clock = null,
     ) {
     }
 
@@ -308,7 +312,7 @@ final class TimeframeValidationService
             );
         }
 
-        $klines = $this->klineProvider->getKlines($symbol, $tfEnum, 250);
+        $klines = $this->fetchClosedKlinesForConditionRegistry($symbol, $tfEnum);
         if ($klines === []) {
             return new TimeframeDecisionDto(
                 timeframe: $timeframe,
@@ -767,5 +771,110 @@ final class TimeframeValidationService
             }
         }
         return $sum;
+    }
+
+    /**
+     * @return array<int,mixed>
+     */
+    private function fetchClosedKlinesForConditionRegistry(string $symbol, TimeframeEnum $timeframe): array
+    {
+        if ($this->klineProvider === null) {
+            return [];
+        }
+
+        $klines = $this->klineProvider->getKlines(
+            $symbol,
+            $timeframe,
+            self::CONDITION_REGISTRY_KLINE_WINDOW_SIZE + 1,
+        );
+        $lastClosedOpenTs = $this->lastClosedKlineOpenTime($this->nowUtc(), $timeframe)->getTimestamp();
+        $closed = [];
+        $hasOpenTime = false;
+
+        foreach ($klines as $kline) {
+            $openTime = $this->extractKlineOpenTime($kline);
+            if ($openTime === null) {
+                continue;
+            }
+
+            $hasOpenTime = true;
+            $openTs = $this->toUtcImmutable($openTime)->getTimestamp();
+            if ($openTs <= $lastClosedOpenTs) {
+                $closed[] = [
+                    'open_ts' => $openTs,
+                    'kline' => $kline,
+                ];
+            }
+        }
+
+        if (!$hasOpenTime) {
+            return \array_slice(
+                \array_slice($klines, 0, max(0, \count($klines) - 1)),
+                -self::CONDITION_REGISTRY_KLINE_WINDOW_SIZE,
+            );
+        }
+
+        \usort(
+            $closed,
+            static fn (array $a, array $b): int => $a['open_ts'] <=> $b['open_ts'],
+        );
+
+        return \array_map(
+            static fn (array $row): mixed => $row['kline'],
+            \array_slice($closed, -self::CONDITION_REGISTRY_KLINE_WINDOW_SIZE),
+        );
+    }
+
+    private function extractKlineOpenTime(mixed $kline): ?\DateTimeImmutable
+    {
+        if (\is_object($kline)) {
+            if (property_exists($kline, 'openTime') && $kline->openTime instanceof \DateTimeInterface) {
+                return \DateTimeImmutable::createFromInterface($kline->openTime);
+            }
+
+            if (method_exists($kline, 'getOpenTime')) {
+                $candidate = $kline->getOpenTime();
+                if ($candidate instanceof \DateTimeInterface) {
+                    return \DateTimeImmutable::createFromInterface($candidate);
+                }
+            }
+        }
+
+        if (\is_array($kline)) {
+            $candidate = $kline['openTime'] ?? $kline['open_time'] ?? null;
+            if ($candidate instanceof \DateTimeInterface) {
+                return \DateTimeImmutable::createFromInterface($candidate);
+            }
+            if (\is_numeric($candidate)) {
+                $timestamp = (int) $candidate;
+                if ($timestamp > 9999999999) {
+                    $timestamp = (int) round($timestamp / 1000);
+                }
+
+                return (new \DateTimeImmutable('@' . $timestamp))->setTimezone(new \DateTimeZone('UTC'));
+            }
+        }
+
+        return null;
+    }
+
+    private function lastClosedKlineOpenTime(\DateTimeInterface $at, TimeframeEnum $timeframe): \DateTimeImmutable
+    {
+        $atTs = $this->toUtcImmutable($at)->getTimestamp();
+        $step = $timeframe->getStepInSeconds();
+        $currentOpenTs = intdiv($atTs, $step) * $step;
+
+        return (new \DateTimeImmutable('@' . ($currentOpenTs - $step)))
+            ->setTimezone(new \DateTimeZone('UTC'));
+    }
+
+    private function nowUtc(): \DateTimeImmutable
+    {
+        return $this->toUtcImmutable($this->clock?->now() ?? new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+    }
+
+    private function toUtcImmutable(\DateTimeInterface $dateTime): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromInterface($dateTime)->setTimezone(new \DateTimeZone('UTC'));
     }
 }

--- a/trading-app/tests/Indicator/Provider/IndicatorProviderServiceClosedKlineTest.php
+++ b/trading-app/tests/Indicator/Provider/IndicatorProviderServiceClosedKlineTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Indicator\Provider;
+
+use App\Common\Dto\IndicatorSnapshotDto;
+use App\Common\Enum\Timeframe;
+use App\Contract\Provider\Dto\KlineDto;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Indicator\Core\AtrCalculator;
+use App\Indicator\Core\Momentum\Macd;
+use App\Indicator\Core\Momentum\Rsi;
+use App\Indicator\Core\Momentum\StochRsi;
+use App\Indicator\Core\Trend\Adx;
+use App\Indicator\Core\Trend\Ema;
+use App\Indicator\Core\Trend\Sma;
+use App\Indicator\Core\Volatility\Bollinger;
+use App\Indicator\Core\Volume\Vwap;
+use App\Indicator\Provider\IndicatorProviderService;
+use App\Indicator\Registry\ConditionRegistry;
+use App\Repository\IndicatorSnapshotRepository;
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+#[CoversClass(IndicatorProviderService::class)]
+final class IndicatorProviderServiceClosedKlineTest extends TestCase
+{
+    public function testSnapshotCalculatesIndicatorsFromClosedWindowOnly(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-31 12:05:30', new \DateTimeZone('UTC'));
+        $klines = $this->klinesEndingWithCurrentCandle($now);
+
+        $klineProvider = $this->createMock(KlineProviderInterface::class);
+        $klineProvider
+            ->expects(self::once())
+            ->method('getKlines')
+            ->with('BTCUSDT', Timeframe::TF_1M, 251, self::anything())
+            ->willReturn($klines);
+
+        $snapshotRepository = $this->createMock(IndicatorSnapshotRepository::class);
+        $snapshotRepository
+            ->expects(self::once())
+            ->method('findLastBySymbolAndTimeframe')
+            ->willReturn(null);
+        $snapshotRepository
+            ->expects(self::once())
+            ->method('upsert');
+
+        $snapshot = $this->service($klineProvider, $snapshotRepository, $now)
+            ->getSnapshot('BTCUSDT', '1m');
+
+        self::assertSame('2026-05-31 12:04:00', $snapshot->klineTime->format('Y-m-d H:i:s'));
+        self::assertEqualsWithDelta(246.0, $snapshot->ma9?->toFloat(), 0.000001);
+    }
+
+    public function testMtfMappingUsesLastClosedClose(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-31 12:05:30', new \DateTimeZone('UTC'));
+        $klines = $this->klinesEndingWithCurrentCandle($now);
+
+        $klineProvider = $this->createMock(KlineProviderInterface::class);
+        $klineProvider
+            ->expects(self::exactly(2))
+            ->method('getKlines')
+            ->with('BTCUSDT', Timeframe::TF_1M, 251, self::anything())
+            ->willReturn($klines);
+
+        $snapshotRepository = $this->createMock(IndicatorSnapshotRepository::class);
+        $snapshotRepository
+            ->expects(self::exactly(2))
+            ->method('findLastBySymbolAndTimeframe')
+            ->willReturn(null);
+        $snapshotRepository
+            ->expects(self::once())
+            ->method('upsert');
+
+        $result = $this->service($klineProvider, $snapshotRepository, $now)
+            ->getIndicatorsForSymbolAndTimeframes('BTCUSDT', ['1m'], $now);
+
+        self::assertSame(250.0, $result['1m']['close'] ?? null);
+        self::assertSame('2026-05-31 12:04:00', $result['1m']['kline_time'] ?? null);
+    }
+
+    public function testSnapshotFreshnessRequiresExpectedClosedCandle(): void
+    {
+        $now = new \DateTimeImmutable('2026-05-31 12:05:30', new \DateTimeZone('UTC'));
+        $service = $this->service(
+            $this->createMock(KlineProviderInterface::class),
+            $this->createMock(IndicatorSnapshotRepository::class),
+            $now,
+        );
+        $method = new \ReflectionMethod($service, 'isSnapshotStale');
+
+        self::assertFalse($method->invoke(
+            $service,
+            $this->snapshotAt('2026-05-31 12:04:00'),
+            $now,
+            Timeframe::TF_1M,
+        ));
+        self::assertTrue($method->invoke(
+            $service,
+            $this->snapshotAt('2026-05-31 12:05:00'),
+            $now,
+            Timeframe::TF_1M,
+        ));
+        self::assertTrue($method->invoke(
+            $service,
+            $this->snapshotAt('2026-05-31 12:03:00'),
+            $now,
+            Timeframe::TF_1M,
+        ));
+
+        $afterCurrentCandleCloses = new \DateTimeImmutable('2026-05-31 12:06:30', new \DateTimeZone('UTC'));
+        self::assertTrue($method->invoke(
+            $service,
+            $this->snapshotAt('2026-05-31 12:05:00', '2026-05-31 12:05:30'),
+            $afterCurrentCandleCloses,
+            Timeframe::TF_1M,
+        ));
+        self::assertFalse($method->invoke(
+            $service,
+            $this->snapshotAt('2026-05-31 12:05:00', '2026-05-31 12:06:01'),
+            $afterCurrentCandleCloses,
+            Timeframe::TF_1M,
+        ));
+    }
+
+    /**
+     * @return KlineDto[]
+     */
+    private function klinesEndingWithCurrentCandle(\DateTimeImmutable $now): array
+    {
+        $currentOpenTs = intdiv($now->getTimestamp(), 60) * 60;
+        $currentOpen = (new \DateTimeImmutable('@' . $currentOpenTs))->setTimezone(new \DateTimeZone('UTC'));
+        $firstOpen = $currentOpen->modify('-250 minutes');
+
+        $klines = [];
+        for ($i = 0; $i <= 250; $i++) {
+            $close = $i === 250 ? 10000.0 : (float) ($i + 1);
+            $klines[] = new KlineDto(
+                symbol: 'BTCUSDT',
+                timeframe: Timeframe::TF_1M,
+                openTime: $firstOpen->modify("+{$i} minutes"),
+                open: BigDecimal::of((string) $close),
+                high: BigDecimal::of((string) ($close + 1.0)),
+                low: BigDecimal::of((string) max(0.0, $close - 1.0)),
+                close: BigDecimal::of((string) $close),
+                volume: BigDecimal::of('100'),
+            );
+        }
+
+        return $klines;
+    }
+
+    private function snapshotAt(string $klineTime, ?string $updatedAt = null): IndicatorSnapshotDto
+    {
+        return new IndicatorSnapshotDto(
+            symbol: 'BTCUSDT',
+            timeframe: Timeframe::TF_1M,
+            klineTime: new \DateTimeImmutable($klineTime, new \DateTimeZone('UTC')),
+            updatedAt: $updatedAt !== null
+                ? new \DateTimeImmutable($updatedAt, new \DateTimeZone('UTC'))
+                : null,
+        );
+    }
+
+    private function service(
+        KlineProviderInterface $klineProvider,
+        IndicatorSnapshotRepository $snapshotRepository,
+        \DateTimeImmutable $now,
+    ): IndicatorProviderService {
+        $logger = new NullLogger();
+
+        return new IndicatorProviderService(
+            $klineProvider,
+            new ConditionRegistry([], $this->emptyLocator(), $logger),
+            $snapshotRepository,
+            new Rsi(),
+            new Ema(),
+            new Macd(),
+            new Adx(),
+            new Bollinger(),
+            new Vwap(),
+            new AtrCalculator($logger),
+            new StochRsi(),
+            new Sma(),
+            $this->fixedClock($now),
+            $logger,
+        );
+    }
+
+    private function fixedClock(\DateTimeImmutable $now): ClockInterface
+    {
+        return new class($now) implements ClockInterface {
+            public function __construct(private readonly \DateTimeImmutable $now)
+            {
+            }
+
+            public function now(): \DateTimeImmutable
+            {
+                return $this->now;
+            }
+        };
+    }
+
+    /**
+     * @return ContainerInterface&ServiceProviderInterface
+     */
+    private function emptyLocator(): ContainerInterface
+    {
+        return new class implements ContainerInterface, ServiceProviderInterface {
+            public function get(string $id): mixed
+            {
+                throw new \RuntimeException(sprintf('Service "%s" is not available in this test locator.', $id));
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+
+            public function getProvidedServices(): array
+            {
+                return [];
+            }
+        };
+    }
+}

--- a/trading-app/tests/MtfValidator/Service/TimeframeValidationServiceFallbackTest.php
+++ b/trading-app/tests/MtfValidator/Service/TimeframeValidationServiceFallbackTest.php
@@ -61,8 +61,15 @@ final class TimeframeValidationServiceFallbackTest extends TestCase
         $klineProvider
             ->expects(self::once())
             ->method('getKlines')
-            ->with('BTCUSDT', Timeframe::TF_5M, 250)
-            ->willReturn([['open' => 1, 'high' => 1, 'low' => 1, 'close' => 1, 'volume' => 1]]);
+            ->with('BTCUSDT', Timeframe::TF_5M, 251)
+            ->willReturn([[
+                'open' => 1,
+                'high' => 1,
+                'low' => 1,
+                'close' => 1,
+                'volume' => 1,
+                'open_time' => new \DateTimeImmutable('2026-05-31 00:00:00', new \DateTimeZone('UTC')),
+            ]]);
 
         $service = new TimeframeValidationService(
             new TimeframeRuleEvaluator($ruleEngine),
@@ -104,6 +111,95 @@ final class TimeframeValidationServiceFallbackTest extends TestCase
         ));
     }
 
+    public function testConditionRegistryWindowDropsTrailingUntimestampedExtraKline(): void
+    {
+        $ruleEngine = new YamlRuleEngine();
+        $logger = new class extends AbstractLogger {
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+            }
+        };
+
+        $conditionRegistry = $this->createMock(MtfConditionRegistry::class);
+        $conditionRegistry
+            ->expects(self::once())
+            ->method('load');
+
+        $conditionEvaluator = $this->createMock(MtfTimeframeEvaluator::class);
+        $conditionEvaluator
+            ->expects(self::once())
+            ->method('evaluate')
+            ->willReturn([
+                'passed' => [
+                    'long' => true,
+                    'short' => false,
+                ],
+                'long' => [
+                    'conditions' => [],
+                ],
+                'short' => [
+                    'conditions' => [],
+                ],
+            ]);
+
+        $indicatorEngine = $this->createMock(IndicatorEngineInterface::class);
+        $indicatorEngine
+            ->expects(self::once())
+            ->method('buildContext')
+            ->with(
+                'BTCUSDT',
+                '1m',
+                self::callback(function (array $klines): bool {
+                    self::assertCount(250, $klines);
+                    self::assertSame(250.0, (float) $klines[249]['close']);
+
+                    return true;
+                }),
+                [],
+            )
+            ->willReturn(['close' => 250.0]);
+
+        $klineProvider = $this->createMock(KlineProviderInterface::class);
+        $klineProvider
+            ->expects(self::once())
+            ->method('getKlines')
+            ->with('BTCUSDT', Timeframe::TF_1M, 251)
+            ->willReturn($this->untimestampedKlinesWithOpenExtra());
+
+        $service = new TimeframeValidationService(
+            new TimeframeRuleEvaluator($ruleEngine),
+            $ruleEngine,
+            $logger,
+            $conditionEvaluator,
+            $conditionRegistry,
+            $indicatorEngine,
+            $klineProvider,
+        );
+
+        $decision = $service->validateTimeframe(
+            symbol: 'BTCUSDT',
+            timeframe: '1m',
+            phase: 'context',
+            mode: 'scalper',
+            mtfConfig: [
+                'rules' => [],
+                'validation' => [
+                    'timeframe' => [
+                        '1m' => [
+                            'long' => [],
+                            'short' => [],
+                        ],
+                    ],
+                ],
+                'filters_mandatory' => [],
+            ],
+            indicators: [],
+        );
+
+        self::assertTrue($decision->valid);
+        self::assertSame('long', $decision->signal);
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -139,5 +235,25 @@ final class TimeframeValidationServiceFallbackTest extends TestCase
             ],
             'filters_mandatory' => [],
         ];
+    }
+
+    /**
+     * @return array<int,array<string,float>>
+     */
+    private function untimestampedKlinesWithOpenExtra(): array
+    {
+        $klines = [];
+        for ($i = 1; $i <= 251; $i++) {
+            $close = $i === 251 ? 10000.0 : (float) $i;
+            $klines[] = [
+                'open' => $close,
+                'high' => $close + 1.0,
+                'low' => max(0.0, $close - 1.0),
+                'close' => $close,
+                'volume' => 100.0,
+            ];
+        }
+
+        return $klines;
     }
 }


### PR DESCRIPTION
Closes #77

## Summary
- Normalize indicator paths to fetch N+1 klines and compute on the last N closed candles.
- Strengthen snapshot and pivot cache freshness so current/future candle timestamps are treated as stale.
- Apply the same closed-candle filtering to the ConditionRegistry MTF validation path.
- Add regression tests proving a current candle with an extreme close does not affect snapshot indicators or MTF close mapping.
- Fix an implicit nullable parameter deprecation in `IndicatorSnapshotDto` touched by the new tests.

## Tests
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Indicator/Provider/IndicatorProviderServiceClosedKlineTest.php tests/MtfValidator/Service/TimeframeValidationServiceFallbackTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/MtfValidator/Service/TimeframeValidationServiceFallbackTest.php tests/MtfValidator/Service/TimeframeValidationServiceScalperTest.php tests/MtfValidator/Validator/ValidationsYamlValidatorTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console app:validate:mtf-config --mode=all` (0 errors, 1 existing warning: `filters_mandatory est vide`)
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction`
- `git diff --check`
- `git diff --cached --check`

## Known existing test debt
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Indicator` still fails before this change on obsolete condition/rule constructors and missing PHPUnit coverage targets.
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Indicator/Snapshot/IndicatorSnapshotRegressionTest.php tests/Indicator/Context/IndicatorContextBuilderIntegrationTest.php` also fails on missing `KERNEL_CLASS` / outdated constructor signatures.