### PR TITLE
Cap PHP worker memory and disable debug

### DIFF
--- a/cron_symfony_mtf_workers/README.md
+++ b/cron_symfony_mtf_workers/README.md
@@ -60,7 +60,7 @@ En production, on préfère la cible Docker (`Dockerfile` + `deploy.sh`) décrit
 | `TEMPORAL_NAMESPACE` | Namespace | `default` |
 | `TASK_QUEUE_NAME` | Task queue consommée par `worker.py` | `cron_symfony_mtf_workers` |
 | `MTF_WORKERS_URL` | URL par défaut de `/api/mtf/run` | `http://trading-app-nginx:80/api/mtf/run` |
-| `MTF_WORKERS_COUNT` | `workers` envoyés à l’API | `5` |
+| `MTF_WORKERS_COUNT` | `workers` envoyés à l’API | `4` |
 | `MTF_WORKERS_DRY_RUN` | Flag `dry_run` | `true` |
 | `REQUEST_TIMEOUT_SECONDS` | Timeout HTTP d’un job (niveau activité) | `900` (15 min, override possible par job) |
 
@@ -81,7 +81,7 @@ Chaque schedule définit ses propres overrides via `job.payload`. Voir `models/m
 | `MTF_WORKERS_WORKFLOW_ID` | `cron-symfony-mtf-workers-runner` | Workflow ID retransmis à Temporal |
 | `MTF_WORKERS_CRON` | `*/1 * * * *` | Cadence (1 minute) |
 | `MTF_WORKERS_URL` | `http://trading-app-nginx:80/api/mtf/run` | Endpoint Symfony |
-| `MTF_WORKERS_COUNT` | `5` | Nombre de workers parallèle côté runner |
+| `MTF_WORKERS_COUNT` | `4` | Nombre de workers parallèle côté runner |
 | `MTF_WORKERS_DRY_RUN` | `true` | On active `dry_run=1` par sécurité en staging |
 
 ```bash
@@ -107,7 +107,7 @@ python scripts/manage_mtf_workers_schedule.py delete       # supprime
 
 ### 4.3 Scalper Micro
 
-- **Objectif** : reproduire le run MTF avec le profil `scalper_micro` (8 workers) toutes les minutes.
+- **Objectif** : reproduire le run MTF avec le profil `scalper_micro` (4 workers) toutes les minutes.
 - **Script** : `scripts/manage_scalper_micro_schedule.py`.
 
 | Variable | Défaut |
@@ -115,7 +115,7 @@ python scripts/manage_mtf_workers_schedule.py delete       # supprime
 | `SCALPER_MICRO_SCHEDULE_ID` | `cron-symfony-mtf-workers-scalper-micro-1m` |
 | `SCALPER_MICRO_WORKFLOW_ID` | `cron-symfony-mtf-workers-scalper-micro-runner` |
 | `SCALPER_MICRO_CRON` | `*/1 * * * *` |
-| `SCALPER_MICRO_WORKERS_COUNT` | `8` |
+| `SCALPER_MICRO_WORKERS_COUNT` | `4` |
 | `SCALPER_MICRO_DRY_RUN` | `true` |
 
 > Le script force automatiquement `{"mtf_profile": "scalper_micro"}` dans la charge utile envoyée à Symfony.

--- a/cron_symfony_mtf_workers/models/mtf_job.py
+++ b/cron_symfony_mtf_workers/models/mtf_job.py
@@ -34,7 +34,7 @@ def _normalize_symbols(raw: Any) -> Optional[List[str]]:
 @dataclass
 class MtfJob:
     url: str
-    workers: int = 5
+    workers: int = 4
     dry_run: bool = True
     force_run: bool = False
     force_timeframe_check: bool = False
@@ -48,7 +48,7 @@ class MtfJob:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "MtfJob":
         url = str(data.get("url"))
-        workers = int(data.get("workers", 5))
+        workers = int(data.get("workers", 4))
         dry_run = _to_bool(data.get("dry_run"), True)
         force_run = _to_bool(data.get("force_run"), False)
         force_timeframe_check = _to_bool(data.get("force_timeframe_check"), False)

--- a/cron_symfony_mtf_workers/scripts/manage_mtf_workers_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_mtf_workers_schedule.py
@@ -42,15 +42,14 @@ except AttributeError:  # pragma: no cover - compatibility with < 1.6
 
 DEFAULT_URL = os.getenv("MTF_WORKERS_URL", "http://trading-app-nginx:80/api/mtf/run")
 # Nombre de workers désiré pour les appels MTF (override via MTF_WORKERS_COUNT)
-DEFAULT_WORKERS = int(os.getenv("MTF_WORKERS_COUNT", "10"))
+DEFAULT_WORKERS = int(os.getenv("MTF_WORKERS_COUNT", "4"))
 DEFAULT_DRY_RUN = os.getenv("MTF_WORKERS_DRY_RUN", "true").lower() not in {"0", "false", "no", "off"}
 
 
 def make_job() -> Dict[str, Any]:
     return {
         "url": DEFAULT_URL,
-        # Utiliser la valeur configurée plutôt qu'un littéral
-        "workers": 10,
+        "workers": max(1, DEFAULT_WORKERS),
         "dry_run": DEFAULT_DRY_RUN,
         "mtf_profile": "scalper",
     }

--- a/cron_symfony_mtf_workers/scripts/manage_scalper_micro_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_scalper_micro_schedule.py
@@ -42,7 +42,7 @@ except AttributeError:  # pragma: no cover - compatibility with < 1.6
 
 DEFAULT_URL = os.getenv("SCALPER_MICRO_URL", "http://trading-app-nginx:80/api/mtf/run")
 # Nombre de workers désiré pour les appels MTF scalper_micro (override via SCALPER_MICRO_WORKERS_COUNT)
-DEFAULT_WORKERS = int(os.getenv("SCALPER_MICRO_WORKERS_COUNT", "8"))
+DEFAULT_WORKERS = int(os.getenv("SCALPER_MICRO_WORKERS_COUNT", "4"))
 DEFAULT_DRY_RUN = os.getenv("SCALPER_MICRO_DRY_RUN", "False").lower() not in {"0", "false", "no", "off"}
 
 
@@ -159,4 +159,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,8 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
       - TASK_QUEUE_NAME=cron_symfony_mtf_workers
       - MTF_WORKERS_URL=http://trading-app-nginx:80/api/mtf/run
-      - MTF_WORKERS_COUNT=8  # Ajusté pour 370 symboles (220 top + 150 mid) avec limites BitMart 12 req/2s
+      - MTF_WORKERS_COUNT=4  # Réduit pour limiter le pic mémoire des workers PHP
+      - SCALPER_MICRO_WORKERS_COUNT=4
       - MTF_WORKERS_DRY_RUN=false
     depends_on:
       temporal:

--- a/trading-app/Dockerfile.mtf
+++ b/trading-app/Dockerfile.mtf
@@ -56,6 +56,6 @@ RUN if [ "$APP_ENV" = "prod" ]; then \
 COPY . .
 RUN chown -R www-data:www-data /var/www/html \
  && chmod -R 755 /var/www/html \
- && echo "memory_limit = 2G" >> /usr/local/etc/php/conf.d/memory.ini
+ && echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/memory.ini
 EXPOSE 9000
 CMD ["php-fpm"]

--- a/trading-app/php/conf.d/memory.ini
+++ b/trading-app/php/conf.d/memory.ini
@@ -1,4 +1,1 @@
-memory_limit = 2G
-
-
-
+memory_limit = 512M

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -822,7 +822,7 @@ final class MtfRunnerService
                 $process = new Process(
                     $this->buildWorkerCommand($symbol, $options),
                     $this->projectDir,
-                    ['APP_DEBUG' => '1']
+                    ['APP_DEBUG' => '0']
                 );
                 $process->start();
                 $workerStartTimes[$symbol] = $workerStart;
@@ -920,6 +920,8 @@ final class MtfRunnerService
         // PHP_BINARY peut pointer vers php-fpm dans un environnement FPM, ce qui ne fonctionne pas pour les commandes CLI
         $command = [
             'php',
+            '-d',
+            'memory_limit=512M',
             $this->projectDir . '/bin/console',
             'mtf:run-worker',
             '--symbols=' . $symbol,

--- a/trading-app/src/MtfValidator/Command/MtfRunCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfRunCommand.php
@@ -369,8 +369,7 @@ class MtfRunCommand extends Command
                 $process = new Process(
                     $this->buildWorkerCommand($symbol, $options),
                     $this->projectDir,
-                    // Forcer l'affichage des traces pour diagnostiquer les erreurs des workers
-                    ['APP_DEBUG' => '1']
+                    ['APP_DEBUG' => '0']
                 );
                 $process->start();
                 $active[] = ['symbol' => $symbol, 'process' => $process];
@@ -629,6 +628,8 @@ class MtfRunCommand extends Command
     {
         $command = [
             PHP_BINARY,
+            '-d',
+            'memory_limit=512M',
             $this->projectDir . '/bin/console',
             'mtf:run-worker',
             '--symbols=' . $symbol,


### PR DESCRIPTION
Closes #74

## Summary
- lower PHP memory_limit from 2G to 512M in the mounted PHP config and Docker image fallback
- spawn MTF worker processes with APP_DEBUG=0 and a CLI memory_limit=512M override
- reduce Temporal MTF/scalper_micro worker defaults to 4 and stop hard-coding 10 workers in the schedule job

## Local review
- verified no remaining 2G PHP memory limit or APP_DEBUG=1 worker spawn path
- checked scheduler defaults so cron-created jobs cannot silently keep 8/10 worker fan-out
- out-of-zone-watcher/ intentionally ignored

## Tests
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console app:validate:mtf-config --mode=all (1 existing warning: filters_mandatory empty)
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- python3 -m py_compile cron_symfony_mtf_workers/scripts/manage_mtf_workers_schedule.py cron_symfony_mtf_workers/scripts/manage_scalper_micro_schedule.py cron_symfony_mtf_workers/models/mtf_job.py
- docker compose config --quiet
- git diff --check

Note: python3 -m pytest cron_symfony_mtf_workers/tests could not run because pytest is not installed locally.