### PR TITLE
Recycle PHP-FPM workers between MTF runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -302,6 +302,7 @@ services:
     volumes:
       - ./trading-app:/var/www/html
       - ./trading-app/php/conf.d:/usr/local/etc/php/conf.d
+      - ./trading-app/php-fpm.d/zz-trading-pool.conf:/usr/local/etc/php-fpm.d/zz-trading-pool.conf:ro
       - ./investigation:/var/www/investigation
       - app-cache:/var/www/html/var/cache
       - var-bitmart:/var/www/html/var/bitmart

--- a/trading-app/Dockerfile.mtf
+++ b/trading-app/Dockerfile.mtf
@@ -53,6 +53,7 @@ RUN if [ "$APP_ENV" = "prod" ]; then \
     else \
       composer install --optimize-autoloader --no-scripts --no-interaction; \
     fi
+COPY php-fpm.d/zz-trading-pool.conf /usr/local/etc/php-fpm.d/zz-trading-pool.conf
 COPY . .
 RUN chown -R www-data:www-data /var/www/html \
  && chmod -R 755 /var/www/html \

--- a/trading-app/php-fpm.d/zz-trading-pool.conf
+++ b/trading-app/php-fpm.d/zz-trading-pool.conf
@@ -1,0 +1,7 @@
+[www]
+pm = ondemand
+pm.max_children = 4
+pm.process_idle_timeout = 10s
+pm.max_requests = 100
+; Keep FPM aligned with PHP max_execution_time and nginx fastcgi timeouts for /api/mtf/run.
+request_terminate_timeout = 900s


### PR DESCRIPTION
Closes #73

## Summary
- add a PHP-FPM pool override for the `www` pool with `pm=ondemand`, `pm.process_idle_timeout=10s`, `pm.max_requests=100`, and `request_terminate_timeout=90s`
- mount that FPM override into the HTTP `trading-app-php` service
- copy the override into the Docker image so non-compose deployments use the same recycling behavior

## Local review
- kept the override as `zz-trading-pool.conf` so Docker official FPM defaults remain intact and only pool recycling directives are changed
- scoped the bind mount to the PHP-FPM HTTP service; CLI messenger containers do not need this pool config
- out-of-zone-watcher/ intentionally ignored

## Tests
- docker run --rm tradingv3-trading-app-php:latest php-fpm -t
- docker run --rm tradingv3-trading-app-php:latest sh -lc 'php-fpm -tt 2>&1 | grep -E "pm =|pm.max_children|pm.process_idle_timeout|pm.max_requests|request_terminate_timeout"'
- docker compose config --quiet
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Exchange tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console app:validate:mtf-config --mode=all (1 existing warning: filters_mandatory empty)
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container --no-debug
- php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console doctrine:schema:validate --skip-sync --no-interaction
- git diff --check