### PR TITLE
feat: add exchange profile runtime schedules

### DIFF
--- a/cron_symfony_mtf_workers/README.md
+++ b/cron_symfony_mtf_workers/README.md
@@ -44,8 +44,12 @@ export TASK_QUEUE_NAME=cron_symfony_mtf_workers
 # 3. Lancer le worker local
 python worker.py
 
-# 4. Créer un schedule MTF (preview)
-python scripts/manage_mtf_workers_schedule.py create --dry-run
+# 4. Créer un schedule MTF multi-exchange (preview Temporal)
+python scripts/manage_exchange_profile_schedule.py create \
+  --exchange=okx \
+  --profile=scalper \
+  --dry-run=true \
+  --dry-run-schedule
 ```
 
 En production, on préfère la cible Docker (`Dockerfile` + `deploy.sh`) décrite dans `DEPLOYMENT.md`.
@@ -70,10 +74,67 @@ Chaque schedule définit ses propres overrides via `job.payload`. Voir `models/m
 
 ## 4. Schedules disponibles
 
-### 4.1 MTF Workers (profil standard)
+### 4.1 Runtime Matrix Exchange/Profile
+
+- **Objectif** : gérer les schedules MTF explicites par couple `exchange/market_type/profile`.
+- **Fichier CLI recommandé** : `scripts/manage_exchange_profile_schedule.py`.
+- **Règle de sécurité** : `dry_run=true` est le défaut pour tous les exchanges, y compris BitMart.
+- **Diagnostic live** : avant `dry_run=false`, le script appelle `docker compose exec -T trading-app-php php bin/console app:exchange:runtime-check <exchange> <market_type>`.
+
+Le script envoie toujours un payload explicite à `/api/mtf/run` :
+
+```json
+{
+  "url": "http://trading-app-nginx:80/api/mtf/run",
+  "workers": 4,
+  "dry_run": true,
+  "mtf_profile": "scalper",
+  "exchange": "okx",
+  "market_type": "perpetual"
+}
+```
+
+Commandes principales :
+
+```bash
+python scripts/manage_exchange_profile_schedule.py create --exchange=okx --profile=scalper --dry-run=true
+python scripts/manage_exchange_profile_schedule.py status --schedule-id=cron-mtf-okx-scalper-1m
+python scripts/manage_exchange_profile_schedule.py pause --schedule-id=cron-mtf-okx-scalper-1m
+python scripts/manage_exchange_profile_schedule.py resume --schedule-id=cron-mtf-okx-scalper-1m
+python scripts/manage_exchange_profile_schedule.py delete --schedule-id=cron-mtf-okx-scalper-1m
+```
+
+`--dry-run` contrôle le payload MTF. `--dry-run-schedule` ne crée pas de schedule Temporal et sert uniquement à prévisualiser la configuration.
+
+IDs générés par défaut :
+
+| Entrée | `schedule_id` | `workflow_id` |
+| --- | --- | --- |
+| `--exchange=okx --profile=scalper --cron="*/1 * * * *"` | `cron-mtf-okx-scalper-1m` | `mtf-okx-scalper-runner` |
+| `--exchange=bitmart --profile=regular --cron="*/5 * * * *"` | `cron-mtf-bitmart-regular-5m` | `mtf-bitmart-regular-runner` |
+| `--exchange=hyperliquid --profile=scalper_micro --cron="*/1 * * * *"` | `cron-mtf-hyperliquid-scalper-micro-1m` | `mtf-hyperliquid-scalper-micro-runner` |
+
+Matrice recommandée :
+
+| Schedule | Exchange | Market type | Profile | Cadence | Défaut |
+| --- | --- | --- | --- | --- | --- |
+| `cron-mtf-bitmart-scalper-1m` | `bitmart` | `perpetual` | `scalper` | `*/1 * * * *` | `dry_run=true` |
+| `cron-mtf-bitmart-scalper-micro-1m` | `bitmart` | `perpetual` | `scalper_micro` | `*/1 * * * *` | `dry_run=true` |
+| `cron-mtf-bitmart-regular-5m` | `bitmart` | `perpetual` | `regular` | `*/5 * * * *` | `dry_run=true` |
+| `cron-mtf-okx-scalper-1m` | `okx` | `perpetual` | `scalper` | `*/1 * * * *` | `dry_run=true` |
+| `cron-mtf-okx-scalper-micro-1m` | `okx` | `perpetual` | `scalper_micro` | `*/1 * * * *` | `dry_run=true` |
+| `cron-mtf-okx-regular-5m` | `okx` | `perpetual` | `regular` | `*/5 * * * *` | `dry_run=true` |
+| `cron-mtf-hyperliquid-scalper-1m` | `hyperliquid` | `perpetual` | `scalper` | `*/1 * * * *` | `dry_run=true` |
+| `cron-mtf-hyperliquid-scalper-micro-1m` | `hyperliquid` | `perpetual` | `scalper_micro` | `*/1 * * * *` | `dry_run=true` |
+| `cron-mtf-hyperliquid-regular-5m` | `hyperliquid` | `perpetual` | `regular` | `*/5 * * * *` | `dry_run=true` |
+
+En `dry_run=true`, le script autorise la création même si `app:exchange:runtime-check` retourne `Schedule ready: no`, avec un warning explicite. En `dry_run=false`, la création est refusée tant que le diagnostic runtime, les credentials et les flags live ne passent pas.
+
+### 4.2 MTF Workers (profil standard, legacy)
 
 - **Objectif** : relancer `/api/mtf/run` toutes les minutes (profil actuel du runner).
 - **Fichier CLI** : `scripts/manage_mtf_workers_schedule.py`.
+- **Statut** : legacy. À conserver pour les déploiements existants, mais ne pas utiliser pour les nouveaux schedules multi-exchange.
 
 | Variable | Défaut | Commentaire |
 | --- | --- | --- |
@@ -92,7 +153,7 @@ python scripts/manage_mtf_workers_schedule.py resume       # relance
 python scripts/manage_mtf_workers_schedule.py delete       # supprime
 ```
 
-### 4.2 Contract Sync
+### 4.3 Contract Sync
 
 - **Objectif** : appeler `/api/mtf/sync-contracts` tous les jours à 09:00 UTC.
 - **Timeout spécifique** : 10 minutes (voir `timeout_minutes` dans la définition du job).
@@ -105,10 +166,11 @@ python scripts/manage_mtf_workers_schedule.py delete       # supprime
 | `CONTRACT_SYNC_CRON` | `0 9 * * *` |
 | `CONTRACT_SYNC_URL` | `http://trading-app-nginx:80/api/mtf/sync-contracts` |
 
-### 4.3 Scalper Micro
+### 4.4 Scalper Micro (legacy)
 
 - **Objectif** : reproduire le run MTF avec le profil `scalper_micro` (4 workers) toutes les minutes.
 - **Script** : `scripts/manage_scalper_micro_schedule.py`.
+- **Statut** : legacy. À conserver pour les déploiements existants, mais ne pas utiliser pour les nouveaux schedules multi-exchange.
 
 | Variable | Défaut |
 | --- | --- |
@@ -118,9 +180,9 @@ python scripts/manage_mtf_workers_schedule.py delete       # supprime
 | `SCALPER_MICRO_WORKERS_COUNT` | `4` |
 | `SCALPER_MICRO_DRY_RUN` | `true` |
 
-> Le script force automatiquement `{"mtf_profile": "scalper_micro"}` dans la charge utile envoyée à Symfony.
+> Le script force automatiquement `{"mtf_profile": "scalper_micro"}` dans la charge utile envoyée à Symfony. Les nouveaux schedules doivent passer par `manage_exchange_profile_schedule.py` afin d'envoyer aussi `exchange` et `market_type`.
 
-### 4.4 Cleanup / jobs personnalisés
+### 4.5 Cleanup / jobs personnalisés
 
 Des scripts supplémentaires sont fournis pour gérer les schedules de cleanup (`scripts/manage_cleanup_schedule.py`) ou tout nouveau job. Inspirez-vous des modèles existants : chaque script construit une instance `MtfJob`, configure la cron et invoque la CLI Temporal.
 

--- a/cron_symfony_mtf_workers/README.md
+++ b/cron_symfony_mtf_workers/README.md
@@ -113,6 +113,9 @@ IDs générés par défaut :
 | `--exchange=okx --profile=scalper --cron="*/1 * * * *"` | `cron-mtf-okx-scalper-1m` | `mtf-okx-scalper-runner` |
 | `--exchange=bitmart --profile=regular --cron="*/5 * * * *"` | `cron-mtf-bitmart-regular-5m` | `mtf-bitmart-regular-runner` |
 | `--exchange=hyperliquid --profile=scalper_micro --cron="*/1 * * * *"` | `cron-mtf-hyperliquid-scalper-micro-1m` | `mtf-hyperliquid-scalper-micro-runner` |
+| `--exchange=okx --market-type=spot --profile=scalper --cron="*/1 * * * *"` | `cron-mtf-okx-spot-scalper-1m` | `mtf-okx-spot-scalper-runner` |
+
+Le `market_type` est omis des IDs pour `perpetual` afin de conserver les noms recommandés historiques, et ajouté pour les autres marchés afin d'éviter les collisions.
 
 Matrice recommandée :
 

--- a/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
@@ -70,12 +70,22 @@ def profile_slug(profile: str) -> str:
     return profile.replace("_", "-")
 
 
-def generate_schedule_id(exchange: str, profile: str, cron_expression: str) -> str:
-    return f"cron-mtf-{exchange}-{profile_slug(profile)}-{cadence_suffix(cron_expression)}"
+def market_slug(market_type: str) -> str:
+    return "" if market_type == "perpetual" else f"{market_type}-"
 
 
-def generate_workflow_id(exchange: str, profile: str) -> str:
-    return f"mtf-{exchange}-{profile_slug(profile)}-runner"
+def generate_schedule_id(
+    exchange: str,
+    profile: str,
+    cron_expression: str,
+    *,
+    market_type: str = "perpetual",
+) -> str:
+    return f"cron-mtf-{exchange}-{market_slug(market_type)}{profile_slug(profile)}-{cadence_suffix(cron_expression)}"
+
+
+def generate_workflow_id(exchange: str, profile: str, *, market_type: str = "perpetual") -> str:
+    return f"mtf-{exchange}-{market_slug(market_type)}{profile_slug(profile)}-runner"
 
 
 def build_job(
@@ -165,28 +175,29 @@ def run_runtime_check(exchange: str, market_type: str) -> Dict[str, str]:
 
 def resolve_schedule_config(args: argparse.Namespace) -> ScheduleConfig:
     cron = args.cron
-    dry_run = parse_bool(getattr(args, "dry_run", None), True)
+    dry_run = parse_bool(getattr(args, "dry_run", None), parse_bool(os.getenv("MTF_WORKERS_DRY_RUN"), True))
     exchange = getattr(args, "exchange", None)
+    market_type = getattr(args, "market_type", "perpetual")
     profile = getattr(args, "profile", None)
 
     if getattr(args, "schedule_id", None):
         schedule_id = args.schedule_id
     elif exchange and profile:
-        schedule_id = generate_schedule_id(exchange, profile, cron)
+        schedule_id = generate_schedule_id(exchange, profile, cron, market_type=market_type)
     else:
         raise SystemExit("--schedule-id is required when --exchange or --profile is omitted")
 
     if getattr(args, "workflow_id", None):
         workflow_id = args.workflow_id
     elif exchange and profile:
-        workflow_id = generate_workflow_id(exchange, profile)
+        workflow_id = generate_workflow_id(exchange, profile, market_type=market_type)
     else:
         workflow_id = "mtf-schedule-runner"
 
     return ScheduleConfig(
         command=args.command,
         exchange=exchange,
-        market_type=getattr(args, "market_type", "perpetual"),
+        market_type=market_type,
         profile=profile,
         workers=max(1, getattr(args, "workers", DEFAULT_WORKERS)),
         dry_run=dry_run,
@@ -334,7 +345,7 @@ def add_common_options(parser: argparse.ArgumentParser, *, require_matrix: bool)
     parser.add_argument("--market-type", default="perpetual", choices=sorted(SUPPORTED_MARKET_TYPES))
     parser.add_argument("--profile", required=require_matrix, choices=sorted(SUPPORTED_PROFILES))
     parser.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
-    parser.add_argument("--dry-run", default="true")
+    parser.add_argument("--dry-run")
     parser.add_argument("--cron", default=DEFAULT_CRON)
     parser.add_argument("--schedule-id")
     parser.add_argument("--workflow-id")

--- a/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
@@ -265,8 +265,8 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
     if not config.skip_runtime_check:
         runtime_check = run_runtime_check(config.exchange, config.market_type)
 
-    for warning in validate_live_guardrails(config.dry_run, runtime_check):
-        print(f"WARNING: {warning}")
+        for warning in validate_live_guardrails(config.dry_run, runtime_check):
+            print(f"WARNING: {warning}")
 
     Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap = temporal_schedule_classes()
     schedule = Schedule(

--- a/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
@@ -234,13 +234,6 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
     if config.exchange is None or config.profile is None:
         raise RuntimeError("create requires --exchange and --profile")
 
-    runtime_check: Dict[str, str] = {}
-    if not config.skip_runtime_check:
-        runtime_check = run_runtime_check(config.exchange, config.market_type)
-
-    for warning in validate_live_guardrails(config.dry_run, runtime_check):
-        print(f"WARNING: {warning}")
-
     job = build_job(
         exchange=config.exchange,
         market_type=config.market_type,
@@ -248,6 +241,22 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
         workers=config.workers,
         dry_run=config.dry_run,
     )
+
+    if config.dry_run_schedule:
+        print(
+            "[DRY-RUN] would create schedule "
+            f"{config.schedule_id} (workflow_id='{config.workflow_id}', cron='{config.cron}', "
+            f"tz='{TIME_ZONE}', job={job})"
+        )
+        return
+
+    runtime_check: Dict[str, str] = {}
+    if not config.skip_runtime_check:
+        runtime_check = run_runtime_check(config.exchange, config.market_type)
+
+    for warning in validate_live_guardrails(config.dry_run, runtime_check):
+        print(f"WARNING: {warning}")
+
     Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap = temporal_schedule_classes()
     schedule = Schedule(
         action=ScheduleActionStartWorkflow(
@@ -262,14 +271,6 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
         ),
         policy=SchedulePolicy(overlap=overlap),
     )
-
-    if config.dry_run_schedule:
-        print(
-            "[DRY-RUN] would create schedule "
-            f"{config.schedule_id} (workflow_id='{config.workflow_id}', cron='{config.cron}', "
-            f"tz='{TIME_ZONE}', job={job})"
-        )
-        return
 
     try:
         await client.create_schedule(config.schedule_id, schedule)
@@ -310,12 +311,13 @@ async def describe_schedule(handle: Any) -> None:
 
 async def async_main(args: argparse.Namespace) -> None:
     config = resolve_schedule_config(args)
-    client = await get_client()
 
     if config.command == "create":
+        client = None if config.dry_run_schedule else await get_client()
         await create_schedule(client, config)
         return
 
+    client = await get_client()
     handle = client.get_schedule_handle(config.schedule_id)
     if config.command == "pause":
         await pause_schedule(handle, config)

--- a/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
@@ -1,0 +1,365 @@
+import argparse
+import asyncio
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+TEMPORAL_ADDRESS = os.getenv("TEMPORAL_ADDRESS", "temporal:7233")
+TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default")
+TASK_QUEUE = os.getenv("TASK_QUEUE_NAME", "cron_symfony_mtf_workers")
+TIME_ZONE = os.getenv("TZ", "UTC")
+
+WORKFLOW_TYPE = "CronSymfonyMtfWorkersWorkflow"
+DEFAULT_URL = os.getenv("MTF_WORKERS_URL", "http://trading-app-nginx:80/api/mtf/run")
+DEFAULT_CRON = os.getenv("MTF_WORKERS_CRON", "*/1 * * * *")
+DEFAULT_WORKERS = int(os.getenv("MTF_WORKERS_COUNT", "4"))
+
+SUPPORTED_EXCHANGES = {"bitmart", "binance", "fake", "hyperliquid", "okx"}
+SUPPORTED_MARKET_TYPES = {"perpetual", "spot"}
+SUPPORTED_PROFILES = {"regular", "scalper", "scalper_micro"}
+
+
+@dataclass(frozen=True)
+class ScheduleConfig:
+    command: str
+    exchange: Optional[str]
+    market_type: str
+    profile: Optional[str]
+    workers: int
+    dry_run: bool
+    cron: str
+    schedule_id: str
+    workflow_id: str
+    dry_run_schedule: bool
+    skip_runtime_check: bool
+
+
+def parse_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    lowered = str(value).strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+
+    return default
+
+
+def cadence_suffix(cron_expression: str) -> str:
+    aliases = {
+        "*/1 * * * *": "1m",
+        "*/5 * * * *": "5m",
+        "*/15 * * * *": "15m",
+        "0 * * * *": "1h",
+    }
+    if cron_expression in aliases:
+        return aliases[cron_expression]
+
+    sanitized = re.sub(r"[^a-zA-Z0-9]+", "-", cron_expression.strip()).strip("-").lower()
+    return f"cron-{sanitized or 'custom'}"
+
+
+def profile_slug(profile: str) -> str:
+    return profile.replace("_", "-")
+
+
+def generate_schedule_id(exchange: str, profile: str, cron_expression: str) -> str:
+    return f"cron-mtf-{exchange}-{profile_slug(profile)}-{cadence_suffix(cron_expression)}"
+
+
+def generate_workflow_id(exchange: str, profile: str) -> str:
+    return f"mtf-{exchange}-{profile_slug(profile)}-runner"
+
+
+def build_job(
+    *,
+    exchange: str,
+    market_type: str,
+    profile: str,
+    workers: int,
+    dry_run: bool,
+    url: str = DEFAULT_URL,
+) -> Dict[str, Any]:
+    return {
+        "url": url,
+        "workers": max(1, workers),
+        "dry_run": dry_run,
+        "mtf_profile": profile,
+        "exchange": exchange,
+        "market_type": market_type,
+    }
+
+
+def parse_runtime_check_output(output: str) -> Dict[str, str]:
+    parsed: Dict[str, str] = {}
+    for line in output.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        parsed[key.strip().lower().replace(" ", "_")] = value.strip().lower()
+
+    return parsed
+
+
+def validate_live_guardrails(dry_run: bool, runtime_check: Dict[str, str]) -> List[str]:
+    if dry_run:
+        if runtime_check.get("schedule_ready") == "no":
+            return ["Runtime check reports Schedule ready: no; schedule creation is allowed because dry_run=true."]
+        return []
+
+    failures = []
+    required = {
+        "schedule_ready": "yes",
+        "credentials": "ok",
+        "live_trading": "enabled",
+    }
+    for key, expected in required.items():
+        if runtime_check.get(key) != expected:
+            failures.append(f"{key} must be {expected} for dry_run=false")
+
+    if failures:
+        raise RuntimeError("; ".join(failures))
+
+    return []
+
+
+def runtime_check_command(exchange: str, market_type: str) -> List[str]:
+    return [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "trading-app-php",
+        "php",
+        "bin/console",
+        "app:exchange:runtime-check",
+        exchange,
+        market_type,
+    ]
+
+
+def run_runtime_check(exchange: str, market_type: str) -> Dict[str, str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        runtime_check_command(exchange, market_type),
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Runtime check failed with exit code "
+            f"{result.returncode}: {(result.stderr or result.stdout).strip()}"
+        )
+
+    return parse_runtime_check_output(result.stdout)
+
+
+def resolve_schedule_config(args: argparse.Namespace) -> ScheduleConfig:
+    cron = args.cron
+    dry_run = parse_bool(getattr(args, "dry_run", None), True)
+    exchange = getattr(args, "exchange", None)
+    profile = getattr(args, "profile", None)
+
+    if getattr(args, "schedule_id", None):
+        schedule_id = args.schedule_id
+    elif exchange and profile:
+        schedule_id = generate_schedule_id(exchange, profile, cron)
+    else:
+        raise SystemExit("--schedule-id is required when --exchange or --profile is omitted")
+
+    if getattr(args, "workflow_id", None):
+        workflow_id = args.workflow_id
+    elif exchange and profile:
+        workflow_id = generate_workflow_id(exchange, profile)
+    else:
+        workflow_id = "mtf-schedule-runner"
+
+    return ScheduleConfig(
+        command=args.command,
+        exchange=exchange,
+        market_type=getattr(args, "market_type", "perpetual"),
+        profile=profile,
+        workers=max(1, getattr(args, "workers", DEFAULT_WORKERS)),
+        dry_run=dry_run,
+        cron=cron,
+        schedule_id=schedule_id,
+        workflow_id=workflow_id,
+        dry_run_schedule=getattr(args, "dry_run_schedule", False),
+        skip_runtime_check=getattr(args, "skip_runtime_check", False),
+    )
+
+
+async def get_client():
+    from temporalio.client import Client
+
+    return await Client.connect(TEMPORAL_ADDRESS, namespace=TEMPORAL_NAMESPACE)
+
+
+def temporal_schedule_classes():
+    from temporalio.api.enums.v1 import ScheduleOverlapPolicy
+
+    try:
+        from temporalio.client import (
+            Schedule,
+            ScheduleActionStartWorkflow,
+            SchedulePolicy,
+            ScheduleSpec,
+        )
+    except ImportError:  # pragma: no cover - compatibility with older Temporal SDKs
+        from temporalio.client.schedule import (  # type: ignore[attr-defined]
+            Schedule,
+            ScheduleActionStartWorkflow,
+            SchedulePolicy,
+            ScheduleSpec,
+        )
+
+    try:
+        overlap = ScheduleOverlapPolicy.BUFFER_ONE
+    except AttributeError:  # pragma: no cover - compatibility with older Temporal SDKs
+        overlap = ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE
+
+    return Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap
+
+
+async def create_schedule(client: Any, config: ScheduleConfig) -> None:
+    if config.exchange is None or config.profile is None:
+        raise RuntimeError("create requires --exchange and --profile")
+
+    runtime_check: Dict[str, str] = {}
+    if not config.skip_runtime_check:
+        runtime_check = run_runtime_check(config.exchange, config.market_type)
+
+    for warning in validate_live_guardrails(config.dry_run, runtime_check):
+        print(f"WARNING: {warning}")
+
+    job = build_job(
+        exchange=config.exchange,
+        market_type=config.market_type,
+        profile=config.profile,
+        workers=config.workers,
+        dry_run=config.dry_run,
+    )
+    Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap = temporal_schedule_classes()
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_TYPE,
+            args=[[job]],
+            id=config.workflow_id,
+            task_queue=TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(
+            cron_expressions=[config.cron],
+            time_zone_name=TIME_ZONE,
+        ),
+        policy=SchedulePolicy(overlap=overlap),
+    )
+
+    if config.dry_run_schedule:
+        print(
+            "[DRY-RUN] would create schedule "
+            f"{config.schedule_id} (workflow_id='{config.workflow_id}', cron='{config.cron}', "
+            f"tz='{TIME_ZONE}', job={job})"
+        )
+        return
+
+    try:
+        await client.create_schedule(config.schedule_id, schedule)
+    except Exception as exc:
+        from temporalio.client import ScheduleAlreadyRunningError
+
+        if isinstance(exc, ScheduleAlreadyRunningError):
+            print(
+                f"schedule '{config.schedule_id}' already exists."
+                " Use 'status' to inspect or 'delete' before recreating."
+            )
+            return
+        raise
+
+    print(f"created schedule '{config.schedule_id}' -> cron='{config.cron}' -> job={job}")
+
+
+async def pause_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.pause("manual pause")
+    print(f"schedule '{config.schedule_id}' paused")
+
+
+async def resume_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.unpause()
+    print(f"schedule '{config.schedule_id}' resumed")
+
+
+async def delete_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.delete()
+    print(f"schedule '{config.schedule_id}' deleted")
+
+
+async def describe_schedule(handle: Any) -> None:
+    description = await handle.describe()
+    print("schedule status:")
+    print(description)
+
+
+async def async_main(args: argparse.Namespace) -> None:
+    config = resolve_schedule_config(args)
+    client = await get_client()
+
+    if config.command == "create":
+        await create_schedule(client, config)
+        return
+
+    handle = client.get_schedule_handle(config.schedule_id)
+    if config.command == "pause":
+        await pause_schedule(handle, config)
+    elif config.command == "resume":
+        await resume_schedule(handle, config)
+    elif config.command == "delete":
+        await delete_schedule(handle, config)
+    elif config.command == "status":
+        await describe_schedule(handle)
+
+
+def add_common_options(parser: argparse.ArgumentParser, *, require_matrix: bool) -> None:
+    parser.add_argument("--exchange", required=require_matrix, choices=sorted(SUPPORTED_EXCHANGES))
+    parser.add_argument("--market-type", default="perpetual", choices=sorted(SUPPORTED_MARKET_TYPES))
+    parser.add_argument("--profile", required=require_matrix, choices=sorted(SUPPORTED_PROFILES))
+    parser.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    parser.add_argument("--dry-run", default="true")
+    parser.add_argument("--cron", default=DEFAULT_CRON)
+    parser.add_argument("--schedule-id")
+    parser.add_argument("--workflow-id")
+    parser.add_argument("--skip-runtime-check", action="store_true")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage exchange/profile Temporal MTF schedules")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create_cmd = sub.add_parser("create", help="Create a schedule")
+    add_common_options(create_cmd, require_matrix=True)
+    create_cmd.add_argument("--dry-run-schedule", action="store_true", help="Preview without creating")
+
+    for command in ("status", "pause", "resume", "delete"):
+        cmd = sub.add_parser(command, help=f"{command.capitalize()} a schedule")
+        add_common_options(cmd, require_matrix=False)
+        cmd.set_defaults(dry_run_schedule=False)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    asyncio.run(async_main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
@@ -59,6 +59,14 @@ def test_generated_ids_use_exchange_profile_and_cron_suffix():
     assert generate_workflow_id("okx", "scalper_micro") == "mtf-okx-scalper-micro-runner"
 
 
+def test_generated_ids_include_non_perpetual_market_type_to_avoid_collisions():
+    assert (
+        generate_schedule_id("okx", "scalper", "*/1 * * * *", market_type="spot")
+        == "cron-mtf-okx-spot-scalper-1m"
+    )
+    assert generate_workflow_id("okx", "scalper", market_type="spot") == "mtf-okx-spot-scalper-runner"
+
+
 def test_runtime_check_output_is_parsed_to_snake_case_keys():
     parsed = parse_runtime_check_output(
         "\n".join(
@@ -110,6 +118,26 @@ def test_parser_defaults_to_dry_run_and_generated_ids():
     assert config.schedule_id == "cron-mtf-okx-scalper-1m"
     assert config.workflow_id == "mtf-okx-scalper-runner"
     assert config.market_type == "perpetual"
+
+
+def test_parser_honors_dry_run_environment_default(monkeypatch):
+    monkeypatch.setenv("MTF_WORKERS_DRY_RUN", "false")
+
+    parser = build_parser()
+    args = parser.parse_args(["create", "--exchange", "bitmart", "--profile", "scalper"])
+    config = resolve_schedule_config(args)
+
+    assert config.dry_run is False
+
+
+def test_explicit_dry_run_overrides_environment_default(monkeypatch):
+    monkeypatch.setenv("MTF_WORKERS_DRY_RUN", "false")
+
+    parser = build_parser()
+    args = parser.parse_args(["create", "--exchange", "bitmart", "--profile", "scalper", "--dry-run=true"])
+    config = resolve_schedule_config(args)
+
+    assert config.dry_run is True
 
 
 def test_status_can_use_explicit_schedule_id_without_exchange_or_profile():

--- a/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
@@ -1,0 +1,132 @@
+"""Tests for the generic exchange/profile Temporal schedule manager."""
+
+import pytest
+
+from scripts.manage_exchange_profile_schedule import (
+    build_job,
+    build_parser,
+    generate_schedule_id,
+    generate_workflow_id,
+    parse_runtime_check_output,
+    resolve_schedule_config,
+    runtime_check_command,
+    validate_live_guardrails,
+)
+
+
+def test_build_job_okx_scalper_payload_is_explicit():
+    job = build_job(
+        exchange="okx",
+        market_type="perpetual",
+        profile="scalper",
+        workers=4,
+        dry_run=True,
+    )
+
+    assert job == {
+        "url": "http://trading-app-nginx:80/api/mtf/run",
+        "workers": 4,
+        "dry_run": True,
+        "mtf_profile": "scalper",
+        "exchange": "okx",
+        "market_type": "perpetual",
+    }
+
+
+def test_build_job_bitmart_scalper_micro_payload_is_explicit():
+    job = build_job(
+        exchange="bitmart",
+        market_type="perpetual",
+        profile="scalper_micro",
+        workers=8,
+        dry_run=False,
+    )
+
+    assert job["dry_run"] is False
+    assert job["workers"] == 8
+    assert job["mtf_profile"] == "scalper_micro"
+    assert job["exchange"] == "bitmart"
+    assert job["market_type"] == "perpetual"
+
+
+def test_generated_ids_use_exchange_profile_and_cron_suffix():
+    assert generate_schedule_id("okx", "scalper", "*/1 * * * *") == "cron-mtf-okx-scalper-1m"
+    assert generate_schedule_id("bitmart", "regular", "*/5 * * * *") == "cron-mtf-bitmart-regular-5m"
+    assert generate_workflow_id("okx", "scalper_micro") == "mtf-okx-scalper-micro-runner"
+
+
+def test_runtime_check_output_is_parsed_to_snake_case_keys():
+    parsed = parse_runtime_check_output(
+        "\n".join(
+            [
+                "Exchange: okx",
+                "Market type: perpetual",
+                "Schedule ready: no",
+                "Live trading: disabled",
+            ]
+        )
+    )
+
+    assert parsed["exchange"] == "okx"
+    assert parsed["market_type"] == "perpetual"
+    assert parsed["schedule_ready"] == "no"
+    assert parsed["live_trading"] == "disabled"
+
+
+def test_dry_run_allows_unready_runtime_with_warning():
+    warnings = validate_live_guardrails(
+        dry_run=True,
+        runtime_check={"schedule_ready": "no"},
+    )
+
+    assert warnings == [
+        "Runtime check reports Schedule ready: no; schedule creation is allowed because dry_run=true."
+    ]
+
+
+def test_live_run_rejects_unready_runtime():
+    with pytest.raises(RuntimeError, match="schedule_ready must be yes"):
+        validate_live_guardrails(
+            dry_run=False,
+            runtime_check={
+                "schedule_ready": "no",
+                "credentials": "missing",
+                "live_trading": "disabled",
+            },
+        )
+
+
+def test_parser_defaults_to_dry_run_and_generated_ids():
+    parser = build_parser()
+    args = parser.parse_args(["create", "--exchange", "okx", "--profile", "scalper"])
+    config = resolve_schedule_config(args)
+
+    assert config.dry_run is True
+    assert config.cron == "*/1 * * * *"
+    assert config.schedule_id == "cron-mtf-okx-scalper-1m"
+    assert config.workflow_id == "mtf-okx-scalper-runner"
+    assert config.market_type == "perpetual"
+
+
+def test_status_can_use_explicit_schedule_id_without_exchange_or_profile():
+    parser = build_parser()
+    args = parser.parse_args(["status", "--schedule-id", "cron-mtf-okx-scalper-1m"])
+    config = resolve_schedule_config(args)
+
+    assert config.schedule_id == "cron-mtf-okx-scalper-1m"
+    assert config.workflow_id == "mtf-schedule-runner"
+
+
+def test_runtime_check_command_uses_docker_compose():
+    assert runtime_check_command("okx", "perpetual") == [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "trading-app-php",
+        "php",
+        "bin/console",
+        "app:exchange:runtime-check",
+        "okx",
+        "perpetual",
+    ]

--- a/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
@@ -6,9 +6,11 @@ import pytest
 
 import scripts.manage_exchange_profile_schedule as schedule_manager
 from scripts.manage_exchange_profile_schedule import (
+    ScheduleConfig,
     async_main,
     build_job,
     build_parser,
+    create_schedule,
     generate_schedule_id,
     generate_workflow_id,
     parse_runtime_check_output,
@@ -191,3 +193,52 @@ def test_create_dry_run_schedule_preview_skips_temporal_and_runtime_check(monkey
     output = capsys.readouterr().out
     assert "[DRY-RUN] would create schedule cron-mtf-okx-scalper-1m" in output
     assert "'exchange': 'okx'" in output
+
+
+def test_create_live_schedule_with_runtime_check_bypass_skips_guardrail_validation(monkeypatch):
+    def fail_runtime_check(exchange, market_type):
+        raise AssertionError("explicit runtime-check bypass must not run Docker runtime checks")
+
+    class DummyScheduleClass:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class CapturingClient:
+        def __init__(self):
+            self.created = []
+
+        async def create_schedule(self, schedule_id, schedule):
+            self.created.append((schedule_id, schedule))
+
+    monkeypatch.setattr(schedule_manager, "run_runtime_check", fail_runtime_check)
+    monkeypatch.setattr(
+        schedule_manager,
+        "temporal_schedule_classes",
+        lambda: (
+            DummyScheduleClass,
+            DummyScheduleClass,
+            DummyScheduleClass,
+            DummyScheduleClass,
+            "buffer_one",
+        ),
+    )
+
+    config = ScheduleConfig(
+        command="create",
+        exchange="okx",
+        market_type="perpetual",
+        profile="scalper",
+        workers=4,
+        dry_run=False,
+        cron="*/1 * * * *",
+        schedule_id="cron-mtf-okx-scalper-1m",
+        workflow_id="mtf-okx-scalper-runner",
+        dry_run_schedule=False,
+        skip_runtime_check=True,
+    )
+    client = CapturingClient()
+
+    asyncio.run(create_schedule(client, config))
+
+    assert client.created[0][0] == "cron-mtf-okx-scalper-1m"

--- a/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
@@ -1,8 +1,12 @@
 """Tests for the generic exchange/profile Temporal schedule manager."""
 
+import asyncio
+
 import pytest
 
+import scripts.manage_exchange_profile_schedule as schedule_manager
 from scripts.manage_exchange_profile_schedule import (
+    async_main,
     build_job,
     build_parser,
     generate_schedule_id,
@@ -130,3 +134,32 @@ def test_runtime_check_command_uses_docker_compose():
         "okx",
         "perpetual",
     ]
+
+
+def test_create_dry_run_schedule_preview_skips_temporal_and_runtime_check(monkeypatch, capsys):
+    async def fail_get_client():
+        raise AssertionError("dry-run schedule preview must not connect to Temporal")
+
+    def fail_runtime_check(exchange, market_type):
+        raise AssertionError("dry-run schedule preview must not run Docker runtime checks")
+
+    monkeypatch.setattr(schedule_manager, "get_client", fail_get_client)
+    monkeypatch.setattr(schedule_manager, "run_runtime_check", fail_runtime_check)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "create",
+            "--exchange",
+            "okx",
+            "--profile",
+            "scalper",
+            "--dry-run-schedule",
+        ]
+    )
+
+    asyncio.run(async_main(args))
+
+    output = capsys.readouterr().out
+    assert "[DRY-RUN] would create schedule cron-mtf-okx-scalper-1m" in output
+    assert "'exchange': 'okx'" in output

--- a/docs/superpowers/plans/2026-06-01-api-11-runtime-matrix-implementation.md
+++ b/docs/superpowers/plans/2026-06-01-api-11-runtime-matrix-implementation.md
@@ -1,0 +1,542 @@
+# API-11 Runtime Matrix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Implement API-11 so Temporal schedules can explicitly target `exchange x market_type x mtf_profile` with dry-run defaults, live guardrails, Symfony runtime diagnostics, tests, and documentation.
+
+**Architecture:** Keep `/api/mtf/run` compatible while expanding exchange normalization through the existing enum. Add a new importable Python schedule manager with pure helper functions for payload/ID/guardrail logic and thin Temporal side effects. Add a Symfony console diagnostic command that uses existing exchange adapter and provider registries, then update worker documentation to mark older scripts as legacy.
+
+**Tech Stack:** PHP 8.2, Symfony Console 7.1, PHPUnit 11, Python 3, pytest, Temporal Python SDK.
+
+---
+
+## File Structure
+
+- Modify `trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php`: replace hardcoded exchange matching with `Exchange::tryFrom()`.
+- Create `trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php`: DTO normalization tests.
+- Create `trading-app/src/Command/ExchangeRuntimeCheckCommand.php`: diagnostic command `app:exchange:runtime-check`.
+- Create `trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php`: command output tests with fake registries.
+- Create `cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py`: generic Temporal schedule manager.
+- Create `cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py`: pure helper and guardrail tests.
+- Modify `cron_symfony_mtf_workers/README.md`: runtime matrix, new script usage, legacy script notes.
+
+## Task 1: DTO Exchange Normalization
+
+**Files:**
+- Modify: `trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php`
+- Create: `trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php`
+
+- [x] **Step 1: Write the failing DTO test**
+
+Create `trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php` with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfRunner\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\MtfRunner\Dto\MtfRunnerRequestDto;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MtfRunnerRequestDto::class)]
+final class MtfRunnerRequestDtoTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: Exchange}>
+     */
+    public static function exchangeProvider(): iterable
+    {
+        yield 'bitmart' => ['bitmart', Exchange::BITMART];
+        yield 'binance' => ['binance', Exchange::BINANCE];
+        yield 'fake' => ['fake', Exchange::FAKE];
+        yield 'okx' => ['okx', Exchange::OKX];
+        yield 'hyperliquid' => ['hyperliquid', Exchange::HYPERLIQUID];
+        yield 'trimmed uppercase okx' => [' OKX ', Exchange::OKX];
+    }
+
+    #[DataProvider('exchangeProvider')]
+    public function testFromArrayNormalizesAllExchangeEnumValues(string $input, Exchange $expected): void
+    {
+        $request = MtfRunnerRequestDto::fromArray(['exchange' => $input]);
+
+        self::assertSame($expected, $request->exchange);
+    }
+
+    public function testFromArrayRejectsUnknownExchange(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported exchange "unknown"');
+
+        MtfRunnerRequestDto::fromArray(['exchange' => 'unknown']);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: MarketType}>
+     */
+    public static function marketTypeProvider(): iterable
+    {
+        yield 'perpetual' => ['perpetual', MarketType::PERPETUAL];
+        yield 'futures alias' => ['futures', MarketType::PERPETUAL];
+        yield 'future alias' => ['future', MarketType::PERPETUAL];
+        yield 'perp alias' => ['perp', MarketType::PERPETUAL];
+        yield 'spot' => ['spot', MarketType::SPOT];
+    }
+
+    #[DataProvider('marketTypeProvider')]
+    public function testFromArrayNormalizesMarketTypeAliases(string $input, MarketType $expected): void
+    {
+        $request = MtfRunnerRequestDto::fromArray(['market_type' => $input]);
+
+        self::assertSame($expected, $request->marketType);
+    }
+}
+```
+
+- [x] **Step 2: Run the DTO test and verify red**
+
+Run:
+
+```bash
+cd trading-app
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+```
+
+Expected: FAIL because `fake`, `okx`, or `hyperliquid` are rejected by the current hardcoded match.
+
+- [x] **Step 3: Implement enum-based normalization**
+
+Change `normalizeExchange()` in `trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php` to:
+
+```php
+private static function normalizeExchange(string $value): Exchange
+{
+    $normalized = strtolower(trim($value));
+
+    return Exchange::tryFrom($normalized)
+        ?? throw new \InvalidArgumentException(sprintf('Unsupported exchange "%s"', $value));
+}
+```
+
+- [x] **Step 4: Run the DTO test and verify green**
+
+Run:
+
+```bash
+cd trading-app
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+```
+
+Expected: PASS.
+
+## Task 2: Symfony Runtime Diagnostic Command
+
+**Files:**
+- Create: `trading-app/src/Command/ExchangeRuntimeCheckCommand.php`
+- Create: `trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php`
+
+- [x] **Step 1: Write failing command tests**
+
+Create tests that instantiate the command with mocked `ExchangeAdapterRegistryInterface` and `ExchangeProviderRegistryInterface`.
+
+The first test uses an OKX adapter mock and an empty provider registry; expected output contains:
+
+```text
+Exchange: okx
+Market type: perpetual
+Adapter: found
+Provider bundle: missing
+Credentials: missing
+REST: unknown
+Private WS: unsupported
+Live trading: disabled
+Recommended dry_run: true
+Schedule ready: no
+```
+
+The second test uses BitMart adapter and provider mocks; expected output contains:
+
+```text
+Exchange: bitmart
+Market type: perpetual
+Adapter: found
+Provider bundle: found
+REST: unknown
+Recommended dry_run: false
+Schedule ready: yes
+```
+
+- [x] **Step 2: Run command tests and verify red**
+
+Run:
+
+```bash
+cd trading-app
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Command/ExchangeRuntimeCheckCommandTest.php
+```
+
+Expected: FAIL because `ExchangeRuntimeCheckCommand` does not exist.
+
+- [x] **Step 3: Implement `ExchangeRuntimeCheckCommand`**
+
+Create `trading-app/src/Command/ExchangeRuntimeCheckCommand.php` with:
+
+```php
+#[AsCommand(
+    name: 'app:exchange:runtime-check',
+    description: 'Diagnose exchange runtime readiness for Temporal MTF schedules'
+)]
+final class ExchangeRuntimeCheckCommand extends Command
+```
+
+The command accepts two required arguments:
+
+```php
+$this
+    ->addArgument('exchange', InputArgument::REQUIRED, 'Exchange enum value')
+    ->addArgument('market_type', InputArgument::REQUIRED, 'Market type enum value');
+```
+
+It resolves:
+
+```php
+$exchange = Exchange::tryFrom(strtolower(trim((string) $input->getArgument('exchange'))));
+$marketType = MarketType::tryFrom(strtolower(trim((string) $input->getArgument('market_type'))));
+$context = new ExchangeContext($exchange, $marketType);
+```
+
+It checks adapter/provider with registry calls and catches missing-registry exceptions:
+
+```php
+$adapter = null;
+$adapterStatus = 'missing';
+try {
+    $adapter = $this->adapters->get($exchange, $marketType);
+    $adapterStatus = 'found';
+} catch (\Throwable) {
+}
+
+$providerStatus = 'missing';
+try {
+    $this->providers->get($context);
+    $providerStatus = 'found';
+} catch (\Throwable) {
+}
+```
+
+It emits stable lines in this order:
+
+```text
+Exchange: <value>
+Market type: <value>
+Adapter: found|missing
+Provider bundle: found|missing
+Credentials: ok|missing
+REST: unknown
+Private WS: enabled|disabled|unsupported
+Live trading: enabled|disabled
+Recommended dry_run: true|false
+Schedule ready: yes|no
+```
+
+- [x] **Step 4: Run command tests and verify green**
+
+Run:
+
+```bash
+cd trading-app
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Command/ExchangeRuntimeCheckCommandTest.php
+```
+
+Expected: PASS.
+
+## Task 3: Generic Temporal Schedule Script
+
+**Files:**
+- Create: `cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py`
+- Create: `cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py`
+
+- [x] **Step 1: Write failing Python tests**
+
+Create tests for pure helpers:
+
+```python
+def test_build_job_okx_scalper_payload_is_explicit():
+    job = build_job(exchange="okx", market_type="perpetual", profile="scalper", workers=4, dry_run=True)
+    assert job == {
+        "url": "http://trading-app-nginx:80/api/mtf/run",
+        "workers": 4,
+        "dry_run": True,
+        "mtf_profile": "scalper",
+        "exchange": "okx",
+        "market_type": "perpetual",
+    }
+```
+
+Add tests for:
+
+```text
+dry_run defaults to true
+cron */1 * * * * generates schedule_id cron-mtf-okx-scalper-1m
+cron */5 * * * * generates workflow_id mtf-bitmart-regular-runner
+parse_runtime_check_output reads Schedule ready: no
+validate_live_guardrails allows dry_run=true with unready runtime and returns a warning
+validate_live_guardrails rejects dry_run=false with unready runtime
+```
+
+- [x] **Step 2: Run Python tests and verify red**
+
+Run:
+
+```bash
+cd cron_symfony_mtf_workers
+PYTHONPATH=$PWD pytest tests/test_manage_exchange_profile_schedule.py
+```
+
+Expected: FAIL because `scripts.manage_exchange_profile_schedule` does not exist.
+
+- [x] **Step 3: Implement importable helper functions**
+
+Create `cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py` with pure helpers:
+
+```python
+SUPPORTED_EXCHANGES = {"bitmart", "binance", "okx", "hyperliquid", "fake"}
+SUPPORTED_MARKET_TYPES = {"perpetual", "spot"}
+SUPPORTED_PROFILES = {"regular", "scalper", "scalper_micro"}
+
+
+def parse_bool(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    lowered = str(value).strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def cadence_suffix(cron_expression: str) -> str:
+    aliases = {"*/1 * * * *": "1m", "*/5 * * * *": "5m", "*/15 * * * *": "15m", "0 * * * *": "1h"}
+    if cron_expression in aliases:
+        return aliases[cron_expression]
+    return "cron-" + re.sub(r"[^a-zA-Z0-9]+", "-", cron_expression.strip()).strip("-").lower()
+
+
+def generate_schedule_id(exchange: str, profile: str, cron_expression: str) -> str:
+    return f"cron-mtf-{exchange}-{profile.replace('_', '-')}-{cadence_suffix(cron_expression)}"
+
+
+def generate_workflow_id(exchange: str, profile: str) -> str:
+    return f"mtf-{exchange}-{profile.replace('_', '-')}-runner"
+
+
+def build_job(exchange: str, market_type: str, profile: str, workers: int, dry_run: bool, url: str = DEFAULT_URL) -> Dict[str, Any]:
+    return {
+        "url": url,
+        "workers": max(1, workers),
+        "dry_run": dry_run,
+        "mtf_profile": profile,
+        "exchange": exchange,
+        "market_type": market_type,
+    }
+
+
+def parse_runtime_check_output(output: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for line in output.splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            result[key.strip().lower().replace(" ", "_")] = value.strip().lower()
+    return result
+
+
+def validate_live_guardrails(dry_run: bool, runtime_check: Dict[str, str]) -> List[str]:
+    if dry_run:
+        if runtime_check.get("schedule_ready") == "no":
+            return ["Runtime check reports Schedule ready: no; schedule creation is allowed because dry_run=true."]
+        return []
+    failures = []
+    for key, expected in {"schedule_ready": "yes", "credentials": "ok", "live_trading": "enabled"}.items():
+        if runtime_check.get(key) != expected:
+            failures.append(f"{key} must be {expected} for dry_run=false")
+    return failures
+```
+
+Implement Temporal side-effect functions following the style of `manage_mtf_workers_schedule.py`.
+
+- [x] **Step 4: Run Python tests and verify green**
+
+Run:
+
+```bash
+cd cron_symfony_mtf_workers
+PYTHONPATH=$PWD pytest tests/test_manage_exchange_profile_schedule.py
+```
+
+Expected: PASS.
+
+## Task 4: CLI Integration And Temporal Commands
+
+**Files:**
+- Modify: `cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py`
+- Modify: `cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py`
+
+- [x] **Step 1: Add tests for CLI defaults**
+
+Test that parser defaults produce:
+
+```text
+dry_run=True
+cron=*/1 * * * *
+schedule_id=cron-mtf-okx-scalper-1m when exchange=okx profile=scalper
+workflow_id=mtf-okx-scalper-runner
+```
+
+- [x] **Step 2: Run tests and verify red**
+
+Run:
+
+```bash
+cd cron_symfony_mtf_workers
+PYTHONPATH=$PWD pytest tests/test_manage_exchange_profile_schedule.py
+```
+
+Expected: FAIL until parser/default resolution is implemented.
+
+- [x] **Step 3: Complete CLI implementation**
+
+Parser requirements:
+
+```python
+parser.add_argument("--exchange", required=True, choices=sorted(SUPPORTED_EXCHANGES))
+parser.add_argument("--market-type", default="perpetual", choices=sorted(SUPPORTED_MARKET_TYPES))
+parser.add_argument("--profile", required=True, choices=sorted(SUPPORTED_PROFILES))
+parser.add_argument("--workers", type=int, default=4)
+parser.add_argument("--dry-run", default="true")
+parser.add_argument("--cron", default=os.getenv("MTF_WORKERS_CRON", "*/1 * * * *"))
+parser.add_argument("--schedule-id")
+parser.add_argument("--workflow-id")
+parser.add_argument("--dry-run-schedule", action="store_true")
+parser.add_argument("--skip-runtime-check", action="store_true")
+```
+
+The `create` command calls Docker Compose runtime check unless `--skip-runtime-check` is used.
+
+The `status`, `pause`, `resume`, and `delete` commands operate on the resolved `schedule_id`.
+
+- [x] **Step 4: Run Python tests and verify green**
+
+Run:
+
+```bash
+cd cron_symfony_mtf_workers
+PYTHONPATH=$PWD pytest tests/test_manage_exchange_profile_schedule.py
+```
+
+Expected: PASS.
+
+## Task 5: Documentation Runtime Matrix
+
+**Files:**
+- Modify: `cron_symfony_mtf_workers/README.md`
+
+- [x] **Step 1: Update README**
+
+Add a section documenting:
+
+```text
+manage_exchange_profile_schedule.py is the recommended script for new multi-exchange schedules.
+manage_mtf_workers_schedule.py and manage_scalper_micro_schedule.py are legacy.
+dry_run=true is the default for all exchanges.
+dry_run=false requires app:exchange:runtime-check through Docker Compose.
+```
+
+Add the matrix:
+
+```text
+cron-mtf-bitmart-scalper-1m
+cron-mtf-bitmart-scalper-micro-1m
+cron-mtf-bitmart-regular-5m
+cron-mtf-okx-scalper-1m
+cron-mtf-okx-scalper-micro-1m
+cron-mtf-okx-regular-5m
+cron-mtf-hyperliquid-scalper-1m
+cron-mtf-hyperliquid-scalper-micro-1m
+cron-mtf-hyperliquid-regular-5m
+```
+
+- [x] **Step 2: Check docs diff**
+
+Run:
+
+```bash
+git diff -- cron_symfony_mtf_workers/README.md
+```
+
+Expected: README includes the new script, matrix, command examples, and legacy note.
+
+## Task 6: Full Verification And Commit
+
+**Files:**
+- All files touched above.
+
+- [x] **Step 1: Run PHP DTO tests**
+
+```bash
+cd trading-app
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+```
+
+Expected: PASS.
+
+- [x] **Step 2: Run PHP command tests**
+
+```bash
+cd trading-app
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Command/ExchangeRuntimeCheckCommandTest.php
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run Python tests**
+
+```bash
+cd cron_symfony_mtf_workers
+PYTHONPATH=$PWD pytest tests/test_manage_exchange_profile_schedule.py
+```
+
+Expected: PASS.
+
+- [x] **Step 4: Run worker test suite**
+
+```bash
+cd cron_symfony_mtf_workers
+PYTHONPATH=$PWD pytest
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [x] **Step 6: Commit implementation**
+
+```bash
+git add trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php trading-app/src/Command/ExchangeRuntimeCheckCommand.php trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py cron_symfony_mtf_workers/README.md docs/superpowers/plans/2026-06-01-api-11-runtime-matrix-implementation.md
+git commit -m "feat: add exchange profile runtime schedules"
+```
+
+Expected: commit contains only API-11 implementation files plus the implementation plan.

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -27,6 +27,13 @@ parameters:
     router.default_uri: 'http://trading-app-nginx'
     messenger.transport.dsn: 'doctrine://default?queue_name=log_messages'
     # Default values for env-backed log levels (so env is optional)
+    env(BITMART_API_KEY): ''
+    env(BITMART_SECRET_KEY): ''
+    env(BITMART_API_MEMO): ''
+    env(BITMART_BASE_URL): 'https://api-cloud-v2.bitmart.com'
+    env(BITMART_PUBLIC_API_URL): 'https://api-cloud-v2.bitmart.com'
+    env(BITMART_PRIVATE_API_URL): 'https://api-cloud-v2.bitmart.com'
+    env(BITMART_WS_PRIVATE_URL): 'wss://openapi-ws-v2.bitmart.com/api?protocol=1.1'
     env(MTF_LOG_LEVEL): 'info'
     env(LOG_LEVEL_MAIN): 'info'
     env(LOG_LEVEL_SIGNALS): 'info'

--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -11,6 +11,7 @@ use App\Exchange\Contract\ExchangeAdapterInterface;
 use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
 use App\Exchange\Hyperliquid\HyperliquidConfig;
 use App\Exchange\Okx\OkxConfig;
+use App\Provider\Bitmart\Http\BitmartConfig;
 use App\Provider\Context\ExchangeContext;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -27,6 +28,7 @@ final class ExchangeRuntimeCheckCommand extends Command
     public function __construct(
         private readonly ExchangeAdapterRegistryInterface $adapters,
         private readonly ExchangeProviderRegistryInterface $providers,
+        private readonly BitmartConfig $bitmartConfig,
         private readonly OkxConfig $okxConfig,
         private readonly HyperliquidConfig $hyperliquidConfig,
     ) {
@@ -127,6 +129,7 @@ final class ExchangeRuntimeCheckCommand extends Command
     private function credentialsStatus(Exchange $exchange): string
     {
         return match ($exchange) {
+            Exchange::BITMART => $this->hasBitmartCredentials() ? 'ok' : 'missing',
             Exchange::OKX => $this->hasOkxCredentials() ? 'ok' : 'missing',
             Exchange::HYPERLIQUID => $this->hasHyperliquidCredentials() ? 'ok' : 'missing',
             default => 'ok',
@@ -164,6 +167,13 @@ final class ExchangeRuntimeCheckCommand extends Command
         return trim($this->okxConfig->apiKey) !== ''
             && trim($this->okxConfig->apiSecret) !== ''
             && trim($this->okxConfig->apiPassphrase) !== '';
+    }
+
+    private function hasBitmartCredentials(): bool
+    {
+        return trim($this->bitmartConfig->getApiKey()) !== ''
+            && trim($this->bitmartConfig->getApiSecret()) !== ''
+            && trim($this->bitmartConfig->getApiMemo()) !== '';
     }
 
     private function hasHyperliquidCredentials(): bool

--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -11,7 +11,6 @@ use App\Exchange\Contract\ExchangeAdapterInterface;
 use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
 use App\Exchange\Hyperliquid\HyperliquidConfig;
 use App\Exchange\Okx\OkxConfig;
-use App\Provider\Bitmart\Http\BitmartConfig;
 use App\Provider\Context\ExchangeContext;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -28,9 +27,9 @@ final class ExchangeRuntimeCheckCommand extends Command
     public function __construct(
         private readonly ExchangeAdapterRegistryInterface $adapters,
         private readonly ExchangeProviderRegistryInterface $providers,
-        private readonly BitmartConfig $bitmartConfig,
         private readonly OkxConfig $okxConfig,
         private readonly HyperliquidConfig $hyperliquidConfig,
+        private readonly array $bitmartEnv = [],
     ) {
         parent::__construct();
     }
@@ -171,14 +170,38 @@ final class ExchangeRuntimeCheckCommand extends Command
 
     private function hasBitmartCredentials(): bool
     {
-        return trim($this->bitmartConfig->getApiKey()) !== ''
-            && trim($this->bitmartConfig->getApiSecret()) !== ''
-            && trim($this->bitmartConfig->getApiMemo()) !== '';
+        return $this->envIsPresent('BITMART_API_KEY')
+            && $this->envIsPresent('BITMART_SECRET_KEY')
+            && $this->envIsPresent('BITMART_API_MEMO');
     }
 
     private function hasHyperliquidCredentials(): bool
     {
         return trim($this->hyperliquidConfig->accountAddress) !== ''
             && trim($this->hyperliquidConfig->privateKey) !== '';
+    }
+
+    private function envIsPresent(string $name): bool
+    {
+        return trim($this->envValue($name)) !== '';
+    }
+
+    private function envValue(string $name): string
+    {
+        if (array_key_exists($name, $this->bitmartEnv)) {
+            return (string) $this->bitmartEnv[$name];
+        }
+
+        if (isset($_ENV[$name])) {
+            return (string) $_ENV[$name];
+        }
+
+        if (isset($_SERVER[$name])) {
+            return (string) $_SERVER[$name];
+        }
+
+        $value = getenv($name);
+
+        return is_string($value) ? $value : '';
     }
 }

--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Contract\Provider\ExchangeProviderRegistryInterface;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
+use App\Exchange\Hyperliquid\HyperliquidConfig;
+use App\Exchange\Okx\OkxConfig;
+use App\Provider\Context\ExchangeContext;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:exchange:runtime-check',
+    description: 'Diagnose exchange runtime readiness for Temporal MTF schedules'
+)]
+final class ExchangeRuntimeCheckCommand extends Command
+{
+    public function __construct(
+        private readonly ExchangeAdapterRegistryInterface $adapters,
+        private readonly ExchangeProviderRegistryInterface $providers,
+        private readonly OkxConfig $okxConfig,
+        private readonly HyperliquidConfig $hyperliquidConfig,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('exchange', InputArgument::REQUIRED, 'Exchange enum value')
+            ->addArgument('market_type', InputArgument::REQUIRED, 'Market type enum value');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $exchange = $this->parseExchange($input->getArgument('exchange'));
+        if (!$exchange instanceof Exchange) {
+            $output->writeln(sprintf('Unsupported exchange: %s', (string) $input->getArgument('exchange')));
+
+            return Command::FAILURE;
+        }
+
+        $marketType = $this->parseMarketType($input->getArgument('market_type'));
+        if (!$marketType instanceof MarketType) {
+            $output->writeln(sprintf('Unsupported market type: %s', (string) $input->getArgument('market_type')));
+
+            return Command::FAILURE;
+        }
+
+        $context = new ExchangeContext($exchange, $marketType);
+        [$adapterStatus, $adapter] = $this->adapterStatus($exchange, $marketType);
+        $providerStatus = $this->providerStatus($context);
+        $credentials = $this->credentialsStatus($exchange);
+        $liveTrading = $this->liveTradingStatus($exchange, $credentials);
+        $privateWs = $this->privateWsStatus($adapter);
+        $scheduleReady = $adapterStatus === 'found' && $providerStatus === 'found';
+        $recommendedDryRun = !$scheduleReady || $credentials !== 'ok' || $liveTrading !== 'enabled';
+
+        $output->writeln(sprintf('Exchange: %s', $exchange->value));
+        $output->writeln(sprintf('Market type: %s', $marketType->value));
+        $output->writeln(sprintf('Adapter: %s', $adapterStatus));
+        $output->writeln(sprintf('Provider bundle: %s', $providerStatus));
+        $output->writeln(sprintf('Credentials: %s', $credentials));
+        $output->writeln('REST: unknown');
+        $output->writeln(sprintf('Private WS: %s', $privateWs));
+        $output->writeln(sprintf('Live trading: %s', $liveTrading));
+        $output->writeln(sprintf('Recommended dry_run: %s', $recommendedDryRun ? 'true' : 'false'));
+        $output->writeln(sprintf('Schedule ready: %s', $scheduleReady ? 'yes' : 'no'));
+
+        return Command::SUCCESS;
+    }
+
+    private function parseExchange(mixed $value): ?Exchange
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return Exchange::tryFrom(strtolower(trim($value)));
+    }
+
+    private function parseMarketType(mixed $value): ?MarketType
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        return match (strtolower(trim($value))) {
+            'perpetual', 'perp', 'future', 'futures' => MarketType::PERPETUAL,
+            'spot' => MarketType::SPOT,
+            default => null,
+        };
+    }
+
+    /**
+     * @return array{0: string, 1: ?ExchangeAdapterInterface}
+     */
+    private function adapterStatus(Exchange $exchange, MarketType $marketType): array
+    {
+        try {
+            return ['found', $this->adapters->get($exchange, $marketType)];
+        } catch (\Throwable) {
+            return ['missing', null];
+        }
+    }
+
+    private function providerStatus(ExchangeContext $context): string
+    {
+        try {
+            $this->providers->get($context);
+
+            return 'found';
+        } catch (\Throwable) {
+            return 'missing';
+        }
+    }
+
+    private function credentialsStatus(Exchange $exchange): string
+    {
+        return match ($exchange) {
+            Exchange::OKX => $this->hasOkxCredentials() ? 'ok' : 'missing',
+            Exchange::HYPERLIQUID => $this->hasHyperliquidCredentials() ? 'ok' : 'missing',
+            default => 'ok',
+        };
+    }
+
+    private function liveTradingStatus(Exchange $exchange, string $credentials): string
+    {
+        if ($credentials !== 'ok') {
+            return 'disabled';
+        }
+
+        return match ($exchange) {
+            Exchange::OKX => $this->okxConfig->isDemo()
+                ? ($this->okxConfig->demoTradingEnabled ? 'enabled' : 'disabled')
+                : ($this->okxConfig->liveEnabled ? 'enabled' : 'disabled'),
+            Exchange::HYPERLIQUID => $this->hyperliquidConfig->isTestnet()
+                ? 'enabled'
+                : ($this->hyperliquidConfig->mainnetEnabled ? 'enabled' : 'disabled'),
+            default => 'enabled',
+        };
+    }
+
+    private function privateWsStatus(?ExchangeAdapterInterface $adapter): string
+    {
+        if (!$adapter instanceof ExchangeAdapterInterface) {
+            return 'disabled';
+        }
+
+        return $adapter->capabilities()->supportsWebSocketPrivate ? 'enabled' : 'unsupported';
+    }
+
+    private function hasOkxCredentials(): bool
+    {
+        return trim($this->okxConfig->apiKey) !== ''
+            && trim($this->okxConfig->apiSecret) !== ''
+            && trim($this->okxConfig->apiPassphrase) !== '';
+    }
+
+    private function hasHyperliquidCredentials(): bool
+    {
+        return trim($this->hyperliquidConfig->accountAddress) !== ''
+            && trim($this->hyperliquidConfig->privateKey) !== '';
+    }
+}

--- a/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
@@ -109,11 +109,10 @@ final class MtfRunnerRequestDto
 
     private static function normalizeExchange(string $value): Exchange
     {
-        return match (strtolower(trim($value))) {
-            'bitmart' => Exchange::BITMART,
-            'binance' => Exchange::BINANCE,
-            default => throw new \InvalidArgumentException(sprintf('Unsupported exchange "%s"', $value)),
-        };
+        $normalized = strtolower(trim($value));
+
+        return Exchange::tryFrom($normalized)
+            ?? throw new \InvalidArgumentException(sprintf('Unsupported exchange "%s"', $value));
     }
 
     private static function normalizeMarketType(string $value): MarketType

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -18,7 +18,6 @@ use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
 use App\Exchange\Dto\ExchangeCapabilities;
 use App\Exchange\Hyperliquid\HyperliquidConfig;
 use App\Exchange\Okx\OkxConfig;
-use App\Provider\Bitmart\Http\BitmartConfig;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Registry\ExchangeProviderBundle;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -34,7 +33,6 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         $command = new ExchangeRuntimeCheckCommand(
             $this->adapterRegistry($this->adapter(Exchange::OKX, MarketType::PERPETUAL)),
             $this->missingProviderRegistry(),
-            new BitmartConfig('', '', ''),
             new OkxConfig(environment: 'demo'),
             new HyperliquidConfig(),
         );
@@ -65,9 +63,9 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         $command = new ExchangeRuntimeCheckCommand(
             $this->adapterRegistry($this->adapter(Exchange::BITMART, MarketType::PERPETUAL)),
             $this->providerRegistry($this->providerBundle(Exchange::BITMART, MarketType::PERPETUAL)),
-            new BitmartConfig('key', 'secret', 'memo'),
             new OkxConfig(environment: 'demo'),
             new HyperliquidConfig(),
+            ['BITMART_API_KEY' => 'key', 'BITMART_SECRET_KEY' => 'secret', 'BITMART_API_MEMO' => 'memo'],
         );
 
         $tester = new CommandTester($command);
@@ -94,9 +92,9 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         $command = new ExchangeRuntimeCheckCommand(
             $this->adapterRegistry($this->adapter(Exchange::BITMART, MarketType::PERPETUAL)),
             $this->providerRegistry($this->providerBundle(Exchange::BITMART, MarketType::PERPETUAL)),
-            new BitmartConfig('', '', ''),
             new OkxConfig(environment: 'demo'),
             new HyperliquidConfig(),
+            ['BITMART_API_KEY' => '', 'BITMART_SECRET_KEY' => '', 'BITMART_API_MEMO' => ''],
         );
 
         $tester = new CommandTester($command);

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -18,6 +18,7 @@ use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
 use App\Exchange\Dto\ExchangeCapabilities;
 use App\Exchange\Hyperliquid\HyperliquidConfig;
 use App\Exchange\Okx\OkxConfig;
+use App\Provider\Bitmart\Http\BitmartConfig;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Registry\ExchangeProviderBundle;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -33,6 +34,7 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         $command = new ExchangeRuntimeCheckCommand(
             $this->adapterRegistry($this->adapter(Exchange::OKX, MarketType::PERPETUAL)),
             $this->missingProviderRegistry(),
+            new BitmartConfig('', '', ''),
             new OkxConfig(environment: 'demo'),
             new HyperliquidConfig(),
         );
@@ -63,6 +65,7 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         $command = new ExchangeRuntimeCheckCommand(
             $this->adapterRegistry($this->adapter(Exchange::BITMART, MarketType::PERPETUAL)),
             $this->providerRegistry($this->providerBundle(Exchange::BITMART, MarketType::PERPETUAL)),
+            new BitmartConfig('key', 'secret', 'memo'),
             new OkxConfig(environment: 'demo'),
             new HyperliquidConfig(),
         );
@@ -83,6 +86,34 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('Credentials: ok', $output);
         self::assertStringContainsString('REST: unknown', $output);
         self::assertStringContainsString('Recommended dry_run: false', $output);
+        self::assertStringContainsString('Schedule ready: yes', $output);
+    }
+
+    public function testReportsUnreadyBitmartRuntimeWhenCredentialsAreMissing(): void
+    {
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(Exchange::BITMART, MarketType::PERPETUAL)),
+            $this->providerRegistry($this->providerBundle(Exchange::BITMART, MarketType::PERPETUAL)),
+            new BitmartConfig('', '', ''),
+            new OkxConfig(environment: 'demo'),
+            new HyperliquidConfig(),
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Exchange: bitmart', $output);
+        self::assertStringContainsString('Adapter: found', $output);
+        self::assertStringContainsString('Provider bundle: found', $output);
+        self::assertStringContainsString('Credentials: missing', $output);
+        self::assertStringContainsString('Live trading: disabled', $output);
+        self::assertStringContainsString('Recommended dry_run: true', $output);
         self::assertStringContainsString('Schedule ready: yes', $output);
     }
 

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\ExchangeRuntimeCheckCommand;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\ContractProviderInterface;
+use App\Contract\Provider\ExchangeProviderRegistryInterface;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Contract\Provider\SystemProviderInterface;
+use App\Exchange\Contract\ExchangeAdapterInterface;
+use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
+use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Hyperliquid\HyperliquidConfig;
+use App\Exchange\Okx\OkxConfig;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Registry\ExchangeProviderBundle;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(ExchangeRuntimeCheckCommand::class)]
+final class ExchangeRuntimeCheckCommandTest extends TestCase
+{
+    public function testReportsUnreadyOkxRuntimeWithoutProviderOrCredentials(): void
+    {
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(Exchange::OKX, MarketType::PERPETUAL)),
+            $this->missingProviderRegistry(),
+            new OkxConfig(environment: 'demo'),
+            new HyperliquidConfig(),
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'exchange' => 'okx',
+            'market_type' => 'perpetual',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Exchange: okx', $output);
+        self::assertStringContainsString('Market type: perpetual', $output);
+        self::assertStringContainsString('Adapter: found', $output);
+        self::assertStringContainsString('Provider bundle: missing', $output);
+        self::assertStringContainsString('Credentials: missing', $output);
+        self::assertStringContainsString('REST: unknown', $output);
+        self::assertStringContainsString('Private WS: unsupported', $output);
+        self::assertStringContainsString('Live trading: disabled', $output);
+        self::assertStringContainsString('Recommended dry_run: true', $output);
+        self::assertStringContainsString('Schedule ready: no', $output);
+    }
+
+    public function testReportsReadyBitmartRuntimeWhenAdapterAndProviderExist(): void
+    {
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(Exchange::BITMART, MarketType::PERPETUAL)),
+            $this->providerRegistry($this->providerBundle(Exchange::BITMART, MarketType::PERPETUAL)),
+            new OkxConfig(environment: 'demo'),
+            new HyperliquidConfig(),
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Exchange: bitmart', $output);
+        self::assertStringContainsString('Market type: perpetual', $output);
+        self::assertStringContainsString('Adapter: found', $output);
+        self::assertStringContainsString('Provider bundle: found', $output);
+        self::assertStringContainsString('Credentials: ok', $output);
+        self::assertStringContainsString('REST: unknown', $output);
+        self::assertStringContainsString('Recommended dry_run: false', $output);
+        self::assertStringContainsString('Schedule ready: yes', $output);
+    }
+
+    private function adapter(Exchange $exchange, MarketType $marketType, bool $supportsPrivateWs = false): ExchangeAdapterInterface
+    {
+        $adapter = $this->createMock(ExchangeAdapterInterface::class);
+        $adapter->method('exchange')->willReturn($exchange);
+        $adapter->method('marketType')->willReturn($marketType);
+        $adapter->method('capabilities')->willReturn(new ExchangeCapabilities(
+            supportsWebSocketPrivate: $supportsPrivateWs,
+        ));
+
+        return $adapter;
+    }
+
+    private function adapterRegistry(ExchangeAdapterInterface $adapter): ExchangeAdapterRegistryInterface
+    {
+        $registry = $this->createMock(ExchangeAdapterRegistryInterface::class);
+        $registry
+            ->method('get')
+            ->with($adapter->exchange(), $adapter->marketType())
+            ->willReturn($adapter);
+
+        return $registry;
+    }
+
+    private function missingProviderRegistry(): ExchangeProviderRegistryInterface
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry
+            ->method('get')
+            ->willThrowException(new \RuntimeException('provider missing'));
+
+        return $registry;
+    }
+
+    private function providerRegistry(ExchangeProviderBundle $bundle): ExchangeProviderRegistryInterface
+    {
+        $registry = $this->createMock(ExchangeProviderRegistryInterface::class);
+        $registry
+            ->method('get')
+            ->with(self::callback(static fn (ExchangeContext $context): bool => (string) $context === (string) $bundle->context()))
+            ->willReturn($bundle);
+
+        return $registry;
+    }
+
+    private function providerBundle(Exchange $exchange, MarketType $marketType): ExchangeProviderBundle
+    {
+        return new ExchangeProviderBundle(
+            new ExchangeContext($exchange, $marketType),
+            $this->createMock(KlineProviderInterface::class),
+            $this->createMock(ContractProviderInterface::class),
+            $this->createMock(OrderProviderInterface::class),
+            $this->createMock(AccountProviderInterface::class),
+            $this->createMock(SystemProviderInterface::class),
+        );
+    }
+}

--- a/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+++ b/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfRunner\Dto;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\MtfRunner\Dto\MtfRunnerRequestDto;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MtfRunnerRequestDto::class)]
+final class MtfRunnerRequestDtoTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{0: string, 1: Exchange}>
+     */
+    public static function exchangeProvider(): iterable
+    {
+        yield 'bitmart' => ['bitmart', Exchange::BITMART];
+        yield 'binance' => ['binance', Exchange::BINANCE];
+        yield 'fake' => ['fake', Exchange::FAKE];
+        yield 'okx' => ['okx', Exchange::OKX];
+        yield 'hyperliquid' => ['hyperliquid', Exchange::HYPERLIQUID];
+        yield 'trimmed uppercase okx' => [' OKX ', Exchange::OKX];
+    }
+
+    #[DataProvider('exchangeProvider')]
+    public function testFromArrayNormalizesAllExchangeEnumValues(string $input, Exchange $expected): void
+    {
+        $request = MtfRunnerRequestDto::fromArray(['exchange' => $input]);
+
+        self::assertSame($expected, $request->exchange);
+    }
+
+    public function testFromArrayRejectsUnknownExchange(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported exchange "unknown"');
+
+        MtfRunnerRequestDto::fromArray(['exchange' => 'unknown']);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: MarketType}>
+     */
+    public static function marketTypeProvider(): iterable
+    {
+        yield 'perpetual' => ['perpetual', MarketType::PERPETUAL];
+        yield 'futures alias' => ['futures', MarketType::PERPETUAL];
+        yield 'future alias' => ['future', MarketType::PERPETUAL];
+        yield 'perp alias' => ['perp', MarketType::PERPETUAL];
+        yield 'spot' => ['spot', MarketType::SPOT];
+    }
+
+    #[DataProvider('marketTypeProvider')]
+    public function testFromArrayNormalizesMarketTypeAliases(string $input, MarketType $expected): void
+    {
+        $request = MtfRunnerRequestDto::fromArray(['market_type' => $input]);
+
+        self::assertSame($expected, $request->marketType);
+    }
+}


### PR DESCRIPTION
## Summary
- Accept all exchanges declared in the Exchange enum in MtfRunnerRequestDto.
- Add app:exchange:runtime-check to diagnose adapter/provider/credential/live readiness.
- Add a generic Temporal schedule manager for exchange/profile schedules with explicit payloads, dry-run defaults, generated IDs, Docker Compose runtime checks, and live guardrails.
- Document the runtime matrix and mark legacy schedule scripts.

## Test Plan
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
- php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Command/ExchangeRuntimeCheckCommandTest.php
- PYTHONPATH=$PWD /private/tmp/tradingv3-pytest-venv/bin/python -m pytest
- APP_SECRET=test DEFAULT_URI=http://localhost LOCK_DSN=flock BITMART_PUBLIC_API_URL=https://api-cloud.bitmart.com BITMART_PRIVATE_API_URL=https://api-cloud-v2.bitmart.com BITMART_API_KEY= BITMART_SECRET_KEY= BITMART_API_MEMO= REDIS_HOST=localhost REDIS_PORT=6379 REDIS_ORDER_WATCH_CHANNEL=watcher:order:watch php bin/console app:exchange:runtime-check okx perpetual
- git diff --check

## Notes
- Existing out-of-zone-watcher/ directory was left untouched and untracked.
- Python tests used a temporary venv under /private/tmp because pytest was not installed globally.