### PR TITLE
feat: add cross-profile symbol execution lock

### DIFF
--- a/docs/superpowers/plans/2026-06-01-api-12-cross-profile-symbol-lock-implementation.md
+++ b/docs/superpowers/plans/2026-06-01-api-12-cross-profile-symbol-lock-implementation.md
@@ -1,0 +1,97 @@
+# API-12 Cross-Profile Symbol Lock Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent two MTF profiles from opening the same `exchange + market_type + symbol` concurrently.
+
+**Architecture:** Add a persistent `symbol_execution_lock` table with a manager service. `OrderIntentManager::reserveIntent()` acquires the global symbol lock in the same transaction as `OrderIntent` creation and returns `cross_profile_symbol_locked` when another active lock owns the symbol.
+
+**Tech Stack:** Symfony 7, Doctrine ORM/DBAL, PostgreSQL partial unique index, PHPUnit, Symfony Console.
+
+---
+
+### File Structure
+
+- Create `trading-app/src/Entity/SymbolExecutionLock.php`: Doctrine entity for active/released symbol locks.
+- Create `trading-app/src/Repository/SymbolExecutionLockRepository.php`: active lock lookup/listing helpers.
+- Create `trading-app/src/Service/SymbolExecutionLockManager.php`: reserve and release API.
+- Modify `trading-app/src/Repository/FuturesOrderRepository.php`: expose local open-order lookup for lock release/reclaim guards.
+- Modify `trading-app/src/Service/OrderIntentManager.php`: reserve global symbol lock around intent creation and release on failed/cancelled intents.
+- Modify `trading-app/src/Service/OrderIntentReservation.php`: carry optional metadata for blocking locks.
+- Create `trading-app/src/Trading/Listener/SymbolExecutionLockReleaseListener.php`: release eligible locks on position-close events.
+- Create `trading-app/src/Command/SymbolLockListCommand.php`: list active locks.
+- Create `trading-app/src/Command/SymbolLockReleaseCommand.php`: guarded manual release.
+- Create `trading-app/migrations/Version20260601000000.php`: create table and partial unique index.
+- Modify `trading-app/tests/Repository/ExchangeScopedStorageTest.php`: add functional lock tests.
+- Create `trading-app/tests/Command/SymbolLockCommandTest.php`: list/release command tests.
+- Create `trading-app/docs/CROSS_PROFILE_SYMBOL_LOCK.md`: runbook.
+
+### Task 1: Entity and Repository
+
+- [x] Write failing repository tests proving active lock lookup does not exist yet.
+- [x] Add `SymbolExecutionLock` entity with `active`, `released`, and `key` helpers.
+- [x] Add `SymbolExecutionLockRepository` with `findActive()`, `findActiveLocks()`.
+- [x] Add migration creating `symbol_execution_lock` and partial unique index.
+- [x] Add the new entity to the schema setup in `ExchangeScopedStorageTest`.
+
+### Task 2: Lock Manager
+
+- [x] Write failing tests for global key generation and same-symbol cross-profile blocking.
+- [x] Implement `SymbolExecutionLockManager::reserveForIntent()` returning a created lock or a blocked lock result.
+- [x] Implement `releaseForIntent()`, `releaseForSymbol()`, and `releaseManual()` with open-position/open-order guard.
+- [x] Verify different exchange, market type, and symbol reservations are allowed.
+- [x] Verify expired locks are reclaimed only when no local open exposure remains.
+
+### Task 3: Order Intent Integration
+
+- [x] Write failing tests using `OrderIntentManager::reserveIntent()` for `scalper` then `scalper_micro` on the same symbol.
+- [x] Inject `SymbolExecutionLockManager` into `OrderIntentManager`.
+- [x] Acquire the global lock in the transaction after decision-key replay check and before flushing the new intent.
+- [x] Acquire the global lock in the fallback reservation path when `decision_key` is absent.
+- [x] Return `OrderIntentReservation::blocked(..., 'cross_profile_symbol_locked', metadata)` when blocked.
+- [x] Release locks when `markAsFailed()` or `markAsCancelled()` is called.
+
+### Task 4: Execution Result Metadata
+
+- [x] Cover lock metadata through `OrderIntentManager` reservation tests and `ExecuteOrderPlan` raw propagation.
+- [x] Add `metadata` to `OrderIntentReservation`.
+- [x] Include `lock` metadata in `ExecutionResult::raw` when the block reason is `cross_profile_symbol_locked`.
+- [x] Add `TradeLifecycleReason::CROSS_PROFILE_SYMBOL_LOCKED`.
+
+### Task 5: Commands
+
+- [x] Write command tests for list and release.
+- [x] Add `app:symbol-lock:list` with optional `--exchange`, `--market-type`, and `--symbol` filters.
+- [x] Add `app:symbol-lock:release SYMBOL --exchange=... --market-type=... --reason=... [--force]`.
+- [x] Ensure release refuses while an open position or open order exists unless `--force`.
+- [x] Release eligible locks automatically on `PositionClosedEvent`.
+
+### Task 6: Documentation and Verification
+
+- [x] Add `trading-app/docs/CROSS_PROFILE_SYMBOL_LOCK.md`.
+- [x] Run targeted tests:
+
+```bash
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Repository/ExchangeScopedStorageTest.php tests/Command/SymbolLockCommandTest.php
+```
+
+- [x] Run a broader PHP check if targeted tests pass:
+
+```bash
+php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit
+```
+
+Result: fails on pre-existing broad-suite issues unrelated to this branch (`539` tests, `1902` assertions, `116` errors, `6` failures, `24` skipped, `144` risky), including missing `App\Domain\Ports\Out\IndicatorProviderPort`, missing `App\Domain\Strategy\Service\StrategyBacktester`, missing `App\Domain\Ports\Out\TradingProviderPort`, undefined `Timeframe::H1/H4/M1`, and strict coverage-risky tests.
+
+- [ ] Review staged diff and commit:
+
+```bash
+git add trading-app/src/Entity/SymbolExecutionLock.php trading-app/src/Repository/SymbolExecutionLockRepository.php trading-app/src/Repository/FuturesOrderRepository.php trading-app/src/Service/SymbolExecutionLockManager.php trading-app/src/Service/OrderIntentManager.php trading-app/src/Service/OrderIntentReservation.php trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php trading-app/src/Trading/Listener/SymbolExecutionLockReleaseListener.php trading-app/src/Logging/TradeLifecycleReason.php trading-app/src/Command/SymbolLockListCommand.php trading-app/src/Command/SymbolLockReleaseCommand.php trading-app/migrations/Version20260601000000.php trading-app/tests/Repository/ExchangeScopedStorageTest.php trading-app/tests/Command/SymbolLockCommandTest.php trading-app/docs/CROSS_PROFILE_SYMBOL_LOCK.md docs/superpowers/specs/2026-06-01-api-12-cross-profile-symbol-lock-design.md docs/superpowers/plans/2026-06-01-api-12-cross-profile-symbol-lock-implementation.md
+git commit -m "feat: add cross-profile symbol execution lock"
+```
+
+### Self-Review
+
+- Spec coverage: the plan covers global key, atomic DB lock, skip reason, manual diagnostics, tests, and docs.
+- Placeholder scan: no unresolved placeholder remains.
+- Scope check: release on position-close is handled by a dedicated listener, while broader reconciliation cleanup beyond the existing event flow is intentionally deferred.

--- a/docs/superpowers/specs/2026-06-01-api-12-cross-profile-symbol-lock-design.md
+++ b/docs/superpowers/specs/2026-06-01-api-12-cross-profile-symbol-lock-design.md
@@ -1,0 +1,103 @@
+# API-12 Cross-Profile Symbol Lock Design
+
+## Context
+
+API-11 makes it possible to run multiple Temporal schedules for the same exchange and market type with different MTF profiles. The current `decision_key` idempotency includes `strategy_profile`, so it blocks duplicate submissions for the same profile but allows two different profiles to reserve the same symbol in the same minute.
+
+The first unsafe case is:
+
+```text
+bitmart:perpetual:BTCUSDT:...:long:scalper:v1
+bitmart:perpetual:BTCUSDT:...:long:scalper_micro:v1
+```
+
+Both decisions are distinct, but they target the same tradable instrument. The global business rule is therefore:
+
+```text
+exchange + market_type + symbol can have only one active opening owner.
+```
+
+## Decision
+
+Use option A from the design discussion: create a dedicated persistent `symbol_execution_lock` table and a small manager service that reserves/releases locks atomically around `OrderIntent` reservation.
+
+This is intentionally separate from `order_intent` idempotency because the lock has a different lifetime, diagnostic surface, and release policy.
+
+## Data Model
+
+`SymbolExecutionLock` stores:
+
+- `exchange`
+- `market_type`
+- `symbol`
+- `status`
+- `owner_profile`
+- `owner_decision_key`
+- `owner_order_intent_id`
+- `locked_at`
+- `expires_at`
+- `released_at`
+- `release_reason`
+- `payload`
+- timestamps
+
+PostgreSQL gets a partial unique index on:
+
+```sql
+(exchange, market_type, symbol) WHERE released_at IS NULL
+```
+
+Doctrine tests also use repository lookups so the behavior remains verifiable in the existing test harness.
+
+## Reservation Flow
+
+`ExecuteOrderPlan` already calls `OrderIntentManager::reserveIntent()` before validating and sending an order. The new lock is acquired inside `OrderIntentManager::reserveIntent()` in the same database transaction, after checking the existing profile-scoped decision key and before flushing a new `OrderIntent`. The legacy reservation path without a `decision_key` also goes through the same global symbol lock.
+
+If another active lock exists, reservation returns a blocked `OrderIntentReservation` with:
+
+```text
+reason = cross_profile_symbol_locked
+```
+
+The returned lock metadata includes the blocking profile, blocking decision key, and blocking order intent id where available.
+
+## Release Flow
+
+The first version releases locks when the local `OrderIntent` reaches a non-active terminal state:
+
+- `FAILED`
+- `CANCELLED`
+- `PositionClosedEvent` for the same exchange/market/symbol, when no local open position remains
+
+The lock remains active when an intent is `SENT`, because that may represent an open order or active position. The existing position-close event flow releases the lock after exposure is closed; no broader reconciliation refactor is included in this PR.
+
+Automatic release and TTL reclaim refuse to release if an open local `positions` row or open local `futures_order` row exists for the same exchange/market/symbol. Manual release uses the same guard unless `--force` is explicitly passed.
+
+## Diagnostics
+
+Add commands:
+
+```bash
+php bin/console app:symbol-lock:list
+php bin/console app:symbol-lock:release BTCUSDT --exchange=bitmart --market-type=perpetual --reason=manual_investigation
+php bin/console app:symbol-lock:release BTCUSDT --exchange=bitmart --market-type=perpetual --reason=manual_investigation --force
+```
+
+Forced releases are logged and persisted with `release_reason`.
+
+## Testing
+
+Regression coverage focuses on the risk boundary:
+
+- same exchange/market/symbol with a different profile is blocked;
+- same symbol on a different exchange or market type is allowed;
+- different symbol is allowed;
+- failed/cancelled intents release the lock;
+- position-close events release the lock when no local open position or open order remains;
+- expired locks are reclaimed only when no local open position or open order remains;
+- manual release refuses while a position is open unless `--force`;
+- list/release command output is covered at command level.
+
+## Scope Limits
+
+This PR does not add profile preemption, does not change MTF validation rules, and does not enable multiple live profiles by itself.

--- a/trading-app/docs/CROSS_PROFILE_SYMBOL_LOCK.md
+++ b/trading-app/docs/CROSS_PROFILE_SYMBOL_LOCK.md
@@ -1,0 +1,132 @@
+# Cross-Profile Symbol Lock
+
+## Problème
+
+La matrice runtime `exchange × market_type × mtf_profile` permet de lancer plusieurs profils MTF en parallèle. L'idempotence par `decision_key` protège un même profil, mais elle inclut `strategy_profile`; deux profils peuvent donc produire deux clés différentes pour le même symbole.
+
+Exemple dangereux :
+
+```text
+bitmart:perpetual:BTCUSDT:1m:...:long:scalper:v1
+bitmart:perpetual:BTCUSDT:1m:...:long:scalper_micro:v1
+```
+
+## Règle
+
+Pour un même `exchange + market_type + symbol`, une seule ouverture peut être active.
+
+La clé globale est :
+
+```text
+exchange:market_type:symbol
+```
+
+Exemples :
+
+```text
+bitmart:perpetual:BTCUSDT
+okx:perpetual:ETHUSDT
+hyperliquid:perpetual:SOLUSDT
+```
+
+## Implémentation
+
+La table `symbol_execution_lock` porte le verrou global.
+
+Un lock actif est une ligne avec `released_at IS NULL`. PostgreSQL impose un index unique partiel sur `(exchange, market_type, symbol)` pour garantir l'atomicité côté DB.
+
+`OrderIntentManager::reserveIntent()` tente de réserver le lock dans la même transaction que la création de l'`OrderIntent`. Si un lock actif existe déjà, l'intention est refusée avec :
+
+```text
+cross_profile_symbol_locked
+```
+
+Le payload de skip expose :
+
+```json
+{
+  "reason": "cross_profile_symbol_locked",
+  "lock": {
+    "exchange": "bitmart",
+    "market_type": "perpetual",
+    "symbol": "BTCUSDT",
+    "current_profile": "scalper_micro",
+    "blocking_profile": "scalper",
+    "blocking_order_intent_id": 123,
+    "blocking_decision_key": "bitmart:perpetual:BTCUSDT:1m:..."
+  }
+}
+```
+
+## Libération
+
+Le lock est libéré automatiquement quand l'`OrderIntent` passe en :
+
+- `FAILED`
+- `CANCELLED`
+
+Il est aussi libéré sur `PositionClosedEvent` pour le même `exchange + market_type + symbol`, à condition qu'aucune position ouverte locale et qu'aucun ordre ouvert local ne reste sur ce symbole.
+
+Le lock reste actif quand l'intention est `SENT`, car un ordre ou une position peut encore exister.
+
+Un lock expiré peut être repris seulement si :
+
+- il n'y a aucune position ouverte locale pour ce symbole ;
+- il n'y a aucun ordre ouvert local pour ce symbole ;
+- l'`OrderIntent` propriétaire n'est plus dans un statut actif.
+
+## Commandes
+
+Lister les locks actifs :
+
+```bash
+php bin/console app:symbol-lock:list
+php bin/console app:symbol-lock:list --exchange=bitmart --market-type=perpetual
+php bin/console app:symbol-lock:list --symbol=BTCUSDT
+```
+
+Libérer un lock après investigation :
+
+```bash
+php bin/console app:symbol-lock:release BTCUSDT \
+  --exchange=bitmart \
+  --market-type=perpetual \
+  --reason=manual_investigation
+```
+
+La commande refuse si une position ouverte ou un ordre ouvert existe. Après investigation manuelle uniquement :
+
+```bash
+php bin/console app:symbol-lock:release BTCUSDT \
+  --exchange=bitmart \
+  --market-type=perpetual \
+  --reason=manual_investigation \
+  --force
+```
+
+Les releases forcées sont logguées avec le préfixe `force:`.
+
+## Procédure d'incident
+
+1. Lister le lock :
+
+   ```bash
+   php bin/console app:symbol-lock:list --symbol=BTCUSDT
+   ```
+
+2. Vérifier les positions et ordres ouverts côté exchange et BDD.
+
+3. Si aucune exposition n'existe, libérer sans `--force`.
+
+4. Si la BDD locale indique encore une position ouverte mais que l'exchange confirme l'absence d'exposition, documenter l'investigation puis utiliser `--force`.
+
+## Lien avec Temporal
+
+Avant d'activer deux schedules live sur le même exchange, par exemple :
+
+```text
+cron-mtf-bitmart-scalper-1m
+cron-mtf-bitmart-scalper-micro-1m
+```
+
+vérifier que cette migration est appliquée et que `app:symbol-lock:list` fonctionne dans le container Symfony.

--- a/trading-app/migrations/Version20260601000000.php
+++ b/trading-app/migrations/Version20260601000000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260601000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add cross-profile symbol execution lock table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+CREATE TABLE IF NOT EXISTS symbol_execution_lock (
+    id BIGSERIAL NOT NULL,
+    owner_order_intent_id BIGINT DEFAULT NULL,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    status VARCHAR(24) NOT NULL,
+    owner_profile VARCHAR(80) DEFAULT NULL,
+    owner_decision_key VARCHAR(255) DEFAULT NULL,
+    locked_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    expires_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    released_at TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL,
+    release_reason VARCHAR(120) DEFAULT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    PRIMARY KEY(id)
+)
+SQL);
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_symbol_execution_lock_owner_intent ON symbol_execution_lock (owner_order_intent_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_symbol_execution_lock_active ON symbol_execution_lock (exchange, market_type, symbol, released_at)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_symbol_execution_lock_active_symbol ON symbol_execution_lock (exchange, market_type, symbol) WHERE released_at IS NULL');
+        $this->addSql('ALTER TABLE symbol_execution_lock ADD CONSTRAINT FK_SYMBOL_EXECUTION_LOCK_OWNER_INTENT FOREIGN KEY (owner_order_intent_id) REFERENCES order_intent (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE symbol_execution_lock DROP CONSTRAINT IF EXISTS FK_SYMBOL_EXECUTION_LOCK_OWNER_INTENT');
+        $this->addSql('DROP INDEX IF EXISTS ux_symbol_execution_lock_active_symbol');
+        $this->addSql('DROP INDEX IF EXISTS idx_symbol_execution_lock_active');
+        $this->addSql('DROP INDEX IF EXISTS idx_symbol_execution_lock_owner_intent');
+        $this->addSql('DROP TABLE IF EXISTS symbol_execution_lock');
+    }
+}

--- a/trading-app/src/Command/SymbolLockListCommand.php
+++ b/trading-app/src/Command/SymbolLockListCommand.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Provider\Context\ExchangeContext;
+use App\Service\SymbolExecutionLockManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:symbol-lock:list',
+    description: 'List active cross-profile symbol execution locks'
+)]
+final class SymbolLockListCommand extends Command
+{
+    public function __construct(private readonly SymbolExecutionLockManager $locks)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('exchange', null, InputOption::VALUE_REQUIRED, 'Exchange filter')
+            ->addOption('market-type', null, InputOption::VALUE_REQUIRED, 'Market type filter')
+            ->addOption('symbol', null, InputOption::VALUE_REQUIRED, 'Symbol filter')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Max rows', 100);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $context = $this->contextFromInput($input, $io);
+        if ($context === false) {
+            return Command::FAILURE;
+        }
+
+        $locks = $this->locks->listActive(
+            context: $context,
+            symbol: $this->stringOption($input, 'symbol'),
+            limit: max(1, (int) $input->getOption('limit')),
+        );
+
+        if ($locks === []) {
+            $io->success('No active symbol execution locks.');
+
+            return Command::SUCCESS;
+        }
+
+        $io->table(
+            ['ID', 'Exchange', 'Market', 'Symbol', 'Profile', 'Intent ID', 'Decision key', 'Locked at', 'Expires at'],
+            array_map(static fn ($lock): array => [
+                $lock->getId(),
+                $lock->getExchange(),
+                $lock->getMarketType(),
+                $lock->getSymbol(),
+                $lock->getOwnerProfile(),
+                $lock->getOwnerOrderIntentId(),
+                $lock->getOwnerDecisionKey(),
+                $lock->getLockedAt()->format(\DateTimeInterface::ATOM),
+                $lock->getExpiresAt()->format(\DateTimeInterface::ATOM),
+            ], $locks),
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function contextFromInput(InputInterface $input, SymfonyStyle $io): ExchangeContext|false|null
+    {
+        $exchangeValue = $this->stringOption($input, 'exchange');
+        $marketTypeValue = $this->stringOption($input, 'market-type');
+        if ($exchangeValue === null && $marketTypeValue === null) {
+            return null;
+        }
+
+        $exchange = Exchange::tryFrom(strtolower((string) $exchangeValue));
+        $marketType = MarketType::tryFrom(strtolower((string) $marketTypeValue));
+        if (!$exchange instanceof Exchange || !$marketType instanceof MarketType) {
+            $io->error('Both --exchange and --market-type must be valid when filtering by runtime context.');
+
+            return false;
+        }
+
+        return new ExchangeContext($exchange, $marketType);
+    }
+
+    private function stringOption(InputInterface $input, string $name): ?string
+    {
+        $value = $input->getOption($name);
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return trim($value);
+    }
+}

--- a/trading-app/src/Command/SymbolLockReleaseCommand.php
+++ b/trading-app/src/Command/SymbolLockReleaseCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Provider\Context\ExchangeContext;
+use App\Service\SymbolExecutionLockManager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:symbol-lock:release',
+    description: 'Release an active cross-profile symbol execution lock'
+)]
+final class SymbolLockReleaseCommand extends Command
+{
+    public function __construct(private readonly SymbolExecutionLockManager $locks)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('symbol', InputArgument::REQUIRED, 'Symbol to release')
+            ->addOption('exchange', null, InputOption::VALUE_REQUIRED, 'Exchange', Exchange::BITMART->value)
+            ->addOption('market-type', null, InputOption::VALUE_REQUIRED, 'Market type', MarketType::PERPETUAL->value)
+            ->addOption('reason', null, InputOption::VALUE_REQUIRED, 'Release reason')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force release even if an open position or order exists');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $symbol = strtoupper(trim((string) $input->getArgument('symbol')));
+        $reason = trim((string) $input->getOption('reason'));
+        if ($reason === '') {
+            $io->error('--reason is required.');
+
+            return Command::FAILURE;
+        }
+
+        $exchange = Exchange::tryFrom(strtolower(trim((string) $input->getOption('exchange'))));
+        $marketType = MarketType::tryFrom(strtolower(trim((string) $input->getOption('market-type'))));
+        if (!$exchange instanceof Exchange || !$marketType instanceof MarketType) {
+            $io->error('Invalid --exchange or --market-type.');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $released = $this->locks->releaseManual(
+                symbol: $symbol,
+                context: new ExchangeContext($exchange, $marketType),
+                reason: $reason,
+                force: (bool) $input->getOption('force'),
+            );
+        } catch (\RuntimeException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        if (!$released) {
+            $io->warning(sprintf('No active lock for %s:%s:%s.', $exchange->value, $marketType->value, $symbol));
+
+            return Command::SUCCESS;
+        }
+
+        $io->success(sprintf('Released lock for %s:%s:%s.', $exchange->value, $marketType->value, $symbol));
+
+        return Command::SUCCESS;
+    }
+}

--- a/trading-app/src/Entity/SymbolExecutionLock.php
+++ b/trading-app/src/Entity/SymbolExecutionLock.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Repository\SymbolExecutionLockRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: SymbolExecutionLockRepository::class)]
+#[ORM\Table(name: 'symbol_execution_lock')]
+#[ORM\Index(name: 'idx_symbol_execution_lock_active', columns: ['exchange', 'market_type', 'symbol', 'released_at'])]
+#[ORM\Index(name: 'idx_symbol_execution_lock_owner_intent', columns: ['owner_order_intent_id'])]
+final class SymbolExecutionLock
+{
+    public const STATUS_ACTIVE = 'ACTIVE';
+    public const STATUS_RELEASED = 'RELEASED';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32)]
+    private string $exchange;
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32)]
+    private string $marketType;
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::STRING, length: 24)]
+    private string $status = self::STATUS_ACTIVE;
+
+    #[ORM\Column(name: 'owner_profile', type: Types::STRING, length: 80, nullable: true)]
+    private ?string $ownerProfile = null;
+
+    #[ORM\Column(name: 'owner_decision_key', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $ownerDecisionKey = null;
+
+    #[ORM\ManyToOne(targetEntity: OrderIntent::class)]
+    #[ORM\JoinColumn(name: 'owner_order_intent_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?OrderIntent $ownerOrderIntent = null;
+
+    #[ORM\Column(name: 'locked_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $lockedAt;
+
+    #[ORM\Column(name: 'expires_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $expiresAt;
+
+    #[ORM\Column(name: 'released_at', type: Types::DATETIMETZ_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $releasedAt = null;
+
+    #[ORM\Column(name: 'release_reason', type: Types::STRING, length: 120, nullable: true)]
+    private ?string $releaseReason = null;
+
+    #[ORM\Column(type: Types::JSON, options: ['jsonb' => true])]
+    private array $payload = [];
+
+    #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(name: 'updated_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(
+        Exchange|string $exchange,
+        MarketType|string $marketType,
+        string $symbol,
+        ?OrderIntent $ownerOrderIntent = null,
+        ?\DateTimeImmutable $expiresAt = null,
+    ) {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $this->setExchange($exchange);
+        $this->setMarketType($marketType);
+        $this->symbol = strtoupper(trim($symbol));
+        $this->ownerOrderIntent = $ownerOrderIntent;
+        $this->lockedAt = $now;
+        $this->expiresAt = $expiresAt ?? $now->modify('+900 seconds');
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+
+        if ($ownerOrderIntent instanceof OrderIntent) {
+            $this->ownerProfile = $ownerOrderIntent->getStrategyProfile();
+            $this->ownerDecisionKey = $ownerOrderIntent->getDecisionKey();
+        }
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower(trim($exchange));
+
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower(trim($marketType));
+
+        return $this->touch();
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getOwnerProfile(): ?string
+    {
+        return $this->ownerProfile;
+    }
+
+    public function getOwnerDecisionKey(): ?string
+    {
+        return $this->ownerDecisionKey;
+    }
+
+    public function getOwnerOrderIntent(): ?OrderIntent
+    {
+        return $this->ownerOrderIntent;
+    }
+
+    public function getOwnerOrderIntentId(): ?int
+    {
+        return $this->ownerOrderIntent?->getId();
+    }
+
+    public function getLockedAt(): \DateTimeImmutable
+    {
+        return $this->lockedAt;
+    }
+
+    public function getExpiresAt(): \DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function getReleasedAt(): ?\DateTimeImmutable
+    {
+        return $this->releasedAt;
+    }
+
+    public function getReleaseReason(): ?string
+    {
+        return $this->releaseReason;
+    }
+
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    public function setPayload(array $payload): self
+    {
+        $this->payload = $payload;
+
+        return $this->touch();
+    }
+
+    public function activeKey(): string
+    {
+        return sprintf('%s:%s:%s', $this->exchange, $this->marketType, $this->symbol);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->releasedAt === null;
+    }
+
+    public function isExpired(?\DateTimeImmutable $now = null): bool
+    {
+        $now ??= new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        return $this->expiresAt <= $now;
+    }
+
+    public function release(string $reason): self
+    {
+        if ($this->releasedAt !== null) {
+            return $this;
+        }
+
+        $this->status = self::STATUS_RELEASED;
+        $this->releaseReason = substr(trim($reason), 0, 120) ?: 'released';
+        $this->releasedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        return $this->touch();
+    }
+
+    private function touch(): self
+    {
+        if (!isset($this->updatedAt)) {
+            return $this;
+        }
+
+        $this->updatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        return $this;
+    }
+}

--- a/trading-app/src/Entity/SymbolExecutionLock.php
+++ b/trading-app/src/Entity/SymbolExecutionLock.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: SymbolExecutionLockRepository::class)]
 #[ORM\Table(name: 'symbol_execution_lock')]
+#[ORM\UniqueConstraint(name: 'ux_symbol_execution_lock_active_symbol', columns: ['exchange', 'market_type', 'symbol'], options: ['where' => 'released_at IS NULL'])]
 #[ORM\Index(name: 'idx_symbol_execution_lock_active', columns: ['exchange', 'market_type', 'symbol', 'released_at'])]
 #[ORM\Index(name: 'idx_symbol_execution_lock_owner_intent', columns: ['owner_order_intent_id'])]
 final class SymbolExecutionLock

--- a/trading-app/src/Logging/TradeLifecycleReason.php
+++ b/trading-app/src/Logging/TradeLifecycleReason.php
@@ -17,6 +17,7 @@ final class TradeLifecycleReason
 
     // Position guards
     public const LEVERAGE_TOO_LOW = 'leverage_too_low';
+    public const CROSS_PROFILE_SYMBOL_LOCKED = 'cross_profile_symbol_locked';
 
     // Expiration / cancel-after
     public const CANCEL_AFTER_TIMEOUT = 'cancel_after_timeout';

--- a/trading-app/src/Repository/FuturesOrderRepository.php
+++ b/trading-app/src/Repository/FuturesOrderRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\OrderIntent;
 use App\Entity\FuturesOrder;
 use App\Provider\Context\ExchangeContext;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -14,6 +15,8 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class FuturesOrderRepository extends ServiceEntityRepository
 {
+    private const OPEN_STATUSES = ['pending', 'partially_filled', 'new', 'sent', 'open', 'submitted'];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, FuturesOrder::class);
@@ -75,10 +78,49 @@ final class FuturesOrderRepository extends ServiceEntityRepository
             ->setParameter('exchange', ExchangeContext::exchangeValue($context))
             ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
-            ->setParameter('statuses', ['pending', 'partially_filled', 'new', 'sent', 'open', 'submitted'])
+            ->setParameter('statuses', self::OPEN_STATUSES)
             ->getQuery()
             ->getSingleScalarResult();
 
         return (int) $count > 0;
+    }
+
+    public function markOpenOrdersCancelledForIntent(OrderIntent $intent): int
+    {
+        $ids = array_values(array_filter([
+            $intent->getExchangeOrderId(),
+            $intent->getOrderId(),
+        ], static fn (?string $id): bool => $id !== null && trim($id) !== ''));
+        $clientOrderId = $intent->getClientOrderId();
+
+        if ($ids === [] && trim($clientOrderId) === '') {
+            return 0;
+        }
+
+        $qb = $this->createQueryBuilder('o')
+            ->update()
+            ->set('o.status', ':cancelled')
+            ->set('o.updatedAt', ':now')
+            ->where('o.exchange = :exchange')
+            ->andWhere('o.marketType = :marketType')
+            ->andWhere('o.symbol = :symbol')
+            ->andWhere('o.status IN (:statuses)')
+            ->setParameter('cancelled', 'cancelled')
+            ->setParameter('now', new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
+            ->setParameter('exchange', $intent->getExchange())
+            ->setParameter('marketType', $intent->getMarketType())
+            ->setParameter('symbol', strtoupper($intent->getSymbol()))
+            ->setParameter('statuses', self::OPEN_STATUSES);
+
+        if ($ids !== []) {
+            $qb->andWhere('(o.clientOrderId = :clientOrderId OR o.orderId IN (:orderIds))')
+                ->setParameter('clientOrderId', $clientOrderId)
+                ->setParameter('orderIds', $ids);
+        } else {
+            $qb->andWhere('o.clientOrderId = :clientOrderId')
+                ->setParameter('clientOrderId', $clientOrderId);
+        }
+
+        return (int) $qb->getQuery()->execute();
     }
 }

--- a/trading-app/src/Repository/FuturesOrderRepository.php
+++ b/trading-app/src/Repository/FuturesOrderRepository.php
@@ -84,13 +84,14 @@ final class FuturesOrderRepository extends ServiceEntityRepository
             ->getResult();
 
         foreach ($orders as $order) {
-            if (
-                \is_array($order)
-                && $this->isOpenOrderState(
-                    $order['status'] ?? null,
-                    \is_array($order['rawData'] ?? null) ? $order['rawData'] : [],
-                )
-            ) {
+            if (!\is_array($order)) {
+                continue;
+            }
+            $rawData = $order['rawData'] ?? null;
+            if (\is_string($rawData)) {
+                $rawData = json_decode($rawData, true) ?? [];
+            }
+            if ($this->isOpenOrderState($order['status'] ?? null, \is_array($rawData) ? $rawData : [])) {
                 return true;
             }
         }
@@ -117,13 +118,14 @@ final class FuturesOrderRepository extends ServiceEntityRepository
             ->where('o.exchange = :exchange')
             ->andWhere('o.marketType = :marketType')
             ->andWhere('o.symbol = :symbol')
-            ->andWhere('(o.status IN (:statuses) OR o.status IS NULL OR o.status = :blankStatus)')
+            ->andWhere('(o.status IN (:statuses) OR o.status IN (:numericStatuses) OR o.status IS NULL OR o.status = :blankStatus)')
             ->setParameter('cancelled', 'cancelled')
             ->setParameter('now', new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
             ->setParameter('exchange', $intent->getExchange())
             ->setParameter('marketType', $intent->getMarketType())
             ->setParameter('symbol', strtoupper($intent->getSymbol()))
             ->setParameter('statuses', self::OPEN_STATUSES)
+            ->setParameter('numericStatuses', self::OPEN_NUMERIC_STATES)
             ->setParameter('blankStatus', '');
 
         if ($ids !== []) {

--- a/trading-app/src/Repository/FuturesOrderRepository.php
+++ b/trading-app/src/Repository/FuturesOrderRepository.php
@@ -16,6 +16,9 @@ use Doctrine\Persistence\ManagerRegistry;
 final class FuturesOrderRepository extends ServiceEntityRepository
 {
     private const OPEN_STATUSES = ['pending', 'partially_filled', 'new', 'sent', 'open', 'submitted'];
+    private const CLOSED_STATUSES = ['filled', 'cancelled', 'canceled', 'rejected', 'expired', 'closed'];
+    private const OPEN_NUMERIC_STATES = ['1', '2'];
+    private const CLOSED_NUMERIC_STATES = ['3', '4', '5'];
 
     public function __construct(ManagerRegistry $registry)
     {
@@ -69,20 +72,30 @@ final class FuturesOrderRepository extends ServiceEntityRepository
 
     public function hasOpenOrderForSymbol(string $symbol, ?ExchangeContext $context = null): bool
     {
-        $count = $this->createQueryBuilder('o')
-            ->select('COUNT(o.id)')
+        $orders = $this->createQueryBuilder('o')
+            ->select('o.status AS status, o.rawData AS rawData')
             ->andWhere('o.exchange = :exchange')
             ->andWhere('o.marketType = :marketType')
             ->andWhere('o.symbol = :symbol')
-            ->andWhere('o.status IN (:statuses)')
             ->setParameter('exchange', ExchangeContext::exchangeValue($context))
             ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
             ->setParameter('symbol', strtoupper($symbol))
-            ->setParameter('statuses', self::OPEN_STATUSES)
             ->getQuery()
-            ->getSingleScalarResult();
+            ->getResult();
 
-        return (int) $count > 0;
+        foreach ($orders as $order) {
+            if (
+                \is_array($order)
+                && $this->isOpenOrderState(
+                    $order['status'] ?? null,
+                    \is_array($order['rawData'] ?? null) ? $order['rawData'] : [],
+                )
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function markOpenOrdersCancelledForIntent(OrderIntent $intent): int
@@ -104,13 +117,14 @@ final class FuturesOrderRepository extends ServiceEntityRepository
             ->where('o.exchange = :exchange')
             ->andWhere('o.marketType = :marketType')
             ->andWhere('o.symbol = :symbol')
-            ->andWhere('o.status IN (:statuses)')
+            ->andWhere('(o.status IN (:statuses) OR o.status IS NULL OR o.status = :blankStatus)')
             ->setParameter('cancelled', 'cancelled')
             ->setParameter('now', new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
             ->setParameter('exchange', $intent->getExchange())
             ->setParameter('marketType', $intent->getMarketType())
             ->setParameter('symbol', strtoupper($intent->getSymbol()))
-            ->setParameter('statuses', self::OPEN_STATUSES);
+            ->setParameter('statuses', self::OPEN_STATUSES)
+            ->setParameter('blankStatus', '');
 
         if ($ids !== []) {
             $qb->andWhere('(o.clientOrderId = :clientOrderId OR o.orderId IN (:orderIds))')
@@ -122,5 +136,65 @@ final class FuturesOrderRepository extends ServiceEntityRepository
         }
 
         return (int) $qb->getQuery()->execute();
+    }
+
+    /**
+     * @param array<string,mixed> $rawData
+     */
+    private function isOpenOrderState(mixed $statusValue, array $rawData): bool
+    {
+        $status = $this->normalizeOrderState($statusValue);
+        if ($status !== null) {
+            if (\in_array($status, self::OPEN_STATUSES, true)) {
+                return true;
+            }
+
+            if (\in_array($status, self::CLOSED_STATUSES, true)) {
+                return false;
+            }
+        }
+
+        foreach (['state', 'status', 'order_state'] as $key) {
+            $rawStatus = $this->normalizeOrderState($rawData[$key] ?? null);
+            if ($rawStatus === null) {
+                continue;
+            }
+
+            if (\in_array($rawStatus, self::OPEN_STATUSES, true)) {
+                return true;
+            }
+
+            if (\in_array($rawStatus, self::CLOSED_STATUSES, true)) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private function normalizeOrderState(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $state = strtolower(trim((string) $value));
+        if ($state === '') {
+            return null;
+        }
+
+        if (\in_array($state, self::OPEN_NUMERIC_STATES, true)) {
+            return $state === '2' ? 'partially_filled' : 'pending';
+        }
+
+        if (\in_array($state, self::CLOSED_NUMERIC_STATES, true)) {
+            return match ($state) {
+                '3' => 'filled',
+                '4' => 'cancelled',
+                default => 'rejected',
+            };
+        }
+
+        return str_replace('-', '_', $state);
     }
 }

--- a/trading-app/src/Repository/FuturesOrderRepository.php
+++ b/trading-app/src/Repository/FuturesOrderRepository.php
@@ -63,4 +63,22 @@ final class FuturesOrderRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getResult();
     }
+
+    public function hasOpenOrderForSymbol(string $symbol, ?ExchangeContext $context = null): bool
+    {
+        $count = $this->createQueryBuilder('o')
+            ->select('COUNT(o.id)')
+            ->andWhere('o.exchange = :exchange')
+            ->andWhere('o.marketType = :marketType')
+            ->andWhere('o.symbol = :symbol')
+            ->andWhere('o.status IN (:statuses)')
+            ->setParameter('exchange', ExchangeContext::exchangeValue($context))
+            ->setParameter('marketType', ExchangeContext::marketTypeValue($context))
+            ->setParameter('symbol', strtoupper($symbol))
+            ->setParameter('statuses', ['pending', 'partially_filled', 'new', 'sent', 'open', 'submitted'])
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count > 0;
+    }
 }

--- a/trading-app/src/Repository/SymbolExecutionLockRepository.php
+++ b/trading-app/src/Repository/SymbolExecutionLockRepository.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\SymbolExecutionLock;
+use App\Provider\Context\ExchangeContext;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<SymbolExecutionLock>
+ */
+final class SymbolExecutionLockRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, SymbolExecutionLock::class);
+    }
+
+    public function findActive(string $exchange, string $marketType, string $symbol): ?SymbolExecutionLock
+    {
+        return $this->findOneBy([
+            'exchange' => strtolower(trim($exchange)),
+            'marketType' => strtolower(trim($marketType)),
+            'symbol' => strtoupper(trim($symbol)),
+            'releasedAt' => null,
+        ]);
+    }
+
+    /**
+     * @return SymbolExecutionLock[]
+     */
+    public function findActiveLocks(
+        ?ExchangeContext $context = null,
+        ?string $symbol = null,
+        int $limit = 100,
+    ): array {
+        $qb = $this->createQueryBuilder('lock')
+            ->andWhere('lock.releasedAt IS NULL')
+            ->orderBy('lock.lockedAt', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($context instanceof ExchangeContext) {
+            $qb
+                ->andWhere('lock.exchange = :exchange')
+                ->andWhere('lock.marketType = :marketType')
+                ->setParameter('exchange', $context->exchange->value)
+                ->setParameter('marketType', $context->marketType->value);
+        }
+
+        if ($symbol !== null && trim($symbol) !== '') {
+            $qb
+                ->andWhere('lock.symbol = :symbol')
+                ->setParameter('symbol', strtoupper(trim($symbol)));
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function save(SymbolExecutionLock $lock): void
+    {
+        $this->getEntityManager()->persist($lock);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -29,6 +29,7 @@ final class OrderIntentManager
         private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
         private readonly DecisionKeyFactory $decisionKeyFactory,
+        private readonly ?SymbolExecutionLockManager $symbolExecutionLockManager = null,
     ) {
     }
 
@@ -87,7 +88,66 @@ final class OrderIntentManager
                 }
             }
 
-            return OrderIntentReservation::created($this->createIntent($orderParams, $quantization, $rawInputs));
+            $connection = $this->entityManager->getConnection();
+            $connection->beginTransaction();
+            try {
+                $intent = $this->buildIntent($orderParams, $quantization, $rawInputs);
+                $this->entityManager->persist($intent);
+
+                if ($this->symbolExecutionLockManager instanceof SymbolExecutionLockManager) {
+                    $lockReservation = $this->symbolExecutionLockManager->reserveForIntent(
+                        $intent,
+                        [
+                            'source' => 'order_intent_reservation',
+                            'decision_key' => null,
+                            'strategy_profile' => $intent->getStrategyProfile(),
+                            'strategy_version' => $intent->getStrategyVersion(),
+                        ],
+                    );
+
+                    if ($lockReservation->blocked) {
+                        $this->entityManager->detach($intent);
+                        $connection->commit();
+
+                        $blockingIntent = $lockReservation->lock->getOwnerOrderIntent() ?? $intent;
+                        $this->logger->warning('[OrderIntentManager] Global symbol lock blocked intent reservation', [
+                            'exchange' => $intent->getExchange(),
+                            'market_type' => $intent->getMarketType(),
+                            'symbol' => $intent->getSymbol(),
+                            'decision_key' => null,
+                            'reason' => 'cross_profile_symbol_locked',
+                            'lock' => $lockReservation->metadata['lock'] ?? null,
+                        ]);
+
+                        return OrderIntentReservation::blocked(
+                            $blockingIntent,
+                            'cross_profile_symbol_locked',
+                            $lockReservation->metadata,
+                        );
+                    }
+                }
+
+                $this->entityManager->flush();
+                $connection->commit();
+
+                $this->logger->debug('[OrderIntentManager] Reserved intent', [
+                    'order_intent_id' => $intent->getId(),
+                    'client_order_id' => $intent->getClientOrderId(),
+                    'decision_key' => $intent->getDecisionKey(),
+                    'exchange' => $intent->getExchange(),
+                    'market_type' => $intent->getMarketType(),
+                    'symbol' => $intent->getSymbol(),
+                    'status' => $intent->getStatus(),
+                ]);
+
+                return OrderIntentReservation::created($intent);
+            } catch (\Throwable $e) {
+                if ($connection->isTransactionActive()) {
+                    $connection->rollBack();
+                }
+
+                throw $e;
+            }
         }
 
         $context = $this->contextFromParams($orderParams);
@@ -106,6 +166,40 @@ final class OrderIntentManager
 
                 $intent = $this->buildIntent($orderParams, $quantization, $rawInputs);
                 $this->entityManager->persist($intent);
+
+                if ($this->symbolExecutionLockManager instanceof SymbolExecutionLockManager) {
+                    $lockReservation = $this->symbolExecutionLockManager->reserveForIntent(
+                        $intent,
+                        [
+                            'source' => 'order_intent_reservation',
+                            'decision_key' => $decisionKey,
+                            'strategy_profile' => $intent->getStrategyProfile(),
+                            'strategy_version' => $intent->getStrategyVersion(),
+                        ],
+                    );
+
+                    if ($lockReservation->blocked) {
+                        $this->entityManager->detach($intent);
+                        $connection->commit();
+
+                        $blockingIntent = $lockReservation->lock->getOwnerOrderIntent() ?? $intent;
+                        $this->logger->warning('[OrderIntentManager] Global symbol lock blocked intent reservation', [
+                            'exchange' => $intent->getExchange(),
+                            'market_type' => $intent->getMarketType(),
+                            'symbol' => $intent->getSymbol(),
+                            'decision_key' => $decisionKey,
+                            'reason' => 'cross_profile_symbol_locked',
+                            'lock' => $lockReservation->metadata['lock'] ?? null,
+                        ]);
+
+                        return OrderIntentReservation::blocked(
+                            $blockingIntent,
+                            'cross_profile_symbol_locked',
+                            $lockReservation->metadata,
+                        );
+                    }
+                }
+
                 $this->entityManager->flush();
                 $connection->commit();
 
@@ -229,6 +323,7 @@ final class OrderIntentManager
     public function markAsFailed(OrderIntent $intent, string $reason): void
     {
         $intent->markAsFailed($reason);
+        $this->symbolExecutionLockManager?->releaseForIntent($intent, 'order_intent_failed');
         $this->entityManager->flush();
 
         $this->logger->warning('[OrderIntentManager] Marked as failed', [
@@ -244,6 +339,7 @@ final class OrderIntentManager
     public function markAsCancelled(OrderIntent $intent): void
     {
         $intent->markAsCancelled();
+        $this->symbolExecutionLockManager?->releaseForIntent($intent, 'order_intent_cancelled');
         $this->entityManager->flush();
 
         $this->logger->info('[OrderIntentManager] Marked as cancelled', [
@@ -352,6 +448,18 @@ final class OrderIntentManager
      */
     private function hydrateIdempotencyFields(OrderIntent $intent, array $orderParams): void
     {
+        if (isset($orderParams['strategy_profile'])) {
+            $intent->setStrategyProfile((string) $orderParams['strategy_profile']);
+        }
+
+        if (isset($orderParams['strategy_version'])) {
+            $intent->setStrategyVersion((string) $orderParams['strategy_version']);
+        }
+
+        if (isset($orderParams['timeframe'])) {
+            $intent->setTimeframe((string) $orderParams['timeframe']);
+        }
+
         $decisionKey = isset($orderParams['decision_key']) ? trim((string) $orderParams['decision_key']) : '';
         if ($decisionKey === '') {
             return;
@@ -360,9 +468,17 @@ final class OrderIntentManager
         $intent->setDecisionKey($decisionKey);
         $parsed = $this->decisionKeyFactory->parse($decisionKey);
 
-        $intent->setStrategyProfile((string)($orderParams['strategy_profile'] ?? $parsed['strategy_profile'] ?? ''));
-        $intent->setStrategyVersion((string)($orderParams['strategy_version'] ?? $parsed['strategy_version'] ?? ''));
-        $intent->setTimeframe((string)($orderParams['timeframe'] ?? $parsed['timeframe'] ?? ''));
+        if ($intent->getStrategyProfile() === null) {
+            $intent->setStrategyProfile((string)($parsed['strategy_profile'] ?? ''));
+        }
+
+        if ($intent->getStrategyVersion() === null) {
+            $intent->setStrategyVersion((string)($parsed['strategy_version'] ?? ''));
+        }
+
+        if ($intent->getTimeframe() === null) {
+            $intent->setTimeframe((string)($parsed['timeframe'] ?? ''));
+        }
 
         $candleOpenTs = $orderParams['candle_open_ts'] ?? $parsed['candle_open_ts'] ?? null;
         $timestamp = $this->decisionKeyFactory->normalizeCandleOpenTs($candleOpenTs, $intent->getTimeframe());

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -106,7 +106,7 @@ final class OrderIntentManager
                     );
 
                     if ($lockReservation->blocked) {
-                        $this->detachIntentGraph($intent);
+                        $this->detachBlockedIntent($intent, $lockReservation);
                         $connection->commit();
 
                         $blockingIntent = $lockReservation->lock->getOwnerOrderIntent() ?? $intent;
@@ -179,7 +179,7 @@ final class OrderIntentManager
                     );
 
                     if ($lockReservation->blocked) {
-                        $this->detachIntentGraph($intent);
+                        $this->detachBlockedIntent($intent, $lockReservation);
                         $connection->commit();
 
                         $blockingIntent = $lockReservation->lock->getOwnerOrderIntent() ?? $intent;
@@ -540,6 +540,15 @@ final class OrderIntentManager
         }
 
         $this->entityManager->detach($intent);
+    }
+
+    private function detachBlockedIntent(OrderIntent $intent, SymbolExecutionLockReservation $lockReservation): void
+    {
+        $this->detachIntentGraph($intent);
+
+        if ($lockReservation->syntheticLockCreated) {
+            $this->entityManager->flush();
+        }
     }
 
     private function lockDecisionKey(ExchangeContext $context, string $decisionKey): void

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -106,7 +106,7 @@ final class OrderIntentManager
                     );
 
                     if ($lockReservation->blocked) {
-                        $this->entityManager->detach($intent);
+                        $this->detachIntentGraph($intent);
                         $connection->commit();
 
                         $blockingIntent = $lockReservation->lock->getOwnerOrderIntent() ?? $intent;
@@ -179,7 +179,7 @@ final class OrderIntentManager
                     );
 
                     if ($lockReservation->blocked) {
-                        $this->entityManager->detach($intent);
+                        $this->detachIntentGraph($intent);
                         $connection->commit();
 
                         $blockingIntent = $lockReservation->lock->getOwnerOrderIntent() ?? $intent;
@@ -272,6 +272,10 @@ final class OrderIntentManager
         if ($errors !== null && count($errors) > 0) {
             $intent->setValidationErrors($errors);
             $intent->markAsFailed('Validation failed: ' . json_encode($errors));
+            $this->symbolExecutionLockManager?->releaseForIntent(
+                $intent,
+                'order_intent_validation_failed',
+            );
             $this->entityManager->flush();
             return false;
         }
@@ -339,7 +343,7 @@ final class OrderIntentManager
     public function markAsCancelled(OrderIntent $intent): void
     {
         $intent->markAsCancelled();
-        $this->symbolExecutionLockManager?->releaseForIntent($intent, 'order_intent_cancelled');
+        $this->symbolExecutionLockManager?->releaseForIntent($intent, 'order_intent_cancelled', true);
         $this->entityManager->flush();
 
         $this->logger->info('[OrderIntentManager] Marked as cancelled', [
@@ -527,6 +531,15 @@ final class OrderIntentManager
             OrderIntent::STATUS_SENT => 'idempotent_sent_replay',
             default => 'idempotent_in_flight',
         };
+    }
+
+    private function detachIntentGraph(OrderIntent $intent): void
+    {
+        foreach ($intent->getProtections() as $protection) {
+            $this->entityManager->detach($protection);
+        }
+
+        $this->entityManager->detach($intent);
     }
 
     private function lockDecisionKey(ExchangeContext $context, string $decisionKey): void

--- a/trading-app/src/Service/OrderIntentManager.php
+++ b/trading-app/src/Service/OrderIntentManager.php
@@ -94,7 +94,10 @@ final class OrderIntentManager
                 $intent = $this->buildIntent($orderParams, $quantization, $rawInputs);
                 $this->entityManager->persist($intent);
 
-                if ($this->symbolExecutionLockManager instanceof SymbolExecutionLockManager) {
+                if (
+                    $this->symbolExecutionLockManager instanceof SymbolExecutionLockManager
+                    && $this->requiresSymbolExecutionLock($intent, $orderParams)
+                ) {
                     $lockReservation = $this->symbolExecutionLockManager->reserveForIntent(
                         $intent,
                         [
@@ -167,7 +170,10 @@ final class OrderIntentManager
                 $intent = $this->buildIntent($orderParams, $quantization, $rawInputs);
                 $this->entityManager->persist($intent);
 
-                if ($this->symbolExecutionLockManager instanceof SymbolExecutionLockManager) {
+                if (
+                    $this->symbolExecutionLockManager instanceof SymbolExecutionLockManager
+                    && $this->requiresSymbolExecutionLock($intent, $orderParams)
+                ) {
                     $lockReservation = $this->symbolExecutionLockManager->reserveForIntent(
                         $intent,
                         [
@@ -549,6 +555,44 @@ final class OrderIntentManager
         if ($lockReservation->syntheticLockCreated) {
             $this->entityManager->flush();
         }
+    }
+
+    /**
+     * @param array<string,mixed> $orderParams
+     */
+    private function requiresSymbolExecutionLock(OrderIntent $intent, array $orderParams): bool
+    {
+        if (\in_array($intent->getSide(), [2, 3], true)) {
+            return false;
+        }
+
+        return !$this->truthyOrderParam($orderParams, 'reduce_only')
+            && !$this->truthyOrderParam($orderParams, 'reduceOnly');
+    }
+
+    /**
+     * @param array<string,mixed> $orderParams
+     */
+    private function truthyOrderParam(array $orderParams, string $key): bool
+    {
+        if (!\array_key_exists($key, $orderParams)) {
+            return false;
+        }
+
+        $value = $orderParams[$key];
+        if (\is_bool($value)) {
+            return $value;
+        }
+
+        if (\is_int($value)) {
+            return $value === 1;
+        }
+
+        if (\is_string($value)) {
+            return \in_array(strtolower(trim($value)), ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return false;
     }
 
     private function lockDecisionKey(ExchangeContext $context, string $decisionKey): void

--- a/trading-app/src/Service/OrderIntentReservation.php
+++ b/trading-app/src/Service/OrderIntentReservation.php
@@ -13,6 +13,7 @@ final class OrderIntentReservation
         public readonly bool $created,
         public readonly bool $blocked,
         public readonly ?string $reason = null,
+        public readonly array $metadata = [],
     ) {
     }
 
@@ -26,8 +27,8 @@ final class OrderIntentReservation
         return new self($intent, false, false);
     }
 
-    public static function blocked(OrderIntent $intent, string $reason): self
+    public static function blocked(OrderIntent $intent, string $reason, array $metadata = []): self
     {
-        return new self($intent, false, true, $reason);
+        return new self($intent, false, true, $reason, $metadata);
     }
 }

--- a/trading-app/src/Service/SymbolExecutionLockManager.php
+++ b/trading-app/src/Service/SymbolExecutionLockManager.php
@@ -47,6 +47,22 @@ final class SymbolExecutionLockManager
             }
         }
 
+        if ($this->hasOpenExposureForKey($intent->getExchange(), $intent->getMarketType(), $intent->getSymbol())) {
+            $lock = new SymbolExecutionLock(
+                exchange: $intent->getExchange(),
+                marketType: $intent->getMarketType(),
+                symbol: $intent->getSymbol(),
+                expiresAt: (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify(
+                    sprintf('+%d seconds', $this->defaultTtlSeconds)
+                ),
+            );
+            $lock->setPayload(array_replace($payload, ['source' => 'existing_open_exposure']));
+            $this->entityManager->persist($lock);
+            $this->entityManager->flush();
+
+            return SymbolExecutionLockReservation::blocked($lock, $this->lockMetadata($lock, $intent, 'existing_open_exposure'));
+        }
+
         $lock = new SymbolExecutionLock(
             exchange: $intent->getExchange(),
             marketType: $intent->getMarketType(),
@@ -62,7 +78,7 @@ final class SymbolExecutionLockManager
         return SymbolExecutionLockReservation::created($lock);
     }
 
-    public function releaseForIntent(OrderIntent $intent, string $reason): bool
+    public function releaseForIntent(OrderIntent $intent, string $reason, bool $allowOpenOrder = false): bool
     {
         $active = $this->locks->findActive($intent->getExchange(), $intent->getMarketType(), $intent->getSymbol());
         if (!$active instanceof SymbolExecutionLock) {
@@ -74,7 +90,11 @@ final class SymbolExecutionLockManager
             return false;
         }
 
-        if ($this->hasOpenExposure($active)) {
+        if ($allowOpenOrder && $reason === 'order_intent_cancelled') {
+            $this->orders->markOpenOrdersCancelledForIntent($intent);
+        }
+
+        if ($this->hasOpenPosition($active) || (!$allowOpenOrder && $this->hasOpenOrder($active))) {
             $this->logger->info('symbol_execution_lock.release_skipped_open_exposure', [
                 'exchange' => $active->getExchange(),
                 'market_type' => $active->getMarketType(),
@@ -199,6 +219,13 @@ final class SymbolExecutionLockManager
         return $this->hasOpenPosition($lock) || $this->hasOpenOrder($lock);
     }
 
+    private function hasOpenExposureForKey(string $exchange, string $marketType, string $symbol): bool
+    {
+        $lock = new SymbolExecutionLock($exchange, $marketType, $symbol);
+
+        return $this->hasOpenExposure($lock);
+    }
+
     private function hasOpenPosition(SymbolExecutionLock $lock): bool
     {
         $context = ExchangeContext::fromValues($lock->getExchange(), $lock->getMarketType());
@@ -224,9 +251,13 @@ final class SymbolExecutionLockManager
     /**
      * @return array{lock: array<string,mixed>}
      */
-    private function lockMetadata(SymbolExecutionLock $lock, OrderIntent $currentIntent): array
+    private function lockMetadata(
+        SymbolExecutionLock $lock,
+        OrderIntent $currentIntent,
+        ?string $blockingReason = null,
+    ): array
     {
-        return [
+        $metadata = [
             'lock' => [
                 'exchange' => $lock->getExchange(),
                 'market_type' => $lock->getMarketType(),
@@ -237,6 +268,12 @@ final class SymbolExecutionLockManager
                 'blocking_decision_key' => $lock->getOwnerDecisionKey(),
             ],
         ];
+
+        if ($blockingReason !== null) {
+            $metadata['lock']['blocking_reason'] = $blockingReason;
+        }
+
+        return $metadata;
     }
 
     private function lockSymbolKey(string $exchange, string $marketType, string $symbol): void

--- a/trading-app/src/Service/SymbolExecutionLockManager.php
+++ b/trading-app/src/Service/SymbolExecutionLockManager.php
@@ -97,7 +97,8 @@ final class SymbolExecutionLockManager
             $this->orders->markOpenOrdersCancelledForIntent($intent);
         }
 
-        if ($this->hasOpenPosition($active) || (!$allowOpenOrder && $this->hasOpenOrder($active))) {
+        $lockHasOwner = $active->getOwnerOrderIntent() instanceof OrderIntent;
+        if ($this->hasOpenPosition($active) || ((!$allowOpenOrder || !$lockHasOwner) && $this->hasOpenOrder($active))) {
             $this->logger->info('symbol_execution_lock.release_skipped_open_exposure', [
                 'exchange' => $active->getExchange(),
                 'market_type' => $active->getMarketType(),
@@ -155,9 +156,14 @@ final class SymbolExecutionLockManager
         ExchangeContext $context,
         string $reason,
         bool $flush = false,
+        ?\DateTimeImmutable $lockedBefore = null,
     ): bool {
         $active = $this->locks->findActive($context->exchange->value, $context->marketType->value, $symbol);
         if (!$active instanceof SymbolExecutionLock) {
+            return false;
+        }
+
+        if ($lockedBefore !== null && $active->getLockedAt() > $lockedBefore) {
             return false;
         }
 

--- a/trading-app/src/Service/SymbolExecutionLockManager.php
+++ b/trading-app/src/Service/SymbolExecutionLockManager.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\OrderIntent;
+use App\Entity\SymbolExecutionLock;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\FuturesOrderRepository;
+use App\Repository\PositionRepository;
+use App\Repository\SymbolExecutionLockRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+final class SymbolExecutionLockManager
+{
+    private const ACTIVE_INTENT_STATUSES = [
+        OrderIntent::STATUS_DRAFT,
+        OrderIntent::STATUS_VALIDATED,
+        OrderIntent::STATUS_READY_TO_SEND,
+        OrderIntent::STATUS_SENT,
+    ];
+
+    public function __construct(
+        private readonly SymbolExecutionLockRepository $locks,
+        private readonly PositionRepository $positions,
+        private readonly FuturesOrderRepository $orders,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+        private readonly int $defaultTtlSeconds = 900,
+    ) {
+    }
+
+    public function reserveForIntent(OrderIntent $intent, array $payload = []): SymbolExecutionLockReservation
+    {
+        $this->lockSymbolKey($intent->getExchange(), $intent->getMarketType(), $intent->getSymbol());
+
+        $active = $this->locks->findActive($intent->getExchange(), $intent->getMarketType(), $intent->getSymbol());
+        if ($active instanceof SymbolExecutionLock) {
+            if ($this->canReclaimExpiredLock($active)) {
+                $active->release('expired_reclaimed');
+                $this->entityManager->persist($active);
+                $this->entityManager->flush();
+            } else {
+                return SymbolExecutionLockReservation::blocked($active, $this->lockMetadata($active, $intent));
+            }
+        }
+
+        $lock = new SymbolExecutionLock(
+            exchange: $intent->getExchange(),
+            marketType: $intent->getMarketType(),
+            symbol: $intent->getSymbol(),
+            ownerOrderIntent: $intent,
+            expiresAt: (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->modify(
+                sprintf('+%d seconds', $this->defaultTtlSeconds)
+            ),
+        );
+        $lock->setPayload($payload);
+        $this->entityManager->persist($lock);
+
+        return SymbolExecutionLockReservation::created($lock);
+    }
+
+    public function releaseForIntent(OrderIntent $intent, string $reason): bool
+    {
+        $active = $this->locks->findActive($intent->getExchange(), $intent->getMarketType(), $intent->getSymbol());
+        if (!$active instanceof SymbolExecutionLock) {
+            return false;
+        }
+
+        $owner = $active->getOwnerOrderIntent();
+        if ($owner instanceof OrderIntent && $owner->getId() !== $intent->getId()) {
+            return false;
+        }
+
+        if ($this->hasOpenExposure($active)) {
+            $this->logger->info('symbol_execution_lock.release_skipped_open_exposure', [
+                'exchange' => $active->getExchange(),
+                'market_type' => $active->getMarketType(),
+                'symbol' => $active->getSymbol(),
+                'lock_id' => $active->getId(),
+                'reason' => $reason,
+            ]);
+
+            return false;
+        }
+
+        $active->release($reason);
+        $this->entityManager->persist($active);
+
+        return true;
+    }
+
+    public function releaseManual(
+        string $symbol,
+        ExchangeContext $context,
+        string $reason,
+        bool $force = false,
+    ): bool {
+        $active = $this->locks->findActive($context->exchange->value, $context->marketType->value, $symbol);
+        if (!$active instanceof SymbolExecutionLock) {
+            return false;
+        }
+
+        if (!$force && $this->hasOpenExposure($active)) {
+            throw new \RuntimeException(sprintf(
+                'Refusing to release %s while an open position or order exists. Use --force only after manual investigation.',
+                $active->activeKey(),
+            ));
+        }
+
+        $releaseReason = $force ? 'force:' . $reason : $reason;
+        $active->release($releaseReason);
+        $this->entityManager->persist($active);
+        $this->entityManager->flush();
+
+        $this->logger->warning('symbol_execution_lock.manual_release', [
+            'exchange' => $active->getExchange(),
+            'market_type' => $active->getMarketType(),
+            'symbol' => $active->getSymbol(),
+            'force' => $force,
+            'reason' => $releaseReason,
+            'lock_id' => $active->getId(),
+        ]);
+
+        return true;
+    }
+
+    public function releaseForSymbol(
+        string $symbol,
+        ExchangeContext $context,
+        string $reason,
+        bool $flush = false,
+    ): bool {
+        $active = $this->locks->findActive($context->exchange->value, $context->marketType->value, $symbol);
+        if (!$active instanceof SymbolExecutionLock) {
+            return false;
+        }
+
+        if ($this->hasOpenExposure($active)) {
+            $this->logger->info('symbol_execution_lock.release_skipped_open_exposure', [
+                'exchange' => $active->getExchange(),
+                'market_type' => $active->getMarketType(),
+                'symbol' => $active->getSymbol(),
+                'lock_id' => $active->getId(),
+                'reason' => $reason,
+            ]);
+
+            return false;
+        }
+
+        $active->release($reason);
+        $this->entityManager->persist($active);
+
+        if ($flush) {
+            $this->entityManager->flush();
+        }
+
+        $this->logger->info('symbol_execution_lock.released_for_symbol', [
+            'exchange' => $active->getExchange(),
+            'market_type' => $active->getMarketType(),
+            'symbol' => $active->getSymbol(),
+            'lock_id' => $active->getId(),
+            'reason' => $reason,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * @return SymbolExecutionLock[]
+     */
+    public function listActive(?ExchangeContext $context = null, ?string $symbol = null, int $limit = 100): array
+    {
+        return $this->locks->findActiveLocks($context, $symbol, $limit);
+    }
+
+    private function canReclaimExpiredLock(SymbolExecutionLock $lock): bool
+    {
+        if (!$lock->isExpired()) {
+            return false;
+        }
+
+        if ($this->hasOpenExposure($lock)) {
+            return false;
+        }
+
+        $owner = $lock->getOwnerOrderIntent();
+        if ($owner instanceof OrderIntent && \in_array($owner->getStatus(), self::ACTIVE_INTENT_STATUSES, true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function hasOpenExposure(SymbolExecutionLock $lock): bool
+    {
+        return $this->hasOpenPosition($lock) || $this->hasOpenOrder($lock);
+    }
+
+    private function hasOpenPosition(SymbolExecutionLock $lock): bool
+    {
+        $context = ExchangeContext::fromValues($lock->getExchange(), $lock->getMarketType());
+
+        foreach (['LONG', 'SHORT'] as $side) {
+            $position = $this->positions->findOneBySymbolSide($lock->getSymbol(), $side, $context);
+            if ($position !== null && $position->getStatus() === 'OPEN') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasOpenOrder(SymbolExecutionLock $lock): bool
+    {
+        return $this->orders->hasOpenOrderForSymbol(
+            $lock->getSymbol(),
+            ExchangeContext::fromValues($lock->getExchange(), $lock->getMarketType()),
+        );
+    }
+
+    /**
+     * @return array{lock: array<string,mixed>}
+     */
+    private function lockMetadata(SymbolExecutionLock $lock, OrderIntent $currentIntent): array
+    {
+        return [
+            'lock' => [
+                'exchange' => $lock->getExchange(),
+                'market_type' => $lock->getMarketType(),
+                'symbol' => $lock->getSymbol(),
+                'current_profile' => $currentIntent->getStrategyProfile(),
+                'blocking_profile' => $lock->getOwnerProfile(),
+                'blocking_order_intent_id' => $lock->getOwnerOrderIntentId(),
+                'blocking_decision_key' => $lock->getOwnerDecisionKey(),
+            ],
+        ];
+    }
+
+    private function lockSymbolKey(string $exchange, string $marketType, string $symbol): void
+    {
+        $connection = $this->entityManager->getConnection();
+        if ($connection->getDatabasePlatform()->getName() !== 'postgresql') {
+            return;
+        }
+
+        $connection->executeStatement(
+            'SELECT pg_advisory_xact_lock(hashtext(:scope), hashtext(:symbol_key))',
+            [
+                'scope' => 'symbol_execution_lock',
+                'symbol_key' => sprintf('%s:%s:%s', strtolower($exchange), strtolower($marketType), strtoupper($symbol)),
+            ],
+        );
+    }
+}

--- a/trading-app/src/Service/SymbolExecutionLockManager.php
+++ b/trading-app/src/Service/SymbolExecutionLockManager.php
@@ -58,9 +58,12 @@ final class SymbolExecutionLockManager
             );
             $lock->setPayload(array_replace($payload, ['source' => 'existing_open_exposure']));
             $this->entityManager->persist($lock);
-            $this->entityManager->flush();
 
-            return SymbolExecutionLockReservation::blocked($lock, $this->lockMetadata($lock, $intent, 'existing_open_exposure'));
+            return SymbolExecutionLockReservation::blocked(
+                $lock,
+                $this->lockMetadata($lock, $intent, 'existing_open_exposure'),
+                true,
+            );
         }
 
         $lock = new SymbolExecutionLock(

--- a/trading-app/src/Service/SymbolExecutionLockReservation.php
+++ b/trading-app/src/Service/SymbolExecutionLockReservation.php
@@ -13,6 +13,7 @@ final class SymbolExecutionLockReservation
         public readonly bool $created,
         public readonly bool $blocked,
         public readonly array $metadata = [],
+        public readonly bool $syntheticLockCreated = false,
     ) {
     }
 
@@ -21,8 +22,8 @@ final class SymbolExecutionLockReservation
         return new self($lock, true, false);
     }
 
-    public static function blocked(SymbolExecutionLock $lock, array $metadata): self
+    public static function blocked(SymbolExecutionLock $lock, array $metadata, bool $syntheticLockCreated = false): self
     {
-        return new self($lock, false, true, $metadata);
+        return new self($lock, false, true, $metadata, $syntheticLockCreated);
     }
 }

--- a/trading-app/src/Service/SymbolExecutionLockReservation.php
+++ b/trading-app/src/Service/SymbolExecutionLockReservation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\SymbolExecutionLock;
+
+final class SymbolExecutionLockReservation
+{
+    private function __construct(
+        public readonly SymbolExecutionLock $lock,
+        public readonly bool $created,
+        public readonly bool $blocked,
+        public readonly array $metadata = [],
+    ) {
+    }
+
+    public static function created(SymbolExecutionLock $lock): self
+    {
+        return new self($lock, true, false);
+    }
+
+    public static function blocked(SymbolExecutionLock $lock, array $metadata): self
+    {
+        return new self($lock, false, true, $metadata);
+    }
+}

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -95,7 +95,7 @@ final class ExecuteOrderPlan
                             'decision_key' => $decisionKey,
                             'order_intent_id' => $reservation->intent->getId(),
                             'existing_status' => $reservation->intent->getStatus(),
-                        ],
+                        ] + $reservation->metadata,
                     );
                 }
 

--- a/trading-app/src/Trading/Listener/SymbolExecutionLockReleaseListener.php
+++ b/trading-app/src/Trading/Listener/SymbolExecutionLockReleaseListener.php
@@ -27,6 +27,7 @@ final class SymbolExecutionLockReleaseListener
             $context,
             'position_closed',
             true,
+            $event->positionHistory->closedAt,
         );
     }
 }

--- a/trading-app/src/Trading/Listener/SymbolExecutionLockReleaseListener.php
+++ b/trading-app/src/Trading/Listener/SymbolExecutionLockReleaseListener.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Listener;
+
+use App\Provider\Context\ExchangeContext;
+use App\Service\SymbolExecutionLockManager;
+use App\Trading\Event\PositionClosedEvent;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(event: PositionClosedEvent::class)]
+final class SymbolExecutionLockReleaseListener
+{
+    public function __construct(
+        private readonly SymbolExecutionLockManager $symbolExecutionLockManager,
+    ) {
+    }
+
+    public function __invoke(PositionClosedEvent $event): void
+    {
+        $marketType = $event->extra['market_type'] ?? $event->extra['marketType'] ?? null;
+        $context = ExchangeContext::fromValues($event->exchange, $marketType);
+
+        $this->symbolExecutionLockManager->releaseForSymbol(
+            $event->positionHistory->symbol,
+            $context,
+            'position_closed',
+            true,
+        );
+    }
+}

--- a/trading-app/tests/Command/SymbolLockCommandTest.php
+++ b/trading-app/tests/Command/SymbolLockCommandTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\SymbolLockListCommand;
+use App\Command\SymbolLockReleaseCommand;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\PositionSide;
+use App\Entity\FuturesOrder;
+use App\Entity\OrderIntent;
+use App\Entity\Position;
+use App\Entity\SymbolExecutionLock;
+use App\Repository\FuturesOrderRepository;
+use App\Repository\PositionRepository;
+use App\Repository\SymbolExecutionLockRepository;
+use App\Service\SymbolExecutionLockManager;
+use App\Trading\Dto\PositionHistoryEntryDto;
+use App\Trading\Event\PositionClosedEvent;
+use App\Trading\Listener\SymbolExecutionLockReleaseListener;
+use Brick\Math\BigDecimal;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversNothing]
+final class SymbolLockCommandTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private SymbolExecutionLockManager $manager;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadata = array_map(
+            fn (string $class) => $this->em->getClassMetadata($class),
+            [
+                FuturesOrder::class,
+                OrderIntent::class,
+                Position::class,
+                SymbolExecutionLock::class,
+            ],
+        );
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+
+        /** @var SymbolExecutionLockRepository $lockRepository */
+        $lockRepository = $this->em->getRepository(SymbolExecutionLock::class);
+        /** @var PositionRepository $positionRepository */
+        $positionRepository = $this->em->getRepository(Position::class);
+        /** @var FuturesOrderRepository $orderRepository */
+        $orderRepository = $this->em->getRepository(FuturesOrder::class);
+        $this->manager = new SymbolExecutionLockManager(
+            $lockRepository,
+            $positionRepository,
+            $orderRepository,
+            $this->em,
+            new NullLogger(),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            $metadata = array_map(
+                fn (string $class) => $this->em->getClassMetadata($class),
+                [
+                    FuturesOrder::class,
+                    OrderIntent::class,
+                    Position::class,
+                    SymbolExecutionLock::class,
+                ],
+            );
+            (new SchemaTool($this->em))->dropSchema($metadata);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testListCommandDisplaysActiveLocks(): void
+    {
+        $intent = $this->persistIntent('BTCUSDT', 'scalper');
+        $this->manager->reserveForIntent($intent);
+        $this->em->flush();
+
+        $tester = new CommandTester(new SymbolLockListCommand($this->manager));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('bitmart', $tester->getDisplay());
+        self::assertStringContainsString('perpetual', $tester->getDisplay());
+        self::assertStringContainsString('BTCUSDT', $tester->getDisplay());
+        self::assertStringContainsString('scalper', $tester->getDisplay());
+    }
+
+    public function testReleaseCommandRefusesOpenPositionWithoutForce(): void
+    {
+        $intent = $this->persistIntent('BTCUSDT', 'scalper');
+        $this->manager->reserveForIntent($intent);
+        $this->em->persist((new Position('BTCUSDT', 'LONG'))->setSize('1'));
+        $this->em->flush();
+
+        $tester = new CommandTester(new SymbolLockReleaseCommand($this->manager));
+        $exitCode = $tester->execute([
+            'symbol' => 'BTCUSDT',
+            '--exchange' => 'bitmart',
+            '--market-type' => 'perpetual',
+            '--reason' => 'manual_investigation',
+        ]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('open position', $tester->getDisplay());
+        self::assertStringContainsString('order exists', $tester->getDisplay());
+        self::assertStringContainsString('exists', $tester->getDisplay());
+    }
+
+    public function testReleaseCommandAllowsForceReleaseWithOpenPosition(): void
+    {
+        $intent = $this->persistIntent('BTCUSDT', 'scalper');
+        $this->manager->reserveForIntent($intent);
+        $this->em->persist((new Position('BTCUSDT', 'LONG'))->setSize('1'));
+        $this->em->flush();
+
+        $tester = new CommandTester(new SymbolLockReleaseCommand($this->manager));
+        $exitCode = $tester->execute([
+            'symbol' => 'BTCUSDT',
+            '--exchange' => 'bitmart',
+            '--market-type' => 'perpetual',
+            '--reason' => 'manual_investigation',
+            '--force' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Released lock for bitmart:perpetual:BTCUSDT', $tester->getDisplay());
+        self::assertNull($this->em->getRepository(SymbolExecutionLock::class)->findActive('bitmart', 'perpetual', 'BTCUSDT'));
+    }
+
+    public function testPositionClosedEventReleasesSymbolLock(): void
+    {
+        $intent = $this->persistIntent('BTCUSDT', 'scalper');
+        $this->manager->reserveForIntent($intent);
+        $this->em->flush();
+
+        (new SymbolExecutionLockReleaseListener($this->manager))->__invoke(new PositionClosedEvent(
+            positionHistory: $this->closedPosition('BTCUSDT'),
+            exchange: 'bitmart',
+            extra: ['market_type' => 'perpetual'],
+        ));
+
+        self::assertNull($this->em->getRepository(SymbolExecutionLock::class)->findActive('bitmart', 'perpetual', 'BTCUSDT'));
+    }
+
+    public function testPositionClosedEventKeepsLockWhileAnotherSideIsOpen(): void
+    {
+        $intent = $this->persistIntent('BTCUSDT', 'scalper');
+        $this->manager->reserveForIntent($intent);
+        $this->em->persist((new Position('BTCUSDT', 'SHORT'))->setSize('1'));
+        $this->em->flush();
+
+        (new SymbolExecutionLockReleaseListener($this->manager))->__invoke(new PositionClosedEvent(
+            positionHistory: $this->closedPosition('BTCUSDT'),
+            exchange: 'bitmart',
+            extra: ['market_type' => 'perpetual'],
+        ));
+
+        self::assertNotNull($this->em->getRepository(SymbolExecutionLock::class)->findActive('bitmart', 'perpetual', 'BTCUSDT'));
+    }
+
+    private function persistIntent(string $symbol, string $profile): OrderIntent
+    {
+        $intent = (new OrderIntent())
+            ->setExchange(Exchange::BITMART)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setDecisionKey(sprintf('bitmart:perpetual:%s:1m:1764160800:long:%s:v1', $symbol, $profile))
+            ->setStrategyProfile($profile)
+            ->setStrategyVersion('v1')
+            ->setSymbol($symbol)
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setPrice('100')
+            ->setSize(1)
+            ->setClientOrderId('cid-' . strtolower($symbol) . '-' . $profile)
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setQuantization([])
+            ->setStatus(OrderIntent::STATUS_DRAFT);
+
+        $this->em->persist($intent);
+
+        return $intent;
+    }
+
+    private function closedPosition(string $symbol): PositionHistoryEntryDto
+    {
+        return new PositionHistoryEntryDto(
+            symbol: $symbol,
+            side: PositionSide::LONG,
+            size: BigDecimal::of('1'),
+            entryPrice: BigDecimal::of('100'),
+            exitPrice: BigDecimal::of('101'),
+            realizedPnl: BigDecimal::of('1'),
+            fees: BigDecimal::of('0.01'),
+            openedAt: new \DateTimeImmutable('2026-05-31 10:00:00', new \DateTimeZone('UTC')),
+            closedAt: new \DateTimeImmutable('2026-05-31 10:05:00', new \DateTimeZone('UTC')),
+        );
+    }
+}

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -459,6 +459,134 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         self::assertTrue($afterCancel->created);
     }
 
+    public function testOrderIntentValidationFailureReleasesSymbolLock(): void
+    {
+        $manager = $this->orderIntentManager();
+        $invalidParams = $this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-validation-failed',
+            size: 0,
+            strategyProfile: 'scalper',
+        );
+
+        $reservation = $manager->reserveIntent($invalidParams);
+        $errors = $manager->validateOrderParams($invalidParams);
+
+        self::assertTrue($reservation->created);
+        self::assertNotNull($errors);
+        self::assertFalse($manager->validateIntent($reservation->intent, $errors));
+
+        $afterValidationFailure = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160860:long:scalper_micro:v1',
+            clientOrderId: 'cid-after-validation-failure',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($afterValidationFailure->created);
+    }
+
+    public function testOrderIntentCancellationReleasesLockDespiteStaleOpenOrderRow(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $first = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-cancelled-stale-order',
+            strategyProfile: 'scalper',
+        ));
+        $manager->markAsSent($first->intent, 'exchange-cancelled-stale-order');
+        $this->em->persist(
+            $this->newFuturesOrder('bitmart', 'exchange-cancelled-stale-order', '1', 'BTCUSDT')
+                ->setClientOrderId($first->intent->getClientOrderId())
+                ->setStatus('pending')
+        );
+        $this->em->flush();
+
+        $manager->markAsCancelled($first->intent);
+
+        $afterCancellation = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160860:long:scalper_micro:v1',
+            clientOrderId: 'cid-after-cancelled-stale-order',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($afterCancellation->created);
+    }
+
+    public function testOrderIntentCancellationKeepsLockWhenPositionIsOpen(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $first = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-cancelled-open-position',
+            strategyProfile: 'scalper',
+        ));
+        $this->em->persist((new Position('BTCUSDT', 'LONG'))->setSize('1'));
+        $this->em->flush();
+
+        $manager->markAsCancelled($first->intent);
+        $afterCancellation = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160860:long:scalper_micro:v1',
+            clientOrderId: 'cid-after-cancelled-open-position',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($afterCancellation->blocked);
+        self::assertSame('cross_profile_symbol_locked', $afterCancellation->reason);
+    }
+
+    public function testOrderIntentReservationBlocksExistingOpenExposureWithoutActiveLock(): void
+    {
+        $manager = $this->orderIntentManager();
+        $this->em->persist(
+            $this->newFuturesOrder('bitmart', 'orphan-open-order', '1', 'BTCUSDT')
+                ->setClientOrderId('orphan-open-order-client')
+                ->setStatus('pending')
+        );
+        $this->em->flush();
+
+        $reservation = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-existing-open-exposure',
+            strategyProfile: 'scalper',
+        ));
+
+        /** @var \App\Repository\SymbolExecutionLockRepository $lockRepository */
+        $lockRepository = $this->em->getRepository(SymbolExecutionLock::class);
+        $lock = $lockRepository->findActive('bitmart', 'perpetual', 'BTCUSDT');
+
+        self::assertTrue($reservation->blocked);
+        self::assertSame('cross_profile_symbol_locked', $reservation->reason);
+        self::assertSame('existing_open_exposure', $reservation->metadata['lock']['blocking_reason'] ?? null);
+        self::assertNotNull($lock);
+        self::assertNull($lock->getOwnerOrderIntentId());
+    }
+
+    public function testBlockedReservationDetachesCascadedProtections(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-protection-owner',
+            strategyProfile: 'scalper',
+        ));
+        $blockedParams = $this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160860:long:scalper_micro:v1',
+            clientOrderId: 'cid-protection-blocked',
+            strategyProfile: 'scalper_micro',
+        );
+        $blockedParams['preset_take_profit_price'] = '110';
+        $blockedParams['preset_stop_loss_price'] = '90';
+
+        $blocked = $manager->reserveIntent($blockedParams);
+        $this->em->flush();
+
+        self::assertTrue($blocked->blocked);
+        self::assertSame(0, $this->em->getRepository(OrderProtection::class)->count([]));
+    }
+
     public function testExpiredSymbolLockIsNotReclaimedWhileOpenOrderExists(): void
     {
         $manager = $this->orderIntentManager();

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -32,6 +32,7 @@ use App\TradeEntry\Idempotency\DecisionKeyFactory;
 use App\Trading\Storage\FuturesOrderOrderStateRepository;
 use App\Trading\Storage\PositionPositionStateRepository;
 use Brick\Math\BigDecimal;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -74,6 +75,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         $schemaTool = new SchemaTool($this->em);
         $schemaTool->dropSchema($metadata);
         $schemaTool->createSchema($metadata);
+        $this->normalizeSqlitePartialUniqueIndexes();
     }
 
     protected function tearDown(): void
@@ -370,6 +372,37 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         ], $scalperMicro->metadata['lock'] ?? null);
     }
 
+    public function testReduceOnlyCloseIntentBypassesGlobalSymbolLock(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $entry = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-entry-lock-owner',
+            strategyProfile: 'scalper',
+        ));
+        $closeParams = $this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160860:close:manual:v1',
+            clientOrderId: 'cid-reduce-only-close',
+            strategyProfile: 'manual_close',
+        );
+        $closeParams['side'] = 2;
+        $closeParams['reduce_only'] = true;
+
+        $close = $manager->reserveIntent($closeParams);
+
+        self::assertTrue($entry->created);
+        self::assertTrue($close->created);
+        self::assertFalse($close->blocked);
+        self::assertSame(2, $close->intent->getSide());
+
+        /** @var \App\Repository\SymbolExecutionLockRepository $lockRepository */
+        $lockRepository = $this->em->getRepository(SymbolExecutionLock::class);
+        $lock = $lockRepository->findActive('bitmart', 'perpetual', 'BTCUSDT');
+
+        self::assertSame($entry->intent->getId(), $lock?->getOwnerOrderIntentId());
+    }
+
     public function testOrderIntentReservationWithoutDecisionKeyStillUsesGlobalSymbolLock(): void
     {
         $manager = $this->orderIntentManager();
@@ -564,6 +597,41 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         self::assertSame(0, $this->em->getRepository(OrderIntent::class)->count([]));
     }
 
+    public function testFuturesOrderRepositoryTreatsBitmartRawStateAsOpen(): void
+    {
+        $this->em->persist(
+            $this->newFuturesOrder('bitmart', 'state-only-open-order', '1', 'BTCUSDT')
+                ->setStatus(null)
+                ->setRawData([
+                    'exchange' => 'bitmart',
+                    'market_type' => 'perpetual',
+                    'state' => 1,
+                ])
+        );
+        $this->em->flush();
+
+        /** @var FuturesOrderRepository $repository */
+        $repository = $this->em->getRepository(FuturesOrder::class);
+
+        self::assertTrue($repository->hasOpenOrderForSymbol('BTCUSDT'));
+    }
+
+    public function testSymbolExecutionLockMetadataDeclaresActiveUniqueConstraint(): void
+    {
+        $metadata = $this->em->getClassMetadata(SymbolExecutionLock::class);
+        $uniqueConstraints = $metadata->table['uniqueConstraints'] ?? [];
+
+        self::assertArrayHasKey('ux_symbol_execution_lock_active_symbol', $uniqueConstraints);
+        self::assertSame(
+            ['exchange', 'market_type', 'symbol'],
+            $uniqueConstraints['ux_symbol_execution_lock_active_symbol']['columns'] ?? null,
+        );
+        self::assertSame(
+            'released_at IS NULL',
+            $uniqueConstraints['ux_symbol_execution_lock_active_symbol']['options']['where'] ?? null,
+        );
+    }
+
     public function testBlockedReservationDetachesCascadedProtections(): void
     {
         $manager = $this->orderIntentManager();
@@ -735,6 +803,20 @@ final class ExchangeScopedStorageTest extends KernelTestCase
             ->setLowPrice(BigDecimal::of('90'))
             ->setClosePrice(BigDecimal::of($close))
             ->setVolume(BigDecimal::of('1'));
+    }
+
+    private function normalizeSqlitePartialUniqueIndexes(): void
+    {
+        $connection = $this->em->getConnection();
+        if (!$connection->getDatabasePlatform() instanceof SqlitePlatform) {
+            return;
+        }
+
+        $connection->executeStatement('DROP INDEX IF EXISTS ux_symbol_execution_lock_active_symbol');
+        $connection->executeStatement(
+            'CREATE UNIQUE INDEX ux_symbol_execution_lock_active_symbol ' .
+            'ON symbol_execution_lock (exchange, market_type, symbol) WHERE released_at IS NULL'
+        );
     }
 
     /**

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -561,6 +561,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         self::assertSame('existing_open_exposure', $reservation->metadata['lock']['blocking_reason'] ?? null);
         self::assertNotNull($lock);
         self::assertNull($lock->getOwnerOrderIntentId());
+        self::assertSame(0, $this->em->getRepository(OrderIntent::class)->count([]));
     }
 
     public function testBlockedReservationDetachesCascadedProtections(): void

--- a/trading-app/tests/Repository/ExchangeScopedStorageTest.php
+++ b/trading-app/tests/Repository/ExchangeScopedStorageTest.php
@@ -13,6 +13,7 @@ use App\Entity\MtfState;
 use App\Entity\OrderIntent;
 use App\Entity\OrderProtection;
 use App\Entity\Position;
+use App\Entity\SymbolExecutionLock;
 use App\MtfValidator\Entity\MtfAudit;
 use App\MtfValidator\Repository\MtfAuditRepository;
 use App\Provider\Context\ExchangeContext;
@@ -20,11 +21,13 @@ use App\Provider\Entity\Contract;
 use App\Provider\Entity\Kline;
 use App\Provider\Repository\ContractRepository;
 use App\Provider\Repository\KlineRepository;
+use App\Repository\FuturesOrderRepository;
 use App\Repository\IndicatorSnapshotRepository;
 use App\Repository\MtfStateRepository;
 use App\Repository\OrderIntentRepository;
 use App\Repository\PositionRepository;
 use App\Service\OrderIntentManager;
+use App\Service\SymbolExecutionLockManager;
 use App\TradeEntry\Idempotency\DecisionKeyFactory;
 use App\Trading\Storage\FuturesOrderOrderStateRepository;
 use App\Trading\Storage\PositionPositionStateRepository;
@@ -61,6 +64,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
                 Position::class,
                 OrderIntent::class,
                 OrderProtection::class,
+                SymbolExecutionLock::class,
                 IndicatorSnapshot::class,
                 MtfState::class,
                 MtfAudit::class,
@@ -84,6 +88,7 @@ final class ExchangeScopedStorageTest extends KernelTestCase
                     Position::class,
                     OrderIntent::class,
                     OrderProtection::class,
+                    SymbolExecutionLock::class,
                     IndicatorSnapshot::class,
                     MtfState::class,
                     MtfAudit::class,
@@ -238,9 +243,11 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         ];
 
         foreach ($cases as $index => $status) {
+            $symbol = ['BTCUSDT', 'ETHUSDT', 'SOLUSDT'][$index];
             $params = $this->orderIntentParams(
-                decisionKey: sprintf('bitmart:perpetual:BTCUSDT:1m:%d:long:scalper_micro:v1', 1764161200 + ($index * 60)),
+                decisionKey: sprintf('bitmart:perpetual:%s:1m:%d:long:scalper_micro:v1', $symbol, 1764161200 + ($index * 60)),
                 clientOrderId: 'cid-' . strtolower($status),
+                symbol: $symbol,
             );
             $first = $manager->reserveIntent($params);
 
@@ -270,9 +277,16 @@ final class ExchangeScopedStorageTest extends KernelTestCase
 
         $index = 1;
         foreach ($cases as $status => $expectedReason) {
+            $symbol = match ($status) {
+                OrderIntent::STATUS_SENT => 'BTCUSDT',
+                OrderIntent::STATUS_FAILED => 'ETHUSDT',
+                OrderIntent::STATUS_CANCELLED => 'SOLUSDT',
+                default => 'XRPUSDT',
+            };
             $params = $this->orderIntentParams(
-                decisionKey: sprintf('bitmart:perpetual:BTCUSDT:1m:%d:long:scalper_micro:v1', 1764160800 + ($index * 60)),
+                decisionKey: sprintf('bitmart:perpetual:%s:1m:%d:long:scalper_micro:v1', $symbol, 1764160800 + ($index * 60)),
                 clientOrderId: 'cid-' . strtolower($status),
+                symbol: $symbol,
             );
             ++$index;
             $first = $manager->reserveIntent($params);
@@ -323,6 +337,179 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         self::assertSame('bitmart', $bitmart->intent->getExchange());
         self::assertSame('binance', $binance->intent->getExchange());
         self::assertSame('spot', $bitmartSpot->intent->getMarketType());
+    }
+
+    public function testOrderIntentReservationBlocksDifferentProfileOnSameExchangeMarketSymbol(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $scalper = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-scalper',
+            strategyProfile: 'scalper',
+        ));
+        $scalperMicro = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160860:long:scalper_micro:v1',
+            clientOrderId: 'cid-scalper-micro',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($scalper->created);
+        self::assertFalse($scalper->blocked);
+        self::assertFalse($scalperMicro->created);
+        self::assertTrue($scalperMicro->blocked);
+        self::assertSame('cross_profile_symbol_locked', $scalperMicro->reason);
+        self::assertSame([
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'BTCUSDT',
+            'current_profile' => 'scalper_micro',
+            'blocking_profile' => 'scalper',
+            'blocking_order_intent_id' => $scalper->intent->getId(),
+            'blocking_decision_key' => $scalper->intent->getDecisionKey(),
+        ], $scalperMicro->metadata['lock'] ?? null);
+    }
+
+    public function testOrderIntentReservationWithoutDecisionKeyStillUsesGlobalSymbolLock(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $first = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: '',
+            clientOrderId: 'cid-no-decision-first',
+            strategyProfile: 'scalper',
+        ));
+        $second = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: '',
+            clientOrderId: 'cid-no-decision-second',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($first->created);
+        self::assertTrue($second->blocked);
+        self::assertSame('cross_profile_symbol_locked', $second->reason);
+        self::assertSame($first->intent->getId(), $second->intent->getId());
+    }
+
+    public function testOrderIntentReservationAllowsSameSymbolOnDifferentExchangeMarketOrSymbol(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $bitmart = $manager->reserveIntent($this->orderIntentParams(
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-bitmart-btc',
+            strategyProfile: 'scalper',
+        ));
+        $okx = $manager->reserveIntent($this->orderIntentParams(
+            exchange: 'okx',
+            marketType: 'perpetual',
+            decisionKey: 'okx:perpetual:BTCUSDT:1m:1764160800:long:scalper_micro:v1',
+            clientOrderId: 'cid-okx-btc',
+            strategyProfile: 'scalper_micro',
+        ));
+        $spot = $manager->reserveIntent($this->orderIntentParams(
+            exchange: 'bitmart',
+            marketType: 'spot',
+            decisionKey: 'bitmart:spot:BTCUSDT:1m:1764160800:long:scalper_micro:v1',
+            clientOrderId: 'cid-bitmart-spot-btc',
+            strategyProfile: 'scalper_micro',
+        ));
+        $eth = $manager->reserveIntent($this->orderIntentParams(
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            decisionKey: 'bitmart:perpetual:ETHUSDT:1m:1764160800:long:scalper_micro:v1',
+            clientOrderId: 'cid-bitmart-eth',
+            symbol: 'ETHUSDT',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($bitmart->created);
+        self::assertTrue($okx->created);
+        self::assertTrue($spot->created);
+        self::assertTrue($eth->created);
+    }
+
+    public function testOrderIntentFailureAndCancellationReleaseSymbolLock(): void
+    {
+        $manager = $this->orderIntentManager();
+
+        $first = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160800:long:scalper:v1',
+            clientOrderId: 'cid-first-failed',
+            strategyProfile: 'scalper',
+        ));
+        $manager->markAsFailed($first->intent, 'exchange rejected');
+
+        $afterFailure = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160860:long:scalper_micro:v1',
+            clientOrderId: 'cid-after-failure',
+            strategyProfile: 'scalper_micro',
+        ));
+        self::assertTrue($afterFailure->created);
+
+        $manager->markAsCancelled($afterFailure->intent);
+        $afterCancel = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160920:long:regular:v1',
+            clientOrderId: 'cid-after-cancel',
+            strategyProfile: 'regular',
+        ));
+
+        self::assertTrue($afterCancel->created);
+    }
+
+    public function testExpiredSymbolLockIsNotReclaimedWhileOpenOrderExists(): void
+    {
+        $manager = $this->orderIntentManager();
+        $owner = $this->expiredLockOwner('BTCUSDT');
+        $lock = new SymbolExecutionLock(
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            ownerOrderIntent: $owner,
+            expiresAt: new \DateTimeImmutable('-1 hour', new \DateTimeZone('UTC')),
+        );
+        $this->em->persist($owner);
+        $this->em->persist($lock);
+        $this->em->persist($this->newFuturesOrder('bitmart', 'open-order-btc', '1', 'BTCUSDT')->setStatus('pending'));
+        $this->em->flush();
+
+        $reservation = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160980:long:scalper_micro:v1',
+            clientOrderId: 'cid-expired-open-order',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($reservation->blocked);
+        self::assertSame('cross_profile_symbol_locked', $reservation->reason);
+        self::assertNull($lock->getReleasedAt());
+    }
+
+    public function testExpiredSymbolLockCanBeReclaimedWithoutOpenExposure(): void
+    {
+        $manager = $this->orderIntentManager();
+        $owner = $this->expiredLockOwner('BTCUSDT');
+        $lock = new SymbolExecutionLock(
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            ownerOrderIntent: $owner,
+            expiresAt: new \DateTimeImmutable('-1 hour', new \DateTimeZone('UTC')),
+        );
+        $this->em->persist($owner);
+        $this->em->persist($lock);
+        $this->em->flush();
+
+        $reservation = $manager->reserveIntent($this->orderIntentParams(
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160980:long:scalper_micro:v1',
+            clientOrderId: 'cid-expired-reclaimed',
+            strategyProfile: 'scalper_micro',
+        ));
+
+        self::assertTrue($reservation->created);
+        self::assertSame('expired_reclaimed', $lock->getReleaseReason());
+        self::assertNotNull($lock->getReleasedAt());
     }
 
     public function testTradingStateReadsCanSelectExplicitExchangeContext(): void
@@ -457,12 +644,25 @@ final class ExchangeScopedStorageTest extends KernelTestCase
     {
         /** @var OrderIntentRepository $repository */
         $repository = $this->em->getRepository(OrderIntent::class);
+        /** @var \App\Repository\SymbolExecutionLockRepository $lockRepository */
+        $lockRepository = $this->em->getRepository(SymbolExecutionLock::class);
+        /** @var PositionRepository $positionRepository */
+        $positionRepository = $this->em->getRepository(Position::class);
+        /** @var FuturesOrderRepository $orderRepository */
+        $orderRepository = $this->em->getRepository(FuturesOrder::class);
 
         return new OrderIntentManager(
             $repository,
             $this->em,
             new NullLogger(),
             new DecisionKeyFactory(),
+            new SymbolExecutionLockManager(
+                $lockRepository,
+                $positionRepository,
+                $orderRepository,
+                $this->em,
+                new NullLogger(),
+            ),
         );
     }
 
@@ -476,15 +676,17 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         string $clientOrderId = 'cid-reservation',
         string $price = '100',
         int $size = 1,
+        string $symbol = 'BTCUSDT',
+        string $strategyProfile = 'scalper_micro',
     ): array {
         return [
             'exchange' => $exchange,
             'market_type' => $marketType,
             'decision_key' => $decisionKey,
-            'symbol' => 'BTCUSDT',
+            'symbol' => $symbol,
             'timeframe' => '1m',
             'candle_open_ts' => '1764160800',
-            'strategy_profile' => 'scalper_micro',
+            'strategy_profile' => $strategyProfile,
             'strategy_version' => 'v1',
             'side' => 1,
             'type' => OrderIntent::TYPE_LIMIT,
@@ -497,12 +699,27 @@ final class ExchangeScopedStorageTest extends KernelTestCase
         ];
     }
 
-    private function newFuturesOrder(string $exchange, string $orderId, string $size): FuturesOrder
+    private function expiredLockOwner(string $symbol): OrderIntent
+    {
+        return $this->newIntent('bitmart', 'cid-expired-owner-' . strtolower($symbol))
+            ->setDecisionKey(sprintf('bitmart:perpetual:%s:1m:1764160800:long:scalper:v1', $symbol))
+            ->setStrategyProfile('scalper')
+            ->setStrategyVersion('v1')
+            ->setSymbol($symbol)
+            ->setStatus(OrderIntent::STATUS_FAILED);
+    }
+
+    private function newFuturesOrder(
+        string $exchange,
+        string $orderId,
+        string $size,
+        string $symbol = 'ETHUSDT',
+    ): FuturesOrder
     {
         return (new FuturesOrder())
             ->setExchange($exchange)
             ->setMarketType(MarketType::PERPETUAL)
-            ->setSymbol('ETHUSDT')
+            ->setSymbol($symbol)
             ->setOrderId($orderId)
             ->setClientOrderId($exchange . '-client')
             ->setStatus('new')


### PR DESCRIPTION
## Summary
- Add a persistent `symbol_execution_lock` table with a PostgreSQL partial unique active lock on `exchange + market_type + symbol`.
- Integrate the lock into `OrderIntentManager::reserveIntent()` for decision-key and no-decision-key reservation paths, returning `cross_profile_symbol_locked` with lock metadata.
- Add guarded release on failed/cancelled intents, position-close events, TTL reclaim without open exposure, and diagnostic list/release commands.
- Document the operational runbook in `trading-app/docs/CROSS_PROFILE_SYMBOL_LOCK.md`.

Closes #127

## Test Plan
- ✅ `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit tests/Repository/ExchangeScopedStorageTest.php tests/Command/SymbolLockCommandTest.php` (`22` tests, `95` assertions, `1` skipped)
- ✅ `php -d error_reporting='E_ALL & ~E_DEPRECATED' bin/console lint:container`
- ✅ `php -l` on modified and new PHP files
- ✅ `git diff --cached --check`
- ⚠️ `php -d error_reporting='E_ALL & ~E_DEPRECATED' ./vendor/bin/phpunit` still fails on pre-existing broad-suite issues unrelated to this PR: missing `App\Domain\Ports\Out\IndicatorProviderPort`, missing `App\Domain\Strategy\Service\StrategyBacktester`, missing `App\Domain\Ports\Out\TradingProviderPort`, undefined legacy `Timeframe::H1/H4/M1`, outdated constructor signatures in older tests, and strict coverage-risky tests. Latest run: `539` tests, `1902` assertions, `116` errors, `6` failures, `24` skipped, `144` risky.
