### PR TITLE
feat: add Symfony ops front with Temporal dashboard

### DIFF
--- a/trading-app/config/routes.yaml
+++ b/trading-app/config/routes.yaml
@@ -4,6 +4,10 @@ controllers:
   resource: '../src/Controller/'
   type: attribute
 
+front:
+  resource: '../src/Front/Controller/'
+  type: attribute
+
 # Import MTF routes
 mtf_api:
     resource: routes_mtf.yaml

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -308,6 +308,22 @@ services:
             $path: '%kernel.project_dir%/config/app/indicator.yaml'
         autowire: false
 
+    App\Front\Query\SystemHealthQuery:
+        arguments:
+            $projectDir: '%kernel.project_dir%'
+
+    App\Front\Query\ConfigSummaryQuery:
+        arguments:
+            $projectDir: '%kernel.project_dir%'
+
+    App\Front\Query\InvestigationQuery:
+        arguments:
+            $projectDir: '%kernel.project_dir%'
+
+    App\Front\Query\TemporalSummaryQuery:
+        arguments:
+            $projectDir: '%kernel.project_dir%'
+
     # Registre des conditions: injection automatique via AutowireLocator/AutowireIterator
     App\MtfValidator\ConditionLoader\ConditionRegistry:
         arguments:

--- a/trading-app/public/front/app.css
+++ b/trading-app/public/front/app.css
@@ -1,0 +1,424 @@
+:root {
+    color-scheme: light;
+    --bg: #f4f5f3;
+    --surface: #ffffff;
+    --surface-2: #eef2ef;
+    --line: #d8ded8;
+    --text: #17201b;
+    --muted: #647067;
+    --green: #126f4f;
+    --teal: #0d6b73;
+    --red: #b42318;
+    --amber: #a65f00;
+    --ink: #20252a;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.45 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+    color: var(--teal);
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.topbar {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    min-height: 56px;
+    padding: 0 24px;
+    background: var(--ink);
+    color: #fff;
+    border-bottom: 1px solid #000;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: #fff;
+    font-weight: 700;
+}
+
+.brand:hover {
+    text-decoration: none;
+}
+
+.brand-mark {
+    display: grid;
+    place-items: center;
+    width: 30px;
+    height: 30px;
+    border-radius: 6px;
+    background: #f2c94c;
+    color: #1d1d1d;
+    font-size: 12px;
+    letter-spacing: 0;
+}
+
+.main-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.main-nav a {
+    color: #dfe7e1;
+    padding: 8px 10px;
+    border-radius: 6px;
+}
+
+.main-nav a.active,
+.main-nav a:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.12);
+    text-decoration: none;
+}
+
+.page-shell {
+    max-width: 1500px;
+    margin: 0 auto;
+    padding: 24px;
+}
+
+.page-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.page-header h1 {
+    margin: 0;
+    font-size: 28px;
+    line-height: 1.1;
+    letter-spacing: 0;
+}
+
+.page-header p {
+    margin: 6px 0 0;
+    color: var(--muted);
+}
+
+.header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--muted);
+    font-size: 12px;
+}
+
+.live-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--green);
+    box-shadow: 0 0 0 3px rgba(18, 111, 79, 0.12);
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.metric {
+    min-height: 86px;
+    padding: 14px 16px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+}
+
+.metric span {
+    display: block;
+    color: var(--muted);
+    font-size: 12px;
+    text-transform: uppercase;
+}
+
+.metric strong {
+    display: block;
+    margin-top: 10px;
+    font-size: 28px;
+    line-height: 1;
+    letter-spacing: 0;
+}
+
+.metric strong.metric-text {
+    overflow-wrap: anywhere;
+    font-size: 18px;
+    line-height: 1.25;
+}
+
+.metric.critical {
+    border-left: 4px solid var(--red);
+}
+
+.metric.warning {
+    border-left: 4px solid var(--amber);
+}
+
+.layout-two {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.panel {
+    margin-bottom: 16px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 6px;
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    min-height: 48px;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--line);
+}
+
+.panel-header h2 {
+    margin: 0;
+    font-size: 16px;
+    letter-spacing: 0;
+}
+
+.table-wrap {
+    width: 100%;
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th,
+td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--line);
+    text-align: left;
+    vertical-align: top;
+}
+
+th {
+    color: var(--muted);
+    background: var(--surface-2);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+tbody tr:last-child td {
+    border-bottom: 0;
+}
+
+.compact th,
+.compact td {
+    padding: 8px 10px;
+}
+
+.num {
+    text-align: right;
+    white-space: nowrap;
+}
+
+.mono {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    font-size: 12px;
+}
+
+.muted,
+.empty {
+    color: var(--muted);
+}
+
+.empty {
+    padding: 18px;
+}
+
+.danger-row {
+    background: #fff1ef;
+}
+
+.alert-list {
+    display: grid;
+    gap: 8px;
+    padding: 12px;
+}
+
+.alert-row {
+    display: grid;
+    grid-template-columns: minmax(140px, 0.35fr) minmax(220px, 1fr) auto;
+    gap: 10px;
+    align-items: center;
+    padding: 10px 12px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+}
+
+.alert-row.critical {
+    border-left: 4px solid var(--red);
+}
+
+.alert-row.warning {
+    border-left: 4px solid var(--amber);
+}
+
+.alert-row em {
+    color: var(--muted);
+    font-style: normal;
+    font-size: 12px;
+}
+
+.kv-grid {
+    display: grid;
+    grid-template-columns: 130px minmax(0, 1fr);
+    gap: 8px 12px;
+    margin: 0;
+    padding: 14px;
+}
+
+.kv-grid dt {
+    color: var(--muted);
+}
+
+.kv-grid dd {
+    margin: 0;
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    padding: 2px 8px;
+    border-radius: 6px;
+    background: var(--surface-2);
+    color: var(--text);
+    font-size: 12px;
+    font-weight: 700;
+}
+
+.pill.ok {
+    background: #e5f4ec;
+    color: var(--green);
+}
+
+.pill.warning,
+.pill.a_verifier {
+    background: #fff4df;
+    color: var(--amber);
+}
+
+.pill.critical {
+    background: #ffe7e2;
+    color: var(--red);
+}
+
+.filter-form {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 12px;
+    padding: 14px;
+}
+
+.filter-form label {
+    display: grid;
+    gap: 6px;
+    color: var(--muted);
+    font-size: 12px;
+    text-transform: uppercase;
+}
+
+.filter-form input {
+    min-width: 0;
+    height: 36px;
+    padding: 7px 9px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    color: var(--text);
+    font: inherit;
+}
+
+.filter-form button,
+.button-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 36px;
+    padding: 8px 12px;
+    border: 1px solid var(--teal);
+    border-radius: 6px;
+    background: var(--teal);
+    color: #fff;
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.button-link:hover {
+    text-decoration: none;
+}
+
+.json-list {
+    display: grid;
+    gap: 10px;
+    padding: 12px;
+}
+
+.json-list pre {
+    max-height: 360px;
+    margin: 0;
+    overflow: auto;
+    padding: 12px;
+    border-radius: 6px;
+    background: #101418;
+    color: #dfe7e1;
+    font-size: 12px;
+}
+
+@media (max-width: 1000px) {
+    .topbar {
+        align-items: flex-start;
+        flex-direction: column;
+        padding: 12px;
+    }
+
+    .metric-grid,
+    .layout-two,
+    .filter-form {
+        grid-template-columns: 1fr;
+    }
+
+    .page-header {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .alert-row {
+        grid-template-columns: 1fr;
+    }
+}

--- a/trading-app/public/front/app.js
+++ b/trading-app/public/front/app.js
@@ -1,0 +1,47 @@
+(function () {
+    function valueAtPath(source, path) {
+        return path.split('.').reduce(function (value, key) {
+            if (value === null || value === undefined) {
+                return undefined;
+            }
+
+            return value[key];
+        }, source);
+    }
+
+    function updateFields(container, payload) {
+        container.querySelectorAll('[data-json-field]').forEach(function (node) {
+            var value = valueAtPath(payload, node.getAttribute('data-json-field') || '');
+            if (value === undefined || value === null) {
+                return;
+            }
+
+            node.textContent = String(value);
+        });
+    }
+
+    document.querySelectorAll('[data-auto-refresh]').forEach(function (container) {
+        var url = container.getAttribute('data-refresh-url');
+        var interval = Number(container.getAttribute('data-refresh-interval') || '30000');
+        if (!url || interval < 5000) {
+            return;
+        }
+
+        window.setInterval(function () {
+            fetch(url, {headers: {'Accept': 'application/json'}})
+                .then(function (response) {
+                    if (!response.ok) {
+                        throw new Error('refresh failed');
+                    }
+
+                    return response.json();
+                })
+                .then(function (payload) {
+                    updateFields(document, payload);
+                })
+                .catch(function () {
+                    container.classList.add('refresh-error');
+                });
+        }, interval);
+    });
+}());

--- a/trading-app/src/Front/Controller/FrontConfigController.php
+++ b/trading-app/src/Front/Controller/FrontConfigController.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Controller;
+
+use App\Front\Query\ConfigSummaryQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FrontConfigController extends AbstractController
+{
+    public function __construct(
+        private readonly ConfigSummaryQuery $configSummaryQuery,
+    ) {
+    }
+
+    #[Route('/app/config', name: 'front_config', methods: ['GET'])]
+    public function config(): Response
+    {
+        return $this->render('front/config.html.twig', [
+            'current' => 'config',
+            'config' => $this->configSummaryQuery->summary(),
+        ]);
+    }
+}

--- a/trading-app/src/Front/Controller/FrontController.php
+++ b/trading-app/src/Front/Controller/FrontController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Controller;
+
+use App\Front\Query\CockpitSummaryQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FrontController extends AbstractController
+{
+    public function __construct(
+        private readonly CockpitSummaryQuery $cockpitSummaryQuery,
+    ) {
+    }
+
+    #[Route('/app', name: 'front_cockpit', methods: ['GET'])]
+    public function cockpit(): Response
+    {
+        return $this->render('front/cockpit.html.twig', [
+            'current' => 'cockpit',
+            'summary' => $this->cockpitSummaryQuery->summary(),
+        ]);
+    }
+
+    #[Route('/app/api/cockpit/summary', name: 'front_api_cockpit_summary', methods: ['GET'])]
+    public function cockpitSummary(): JsonResponse
+    {
+        return $this->json($this->cockpitSummaryQuery->summary()->toArray());
+    }
+}

--- a/trading-app/src/Front/Controller/FrontDecisionController.php
+++ b/trading-app/src/Front/Controller/FrontDecisionController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Controller;
+
+use App\Front\Query\DecisionSummaryQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FrontDecisionController extends AbstractController
+{
+    public function __construct(
+        private readonly DecisionSummaryQuery $decisionSummaryQuery,
+    ) {
+    }
+
+    #[Route('/app/decisions', name: 'front_decisions', methods: ['GET'])]
+    public function decisions(): Response
+    {
+        return $this->render('front/decisions.html.twig', [
+            'current' => 'decisions',
+            'view' => $this->decisionSummaryQuery->latest(),
+        ]);
+    }
+
+    #[Route('/app/decisions/{decisionKey}', name: 'front_decision_detail', requirements: ['decisionKey' => '.+'], methods: ['GET'])]
+    public function detail(string $decisionKey): Response
+    {
+        return $this->render('front/decision_detail.html.twig', [
+            'current' => 'decisions',
+            'detail' => $this->decisionSummaryQuery->detail($decisionKey),
+        ]);
+    }
+
+    #[Route('/app/api/decisions/latest', name: 'front_api_decisions_latest', methods: ['GET'])]
+    public function latest(): JsonResponse
+    {
+        return $this->json($this->decisionSummaryQuery->latest()->toArray());
+    }
+}

--- a/trading-app/src/Front/Controller/FrontInvestigationController.php
+++ b/trading-app/src/Front/Controller/FrontInvestigationController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Controller;
+
+use App\Front\Query\InvestigationQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FrontInvestigationController extends AbstractController
+{
+    public function __construct(
+        private readonly InvestigationQuery $investigationQuery,
+    ) {
+    }
+
+    #[Route('/app/investigate', name: 'front_investigate', methods: ['GET'])]
+    public function investigate(Request $request): Response
+    {
+        return $this->render('front/investigate.html.twig', [
+            'current' => 'investigate',
+            'result' => $this->investigationQuery->investigate(
+                $request->query->get('symbol'),
+                $request->query->get('date'),
+                $request->query->get('decision_key'),
+                $request->query->get('run_id'),
+            ),
+        ]);
+    }
+}

--- a/trading-app/src/Front/Controller/FrontRiskController.php
+++ b/trading-app/src/Front/Controller/FrontRiskController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Controller;
+
+use App\Front\Query\RiskSummaryQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FrontRiskController extends AbstractController
+{
+    public function __construct(
+        private readonly RiskSummaryQuery $riskSummaryQuery,
+    ) {
+    }
+
+    #[Route('/app/risk', name: 'front_risk', methods: ['GET'])]
+    public function risk(): Response
+    {
+        return $this->render('front/risk.html.twig', [
+            'current' => 'risk',
+            'view' => $this->riskSummaryQuery->getSummary(),
+        ]);
+    }
+
+    #[Route('/app/api/risk/summary', name: 'front_api_risk_summary', methods: ['GET'])]
+    public function summary(): JsonResponse
+    {
+        return $this->json($this->riskSummaryQuery->getSummary()->toArray());
+    }
+}

--- a/trading-app/src/Front/Controller/FrontSystemController.php
+++ b/trading-app/src/Front/Controller/FrontSystemController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Controller;
+
+use App\Front\Query\SystemHealthQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FrontSystemController extends AbstractController
+{
+    public function __construct(
+        private readonly SystemHealthQuery $systemHealthQuery,
+    ) {
+    }
+
+    #[Route('/app/system', name: 'front_system', methods: ['GET'])]
+    public function system(): Response
+    {
+        return $this->render('front/system.html.twig', [
+            'current' => 'system',
+            'health' => $this->systemHealthQuery->health(),
+        ]);
+    }
+
+    #[Route('/app/api/system/health', name: 'front_api_system_health', methods: ['GET'])]
+    public function health(): JsonResponse
+    {
+        return $this->json($this->systemHealthQuery->health());
+    }
+}

--- a/trading-app/src/Front/Controller/FrontTemporalController.php
+++ b/trading-app/src/Front/Controller/FrontTemporalController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Controller;
+
+use App\Front\Query\TemporalSummaryQuery;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class FrontTemporalController extends AbstractController
+{
+    public function __construct(
+        private readonly TemporalSummaryQuery $temporalSummaryQuery,
+    ) {
+    }
+
+    #[Route('/app/temporal', name: 'front_temporal', methods: ['GET'])]
+    public function temporal(): Response
+    {
+        return $this->render('front/temporal.html.twig', [
+            'current' => 'temporal',
+            'temporal' => $this->temporalSummaryQuery->summary(),
+        ]);
+    }
+
+    #[Route('/app/api/temporal/summary', name: 'front_api_temporal_summary', methods: ['GET'])]
+    public function summary(): JsonResponse
+    {
+        return $this->json($this->temporalSummaryQuery->summary());
+    }
+}

--- a/trading-app/src/Front/Query/CockpitSummaryQuery.php
+++ b/trading-app/src/Front/Query/CockpitSummaryQuery.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use App\Front\ViewModel\CockpitSummaryView;
+
+final readonly class CockpitSummaryQuery
+{
+    public function __construct(
+        private RiskSummaryQuery $riskSummaryQuery,
+        private DecisionSummaryQuery $decisionSummaryQuery,
+        private SystemHealthQuery $systemHealthQuery,
+        private ConfigSummaryQuery $configSummaryQuery,
+    ) {
+    }
+
+    public function summary(): CockpitSummaryView
+    {
+        return new CockpitSummaryView(
+            risk: $this->riskSummaryQuery->getSummary(),
+            decisions: $this->decisionSummaryQuery->latest(5, 80),
+            mode: $this->configSummaryQuery->activeMode(),
+            system: $this->systemHealthQuery->health(),
+        );
+    }
+}

--- a/trading-app/src/Front/Query/ConfigSummaryQuery.php
+++ b/trading-app/src/Front/Query/ConfigSummaryQuery.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use Symfony\Component\Yaml\Yaml;
+
+final class ConfigSummaryQuery
+{
+    public function __construct(
+        private readonly string $projectDir,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function summary(): array
+    {
+        return [
+            'modes' => $this->modes(),
+            'files' => $this->configFiles(),
+            'active_mode' => $this->activeMode(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function activeMode(): array
+    {
+        $modes = $this->modes();
+        $enabled = array_values(array_filter($modes, static fn (array $mode): bool => (bool) ($mode['enabled'] ?? false)));
+        usort($enabled, static fn (array $a, array $b): int => ((int) ($b['priority'] ?? 0)) <=> ((int) ($a['priority'] ?? 0)));
+
+        return $enabled[0] ?? ['name' => 'unknown', 'enabled' => false, 'priority' => null];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function modes(): array
+    {
+        $path = $this->projectDir . '/config/services.yaml';
+        if (!is_file($path)) {
+            return [];
+        }
+
+        $data = Yaml::parseFile($path);
+        $modes = $data['parameters']['mode'] ?? [];
+
+        if (!is_array($modes)) {
+            return [];
+        }
+
+        return array_values(array_map(fn (mixed $mode): array => $this->normalizeMode($mode), $modes));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function configFiles(): array
+    {
+        $files = array_merge(
+            glob($this->projectDir . '/config/app/*.yaml') ?: [],
+            glob($this->projectDir . '/src/MtfValidator/config/*.yaml') ?: [],
+        );
+        sort($files);
+
+        return array_map(fn (string $path): array => [
+            'path' => str_replace($this->projectDir . '/', '', $path),
+            'name' => basename($path),
+            'updated_at' => date('Y-m-d H:i:s', (int) filemtime($path)),
+            'size_kb' => round(filesize($path) / 1024, 1),
+        ], $files);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeMode(mixed $mode): array
+    {
+        if (!is_array($mode)) {
+            return ['name' => (string) $mode, 'enabled' => false, 'priority' => 0];
+        }
+
+        if (array_key_exists('name', $mode)) {
+            return $mode;
+        }
+
+        $normalized = [];
+        foreach ($mode as $part) {
+            if (is_array($part)) {
+                $normalized = array_replace($normalized, $part);
+            }
+        }
+
+        return [
+            'name' => (string) ($normalized['name'] ?? 'unknown'),
+            'enabled' => (bool) ($normalized['enabled'] ?? false),
+            'priority' => (int) ($normalized['priority'] ?? 0),
+        ];
+    }
+}

--- a/trading-app/src/Front/Query/DecisionSummaryQuery.php
+++ b/trading-app/src/Front/Query/DecisionSummaryQuery.php
@@ -76,13 +76,31 @@ final class DecisionSummaryQuery
                 ['decisionKey' => $decisionKey, 'decisionPrefix' => $decisionKey . '%'],
             ),
             'lifecycle_events' => $this->db->fetchAll(
-                ['trade_lifecycle_event'],
+                ['trade_lifecycle_event', 'order_intent'],
                 "SELECT id, symbol, event_type, run_id, order_id, client_order_id, side, qty, price, timeframe,
                         config_profile, config_version, reason_code, extra, happened_at
                  FROM trade_lifecycle_event
                  WHERE CAST(extra AS TEXT) LIKE :needle
                     OR client_order_id = :decisionKey
                     OR order_id = :decisionKey
+                    OR client_order_id IN (
+                        SELECT client_order_id
+                        FROM order_intent
+                        WHERE decision_key = :decisionKey
+                          AND client_order_id IS NOT NULL
+                    )
+                    OR order_id IN (
+                        SELECT order_id
+                        FROM order_intent
+                        WHERE decision_key = :decisionKey
+                          AND order_id IS NOT NULL
+                    )
+                    OR order_id IN (
+                        SELECT exchange_order_id
+                        FROM order_intent
+                        WHERE decision_key = :decisionKey
+                          AND exchange_order_id IS NOT NULL
+                    )
                  ORDER BY happened_at DESC
                  LIMIT 50",
                 ['needle' => '%' . $decisionKey . '%', 'decisionKey' => $decisionKey],

--- a/trading-app/src/Front/Query/DecisionSummaryQuery.php
+++ b/trading-app/src/Front/Query/DecisionSummaryQuery.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use App\Front\ViewModel\DecisionSummaryView;
+use Doctrine\DBAL\Connection;
+
+final class DecisionSummaryQuery
+{
+    private readonly FrontDatabase $db;
+
+    public function __construct(Connection $connection)
+    {
+        $this->db = new FrontDatabase($connection);
+    }
+
+    public function latest(int $runLimit = 12, int $symbolLimit = 200): DecisionSummaryView
+    {
+        $runLimit = max(1, min(50, $runLimit));
+        $symbolLimit = max(1, min(500, $symbolLimit));
+
+        $runs = $this->db->fetchAll(
+            ['mtf_run'],
+            "SELECT run_id, status, execution_time_seconds, symbols_requested, symbols_processed, symbols_successful,
+                    symbols_failed, symbols_skipped, success_rate, dry_run, force_run, current_tf, started_at, finished_at, workers
+             FROM mtf_run
+             ORDER BY started_at DESC
+             LIMIT {$runLimit}",
+        );
+
+        $runId = isset($runs[0]['run_id']) ? (string) $runs[0]['run_id'] : null;
+        $symbols = $runId !== null ? $this->symbolsForRun($runId, $symbolLimit) : [];
+        $reasonCounts = $this->reasonCounts($symbols);
+
+        return new DecisionSummaryView($runs, $symbols, $reasonCounts);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function detail(string $decisionKey): array
+    {
+        $decisionKey = trim($decisionKey);
+        if ($decisionKey === '') {
+            return [
+                'decision_key' => '',
+                'order_intents' => [],
+                'zone_events' => [],
+                'lifecycle_events' => [],
+            ];
+        }
+
+        return [
+            'decision_key' => $decisionKey,
+            'order_intents' => $this->db->fetchAll(
+                ['order_intent'],
+                "SELECT id, exchange, market_type, symbol, timeframe, side, type, status, price, size, client_order_id,
+                        order_id, exchange_order_id, failure_reason, decision_key, strategy_profile, strategy_version, created_at, updated_at, sent_at
+                 FROM order_intent
+                 WHERE decision_key = :decisionKey
+                 ORDER BY updated_at DESC
+                 LIMIT 50",
+                ['decisionKey' => $decisionKey],
+            ),
+            'zone_events' => $this->db->fetchAll(
+                ['trade_zone_events'],
+                "SELECT id, exchange, market_type, symbol, happened_at, reason, decision_key, timeframe, config_profile,
+                        zone_min, zone_max, candidate_price, zone_dev_pct, zone_max_dev_pct, atr_pct, spread_bps,
+                        volume_ratio, vwap_distance_pct, entry_zone_width_pct, mtf_level, category
+                 FROM trade_zone_events
+                 WHERE decision_key = :decisionKey OR decision_key LIKE :decisionPrefix
+                 ORDER BY happened_at DESC
+                 LIMIT 50",
+                ['decisionKey' => $decisionKey, 'decisionPrefix' => $decisionKey . '%'],
+            ),
+            'lifecycle_events' => $this->db->fetchAll(
+                ['trade_lifecycle_event'],
+                "SELECT id, symbol, event_type, run_id, order_id, client_order_id, side, qty, price, timeframe,
+                        config_profile, config_version, reason_code, extra, happened_at
+                 FROM trade_lifecycle_event
+                 WHERE CAST(extra AS TEXT) LIKE :needle
+                    OR client_order_id = :decisionKey
+                    OR order_id = :decisionKey
+                 ORDER BY happened_at DESC
+                 LIMIT 50",
+                ['needle' => '%' . $decisionKey . '%', 'decisionKey' => $decisionKey],
+            ),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function symbolsForRun(string $runId, int $limit): array
+    {
+        $symbols = $this->db->fetchAll(
+            ['mtf_run_symbol'],
+            "SELECT id, run_id, symbol, status, execution_tf, blocking_tf, signal_side, current_price,
+                    trading_decision, error, context, created_at
+             FROM mtf_run_symbol
+             WHERE run_id = :runId
+             ORDER BY created_at DESC, symbol ASC
+             LIMIT {$limit}",
+            ['runId' => $runId],
+        );
+
+        foreach ($symbols as $index => $symbol) {
+            $tradingDecision = FrontDatabase::jsonObject($symbol['trading_decision'] ?? null);
+            $error = FrontDatabase::jsonObject($symbol['error'] ?? null);
+            $context = FrontDatabase::jsonObject($symbol['context'] ?? null);
+
+            $symbols[$index]['trading_decision'] = $tradingDecision;
+            $symbols[$index]['error'] = $error;
+            $symbols[$index]['context'] = $context;
+            $symbols[$index]['decision_key'] = $tradingDecision['decision_key'] ?? $context['decision_key'] ?? null;
+            $symbols[$index]['failed_rules'] = $this->failedRules($tradingDecision, $context);
+            $symbols[$index]['primary_reason'] = $this->primaryReason($symbol, $tradingDecision, $error, $context);
+        }
+
+        return $symbols;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $symbols
+     * @return list<array{reason: string, count: int}>
+     */
+    private function reasonCounts(array $symbols): array
+    {
+        $counts = [];
+        foreach ($symbols as $symbol) {
+            $reason = (string) ($symbol['primary_reason'] ?? 'Inconnu');
+            $counts[$reason] = ($counts[$reason] ?? 0) + 1;
+        }
+
+        arsort($counts);
+
+        $rows = [];
+        foreach ($counts as $reason => $count) {
+            $rows[] = ['reason' => $reason, 'count' => $count];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, mixed> $symbol
+     * @param array<string, mixed> $tradingDecision
+     * @param array<string, mixed> $error
+     * @param array<string, mixed> $context
+     */
+    private function primaryReason(array $symbol, array $tradingDecision, array $error, array $context): string
+    {
+        $rawReason = $tradingDecision['reason']
+            ?? $tradingDecision['message']
+            ?? $tradingDecision['error']
+            ?? $error['message']
+            ?? $error['error']
+            ?? $context['reason']
+            ?? $context['primary_reason']
+            ?? $symbol['status']
+            ?? 'unknown';
+
+        $reason = is_scalar($rawReason) ? (string) $rawReason : 'unknown';
+
+        return match ($reason) {
+            'filters_mandatory_failed_execution_selector_empty',
+            'filters_mandatory_failed' => 'Filtres obligatoires non validés',
+            'NO_LONG_NO_SHORT' => 'Aucun côté long/short valide',
+            'LONG_AND_SHORT' => 'Conflit long et short',
+            'entry_zone_invalid_or_filters_failed' => 'EntryZone ou filtres invalides',
+            'skipped_out_of_zone',
+            'entry_zone.rejected_by_deviation' => 'Prix hors EntryZone',
+            default => $this->humanizeReason($reason),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $tradingDecision
+     * @param array<string, mixed> $context
+     * @return list<string>
+     */
+    private function failedRules(array $tradingDecision, array $context): array
+    {
+        $candidates = [
+            $context['rules_failed'] ?? null,
+            $context['failed_rules'] ?? null,
+            $context['conditions_failed'] ?? null,
+            $context['failed_conditions_long'] ?? null,
+            $context['failed_conditions_short'] ?? null,
+            $tradingDecision['failed_checks'] ?? null,
+            $tradingDecision['rules_failed'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (!is_array($candidate) || $candidate === []) {
+                continue;
+            }
+
+            return array_values(array_map(static fn (mixed $value): string => (string) $value, $candidate));
+        }
+
+        return [];
+    }
+
+    private function humanizeReason(string $reason): string
+    {
+        $reason = trim($reason);
+        if ($reason === '') {
+            return 'Inconnu';
+        }
+
+        return ucfirst(str_replace('_', ' ', $reason));
+    }
+}

--- a/trading-app/src/Front/Query/FrontDatabase.php
+++ b/trading-app/src/Front/Query/FrontDatabase.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use Doctrine\DBAL\Connection;
+
+final class FrontDatabase
+{
+    /** @var array<string, bool> */
+    private array $tableExists = [];
+
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * @param list<string> $tables
+     * @param array<string, mixed> $params
+     * @return list<array<string, mixed>>
+     */
+    public function fetchAll(array $tables, string $sql, array $params = []): array
+    {
+        if (!$this->tablesExist($tables)) {
+            return [];
+        }
+
+        try {
+            /** @var list<array<string, mixed>> $rows */
+            $rows = $this->connection->executeQuery($sql, $params)->fetchAllAssociative();
+
+            return $rows;
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @param list<string> $tables
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>|null
+     */
+    public function fetchOne(array $tables, string $sql, array $params = []): ?array
+    {
+        $rows = $this->fetchAll($tables, $sql, $params);
+
+        return $rows[0] ?? null;
+    }
+
+    /**
+     * @param list<string> $tables
+     */
+    public function tablesExist(array $tables): bool
+    {
+        foreach ($tables as $table) {
+            if (!$this->tableExists($table)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function tableExists(string $table): bool
+    {
+        if (array_key_exists($table, $this->tableExists)) {
+            return $this->tableExists[$table];
+        }
+
+        try {
+            $tables = array_map('strtolower', $this->connection->createSchemaManager()->listTableNames());
+            $this->tableExists[$table] = in_array(strtolower($table), $tables, true);
+        } catch (\Throwable) {
+            $this->tableExists[$table] = false;
+        }
+
+        return $this->tableExists[$table];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function jsonObject(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (!is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public static function truthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value !== 0.0;
+        }
+
+        if (is_string($value)) {
+            return in_array(strtolower(trim($value)), ['1', 'true', 'yes', 'on'], true);
+        }
+
+        return false;
+    }
+}

--- a/trading-app/src/Front/Query/InvestigationQuery.php
+++ b/trading-app/src/Front/Query/InvestigationQuery.php
@@ -229,19 +229,39 @@ final class InvestigationQuery
             $params['runId'] = $runId;
         }
         if ($decisionKey !== '') {
-            $where[] = '(CAST(extra AS TEXT) LIKE :needle OR client_order_id = :decisionKey OR order_id = :decisionKey)';
+            $where[] = "(CAST(extra AS TEXT) LIKE :needle
+                OR client_order_id = :decisionKey
+                OR order_id = :decisionKey
+                OR client_order_id IN (
+                    SELECT client_order_id
+                    FROM order_intent
+                    WHERE decision_key = :decisionKey
+                      AND client_order_id IS NOT NULL
+                )
+                OR order_id IN (
+                    SELECT order_id
+                    FROM order_intent
+                    WHERE decision_key = :decisionKey
+                      AND order_id IS NOT NULL
+                )
+                OR order_id IN (
+                    SELECT exchange_order_id
+                    FROM order_intent
+                    WHERE decision_key = :decisionKey
+                      AND exchange_order_id IS NOT NULL
+                ))";
             $params['needle'] = '%' . $decisionKey . '%';
             $params['decisionKey'] = $decisionKey;
         }
         $this->addWindow($where, $params, 'happened_at', $window);
 
-        return $this->selectWithWhere(
-            'trade_lifecycle_event',
-            'SELECT id, symbol, event_type, run_id, order_id, client_order_id, side, qty, price, timeframe, config_profile, config_version, reason_code, extra, happened_at FROM trade_lifecycle_event',
-            $where,
-            $params,
-            'happened_at DESC',
-        );
+        $sql = 'SELECT id, symbol, event_type, run_id, order_id, client_order_id, side, qty, price, timeframe, config_profile, config_version, reason_code, extra, happened_at FROM trade_lifecycle_event';
+        if ($where !== []) {
+            $sql .= ' WHERE ' . implode(' AND ', $where);
+        }
+        $sql .= ' ORDER BY happened_at DESC LIMIT 80';
+
+        return $this->db->fetchAll(['trade_lifecycle_event', 'order_intent'], $sql, $params);
     }
 
     /**

--- a/trading-app/src/Front/Query/InvestigationQuery.php
+++ b/trading-app/src/Front/Query/InvestigationQuery.php
@@ -67,6 +67,10 @@ final class InvestigationQuery
      */
     private function mtfSymbols(string $symbol, string $runId, array $window): array
     {
+        if ($symbol === '' && $runId === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -94,6 +98,10 @@ final class InvestigationQuery
      */
     private function mtfAudit(string $symbol, string $runId, array $window): array
     {
+        if ($symbol === '' && $runId === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -121,6 +129,10 @@ final class InvestigationQuery
      */
     private function orderIntents(string $symbol, string $decisionKey, array $window): array
     {
+        if ($symbol === '' && $decisionKey === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -148,6 +160,10 @@ final class InvestigationQuery
      */
     private function orders(string $symbol, array $window): array
     {
+        if ($symbol === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -171,6 +187,10 @@ final class InvestigationQuery
      */
     private function planOrders(string $symbol, array $window): array
     {
+        if ($symbol === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -194,6 +214,10 @@ final class InvestigationQuery
      */
     private function lifecycle(string $symbol, string $decisionKey, string $runId, array $window): array
     {
+        if ($symbol === '' && $decisionKey === '' && $runId === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -225,6 +249,10 @@ final class InvestigationQuery
      */
     private function zoneEvents(string $symbol, string $decisionKey, array $window): array
     {
+        if ($symbol === '' && $decisionKey === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -253,6 +281,10 @@ final class InvestigationQuery
      */
     private function snapshots(string $symbol, string $runId, array $window): array
     {
+        if ($symbol === '' && $runId === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {
@@ -280,6 +312,10 @@ final class InvestigationQuery
      */
     private function entryZones(string $symbol, array $window): array
     {
+        if ($symbol === '') {
+            return [];
+        }
+
         $where = [];
         $params = [];
         if ($symbol !== '') {

--- a/trading-app/src/Front/Query/InvestigationQuery.php
+++ b/trading-app/src/Front/Query/InvestigationQuery.php
@@ -1,0 +1,374 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use Doctrine\DBAL\Connection;
+
+final class InvestigationQuery
+{
+    private readonly FrontDatabase $db;
+
+    public function __construct(
+        Connection $connection,
+        private readonly string $projectDir,
+    ) {
+        $this->db = new FrontDatabase($connection);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function investigate(?string $symbol, ?string $date, ?string $decisionKey, ?string $runId): array
+    {
+        $symbol = $symbol !== null ? strtoupper(trim($symbol)) : '';
+        $decisionKey = $decisionKey !== null ? trim($decisionKey) : '';
+        $runId = $runId !== null ? trim($runId) : '';
+        $center = $this->parseDate($date);
+        $window = $this->window($center);
+
+        if ($symbol === '' && $decisionKey === '' && $runId === '') {
+            return [
+                'searched' => false,
+                'criteria' => compact('symbol', 'date', 'decisionKey', 'runId'),
+                'sections' => [],
+                'exports' => [],
+            ];
+        }
+
+        $sections = [
+            'mtf_symbols' => $this->mtfSymbols($symbol, $runId),
+            'mtf_audit' => $this->mtfAudit($symbol, $runId, $window),
+            'order_intents' => $this->orderIntents($symbol, $decisionKey, $window),
+            'orders' => $this->orders($symbol, $window),
+            'plan_orders' => $this->planOrders($symbol, $window),
+            'lifecycle' => $this->lifecycle($symbol, $decisionKey, $runId, $window),
+            'zone_events' => $this->zoneEvents($symbol, $decisionKey, $window),
+            'snapshots' => $this->snapshots($symbol, $runId, $window),
+            'entry_zones' => $this->entryZones($symbol, $window),
+        ];
+
+        return [
+            'searched' => true,
+            'criteria' => compact('symbol', 'date', 'decisionKey', 'runId'),
+            'window' => [
+                'from' => $window[0]?->format('Y-m-d H:i:s'),
+                'to' => $window[1]?->format('Y-m-d H:i:s'),
+            ],
+            'sections' => $sections,
+            'exports' => $this->exports($symbol),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function mtfSymbols(string $symbol, string $runId): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        if ($runId !== '') {
+            $where[] = 'run_id = :runId';
+            $params['runId'] = $runId;
+        }
+
+        return $this->selectWithWhere(
+            'mtf_run_symbol',
+            'SELECT id, run_id, symbol, status, execution_tf, blocking_tf, signal_side, current_price, trading_decision, error, context, created_at FROM mtf_run_symbol',
+            $where,
+            $params,
+            'created_at DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function mtfAudit(string $symbol, string $runId, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        if ($runId !== '') {
+            $where[] = 'run_id = :runId';
+            $params['runId'] = $runId;
+        }
+        $this->addWindow($where, $params, 'created_at', $window);
+
+        return $this->selectWithWhere(
+            'mtf_audit',
+            'SELECT id, symbol, run_id, step, timeframe, cause, details, trace_id, severity, created_at, candle_open_ts FROM mtf_audit',
+            $where,
+            $params,
+            'created_at DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function orderIntents(string $symbol, string $decisionKey, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        if ($decisionKey !== '') {
+            $where[] = 'decision_key = :decisionKey';
+            $params['decisionKey'] = $decisionKey;
+        }
+        $this->addWindow($where, $params, 'created_at', $window);
+
+        return $this->selectWithWhere(
+            'order_intent',
+            'SELECT id, exchange, market_type, decision_key, strategy_profile, strategy_version, symbol, timeframe, side, type, status, price, size, client_order_id, order_id, exchange_order_id, failure_reason, created_at, updated_at, sent_at FROM order_intent',
+            $where,
+            $params,
+            'created_at DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function orders(string $symbol, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        $this->addWindow($where, $params, 'created_at', $window);
+
+        return $this->selectWithWhere(
+            'futures_order',
+            'SELECT id, exchange, market_type, symbol, side, type, status, price, size, filled_size, client_order_id, order_id, created_at, updated_at FROM futures_order',
+            $where,
+            $params,
+            'created_at DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function planOrders(string $symbol, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        $this->addWindow($where, $params, 'created_at', $window);
+
+        return $this->selectWithWhere(
+            'futures_plan_order',
+            'SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, execution_price, price, size, plan_type, client_order_id, order_id, created_at, updated_at FROM futures_plan_order',
+            $where,
+            $params,
+            'created_at DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function lifecycle(string $symbol, string $decisionKey, string $runId, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        if ($runId !== '') {
+            $where[] = 'run_id = :runId';
+            $params['runId'] = $runId;
+        }
+        if ($decisionKey !== '') {
+            $where[] = 'CAST(extra AS TEXT) LIKE :needle';
+            $params['needle'] = '%' . $decisionKey . '%';
+        }
+        $this->addWindow($where, $params, 'happened_at', $window);
+
+        return $this->selectWithWhere(
+            'trade_lifecycle_event',
+            'SELECT id, symbol, event_type, run_id, order_id, client_order_id, side, qty, price, timeframe, config_profile, config_version, reason_code, extra, happened_at FROM trade_lifecycle_event',
+            $where,
+            $params,
+            'happened_at DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function zoneEvents(string $symbol, string $decisionKey, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        if ($decisionKey !== '') {
+            $where[] = '(decision_key = :decisionKey OR decision_key LIKE :decisionPrefix)';
+            $params['decisionKey'] = $decisionKey;
+            $params['decisionPrefix'] = $decisionKey . '%';
+        }
+        $this->addWindow($where, $params, 'happened_at', $window);
+
+        return $this->selectWithWhere(
+            'trade_zone_events',
+            'SELECT id, exchange, market_type, symbol, happened_at, reason, decision_key, timeframe, config_profile, zone_min, zone_max, candidate_price, zone_dev_pct, zone_max_dev_pct, atr_pct, spread_bps, volume_ratio, vwap_distance_pct, entry_zone_width_pct, mtf_level, category FROM trade_zone_events',
+            $where,
+            $params,
+            'happened_at DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function snapshots(string $symbol, string $runId, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        if ($runId !== '') {
+            $where[] = 'run_id = :runId';
+            $params['runId'] = $runId;
+        }
+        $this->addWindow($where, $params, 'kline_time', $window);
+
+        return $this->selectWithWhere(
+            'indicator_snapshots',
+            'SELECT id, exchange, market_type, symbol, timeframe, run_id, kline_time, "values" AS values_json, trace_id, source, inserted_at FROM indicator_snapshots',
+            $where,
+            $params,
+            'kline_time DESC',
+        );
+    }
+
+    /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     * @return list<array<string, mixed>>
+     */
+    private function entryZones(string $symbol, array $window): array
+    {
+        $where = [];
+        $params = [];
+        if ($symbol !== '') {
+            $where[] = 'symbol = :symbol';
+            $params['symbol'] = $symbol;
+        }
+        $this->addWindow($where, $params, 'created_at', $window);
+
+        return $this->selectWithWhere(
+            'entry_zone_live',
+            'SELECT id, symbol, side, price_min, price_max, atr_pct1m, vwap, volume_ratio, config_profile, config_version, valid_from, valid_until, created_at, status FROM entry_zone_live',
+            $where,
+            $params,
+            'created_at DESC',
+        );
+    }
+
+    /**
+     * @param list<string> $where
+     * @param array<string, mixed> $params
+     * @return list<array<string, mixed>>
+     */
+    private function selectWithWhere(string $table, string $selectSql, array $where, array $params, string $orderBy): array
+    {
+        $sql = $selectSql;
+        if ($where !== []) {
+            $sql .= ' WHERE ' . implode(' AND ', $where);
+        }
+        $sql .= ' ORDER BY ' . $orderBy . ' LIMIT 80';
+
+        return $this->db->fetchAll([$table], $sql, $params);
+    }
+
+    /**
+     * @param list<string> $where
+     * @param array<string, mixed> $params
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
+     */
+    private function addWindow(array &$where, array &$params, string $column, array $window): void
+    {
+        if ($window[0] !== null) {
+            $where[] = $column . ' >= :windowFrom';
+            $params['windowFrom'] = $window[0]->format('Y-m-d H:i:s');
+        }
+        if ($window[1] !== null) {
+            $where[] = $column . ' <= :windowTo';
+            $params['windowTo'] = $window[1]->format('Y-m-d H:i:s');
+        }
+    }
+
+    private function parseDate(?string $date): ?\DateTimeImmutable
+    {
+        if ($date === null || trim($date) === '') {
+            return null;
+        }
+
+        try {
+            return (new \DateTimeImmutable(trim($date), new \DateTimeZone('UTC')))->setTimezone(new \DateTimeZone('UTC'));
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @return array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable}
+     */
+    private function window(?\DateTimeImmutable $center): array
+    {
+        if ($center === null) {
+            return [null, null];
+        }
+
+        return [$center->modify('-1 hour'), $center->modify('+1 hour')];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function exports(string $symbol): array
+    {
+        if ($symbol === '') {
+            return [];
+        }
+
+        $files = glob($this->projectDir . '/investigation/symbol_data_' . $symbol . '_*.json') ?: [];
+        usort($files, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+
+        return array_map(fn (string $file): array => [
+            'name' => basename($file),
+            'path' => str_replace($this->projectDir . '/', '', $file),
+            'updated_at' => date('Y-m-d H:i:s', (int) filemtime($file)),
+        ], array_slice($files, 0, 10));
+    }
+}

--- a/trading-app/src/Front/Query/InvestigationQuery.php
+++ b/trading-app/src/Front/Query/InvestigationQuery.php
@@ -38,7 +38,7 @@ final class InvestigationQuery
         }
 
         $sections = [
-            'mtf_symbols' => $this->mtfSymbols($symbol, $runId),
+            'mtf_symbols' => $this->mtfSymbols($symbol, $runId, $window),
             'mtf_audit' => $this->mtfAudit($symbol, $runId, $window),
             'order_intents' => $this->orderIntents($symbol, $decisionKey, $window),
             'orders' => $this->orders($symbol, $window),
@@ -62,9 +62,10 @@ final class InvestigationQuery
     }
 
     /**
+     * @param array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} $window
      * @return list<array<string, mixed>>
      */
-    private function mtfSymbols(string $symbol, string $runId): array
+    private function mtfSymbols(string $symbol, string $runId, array $window): array
     {
         $where = [];
         $params = [];
@@ -76,6 +77,7 @@ final class InvestigationQuery
             $where[] = 'run_id = :runId';
             $params['runId'] = $runId;
         }
+        $this->addWindow($where, $params, 'created_at', $window);
 
         return $this->selectWithWhere(
             'mtf_run_symbol',
@@ -288,7 +290,7 @@ final class InvestigationQuery
 
         return $this->selectWithWhere(
             'entry_zone_live',
-            'SELECT id, symbol, side, price_min, price_max, atr_pct1m, vwap, volume_ratio, config_profile, config_version, valid_from, valid_until, created_at, status FROM entry_zone_live',
+            'SELECT id, symbol, side, price_min, price_max, atr_pct_1m, vwap, volume_ratio, config_profile, config_version, valid_from, valid_until, created_at, status FROM entry_zone_live',
             $where,
             $params,
             'created_at DESC',

--- a/trading-app/src/Front/Query/InvestigationQuery.php
+++ b/trading-app/src/Front/Query/InvestigationQuery.php
@@ -229,8 +229,9 @@ final class InvestigationQuery
             $params['runId'] = $runId;
         }
         if ($decisionKey !== '') {
-            $where[] = 'CAST(extra AS TEXT) LIKE :needle';
+            $where[] = '(CAST(extra AS TEXT) LIKE :needle OR client_order_id = :decisionKey OR order_id = :decisionKey)';
             $params['needle'] = '%' . $decisionKey . '%';
+            $params['decisionKey'] = $decisionKey;
         }
         $this->addWindow($where, $params, 'happened_at', $window);
 

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -140,11 +140,13 @@ final class RiskSummaryQuery
     {
         return $this->db->fetchAll(
             ['order_protection', 'order_intent'],
-            "SELECT op.id, oi.symbol, oi.side, op.type, op.price, op.client_order_id, op.order_id, op.updated_at
+            "SELECT op.id, oi.exchange, oi.market_type, oi.symbol, oi.side, op.type, op.price, op.client_order_id, op.order_id, op.updated_at
              FROM order_protection op
              INNER JOIN order_intent oi ON oi.id = op.order_intent_id
              WHERE LOWER(COALESCE(op.type, '')) = 'stop_loss'
                AND op.price > 0
+               AND oi.status = 'SENT'
+               AND COALESCE(op.order_id, op.client_order_id, '') <> ''
              ORDER BY op.updated_at DESC
              LIMIT 100",
         );
@@ -238,6 +240,10 @@ final class RiskSummaryQuery
                 continue;
             }
 
+            if (!$this->protectionMatchesPositionScope($protection, $position)) {
+                continue;
+            }
+
             if (!$this->rowIndicatesStopLoss($protection)) {
                 continue;
             }
@@ -250,6 +256,45 @@ final class RiskSummaryQuery
         }
 
         return false;
+    }
+
+    /**
+     * @param array<string, mixed> $protection
+     * @param array<string, mixed> $position
+     */
+    private function protectionMatchesPositionScope(array $protection, array $position): bool
+    {
+        foreach (['exchange', 'market_type'] as $key) {
+            $positionValue = strtolower((string) ($position[$key] ?? ''));
+            $protectionValue = strtolower((string) ($protection[$key] ?? ''));
+            if ($positionValue !== '' && $protectionValue !== '' && $positionValue !== $protectionValue) {
+                return false;
+            }
+        }
+
+        $positionSide = $this->normalizePositionSide($position['side'] ?? null);
+        $protectionSide = $this->normalizePositionSide($protection['side'] ?? null);
+
+        return $positionSide !== null && $protectionSide !== null && $positionSide === $protectionSide;
+    }
+
+    private function normalizePositionSide(mixed $side): ?string
+    {
+        if (is_numeric($side)) {
+            return match ((int) $side) {
+                1, 3 => 'LONG',
+                2, 4 => 'SHORT',
+                default => null,
+            };
+        }
+
+        $normalized = strtolower(trim((string) $side));
+
+        return match ($normalized) {
+            'long', 'open_long', 'close_long' => 'LONG',
+            'short', 'open_short', 'close_short' => 'SHORT',
+            default => null,
+        };
     }
 
     /**

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use App\Front\ViewModel\FrontAlert;
+use App\Front\ViewModel\RiskSummaryView;
+use Doctrine\DBAL\Connection;
+use Psr\Clock\ClockInterface;
+
+final class RiskSummaryQuery
+{
+    private readonly FrontDatabase $db;
+
+    public function __construct(
+        Connection $connection,
+        private readonly ClockInterface $clock,
+    ) {
+        $this->db = new FrontDatabase($connection);
+    }
+
+    public function getSummary(): RiskSummaryView
+    {
+        $now = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'));
+        $positions = $this->loadOpenPositions();
+        $orders = $this->loadOpenOrders();
+        $planOrders = $this->loadOpenPlanOrders();
+        $locks = $this->loadActiveLocks($now);
+        $intents = $this->loadStaleOrderIntents($now);
+        $alerts = [];
+
+        foreach ($positions as $index => $position) {
+            $payload = FrontDatabase::jsonObject($position['payload'] ?? null);
+            $positions[$index]['payload'] = $payload;
+            $positions[$index]['has_stop_loss'] = $this->hasStopLoss($payload);
+
+            if (!$positions[$index]['has_stop_loss']) {
+                $alerts[] = new FrontAlert(
+                    severity: 'critical',
+                    code: 'position_without_stop_loss',
+                    title: 'Position sans SL',
+                    message: sprintf('%s %s ouverte sans SL detecte.', (string) $position['symbol'], (string) $position['side']),
+                    symbol: (string) $position['symbol'],
+                    context: [
+                        'side' => $position['side'] ?? null,
+                        'size' => $position['size'] ?? null,
+                        'updated_at' => $position['updated_at'] ?? null,
+                    ],
+                );
+            }
+        }
+
+        foreach ($locks as $lock) {
+            if (($lock['is_stale'] ?? false) !== true) {
+                continue;
+            }
+
+            $alerts[] = new FrontAlert(
+                severity: 'critical',
+                code: 'stale_symbol_lock',
+                title: 'Lock stale',
+                message: sprintf('%s verrouille apres expiration.', (string) $lock['symbol']),
+                symbol: (string) $lock['symbol'],
+                context: [
+                    'owner_decision_key' => $lock['owner_decision_key'] ?? null,
+                    'expires_at' => $lock['expires_at'] ?? null,
+                ],
+            );
+        }
+
+        foreach ($intents as $intent) {
+            $alerts[] = new FrontAlert(
+                severity: 'warning',
+                code: 'stale_order_intent',
+                title: 'Ordre bloque',
+                message: sprintf('%s %s en statut %s depuis plus de 10 minutes.', (string) $intent['symbol'], (string) ($intent['client_order_id'] ?? ''), (string) $intent['status']),
+                symbol: (string) $intent['symbol'],
+                context: [
+                    'decision_key' => $intent['decision_key'] ?? null,
+                    'updated_at' => $intent['updated_at'] ?? null,
+                ],
+            );
+        }
+
+        return new RiskSummaryView($positions, $orders, $planOrders, $locks, $alerts);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadOpenPositions(): array
+    {
+        return $this->db->fetchAll(
+            ['positions'],
+            "SELECT id, exchange, market_type, symbol, side, size, avg_entry_price, leverage, unrealized_pnl, status, payload, updated_at
+             FROM positions
+             WHERE UPPER(status) = 'OPEN'
+             ORDER BY updated_at DESC
+             LIMIT 100",
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadOpenOrders(): array
+    {
+        return $this->db->fetchAll(
+            ['futures_order'],
+            "SELECT id, exchange, market_type, symbol, side, type, status, price, size, client_order_id, order_id, updated_at
+             FROM futures_order
+             WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'partially_filled', 'partially-filled')
+             ORDER BY updated_at DESC
+             LIMIT 100",
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadOpenPlanOrders(): array
+    {
+        return $this->db->fetchAll(
+            ['futures_plan_order'],
+            "SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, price, size, client_order_id, order_id, updated_at
+             FROM futures_plan_order
+             WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered')
+             ORDER BY updated_at DESC
+             LIMIT 100",
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadActiveLocks(\DateTimeImmutable $now): array
+    {
+        $locks = $this->db->fetchAll(
+            ['symbol_execution_lock'],
+            "SELECT id, exchange, market_type, symbol, status, owner_profile, owner_decision_key, locked_at, expires_at, released_at
+             FROM symbol_execution_lock
+             WHERE released_at IS NULL
+             ORDER BY expires_at ASC
+             LIMIT 100",
+        );
+
+        foreach ($locks as $index => $lock) {
+            $expiresAt = $this->dateOrNull($lock['expires_at'] ?? null);
+            $locks[$index]['is_stale'] = $expiresAt !== null && $expiresAt <= $now;
+        }
+
+        return $locks;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadStaleOrderIntents(\DateTimeImmutable $now): array
+    {
+        $threshold = $now->modify('-10 minutes')->format('Y-m-d H:i:s');
+
+        return $this->db->fetchAll(
+            ['order_intent'],
+            "SELECT id, exchange, market_type, symbol, status, client_order_id, decision_key, updated_at
+             FROM order_intent
+             WHERE status IN ('DRAFT', 'VALIDATED', 'READY_TO_SEND', 'SENT')
+               AND updated_at < :threshold
+             ORDER BY updated_at ASC
+             LIMIT 100",
+            ['threshold' => $threshold],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function hasStopLoss(array $payload): bool
+    {
+        $keys = [
+            'stop_loss',
+            'stopLoss',
+            'stop_loss_price',
+            'stopLossPrice',
+            'sl',
+            'sl_price',
+            'preset_stop_loss_price',
+            'attached_stop_loss_price',
+        ];
+
+        foreach ($payload as $key => $value) {
+            if (in_array((string) $key, $keys, true) && $this->isMeaningfulPrice($value)) {
+                return true;
+            }
+
+            if (is_array($value) && $this->hasStopLoss($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isMeaningfulPrice(mixed $value): bool
+    {
+        if (is_numeric($value)) {
+            return (float) $value > 0.0;
+        }
+
+        if (is_string($value)) {
+            return trim($value) !== '' && strtolower(trim($value)) !== 'none';
+        }
+
+        return FrontDatabase::truthy($value);
+    }
+
+    private function dateOrNull(mixed $value): ?\DateTimeImmutable
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return $value->setTimezone(new \DateTimeZone('UTC'));
+        }
+
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return (new \DateTimeImmutable($value))->setTimezone(new \DateTimeZone('UTC'));
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -339,8 +339,8 @@ final class RiskSummaryQuery
     {
         if (is_numeric($side)) {
             return match ((int) $side) {
-                1, 2 => 'LONG',
-                3, 4 => 'SHORT',
+                1, 3 => 'LONG',
+                2, 4 => 'SHORT',
                 default => null,
             };
         }

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -124,12 +124,12 @@ final class RiskSummaryQuery
     private function loadOpenPlanOrders(): array
     {
         return $this->db->fetchAll(
-            ['futures_plan_order'],
-            "SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, price, size, client_order_id, order_id, plan_type, raw_data, updated_at
-             FROM futures_plan_order
-             WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered')
-             ORDER BY updated_at DESC
-             LIMIT 100",
+             ['futures_plan_order'],
+             "SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, price, size, client_order_id, order_id, plan_type, raw_data, updated_at
+              FROM futures_plan_order
+             WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered', '1')
+              ORDER BY updated_at DESC
+              LIMIT 100",
         );
     }
 
@@ -139,14 +139,35 @@ final class RiskSummaryQuery
     private function loadStopLossProtections(): array
     {
         return $this->db->fetchAll(
-            ['order_protection', 'order_intent'],
-            "SELECT op.id, oi.exchange, oi.market_type, oi.symbol, oi.side, op.type, op.price, op.client_order_id, op.order_id, op.updated_at
+            ['order_protection', 'order_intent', 'futures_plan_order', 'futures_order'],
+            "SELECT op.id,
+                    oi.exchange,
+                    oi.market_type,
+                    oi.symbol,
+                    COALESCE(fpo.side, fo.side, oi.side) AS side,
+                    op.type,
+                    op.price,
+                    op.client_order_id,
+                    op.order_id,
+                    op.updated_at
              FROM order_protection op
              INNER JOIN order_intent oi ON oi.id = op.order_intent_id
+             LEFT JOIN futures_plan_order fpo
+                ON fpo.exchange = oi.exchange
+               AND fpo.market_type = oi.market_type
+               AND (fpo.order_id = op.order_id OR fpo.client_order_id = op.client_order_id)
+             LEFT JOIN futures_order fo
+                ON fo.exchange = oi.exchange
+               AND fo.market_type = oi.market_type
+               AND (fo.order_id = op.order_id OR fo.client_order_id = op.client_order_id)
              WHERE LOWER(COALESCE(op.type, '')) = 'stop_loss'
                AND op.price > 0
                AND oi.status = 'SENT'
                AND COALESCE(op.order_id, op.client_order_id, '') <> ''
+               AND (
+                   LOWER(COALESCE(fpo.status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered', '1')
+                   OR LOWER(COALESCE(fo.status, '')) IN ('new', 'open', 'pending', 'sent', 'submitted', 'partially_filled', 'partially-filled', '1', '2')
+               )
              ORDER BY op.updated_at DESC
              LIMIT 100",
         );
@@ -282,8 +303,8 @@ final class RiskSummaryQuery
     {
         if (is_numeric($side)) {
             return match ((int) $side) {
-                1, 3 => 'LONG',
-                2, 4 => 'SHORT',
+                1, 2 => 'LONG',
+                3, 4 => 'SHORT',
                 default => null,
             };
         }

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -110,7 +110,7 @@ final class RiskSummaryQuery
             ['futures_order'],
             "SELECT id, exchange, market_type, symbol, side, type, status, price, size, client_order_id, order_id, updated_at
              FROM futures_order
-             WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'partially_filled', 'partially-filled')
+             WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'sent', 'submitted', 'partially_filled', 'partially-filled', '1', '2')
              ORDER BY updated_at DESC
              LIMIT 100",
         );

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -26,6 +26,7 @@ final class RiskSummaryQuery
         $positions = $this->loadOpenPositions();
         $orders = $this->loadOpenOrders();
         $planOrders = $this->loadOpenPlanOrders();
+        $stopLossProtections = $this->loadStopLossProtections();
         $locks = $this->loadActiveLocks($now);
         $intents = $this->loadStaleOrderIntents($now);
         $alerts = [];
@@ -33,7 +34,8 @@ final class RiskSummaryQuery
         foreach ($positions as $index => $position) {
             $payload = FrontDatabase::jsonObject($position['payload'] ?? null);
             $positions[$index]['payload'] = $payload;
-            $positions[$index]['has_stop_loss'] = $this->hasStopLoss($payload);
+            $positions[$index]['has_stop_loss'] = $this->hasStopLoss($payload)
+                || $this->hasActiveStopLossProtection($position, $orders, $planOrders, $stopLossProtections);
 
             if (!$positions[$index]['has_stop_loss']) {
                 $alerts[] = new FrontAlert(
@@ -123,10 +125,27 @@ final class RiskSummaryQuery
     {
         return $this->db->fetchAll(
             ['futures_plan_order'],
-            "SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, price, size, client_order_id, order_id, updated_at
+            "SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, price, size, client_order_id, order_id, plan_type, raw_data, updated_at
              FROM futures_plan_order
              WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered')
              ORDER BY updated_at DESC
+             LIMIT 100",
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadStopLossProtections(): array
+    {
+        return $this->db->fetchAll(
+            ['order_protection', 'order_intent'],
+            "SELECT op.id, oi.symbol, oi.side, op.type, op.price, op.client_order_id, op.order_id, op.updated_at
+             FROM order_protection op
+             INNER JOIN order_intent oi ON oi.id = op.order_intent_id
+             WHERE LOWER(COALESCE(op.type, '')) = 'stop_loss'
+               AND op.price > 0
+             ORDER BY op.updated_at DESC
              LIMIT 100",
         );
     }
@@ -199,6 +218,55 @@ final class RiskSummaryQuery
         }
 
         return false;
+    }
+
+    /**
+     * @param array<string, mixed> $position
+     * @param list<array<string, mixed>> $orders
+     * @param list<array<string, mixed>> $planOrders
+     * @param list<array<string, mixed>> $stopLossProtections
+     */
+    private function hasActiveStopLossProtection(array $position, array $orders, array $planOrders, array $stopLossProtections): bool
+    {
+        $symbol = strtoupper((string) ($position['symbol'] ?? ''));
+        if ($symbol === '') {
+            return false;
+        }
+
+        foreach (array_merge($orders, $planOrders, $stopLossProtections) as $protection) {
+            if (strtoupper((string) ($protection['symbol'] ?? '')) !== $symbol) {
+                continue;
+            }
+
+            if (!$this->rowIndicatesStopLoss($protection)) {
+                continue;
+            }
+
+            if ($this->isMeaningfulPrice($protection['trigger_price'] ?? null)
+                || $this->isMeaningfulPrice($protection['price'] ?? null)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function rowIndicatesStopLoss(array $row): bool
+    {
+        foreach (['type', 'plan_type', 'client_order_id', 'order_id'] as $key) {
+            $value = strtolower((string) ($row[$key] ?? ''));
+            if (str_contains($value, 'stop') || str_contains($value, 'sl')) {
+                return true;
+            }
+        }
+
+        $rawData = FrontDatabase::jsonObject($row['raw_data'] ?? null);
+
+        return $rawData !== [] && $this->hasStopLoss($rawData);
     }
 
     private function isMeaningfulPrice(mixed $value): bool

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -128,10 +128,15 @@ final class RiskSummaryQuery
              "SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, price, size, client_order_id, order_id, plan_type, raw_data, updated_at
               FROM futures_plan_order
              WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered', '1')
-                OR CAST(raw_data AS TEXT) LIKE '%\"state\":1%'
-                OR CAST(raw_data AS TEXT) LIKE '%\"state\": 1%'
-                OR CAST(raw_data AS TEXT) LIKE '%\"state\":\"1\"%'
-                OR CAST(raw_data AS TEXT) LIKE '%\"state\": \"1\"%'
+                OR (
+                    (status IS NULL OR TRIM(status) = '' OR LOWER(TRIM(status)) NOT IN ('cancelled', 'canceled', 'closed', 'filled', 'failed', 'rejected', 'expired', 'triggered', 'executed', 'completed', 'complete'))
+                    AND (
+                        CAST(raw_data AS TEXT) LIKE '%\"state\":1%'
+                        OR CAST(raw_data AS TEXT) LIKE '%\"state\": 1%'
+                        OR CAST(raw_data AS TEXT) LIKE '%\"state\":\"1\"%'
+                        OR CAST(raw_data AS TEXT) LIKE '%\"state\": \"1\"%'
+                    )
+                )
               ORDER BY updated_at DESC
               LIMIT 100",
         );
@@ -170,21 +175,33 @@ final class RiskSummaryQuery
                 ON fo.exchange = oi.exchange
                AND fo.market_type = oi.market_type
                AND (
-                   fo.order_id = op.order_id
-                   OR fo.order_id = oi.order_id
-                   OR fo.order_id = oi.exchange_order_id
-                   OR fo.client_order_id = op.client_order_id
-                   OR fo.client_order_id = oi.client_order_id
+                   (op.order_id IS NOT NULL AND op.order_id <> '' AND fo.order_id = op.order_id)
+                   OR (op.client_order_id IS NOT NULL AND op.client_order_id <> '' AND fo.client_order_id = op.client_order_id)
                )
              WHERE LOWER(COALESCE(op.type, '')) = 'stop_loss'
                AND op.price > 0
                AND oi.status = 'SENT'
                AND (
-                   LOWER(COALESCE(fpo.status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered', '1')
-                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\":1%'
-                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\": 1%'
-                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\":\"1\"%'
-                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\": \"1\"%'
+                   (
+                       (
+                           LOWER(COALESCE(fpo.status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered', '1')
+                           OR (
+                               (fpo.status IS NULL OR TRIM(fpo.status) = '' OR LOWER(TRIM(fpo.status)) NOT IN ('cancelled', 'canceled', 'closed', 'filled', 'failed', 'rejected', 'expired', 'triggered', 'executed', 'completed', 'complete'))
+                               AND (
+                                   CAST(fpo.raw_data AS TEXT) LIKE '%\"state\":1%'
+                                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\": 1%'
+                                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\":\"1\"%'
+                                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\": \"1\"%'
+                               )
+                           )
+                       )
+                       AND (
+                           LOWER(COALESCE(fpo.type, '')) LIKE '%stop%'
+                           OR LOWER(COALESCE(fpo.plan_type, '')) LIKE '%stop%'
+                           OR LOWER(COALESCE(fpo.client_order_id, '')) LIKE '%sl%'
+                           OR LOWER(COALESCE(fpo.order_id, '')) LIKE '%sl%'
+                       )
+                   )
                    OR LOWER(COALESCE(fo.status, '')) IN ('new', 'open', 'pending', 'sent', 'submitted', 'partially_filled', 'partially-filled', '1', '2')
                )
              ORDER BY op.updated_at DESC

--- a/trading-app/src/Front/Query/RiskSummaryQuery.php
+++ b/trading-app/src/Front/Query/RiskSummaryQuery.php
@@ -128,6 +128,10 @@ final class RiskSummaryQuery
              "SELECT id, exchange, market_type, symbol, side, type, status, trigger_price, price, size, client_order_id, order_id, plan_type, raw_data, updated_at
               FROM futures_plan_order
              WHERE LOWER(COALESCE(status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered', '1')
+                OR CAST(raw_data AS TEXT) LIKE '%\"state\":1%'
+                OR CAST(raw_data AS TEXT) LIKE '%\"state\": 1%'
+                OR CAST(raw_data AS TEXT) LIKE '%\"state\":\"1\"%'
+                OR CAST(raw_data AS TEXT) LIKE '%\"state\": \"1\"%'
               ORDER BY updated_at DESC
               LIMIT 100",
         );
@@ -153,19 +157,34 @@ final class RiskSummaryQuery
              FROM order_protection op
              INNER JOIN order_intent oi ON oi.id = op.order_intent_id
              LEFT JOIN futures_plan_order fpo
-                ON fpo.exchange = oi.exchange
-               AND fpo.market_type = oi.market_type
-               AND (fpo.order_id = op.order_id OR fpo.client_order_id = op.client_order_id)
+               ON fpo.exchange = oi.exchange
+              AND fpo.market_type = oi.market_type
+               AND (
+                   fpo.order_id = op.order_id
+                   OR fpo.order_id = oi.order_id
+                   OR fpo.order_id = oi.exchange_order_id
+                   OR fpo.client_order_id = op.client_order_id
+                   OR fpo.client_order_id = oi.client_order_id
+               )
              LEFT JOIN futures_order fo
                 ON fo.exchange = oi.exchange
                AND fo.market_type = oi.market_type
-               AND (fo.order_id = op.order_id OR fo.client_order_id = op.client_order_id)
+               AND (
+                   fo.order_id = op.order_id
+                   OR fo.order_id = oi.order_id
+                   OR fo.order_id = oi.exchange_order_id
+                   OR fo.client_order_id = op.client_order_id
+                   OR fo.client_order_id = oi.client_order_id
+               )
              WHERE LOWER(COALESCE(op.type, '')) = 'stop_loss'
                AND op.price > 0
                AND oi.status = 'SENT'
-               AND COALESCE(op.order_id, op.client_order_id, '') <> ''
                AND (
                    LOWER(COALESCE(fpo.status, '')) IN ('new', 'open', 'pending', 'submitted', 'active', 'live', 'untriggered', '1')
+                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\":1%'
+                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\": 1%'
+                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\":\"1\"%'
+                   OR CAST(fpo.raw_data AS TEXT) LIKE '%\"state\": \"1\"%'
                    OR LOWER(COALESCE(fo.status, '')) IN ('new', 'open', 'pending', 'sent', 'submitted', 'partially_filled', 'partially-filled', '1', '2')
                )
              ORDER BY op.updated_at DESC

--- a/trading-app/src/Front/Query/SystemHealthQuery.php
+++ b/trading-app/src/Front/Query/SystemHealthQuery.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use Doctrine\DBAL\Connection;
+use Psr\Clock\ClockInterface;
+
+final class SystemHealthQuery
+{
+    private readonly FrontDatabase $db;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly ClockInterface $clock,
+        private readonly string $projectDir,
+    ) {
+        $this->db = new FrontDatabase($connection);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function health(): array
+    {
+        return [
+            'generated_at' => $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->format(DATE_ATOM),
+            'checks' => $this->checks(),
+            'queues' => $this->queues(),
+            'workers' => $this->workers(),
+            'logs' => $this->logs(),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function checks(): array
+    {
+        $checks = [];
+
+        try {
+            $this->connection->executeQuery('SELECT 1')->fetchOne();
+            $checks[] = ['name' => 'Postgres/DBAL', 'status' => 'ok', 'detail' => 'Connexion disponible'];
+        } catch (\Throwable $exception) {
+            $checks[] = ['name' => 'Postgres/DBAL', 'status' => 'critical', 'detail' => $exception->getMessage()];
+        }
+
+        foreach (['mtf_run', 'mtf_run_symbol', 'positions', 'futures_order', 'symbol_execution_lock', 'messenger_messages'] as $table) {
+            $checks[] = [
+                'name' => $table,
+                'status' => $this->db->tableExists($table) ? 'ok' : 'warning',
+                'detail' => $this->db->tableExists($table) ? 'table presente' : 'table absente',
+            ];
+        }
+
+        return $checks;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function queues(): array
+    {
+        return $this->db->fetchAll(
+            ['messenger_messages'],
+            "SELECT queue_name, COUNT(*) AS message_count
+             FROM messenger_messages
+             GROUP BY queue_name
+             ORDER BY queue_name ASC",
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function workers(): array
+    {
+        return [
+            ['name' => 'trading-app-messenger-trading', 'transport' => 'mtf_decision', 'status' => 'a_verifier'],
+            ['name' => 'trading-app-messenger-order-timeout', 'transport' => 'order_timeout', 'status' => 'a_verifier'],
+            ['name' => 'trading-app-messenger-projection', 'transport' => 'mtf_projection', 'status' => 'a_verifier'],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function logs(): array
+    {
+        $files = glob($this->projectDir . '/var/log/*.log') ?: [];
+        usort($files, static fn (string $a, string $b): int => filemtime($b) <=> filemtime($a));
+
+        return array_map(
+            fn (string $file): array => [
+                'path' => str_replace($this->projectDir . '/', '', $file),
+                'name' => basename($file),
+                'updated_at' => date('Y-m-d H:i:s', (int) filemtime($file)),
+                'size_kb' => round(filesize($file) / 1024, 1),
+            ],
+            array_slice($files, 0, 12),
+        );
+    }
+}

--- a/trading-app/src/Front/Query/SystemHealthQuery.php
+++ b/trading-app/src/Front/Query/SystemHealthQuery.php
@@ -9,6 +9,13 @@ use Psr\Clock\ClockInterface;
 
 final class SystemHealthQuery
 {
+    private const MESSENGER_TABLES = [
+        'messenger_messages_order_timeout',
+        'messenger_messages_mtf_projection',
+        'messenger_messages_mtf_decision',
+        'messenger_messages_failed',
+    ];
+
     private readonly FrontDatabase $db;
 
     public function __construct(
@@ -47,7 +54,7 @@ final class SystemHealthQuery
             $checks[] = ['name' => 'Postgres/DBAL', 'status' => 'critical', 'detail' => $exception->getMessage()];
         }
 
-        foreach (['mtf_run', 'mtf_run_symbol', 'positions', 'futures_order', 'symbol_execution_lock', 'messenger_messages'] as $table) {
+        foreach (array_merge(['mtf_run', 'mtf_run_symbol', 'positions', 'futures_order', 'symbol_execution_lock'], self::MESSENGER_TABLES) as $table) {
             $checks[] = [
                 'name' => $table,
                 'status' => $this->db->tableExists($table) ? 'ok' : 'warning',
@@ -63,13 +70,29 @@ final class SystemHealthQuery
      */
     private function queues(): array
     {
-        return $this->db->fetchAll(
-            ['messenger_messages'],
-            "SELECT queue_name, COUNT(*) AS message_count
-             FROM messenger_messages
-             GROUP BY queue_name
-             ORDER BY queue_name ASC",
-        );
+        $queues = [];
+
+        foreach (self::MESSENGER_TABLES as $table) {
+            if (!$this->db->tableExists($table)) {
+                continue;
+            }
+
+            foreach ($this->db->fetchAll(
+                [$table],
+                sprintf(
+                    "SELECT queue_name, COUNT(*) AS message_count, '%s' AS table_name
+                     FROM %s
+                     GROUP BY queue_name
+                     ORDER BY queue_name ASC",
+                    $table,
+                    $table,
+                ),
+            ) as $row) {
+                $queues[] = $row;
+            }
+        }
+
+        return $queues;
     }
 
     /**

--- a/trading-app/src/Front/Query/TemporalSummaryQuery.php
+++ b/trading-app/src/Front/Query/TemporalSummaryQuery.php
@@ -104,7 +104,7 @@ final class TemporalSummaryQuery
                 'name' => $name,
                 'image' => $definition['image'] ?? null,
                 'container_name' => $definition['container_name'] ?? $name,
-                'ports' => $this->normalizeList($definition['ports'] ?? []),
+                'ports' => $this->normalizePorts($definition['ports'] ?? []),
                 'expose' => $this->normalizeList($definition['expose'] ?? []),
                 'environment' => $environment,
                 'mem_limit' => $definition['mem_limit'] ?? null,
@@ -338,6 +338,35 @@ final class TemporalSummaryQuery
     }
 
     /**
+     * @return list<string>
+     */
+    private function normalizePorts(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $ports = [];
+        foreach ($value as $item) {
+            if (is_array($item)) {
+                $target = (string) ($item['target'] ?? '');
+                $published = (string) ($item['published'] ?? '');
+                $hostIp = (string) ($item['host_ip'] ?? '');
+                if ($target === '') {
+                    continue;
+                }
+
+                $ports[] = ($hostIp !== '' ? $hostIp . ':' : '') . ($published !== '' ? $published . ':' : '') . $target;
+                continue;
+            }
+
+            $ports[] = (string) $item;
+        }
+
+        return $ports;
+    }
+
+    /**
      * @param list<string>|mixed $ports
      */
     private function firstHostPort(mixed $ports, string $containerPort): ?string
@@ -348,11 +377,13 @@ final class TemporalSummaryQuery
 
         foreach ($ports as $port) {
             $port = trim((string) $port, '"\'');
-            if (!str_ends_with($port, ':' . $containerPort)) {
+            $portWithoutProtocol = explode('/', $port, 2)[0];
+            $parts = explode(':', $portWithoutProtocol);
+            if ((string) end($parts) !== $containerPort) {
                 continue;
             }
 
-            return explode(':', $port)[0] ?? null;
+            return $parts[count($parts) - 2] ?? $containerPort;
         }
 
         return null;

--- a/trading-app/src/Front/Query/TemporalSummaryQuery.php
+++ b/trading-app/src/Front/Query/TemporalSummaryQuery.php
@@ -1,0 +1,398 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Query;
+
+use Symfony\Component\Yaml\Yaml;
+
+final class TemporalSummaryQuery
+{
+    public function __construct(
+        private readonly string $projectDir,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function summary(): array
+    {
+        $mtfConfig = $this->readYaml($this->projectDir . '/config/mtf.yaml');
+        $compose = $this->readYaml($this->composePath());
+        $services = $this->temporalServices($compose);
+        $cluster = $this->cluster($mtfConfig, $services);
+        $ui = $this->ui($services['temporal-ui'] ?? []);
+        $workers = $this->workers($services);
+        $taskQueues = $this->taskQueues($cluster, $workers);
+
+        return [
+            'cluster' => $cluster,
+            'ui' => $ui,
+            'services' => $services,
+            'workers' => $workers,
+            'task_queues' => $taskQueues,
+            'checks' => $this->checks($mtfConfig, $compose, $services),
+            'admin_commands' => $this->adminCommands($cluster),
+            'config_files' => $this->configFiles(),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $mtfConfig
+     * @param array<string, array<string, mixed>> $services
+     * @return array<string, mixed>
+     */
+    private function cluster(array $mtfConfig, array $services): array
+    {
+        $temporal = $mtfConfig['mtf']['temporal'] ?? [];
+        $workerEnv = $this->firstWorkerEnvironment($services);
+        $server = $services['temporal'] ?? [];
+
+        return [
+            'address' => (string) ($temporal['address'] ?? $workerEnv['TEMPORAL_ADDRESS'] ?? 'temporal:7233'),
+            'namespace' => (string) ($temporal['namespace'] ?? 'default'),
+            'task_queue' => (string) ($temporal['task_queue'] ?? $workerEnv['TASK_QUEUE_NAME'] ?? ''),
+            'workflow_id' => (string) ($temporal['workflow_id'] ?? ''),
+            'grpc_port' => $this->firstHostPort($server['ports'] ?? [], '7233') ?? '7233',
+            'http_api_enabled' => $this->envTruthy($server['environment']['ENABLE_HTTP_API'] ?? null),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $service
+     * @return array<string, mixed>
+     */
+    private function ui(array $service): array
+    {
+        $hostPort = $this->firstHostPort($service['ports'] ?? [], '8080') ?? '8233';
+
+        return [
+            'url' => 'http://localhost:' . $hostPort,
+            'container_name' => $service['container_name'] ?? 'temporal_ui',
+            'auth_enabled' => $this->envTruthy($service['environment']['TEMPORAL_UI_AUTH_ENABLED'] ?? null),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $compose
+     * @return array<string, array<string, mixed>>
+     */
+    private function temporalServices(array $compose): array
+    {
+        $services = $compose['services'] ?? [];
+        if (!is_array($services)) {
+            return [];
+        }
+
+        $selected = [];
+        foreach ($services as $name => $definition) {
+            if (!is_string($name) || !is_array($definition)) {
+                continue;
+            }
+
+            $environment = $this->normalizeEnvironment($definition['environment'] ?? []);
+            $isTemporal = str_contains($name, 'temporal')
+                || isset($environment['TEMPORAL_ADDRESS'])
+                || isset($environment['TASK_QUEUE_NAME']);
+
+            if (!$isTemporal) {
+                continue;
+            }
+
+            $selected[$name] = [
+                'name' => $name,
+                'image' => $definition['image'] ?? null,
+                'container_name' => $definition['container_name'] ?? $name,
+                'ports' => $this->normalizeList($definition['ports'] ?? []),
+                'expose' => $this->normalizeList($definition['expose'] ?? []),
+                'environment' => $environment,
+                'mem_limit' => $definition['mem_limit'] ?? null,
+                'restart' => $definition['restart'] ?? null,
+                'has_healthcheck' => isset($definition['healthcheck']),
+                'depends_on' => $definition['depends_on'] ?? [],
+            ];
+        }
+
+        return $selected;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $services
+     * @return list<array<string, mixed>>
+     */
+    private function workers(array $services): array
+    {
+        $workers = [];
+        foreach ($services as $name => $service) {
+            $environment = $service['environment'] ?? [];
+            if (!is_array($environment) || !isset($environment['TASK_QUEUE_NAME'])) {
+                continue;
+            }
+
+            $workers[] = [
+                'service' => $name,
+                'container_name' => $service['container_name'] ?? $name,
+                'task_queue' => (string) $environment['TASK_QUEUE_NAME'],
+                'temporal_address' => (string) ($environment['TEMPORAL_ADDRESS'] ?? ''),
+                'workers_count' => (string) ($environment['MTF_WORKERS_COUNT'] ?? ''),
+                'scalper_micro_workers_count' => (string) ($environment['SCALPER_MICRO_WORKERS_COUNT'] ?? ''),
+                'target_url' => (string) ($environment['MTF_WORKERS_URL'] ?? ''),
+                'dry_run' => (string) ($environment['MTF_WORKERS_DRY_RUN'] ?? ''),
+            ];
+        }
+
+        return $workers;
+    }
+
+    /**
+     * @param array<string, mixed> $cluster
+     * @param list<array<string, mixed>> $workers
+     * @return list<string>
+     */
+    private function taskQueues(array $cluster, array $workers): array
+    {
+        $queues = [];
+        if (($cluster['task_queue'] ?? '') !== '') {
+            $queues[] = (string) $cluster['task_queue'];
+        }
+
+        foreach ($workers as $worker) {
+            if (($worker['task_queue'] ?? '') !== '') {
+                $queues[] = (string) $worker['task_queue'];
+            }
+        }
+
+        return array_values(array_unique($queues));
+    }
+
+    /**
+     * @param array<string, mixed> $mtfConfig
+     * @param array<string, mixed> $compose
+     * @param array<string, array<string, mixed>> $services
+     * @return list<array<string, string>>
+     */
+    private function checks(array $mtfConfig, array $compose, array $services): array
+    {
+        return [
+            [
+                'name' => 'config/mtf.yaml',
+                'status' => isset($mtfConfig['mtf']['temporal']) ? 'ok' : 'warning',
+                'detail' => isset($mtfConfig['mtf']['temporal']) ? 'Configuration Temporal MTF trouvee' : 'Configuration Temporal MTF absente',
+            ],
+            [
+                'name' => 'docker-compose.yml',
+                'status' => isset($compose['services']) ? 'ok' : 'warning',
+                'detail' => isset($compose['services']) ? 'Stack Docker lisible' : 'Stack Docker non trouvee',
+            ],
+            [
+                'name' => 'temporal',
+                'status' => isset($services['temporal']) ? 'ok' : 'critical',
+                'detail' => isset($services['temporal']) ? 'Service serveur declare' : 'Service serveur absent',
+            ],
+            [
+                'name' => 'temporal-ui',
+                'status' => isset($services['temporal-ui']) ? 'ok' : 'warning',
+                'detail' => isset($services['temporal-ui']) ? 'UI declaree' : 'UI absente',
+            ],
+            [
+                'name' => 'worker Temporal',
+                'status' => $this->workers($services) !== [] ? 'ok' : 'warning',
+                'detail' => $this->workers($services) !== [] ? 'Au moins un worker declare' : 'Aucun worker declare',
+            ],
+            [
+                'name' => 'Temporal PHP SDK',
+                'status' => class_exists('Temporal\Client\WorkflowClient') ? 'ok' : 'warning',
+                'detail' => class_exists('Temporal\Client\WorkflowClient') ? 'Classes SDK disponibles' : 'SDK PHP non charge dans ce runtime',
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $cluster
+     * @return list<array<string, string>>
+     */
+    private function adminCommands(array $cluster): array
+    {
+        $address = $this->commandAddress((string) ($cluster['address'] ?? 'temporal:7233'));
+        $namespace = (string) ($cluster['namespace'] ?? 'default');
+        $workflowId = (string) ($cluster['workflow_id'] ?? '<workflow-id>');
+
+        return [
+            [
+                'label' => 'Health cluster',
+                'command' => sprintf('docker compose exec temporal temporal operator cluster health --address %s', $address),
+            ],
+            [
+                'label' => 'Lister namespaces',
+                'command' => sprintf('docker compose exec temporal temporal operator namespace list --address %s', $address),
+            ],
+            [
+                'label' => 'Lister workflows ouverts',
+                'command' => sprintf('docker compose exec temporal temporal workflow list --address %s --namespace %s', $address, $namespace),
+            ],
+            [
+                'label' => 'Decrire workflow MTF',
+                'command' => sprintf('docker compose exec temporal temporal workflow describe --address %s --namespace %s --workflow-id %s', $address, $namespace, $workflowId),
+            ],
+            [
+                'label' => 'Logs serveur',
+                'command' => 'docker compose logs -f temporal temporal-ui cron-symfony-mtf-workers',
+            ],
+            [
+                'label' => 'Etat containers',
+                'command' => 'docker compose ps temporal temporal-ui cron-symfony-mtf-workers postgresql',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function configFiles(): array
+    {
+        $paths = [
+            $this->projectDir . '/config/mtf.yaml',
+            $this->projectDir . '/config/services_mtf.yaml',
+            $this->composePath(),
+        ];
+
+        $files = [];
+        foreach ($paths as $path) {
+            $files[] = [
+                'path' => $this->relativePath($path),
+                'exists' => is_file($path),
+                'updated_at' => is_file($path) ? date('Y-m-d H:i:s', (int) filemtime($path)) : null,
+                'size_kb' => is_file($path) ? round(filesize($path) / 1024, 1) : null,
+            ];
+        }
+
+        return $files;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readYaml(string $path): array
+    {
+        if (!is_file($path)) {
+            return [];
+        }
+
+        try {
+            $parsed = Yaml::parseFile($path);
+        } catch (\Throwable) {
+            return [];
+        }
+
+        return is_array($parsed) ? $parsed : [];
+    }
+
+    private function composePath(): string
+    {
+        $local = $this->projectDir . '/docker-compose.yml';
+        if (is_file($local)) {
+            return $local;
+        }
+
+        return dirname($this->projectDir) . '/docker-compose.yml';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function normalizeEnvironment(mixed $environment): array
+    {
+        if (!is_array($environment)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($environment as $key => $value) {
+            if (is_string($key)) {
+                $normalized[$key] = is_scalar($value) ? (string) $value : '';
+                continue;
+            }
+
+            if (!is_string($value) || !str_contains($value, '=')) {
+                continue;
+            }
+
+            [$envKey, $envValue] = explode('=', $value, 2);
+            $normalized[$envKey] = $envValue;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn (mixed $item): string => (string) $item, $value));
+    }
+
+    /**
+     * @param list<string>|mixed $ports
+     */
+    private function firstHostPort(mixed $ports, string $containerPort): ?string
+    {
+        if (!is_array($ports)) {
+            return null;
+        }
+
+        foreach ($ports as $port) {
+            $port = trim((string) $port, '"\'');
+            if (!str_ends_with($port, ':' . $containerPort)) {
+                continue;
+            }
+
+            return explode(':', $port)[0] ?? null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $services
+     * @return array<string, string>
+     */
+    private function firstWorkerEnvironment(array $services): array
+    {
+        foreach ($services as $service) {
+            $environment = $service['environment'] ?? [];
+            if (is_array($environment) && isset($environment['TASK_QUEUE_NAME'])) {
+                /** @var array<string, string> $environment */
+                return $environment;
+            }
+        }
+
+        return [];
+    }
+
+    private function envTruthy(mixed $value): bool
+    {
+        return in_array(strtolower((string) $value), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function commandAddress(string $address): string
+    {
+        if (str_starts_with($address, '%env(')) {
+            return 'temporal:7233';
+        }
+
+        return $address;
+    }
+
+    private function relativePath(string $path): string
+    {
+        $root = is_file($this->projectDir . '/docker-compose.yml') ? $this->projectDir : dirname($this->projectDir);
+
+        return str_replace($root . '/', '', $path);
+    }
+}

--- a/trading-app/src/Front/Query/TemporalSummaryQuery.php
+++ b/trading-app/src/Front/Query/TemporalSummaryQuery.php
@@ -215,7 +215,7 @@ final class TemporalSummaryQuery
     private function adminCommands(array $cluster): array
     {
         $address = $this->commandAddress((string) ($cluster['address'] ?? 'temporal:7233'));
-        $namespace = (string) ($cluster['namespace'] ?? 'default');
+        $namespace = $this->commandNamespace((string) ($cluster['namespace'] ?? 'default'));
         $workflowId = (string) ($cluster['workflow_id'] ?? '<workflow-id>');
 
         return [
@@ -382,11 +382,23 @@ final class TemporalSummaryQuery
 
     private function commandAddress(string $address): string
     {
-        if (str_starts_with($address, '%env(')) {
-            return 'temporal:7233';
+        return $this->resolveEnvPlaceholder($address, 'temporal:7233');
+    }
+
+    private function commandNamespace(string $namespace): string
+    {
+        return $this->resolveEnvPlaceholder($namespace, 'default');
+    }
+
+    private function resolveEnvPlaceholder(string $value, string $default): string
+    {
+        if (!preg_match('/^%env\(([^)]+)\)%$/', $value, $matches)) {
+            return $value;
         }
 
-        return $address;
+        $envValue = $_ENV[$matches[1]] ?? $_SERVER[$matches[1]] ?? getenv($matches[1]);
+
+        return is_string($envValue) && trim($envValue) !== '' ? $envValue : $default;
     }
 
     private function relativePath(string $path): string

--- a/trading-app/src/Front/Security/OpsFrontAccessSubscriber.php
+++ b/trading-app/src/Front/Security/OpsFrontAccessSubscriber.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\Security;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class OpsFrontAccessSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['guardOpsFront', 128],
+        ];
+    }
+
+    public function guardOpsFront(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $path = $request->getPathInfo();
+        if ($path !== '/app' && !str_starts_with($path, '/app/')) {
+            return;
+        }
+
+        $password = $this->env('OPS_FRONT_PASSWORD');
+        $token = $this->env('OPS_FRONT_TOKEN');
+        if ($password === '' && $token === '') {
+            if (in_array($this->env('APP_ENV'), ['dev', 'test'], true)) {
+                return;
+            }
+
+            $event->setResponse(new Response('Ops front access is not configured.', Response::HTTP_SERVICE_UNAVAILABLE));
+
+            return;
+        }
+
+        if ($token !== '' && hash_equals($token, (string) $request->headers->get('X-Ops-Token', ''))) {
+            return;
+        }
+
+        $authorization = (string) $request->headers->get('Authorization', '');
+        if ($token !== '' && str_starts_with($authorization, 'Bearer ')) {
+            if (hash_equals($token, trim(substr($authorization, 7)))) {
+                return;
+            }
+        }
+
+        if ($password !== '') {
+            $user = $this->env('OPS_FRONT_USER') !== '' ? $this->env('OPS_FRONT_USER') : 'ops';
+            if (hash_equals($user, (string) $request->getUser())
+                && hash_equals($password, (string) $request->getPassword())
+            ) {
+                return;
+            }
+        }
+
+        $response = new Response('Authentication required.', Response::HTTP_UNAUTHORIZED);
+        $response->headers->set('WWW-Authenticate', 'Basic realm="TradingV3 Ops"');
+        $event->setResponse($response);
+    }
+
+    private function env(string $key): string
+    {
+        $value = $_SERVER[$key] ?? $_ENV[$key] ?? getenv($key);
+
+        return is_string($value) ? trim($value) : '';
+    }
+}

--- a/trading-app/src/Front/ViewModel/CockpitSummaryView.php
+++ b/trading-app/src/Front/ViewModel/CockpitSummaryView.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\ViewModel;
+
+final readonly class CockpitSummaryView
+{
+    /**
+     * @param array<string, mixed> $mode
+     * @param array<string, mixed> $system
+     */
+    public function __construct(
+        public RiskSummaryView $risk,
+        public DecisionSummaryView $decisions,
+        public array $mode,
+        public array $system,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'risk' => $this->risk->toArray(),
+            'decisions' => $this->decisions->toArray(),
+            'mode' => $this->mode,
+            'system' => $this->system,
+        ];
+    }
+}

--- a/trading-app/src/Front/ViewModel/DecisionSummaryView.php
+++ b/trading-app/src/Front/ViewModel/DecisionSummaryView.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\ViewModel;
+
+final readonly class DecisionSummaryView
+{
+    /**
+     * @param list<array<string, mixed>> $runs
+     * @param list<array<string, mixed>> $symbols
+     * @param list<array<string, mixed>> $reasonCounts
+     */
+    public function __construct(
+        public array $runs,
+        public array $symbols,
+        public array $reasonCounts,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'runs' => $this->runs,
+            'symbols' => $this->symbols,
+            'reason_counts' => $this->reasonCounts,
+        ];
+    }
+}

--- a/trading-app/src/Front/ViewModel/FrontAlert.php
+++ b/trading-app/src/Front/ViewModel/FrontAlert.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\ViewModel;
+
+final readonly class FrontAlert
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function __construct(
+        public string $severity,
+        public string $code,
+        public string $title,
+        public string $message,
+        public ?string $symbol = null,
+        public array $context = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'severity' => $this->severity,
+            'code' => $this->code,
+            'title' => $this->title,
+            'message' => $this->message,
+            'symbol' => $this->symbol,
+            'context' => $this->context,
+        ];
+    }
+}

--- a/trading-app/src/Front/ViewModel/RiskSummaryView.php
+++ b/trading-app/src/Front/ViewModel/RiskSummaryView.php
@@ -9,6 +9,7 @@ final readonly class RiskSummaryView
     public int $openPositionCount;
     public int $openOrderCount;
     public int $openPlanOrderCount;
+    public int $openOrderTotalCount;
     public int $activeLockCount;
     public int $staleLockCount;
     public int $criticalAlertCount;
@@ -30,6 +31,7 @@ final readonly class RiskSummaryView
         $this->openPositionCount = count($positions);
         $this->openOrderCount = count($orders);
         $this->openPlanOrderCount = count($planOrders);
+        $this->openOrderTotalCount = $this->openOrderCount + $this->openPlanOrderCount;
         $this->activeLockCount = count($locks);
         $this->staleLockCount = count(array_filter($locks, static fn (array $lock): bool => (bool) ($lock['is_stale'] ?? false)));
         $this->criticalAlertCount = count(array_filter($alerts, static fn (FrontAlert $alert): bool => $alert->severity === 'critical'));
@@ -44,6 +46,7 @@ final readonly class RiskSummaryView
             'open_position_count' => $this->openPositionCount,
             'open_order_count' => $this->openOrderCount,
             'open_plan_order_count' => $this->openPlanOrderCount,
+            'open_order_total_count' => $this->openOrderTotalCount,
             'active_lock_count' => $this->activeLockCount,
             'stale_lock_count' => $this->staleLockCount,
             'critical_alert_count' => $this->criticalAlertCount,

--- a/trading-app/src/Front/ViewModel/RiskSummaryView.php
+++ b/trading-app/src/Front/ViewModel/RiskSummaryView.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Front\ViewModel;
+
+final readonly class RiskSummaryView
+{
+    public int $openPositionCount;
+    public int $openOrderCount;
+    public int $openPlanOrderCount;
+    public int $activeLockCount;
+    public int $staleLockCount;
+    public int $criticalAlertCount;
+
+    /**
+     * @param list<array<string, mixed>> $positions
+     * @param list<array<string, mixed>> $orders
+     * @param list<array<string, mixed>> $planOrders
+     * @param list<array<string, mixed>> $locks
+     * @param list<FrontAlert> $alerts
+     */
+    public function __construct(
+        public array $positions,
+        public array $orders,
+        public array $planOrders,
+        public array $locks,
+        public array $alerts,
+    ) {
+        $this->openPositionCount = count($positions);
+        $this->openOrderCount = count($orders);
+        $this->openPlanOrderCount = count($planOrders);
+        $this->activeLockCount = count($locks);
+        $this->staleLockCount = count(array_filter($locks, static fn (array $lock): bool => (bool) ($lock['is_stale'] ?? false)));
+        $this->criticalAlertCount = count(array_filter($alerts, static fn (FrontAlert $alert): bool => $alert->severity === 'critical'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'open_position_count' => $this->openPositionCount,
+            'open_order_count' => $this->openOrderCount,
+            'open_plan_order_count' => $this->openPlanOrderCount,
+            'active_lock_count' => $this->activeLockCount,
+            'stale_lock_count' => $this->staleLockCount,
+            'critical_alert_count' => $this->criticalAlertCount,
+            'positions' => $this->positions,
+            'orders' => $this->orders,
+            'plan_orders' => $this->planOrders,
+            'locks' => $this->locks,
+            'alerts' => array_map(static fn (FrontAlert $alert): array => $alert->toArray(), $this->alerts),
+        ];
+    }
+}

--- a/trading-app/templates/front/base.html.twig
+++ b/trading-app/templates/front/base.html.twig
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>{% block title %}TradingV3 Ops{% endblock %}</title>
+        <link rel="stylesheet" href="/front/app.css">
+        {% block stylesheets %}{% endblock %}
+    </head>
+    <body>
+        <header class="topbar">
+            <a class="brand" href="{{ path('front_cockpit') }}">
+                <span class="brand-mark">T3</span>
+                <span>TradingV3 Ops</span>
+            </a>
+            <nav class="main-nav" aria-label="Navigation principale">
+                <a class="{{ current|default('cockpit') == 'cockpit' ? 'active' : '' }}" href="{{ path('front_cockpit') }}">Cockpit</a>
+                <a class="{{ current|default('') == 'risk' ? 'active' : '' }}" href="{{ path('front_risk') }}">Risk Center</a>
+                <a class="{{ current|default('') == 'decisions' ? 'active' : '' }}" href="{{ path('front_decisions') }}">Decision Explorer</a>
+                <a class="{{ current|default('') == 'investigate' ? 'active' : '' }}" href="{{ path('front_investigate') }}">Investigation</a>
+                <a class="{{ current|default('') == 'system' ? 'active' : '' }}" href="{{ path('front_system') }}">System</a>
+                <a class="{{ current|default('') == 'temporal' ? 'active' : '' }}" href="{{ path('front_temporal') }}">Temporal</a>
+                <a class="{{ current|default('') == 'config' ? 'active' : '' }}" href="{{ path('front_config') }}">Config</a>
+            </nav>
+        </header>
+
+        <main class="page-shell">
+            {% block body %}{% endblock %}
+        </main>
+
+        <script src="/front/app.js" defer></script>
+        {% block javascripts %}{% endblock %}
+    </body>
+</html>

--- a/trading-app/templates/front/cockpit.html.twig
+++ b/trading-app/templates/front/cockpit.html.twig
@@ -25,7 +25,7 @@
         </div>
         <div class="metric">
             <span>Ordres ouverts</span>
-            <strong data-json-field="risk.open_order_count">{{ summary.risk.openOrderCount + summary.risk.openPlanOrderCount }}</strong>
+            <strong data-json-field="risk.open_order_total_count">{{ summary.risk.openOrderTotalCount }}</strong>
         </div>
         <div class="metric warning">
             <span>Locks stale</span>

--- a/trading-app/templates/front/cockpit.html.twig
+++ b/trading-app/templates/front/cockpit.html.twig
@@ -1,0 +1,104 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}Cockpit | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>Cockpit</h1>
+            <p>Mode actif: <strong>{{ summary.mode.name|default('unknown') }}</strong></p>
+        </div>
+        <div class="header-actions" data-auto-refresh data-refresh-url="{{ path('front_api_cockpit_summary') }}" data-refresh-interval="30000">
+            <span class="live-dot"></span>
+            <span data-json-field="system.generated_at">{{ summary.system.generated_at|default('') }}</span>
+        </div>
+    </section>
+
+    <section class="metric-grid">
+        <div class="metric critical">
+            <span>Alertes critiques</span>
+            <strong data-json-field="risk.critical_alert_count">{{ summary.risk.criticalAlertCount }}</strong>
+        </div>
+        <div class="metric">
+            <span>Positions ouvertes</span>
+            <strong data-json-field="risk.open_position_count">{{ summary.risk.openPositionCount }}</strong>
+        </div>
+        <div class="metric">
+            <span>Ordres ouverts</span>
+            <strong data-json-field="risk.open_order_count">{{ summary.risk.openOrderCount + summary.risk.openPlanOrderCount }}</strong>
+        </div>
+        <div class="metric warning">
+            <span>Locks stale</span>
+            <strong data-json-field="risk.stale_lock_count">{{ summary.risk.staleLockCount }}</strong>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header">
+                <h2>Alertes</h2>
+                <a href="{{ path('front_risk') }}">Risk Center</a>
+            </div>
+            {% if summary.risk.alerts is empty %}
+                <p class="empty">Aucune alerte active.</p>
+            {% else %}
+                <div class="alert-list">
+                    {% for alert in summary.risk.alerts|slice(0, 8) %}
+                        <article class="alert-row {{ alert.severity }}">
+                            <strong>{{ alert.title }}</strong>
+                            <span>{{ alert.message }}</span>
+                            {% if alert.symbol %}<em>{{ alert.symbol }}</em>{% endif %}
+                        </article>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="panel">
+            <div class="panel-header">
+                <h2>Dernier run MTF</h2>
+                <a href="{{ path('front_decisions') }}">Decisions</a>
+            </div>
+            {% set run = summary.decisions.runs[0]|default(null) %}
+            {% if run %}
+                <dl class="kv-grid">
+                    <dt>Run</dt><dd class="mono">{{ run.run_id }}</dd>
+                    <dt>Status</dt><dd><span class="pill">{{ run.status }}</span></dd>
+                    <dt>Workers</dt><dd>{{ run.workers|default('-') }}</dd>
+                    <dt>Duree</dt><dd>{{ run.execution_time_seconds|default(0) }} s</dd>
+                    <dt>Symboles</dt><dd>{{ run.symbols_processed|default(0) }}/{{ run.symbols_requested|default(0) }}</dd>
+                    <dt>Dry-run</dt><dd>{{ run.dry_run ? 'oui' : 'non' }}</dd>
+                </dl>
+            {% else %}
+                <p class="empty">Aucun run MTF trouve.</p>
+            {% endif %}
+        </div>
+    </section>
+
+    <section class="panel">
+        <div class="panel-header">
+            <h2>Refus principaux</h2>
+            <a href="{{ path('front_decisions') }}">Explorer</a>
+        </div>
+        <div class="table-wrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Raison</th>
+                        <th class="num">Symboles</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for row in summary.decisions.reasonCounts %}
+                    <tr>
+                        <td>{{ row.reason }}</td>
+                        <td class="num">{{ row.count }}</td>
+                    </tr>
+                {% else %}
+                    <tr><td colspan="2" class="empty">Aucun refus recent.</td></tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+{% endblock %}

--- a/trading-app/templates/front/config.html.twig
+++ b/trading-app/templates/front/config.html.twig
@@ -1,0 +1,45 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}Config | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>Config</h1>
+            <p>Mode actif: <strong>{{ config.active_mode.name|default('unknown') }}</strong></p>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header"><h2>Modes</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Mode</th><th>Enabled</th><th class="num">Priority</th></tr></thead>
+                    <tbody>
+                    {% for mode in config.modes %}
+                        <tr><td>{{ mode.name }}</td><td>{{ mode.enabled ? 'oui' : 'non' }}</td><td class="num">{{ mode.priority }}</td></tr>
+                    {% else %}
+                        <tr><td colspan="3" class="empty">Aucun mode trouve.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="panel">
+            <div class="panel-header"><h2>Fichiers YAML</h2><span>{{ config.files|length }}</span></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Fichier</th><th>Updated</th><th class="num">KB</th></tr></thead>
+                    <tbody>
+                    {% for file in config.files %}
+                        <tr><td class="mono">{{ file.path }}</td><td>{{ file.updated_at }}</td><td class="num">{{ file.size_kb }}</td></tr>
+                    {% else %}
+                        <tr><td colspan="3" class="empty">Aucun fichier trouve.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/trading-app/templates/front/decision_detail.html.twig
+++ b/trading-app/templates/front/decision_detail.html.twig
@@ -1,0 +1,30 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}Decision {{ detail.decision_key }} | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>Decision</h1>
+            <p class="mono">{{ detail.decision_key }}</p>
+        </div>
+        <a class="button-link" href="{{ path('front_decisions') }}">Retour</a>
+    </section>
+
+    {% for title, rows in {
+        'Order intents': detail.order_intents,
+        'Zone events': detail.zone_events,
+        'Lifecycle': detail.lifecycle_events
+    } %}
+        <section class="panel">
+            <div class="panel-header"><h2>{{ title }}</h2><span>{{ rows|length }}</span></div>
+            <div class="json-list">
+                {% for row in rows %}
+                    <pre>{{ row|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                {% else %}
+                    <p class="empty">Aucune donnee.</p>
+                {% endfor %}
+            </div>
+        </section>
+    {% endfor %}
+{% endblock %}

--- a/trading-app/templates/front/decisions.html.twig
+++ b/trading-app/templates/front/decisions.html.twig
@@ -1,0 +1,85 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}Decision Explorer | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>Decision Explorer</h1>
+            <p>{{ view.runs|length }} run(s) recent(s), {{ view.symbols|length }} symbole(s) sur le dernier run</p>
+        </div>
+        <div class="header-actions" data-auto-refresh data-refresh-url="{{ path('front_api_decisions_latest') }}" data-refresh-interval="30000">
+            <span class="live-dot"></span>
+            <span>refresh</span>
+        </div>
+    </section>
+
+    <section class="panel">
+        <div class="panel-header"><h2>Runs MTF</h2></div>
+        <div class="table-wrap">
+            <table>
+                <thead><tr><th>Run</th><th>Status</th><th>Start</th><th class="num">Duree</th><th class="num">Workers</th><th class="num">Processed</th><th class="num">Success</th></tr></thead>
+                <tbody>
+                {% for run in view.runs %}
+                    <tr>
+                        <td class="mono">{{ run.run_id }}</td>
+                        <td><span class="pill">{{ run.status }}</span></td>
+                        <td>{{ run.started_at }}</td>
+                        <td class="num">{{ run.execution_time_seconds }} s</td>
+                        <td class="num">{{ run.workers|default('-') }}</td>
+                        <td class="num">{{ run.symbols_processed }}/{{ run.symbols_requested }}</td>
+                        <td class="num">{{ run.success_rate }}%</td>
+                    </tr>
+                {% else %}
+                    <tr><td colspan="7" class="empty">Aucun run MTF trouve.</td></tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header"><h2>Raisons principales</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Raison</th><th class="num">Count</th></tr></thead>
+                    <tbody>
+                    {% for row in view.reasonCounts %}
+                        <tr><td>{{ row.reason }}</td><td class="num">{{ row.count }}</td></tr>
+                    {% else %}
+                        <tr><td colspan="2" class="empty">Aucune raison calculee.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="panel">
+            <div class="panel-header"><h2>Symboles dernier run</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Symbole</th><th>Status</th><th>TF</th><th>Raison</th><th>Decision</th></tr></thead>
+                    <tbody>
+                    {% for symbol in view.symbols %}
+                        <tr>
+                            <td class="mono">{{ symbol.symbol }}</td>
+                            <td>{{ symbol.status }}</td>
+                            <td>{{ symbol.blocking_tf|default(symbol.execution_tf|default('-')) }}</td>
+                            <td>{{ symbol.primary_reason }}</td>
+                            <td>
+                                {% if symbol.decision_key|default(null) %}
+                                    <a href="{{ path('front_decision_detail', {decisionKey: symbol.decision_key}) }}">ouvrir</a>
+                                {% else %}
+                                    <span class="muted">-</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="5" class="empty">Aucun symbole pour le dernier run.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/trading-app/templates/front/investigate.html.twig
+++ b/trading-app/templates/front/investigate.html.twig
@@ -1,0 +1,61 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}Investigation | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>Investigation</h1>
+            <p>Recherche consolidee BDD par symbole, date, decision_key ou run_id.</p>
+        </div>
+    </section>
+
+    <section class="panel">
+        <form class="filter-form" method="get" action="{{ path('front_investigate') }}">
+            <label>Symbole <input name="symbol" value="{{ app.request.query.get('symbol') }}" placeholder="LINKUSDT"></label>
+            <label>Date UTC <input name="date" value="{{ app.request.query.get('date') }}" placeholder="2025-11-30 13:02"></label>
+            <label>Decision key <input name="decision_key" value="{{ app.request.query.get('decision_key') }}"></label>
+            <label>Run ID <input name="run_id" value="{{ app.request.query.get('run_id') }}"></label>
+            <button type="submit">Rechercher</button>
+        </form>
+    </section>
+
+    {% if result.searched %}
+        <section class="metric-grid">
+            {% for name, rows in result.sections %}
+                <div class="metric"><span>{{ name }}</span><strong>{{ rows|length }}</strong></div>
+            {% endfor %}
+        </section>
+
+        {% if result.exports is not empty %}
+            <section class="panel">
+                <div class="panel-header"><h2>Exports existants</h2></div>
+                <div class="table-wrap compact">
+                    <table>
+                        <thead><tr><th>Fichier</th><th>Chemin</th><th>Updated</th></tr></thead>
+                        <tbody>
+                        {% for export in result.exports %}
+                            <tr><td>{{ export.name }}</td><td class="mono">{{ export.path }}</td><td>{{ export.updated_at }}</td></tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        {% endif %}
+
+        {% for name, rows in result.sections %}
+            <section class="panel">
+                <div class="panel-header"><h2>{{ name }}</h2><span>{{ rows|length }}</span></div>
+                <div class="json-list">
+                    {% for row in rows %}
+                        <pre>{{ row|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                    {% else %}
+                        <p class="empty">Aucune donnee.</p>
+                    {% endfor %}
+                </div>
+            </section>
+        {% endfor %}
+    {% else %}
+        <section class="panel"><p class="empty">Aucune recherche lancee.</p></section>
+    {% endif %}
+{% endblock %}

--- a/trading-app/templates/front/risk.html.twig
+++ b/trading-app/templates/front/risk.html.twig
@@ -1,0 +1,105 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}Risk Center | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>Risk Center</h1>
+            <p>{{ view.openPositionCount }} position(s), {{ view.openOrderCount + view.openPlanOrderCount }} ordre(s), {{ view.activeLockCount }} lock(s)</p>
+        </div>
+        <div class="header-actions" data-auto-refresh data-refresh-url="{{ path('front_api_risk_summary') }}" data-refresh-interval="20000">
+            <span class="live-dot"></span>
+            <span>refresh</span>
+        </div>
+    </section>
+
+    <section class="metric-grid">
+        <div class="metric critical"><span>Critiques</span><strong data-json-field="critical_alert_count">{{ view.criticalAlertCount }}</strong></div>
+        <div class="metric"><span>Positions</span><strong data-json-field="open_position_count">{{ view.openPositionCount }}</strong></div>
+        <div class="metric"><span>Ordres</span><strong data-json-field="open_order_count">{{ view.openOrderCount }}</strong></div>
+        <div class="metric warning"><span>Locks stale</span><strong data-json-field="stale_lock_count">{{ view.staleLockCount }}</strong></div>
+    </section>
+
+    <section class="panel">
+        <div class="panel-header"><h2>Alertes risk</h2></div>
+        {% if view.alerts is empty %}
+            <p class="empty">Aucune alerte active.</p>
+        {% else %}
+            <div class="alert-list">
+                {% for alert in view.alerts %}
+                    <article class="alert-row {{ alert.severity }}">
+                        <strong>{{ alert.title }}</strong>
+                        <span>{{ alert.message }}</span>
+                        <em>{{ alert.code }}</em>
+                    </article>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </section>
+
+    <section class="panel">
+        <div class="panel-header"><h2>Positions ouvertes</h2></div>
+        <div class="table-wrap">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Symbole</th><th>Side</th><th class="num">Size</th><th class="num">Entry</th><th class="num">Lev</th><th class="num">PnL</th><th>SL</th><th>Updated</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for row in view.positions %}
+                    <tr class="{{ row.has_stop_loss ? '' : 'danger-row' }}">
+                        <td class="mono">{{ row.symbol }}</td>
+                        <td>{{ row.side }}</td>
+                        <td class="num">{{ row.size|default('-') }}</td>
+                        <td class="num">{{ row.avg_entry_price|default('-') }}</td>
+                        <td class="num">{{ row.leverage|default('-') }}</td>
+                        <td class="num">{{ row.unrealized_pnl|default('-') }}</td>
+                        <td>{{ row.has_stop_loss ? 'ok' : 'manquant' }}</td>
+                        <td>{{ row.updated_at|default('-') }}</td>
+                    </tr>
+                {% else %}
+                    <tr><td colspan="8" class="empty">Aucune position ouverte.</td></tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header"><h2>Ordres ouverts</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Symbole</th><th>Status</th><th>Type</th><th class="num">Prix</th><th>Client ID</th></tr></thead>
+                    <tbody>
+                    {% for row in view.orders %}
+                        <tr><td class="mono">{{ row.symbol }}</td><td>{{ row.status }}</td><td>{{ row.type }}</td><td class="num">{{ row.price|default('-') }}</td><td class="mono">{{ row.client_order_id|default('-') }}</td></tr>
+                    {% else %}
+                        <tr><td colspan="5" class="empty">Aucun ordre ouvert.</td></tr>
+                    {% endfor %}
+                    {% for row in view.planOrders %}
+                        <tr><td class="mono">{{ row.symbol }}</td><td>{{ row.status }}</td><td>{{ row.type }} plan</td><td class="num">{{ row.trigger_price|default(row.price|default('-')) }}</td><td class="mono">{{ row.client_order_id|default('-') }}</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="panel">
+            <div class="panel-header"><h2>Locks actifs</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Symbole</th><th>Profil</th><th>Expire</th><th>Etat</th></tr></thead>
+                    <tbody>
+                    {% for row in view.locks %}
+                        <tr class="{{ row.is_stale ? 'danger-row' : '' }}"><td class="mono">{{ row.symbol }}</td><td>{{ row.owner_profile|default('-') }}</td><td>{{ row.expires_at }}</td><td>{{ row.is_stale ? 'stale' : 'actif' }}</td></tr>
+                    {% else %}
+                        <tr><td colspan="4" class="empty">Aucun lock actif.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/trading-app/templates/front/system.html.twig
+++ b/trading-app/templates/front/system.html.twig
@@ -1,0 +1,78 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}System | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>System</h1>
+            <p>{{ health.generated_at }}</p>
+        </div>
+        <div class="header-actions" data-auto-refresh data-refresh-url="{{ path('front_api_system_health') }}" data-refresh-interval="30000">
+            <span class="live-dot"></span>
+            <span>refresh</span>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header"><h2>Health</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Check</th><th>Status</th><th>Detail</th></tr></thead>
+                    <tbody>
+                    {% for check in health.checks %}
+                        <tr><td>{{ check.name }}</td><td><span class="pill {{ check.status }}">{{ check.status }}</span></td><td>{{ check.detail }}</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="panel">
+            <div class="panel-header"><h2>Workers attendus</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Container</th><th>Transport</th><th>Status</th></tr></thead>
+                    <tbody>
+                    {% for worker in health.workers %}
+                        <tr><td class="mono">{{ worker.name }}</td><td>{{ worker.transport }}</td><td>{{ worker.status }}</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header"><h2>Messenger queues</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Queue</th><th class="num">Messages</th></tr></thead>
+                    <tbody>
+                    {% for queue in health.queues %}
+                        <tr><td>{{ queue.queue_name }}</td><td class="num">{{ queue.message_count }}</td></tr>
+                    {% else %}
+                        <tr><td colspan="2" class="empty">Aucune queue lisible.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="panel">
+            <div class="panel-header"><h2>Logs recents</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Log</th><th>Updated</th><th class="num">KB</th></tr></thead>
+                    <tbody>
+                    {% for log in health.logs %}
+                        <tr><td class="mono">{{ log.path }}</td><td>{{ log.updated_at }}</td><td class="num">{{ log.size_kb }}</td></tr>
+                    {% else %}
+                        <tr><td colspan="3" class="empty">Aucun log trouve.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/trading-app/templates/front/temporal.html.twig
+++ b/trading-app/templates/front/temporal.html.twig
@@ -1,0 +1,135 @@
+{% extends 'front/base.html.twig' %}
+
+{% block title %}Temporal | TradingV3 Ops{% endblock %}
+
+{% block body %}
+    <section class="page-header">
+        <div>
+            <h1>Temporal</h1>
+            <p>Administration et monitoring de la stack Temporal MTF.</p>
+        </div>
+        <div class="header-actions" data-auto-refresh data-refresh-url="{{ path('front_api_temporal_summary') }}" data-refresh-interval="30000">
+            <span class="live-dot"></span>
+            <a href="{{ temporal.ui.url }}" target="_blank" rel="noreferrer">Temporal UI</a>
+        </div>
+    </section>
+
+    <section class="metric-grid">
+        <div class="metric">
+            <span>Address</span>
+            <strong class="metric-text">{{ temporal.cluster.address }}</strong>
+        </div>
+        <div class="metric">
+            <span>Namespace</span>
+            <strong class="metric-text">{{ temporal.cluster.namespace }}</strong>
+        </div>
+        <div class="metric">
+            <span>Task queues</span>
+            <strong>{{ temporal.task_queues|length }}</strong>
+        </div>
+        <div class="metric {{ temporal.workers is empty ? 'warning' : '' }}">
+            <span>Workers</span>
+            <strong>{{ temporal.workers|length }}</strong>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header"><h2>Cluster</h2></div>
+            <dl class="kv-grid">
+                <dt>gRPC</dt><dd class="mono">{{ temporal.cluster.address }} / host {{ temporal.cluster.grpc_port }}</dd>
+                <dt>Namespace</dt><dd class="mono">{{ temporal.cluster.namespace }}</dd>
+                <dt>Task queue MTF</dt><dd class="mono">{{ temporal.cluster.task_queue|default('-') }}</dd>
+                <dt>Workflow ID</dt><dd class="mono">{{ temporal.cluster.workflow_id|default('-') }}</dd>
+                <dt>HTTP API</dt><dd>{{ temporal.cluster.http_api_enabled ? 'activee' : 'non declaree' }}</dd>
+                <dt>UI</dt><dd><a href="{{ temporal.ui.url }}" target="_blank" rel="noreferrer">{{ temporal.ui.url }}</a></dd>
+            </dl>
+        </div>
+        <div class="panel">
+            <div class="panel-header"><h2>Checks</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Check</th><th>Status</th><th>Detail</th></tr></thead>
+                    <tbody>
+                    {% for check in temporal.checks %}
+                        <tr><td>{{ check.name }}</td><td><span class="pill {{ check.status }}">{{ check.status }}</span></td><td>{{ check.detail }}</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+
+    <section class="layout-two">
+        <div class="panel">
+            <div class="panel-header"><h2>Services Docker</h2><span>{{ temporal.services|length }}</span></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Service</th><th>Container</th><th>Image</th><th>Ports</th><th>Health</th></tr></thead>
+                    <tbody>
+                    {% for service in temporal.services %}
+                        <tr>
+                            <td class="mono">{{ service.name }}</td>
+                            <td class="mono">{{ service.container_name }}</td>
+                            <td>{{ service.image|default('-') }}</td>
+                            <td class="mono">{{ service.ports|join(', ') ?: service.expose|join(', ') }}</td>
+                            <td>{{ service.has_healthcheck ? 'oui' : 'non' }}</td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="5" class="empty">Aucun service Temporal trouve.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="panel">
+            <div class="panel-header"><h2>Workers & task queues</h2></div>
+            <div class="table-wrap compact">
+                <table>
+                    <thead><tr><th>Worker</th><th>Task queue</th><th class="num">MTF</th><th class="num">Micro</th><th>Target</th></tr></thead>
+                    <tbody>
+                    {% for worker in temporal.workers %}
+                        <tr>
+                            <td class="mono">{{ worker.container_name }}</td>
+                            <td class="mono">{{ worker.task_queue }}</td>
+                            <td class="num">{{ worker.workers_count|default('-') }}</td>
+                            <td class="num">{{ worker.scalper_micro_workers_count|default('-') }}</td>
+                            <td class="mono">{{ worker.target_url|default('-') }}</td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="5" class="empty">Aucun worker Temporal declare.</td></tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+
+    <section class="panel">
+        <div class="panel-header"><h2>Commandes admin</h2></div>
+        <div class="table-wrap">
+            <table>
+                <thead><tr><th>Action</th><th>Commande</th></tr></thead>
+                <tbody>
+                {% for command in temporal.admin_commands %}
+                    <tr><td>{{ command.label }}</td><td class="mono">{{ command.command }}</td></tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="panel">
+        <div class="panel-header"><h2>Fichiers surveilles</h2></div>
+        <div class="table-wrap compact">
+            <table>
+                <thead><tr><th>Fichier</th><th>Existe</th><th>Updated</th><th class="num">KB</th></tr></thead>
+                <tbody>
+                {% for file in temporal.config_files %}
+                    <tr><td class="mono">{{ file.path }}</td><td>{{ file.exists ? 'oui' : 'non' }}</td><td>{{ file.updated_at|default('-') }}</td><td class="num">{{ file.size_kb|default('-') }}</td></tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+{% endblock %}

--- a/trading-app/tests/Front/FrontRouteRegistrationTest.php
+++ b/trading-app/tests/Front/FrontRouteRegistrationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Front;
+
+use App\Kernel;
+use App\Front\Controller\FrontConfigController;
+use App\Front\Controller\FrontController;
+use App\Front\Controller\FrontDecisionController;
+use App\Front\Controller\FrontInvestigationController;
+use App\Front\Controller\FrontRiskController;
+use App\Front\Controller\FrontSystemController;
+use App\Front\Controller\FrontTemporalController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+#[CoversClass(FrontController::class)]
+#[CoversClass(FrontRiskController::class)]
+#[CoversClass(FrontDecisionController::class)]
+#[CoversClass(FrontInvestigationController::class)]
+#[CoversClass(FrontSystemController::class)]
+#[CoversClass(FrontConfigController::class)]
+#[CoversClass(FrontTemporalController::class)]
+final class FrontRouteRegistrationTest extends KernelTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $_ENV['DEFAULT_URI'] = 'http://localhost';
+        $_SERVER['DEFAULT_URI'] = 'http://localhost';
+        putenv('DEFAULT_URI=http://localhost');
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    public function testMainFrontRoutesAreRegistered(): void
+    {
+        self::bootKernel();
+
+        $router = self::$kernel?->getContainer()->get('router');
+        self::assertInstanceOf(RouterInterface::class, $router);
+
+        $expectedRoutes = [
+            'front_cockpit' => '/app',
+            'front_risk' => '/app/risk',
+            'front_decisions' => '/app/decisions',
+            'front_decision_detail' => '/app/decisions/decision-key',
+            'front_investigate' => '/app/investigate',
+            'front_system' => '/app/system',
+            'front_temporal' => '/app/temporal',
+            'front_config' => '/app/config',
+            'front_api_cockpit_summary' => '/app/api/cockpit/summary',
+            'front_api_risk_summary' => '/app/api/risk/summary',
+            'front_api_decisions_latest' => '/app/api/decisions/latest',
+            'front_api_system_health' => '/app/api/system/health',
+            'front_api_temporal_summary' => '/app/api/temporal/summary',
+        ];
+
+        foreach ($expectedRoutes as $name => $path) {
+            self::assertSame($path, $router->generate($name, $name === 'front_decision_detail' ? ['decisionKey' => 'decision-key'] : []));
+        }
+    }
+}

--- a/trading-app/tests/Front/Query/DecisionSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/DecisionSummaryQueryTest.php
@@ -55,6 +55,74 @@ CREATE TABLE mtf_run_symbol (
     created_at DATETIME NOT NULL
 )
 SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE order_intent (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    timeframe VARCHAR(10) NULL,
+    side INTEGER NULL,
+    type VARCHAR(20) NULL,
+    status VARCHAR(30) NOT NULL,
+    price NUMERIC NULL,
+    size INTEGER NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    exchange_order_id VARCHAR(80) NULL,
+    failure_reason TEXT NULL,
+    decision_key VARCHAR(255) NULL,
+    strategy_profile VARCHAR(80) NULL,
+    strategy_version VARCHAR(80) NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    sent_at DATETIME NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE trade_zone_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    happened_at DATETIME NOT NULL,
+    reason VARCHAR(80) NOT NULL,
+    decision_key VARCHAR(255) NULL,
+    timeframe VARCHAR(10) NULL,
+    config_profile VARCHAR(80) NULL,
+    zone_min NUMERIC NULL,
+    zone_max NUMERIC NULL,
+    candidate_price NUMERIC NULL,
+    zone_dev_pct NUMERIC NULL,
+    zone_max_dev_pct NUMERIC NULL,
+    atr_pct NUMERIC NULL,
+    spread_bps NUMERIC NULL,
+    volume_ratio NUMERIC NULL,
+    vwap_distance_pct NUMERIC NULL,
+    entry_zone_width_pct NUMERIC NULL,
+    mtf_level VARCHAR(20) NULL,
+    category VARCHAR(80) NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE trade_lifecycle_event (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol VARCHAR(50) NOT NULL,
+    event_type VARCHAR(80) NOT NULL,
+    run_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    client_order_id VARCHAR(80) NULL,
+    side VARCHAR(10) NULL,
+    qty NUMERIC NULL,
+    price NUMERIC NULL,
+    timeframe VARCHAR(10) NULL,
+    config_profile VARCHAR(80) NULL,
+    config_version VARCHAR(80) NULL,
+    reason_code VARCHAR(80) NULL,
+    extra TEXT NULL,
+    happened_at DATETIME NOT NULL
+)
+SQL);
     }
 
     public function testRejectedSymbolShowsReadablePrimaryReason(): void
@@ -96,5 +164,50 @@ SQL);
         self::assertSame('ETHUSDT', $view->symbols[0]['symbol']);
         self::assertSame('Filtres obligatoires non validés', $view->symbols[0]['primary_reason']);
         self::assertSame(['rsi_bullish', 'near_vwap'], $view->symbols[0]['failed_rules']);
+    }
+
+    public function testDetailFindsLifecycleRowsThroughOrderIntentOrderIds(): void
+    {
+        $this->connection->insert('order_intent', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'timeframe' => '1m',
+            'side' => 1,
+            'type' => 'limit',
+            'status' => 'SENT',
+            'price' => '14.2',
+            'size' => 1,
+            'client_order_id' => 'client-order-1',
+            'order_id' => null,
+            'exchange_order_id' => 'exchange-order-1',
+            'failure_reason' => null,
+            'decision_key' => 'decision-1',
+            'strategy_profile' => 'scalper_micro',
+            'strategy_version' => 'test',
+            'created_at' => '2026-06-01 10:00:00',
+            'updated_at' => '2026-06-01 10:01:00',
+            'sent_at' => '2026-06-01 10:01:00',
+        ]);
+        $this->connection->insert('trade_lifecycle_event', [
+            'symbol' => 'LINKUSDT',
+            'event_type' => 'order_submitted',
+            'run_id' => null,
+            'order_id' => 'exchange-order-1',
+            'client_order_id' => null,
+            'side' => 'LONG',
+            'qty' => '1',
+            'price' => '14.2',
+            'timeframe' => '1m',
+            'config_profile' => 'scalper_micro',
+            'config_version' => 'test',
+            'reason_code' => null,
+            'extra' => '{}',
+            'happened_at' => '2026-06-01 10:02:00',
+        ]);
+
+        $detail = (new DecisionSummaryQuery($this->connection))->detail('decision-1');
+
+        self::assertSame(['exchange-order-1'], array_column($detail['lifecycle_events'], 'order_id'));
     }
 }

--- a/trading-app/tests/Front/Query/DecisionSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/DecisionSummaryQueryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Front\Query;
+
+use App\Front\Query\DecisionSummaryQuery;
+use App\Front\ViewModel\DecisionSummaryView;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DecisionSummaryQuery::class)]
+#[CoversClass(DecisionSummaryView::class)]
+final class DecisionSummaryQueryTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE mtf_run (
+    run_id VARCHAR(64) PRIMARY KEY,
+    status VARCHAR(64) NOT NULL,
+    execution_time_seconds NUMERIC NOT NULL,
+    symbols_requested INTEGER NOT NULL,
+    symbols_processed INTEGER NOT NULL,
+    symbols_successful INTEGER NOT NULL,
+    symbols_failed INTEGER NOT NULL,
+    symbols_skipped INTEGER NOT NULL,
+    success_rate NUMERIC NOT NULL,
+    dry_run BOOLEAN NOT NULL,
+    force_run BOOLEAN NOT NULL,
+    current_tf VARCHAR(8) NULL,
+    started_at DATETIME NOT NULL,
+    finished_at DATETIME NULL,
+    workers INTEGER NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE mtf_run_symbol (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id VARCHAR(64) NOT NULL,
+    symbol VARCHAR(32) NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    execution_tf VARCHAR(8) NULL,
+    blocking_tf VARCHAR(8) NULL,
+    signal_side VARCHAR(8) NULL,
+    current_price NUMERIC NULL,
+    trading_decision TEXT NULL,
+    error TEXT NULL,
+    context TEXT NULL,
+    created_at DATETIME NOT NULL
+)
+SQL);
+    }
+
+    public function testRejectedSymbolShowsReadablePrimaryReason(): void
+    {
+        $this->connection->insert('mtf_run', [
+            'run_id' => 'run-1',
+            'status' => 'completed',
+            'execution_time_seconds' => '18.3',
+            'symbols_requested' => 1,
+            'symbols_processed' => 1,
+            'symbols_successful' => 0,
+            'symbols_failed' => 1,
+            'symbols_skipped' => 0,
+            'success_rate' => '0.00',
+            'dry_run' => 0,
+            'force_run' => 0,
+            'current_tf' => '1m',
+            'started_at' => '2026-06-01 10:00:00',
+            'finished_at' => '2026-06-01 10:00:18',
+            'workers' => 8,
+        ]);
+        $this->connection->insert('mtf_run_symbol', [
+            'run_id' => 'run-1',
+            'symbol' => 'ETHUSDT',
+            'status' => 'NO_LONG_NO_SHORT',
+            'execution_tf' => '1m',
+            'blocking_tf' => '5m',
+            'signal_side' => null,
+            'current_price' => '3720.10',
+            'trading_decision' => json_encode(['status' => 'SKIPPED', 'reason' => 'filters_mandatory_failed_execution_selector_empty'], JSON_THROW_ON_ERROR),
+            'error' => null,
+            'context' => json_encode(['rules_failed' => ['rsi_bullish', 'near_vwap']], JSON_THROW_ON_ERROR),
+            'created_at' => '2026-06-01 10:00:18',
+        ]);
+
+        $view = (new DecisionSummaryQuery($this->connection))->latest();
+
+        self::assertSame('run-1', $view->runs[0]['run_id']);
+        self::assertSame('ETHUSDT', $view->symbols[0]['symbol']);
+        self::assertSame('Filtres obligatoires non validés', $view->symbols[0]['primary_reason']);
+        self::assertSame(['rsi_bullish', 'near_vwap'], $view->symbols[0]['failed_rules']);
+    }
+}

--- a/trading-app/tests/Front/Query/InvestigationQueryTest.php
+++ b/trading-app/tests/Front/Query/InvestigationQueryTest.php
@@ -52,6 +52,44 @@ CREATE TABLE entry_zone_live (
     status VARCHAR(30) NULL
 )
 SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE futures_order (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side INTEGER NULL,
+    type VARCHAR(20) NULL,
+    status VARCHAR(30) NULL,
+    price NUMERIC NULL,
+    size INTEGER NULL,
+    filled_size NUMERIC NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE futures_plan_order (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side INTEGER NULL,
+    type VARCHAR(20) NULL,
+    status VARCHAR(30) NULL,
+    trigger_price NUMERIC NULL,
+    execution_price NUMERIC NULL,
+    price NUMERIC NULL,
+    size INTEGER NULL,
+    plan_type VARCHAR(20) NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL
+)
+SQL);
     }
 
     public function testInvestigationScopesMtfSymbolsToRequestedTimeWindowAndReadsEntryZoneAtr(): void
@@ -107,5 +145,71 @@ SQL);
 
         self::assertSame(['run-in-window'], array_column($result['sections']['mtf_symbols'], 'run_id'));
         self::assertSame('0.0042', (string) $result['sections']['entry_zones'][0]['atr_pct_1m']);
+    }
+
+    public function testInvestigationSkipsSectionsThatCannotBeScopedByTheSubmittedCriteria(): void
+    {
+        $this->connection->insert('mtf_run_symbol', [
+            'run_id' => 'unrelated-run',
+            'symbol' => 'LINKUSDT',
+            'status' => 'VALID',
+            'execution_tf' => '1m',
+            'blocking_tf' => null,
+            'signal_side' => 'LONG',
+            'current_price' => '14.2',
+            'trading_decision' => 'LONG',
+            'error' => null,
+            'context' => '{}',
+            'created_at' => '2026-06-01 10:15:00',
+        ]);
+        $this->connection->insert('futures_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 1,
+            'type' => 'limit',
+            'status' => 'open',
+            'price' => '14.2',
+            'size' => 1,
+            'filled_size' => '0',
+            'client_order_id' => 'unrelated-order',
+            'order_id' => 'exchange-unrelated-order',
+            'created_at' => '2026-06-01 10:15:00',
+            'updated_at' => '2026-06-01 10:15:00',
+        ]);
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 1,
+            'type' => 'stop_loss',
+            'status' => 'active',
+            'trigger_price' => '13.9',
+            'execution_price' => null,
+            'price' => '13.9',
+            'size' => 1,
+            'plan_type' => 'stop_loss',
+            'client_order_id' => 'unrelated-plan',
+            'order_id' => 'exchange-unrelated-plan',
+            'created_at' => '2026-06-01 10:15:00',
+            'updated_at' => '2026-06-01 10:15:00',
+        ]);
+
+        $decisionKeyOnly = (new InvestigationQuery($this->connection, sys_get_temp_dir()))->investigate(
+            null,
+            null,
+            'decision-key-only',
+            null,
+        );
+        $runIdOnly = (new InvestigationQuery($this->connection, sys_get_temp_dir()))->investigate(
+            null,
+            null,
+            null,
+            'run-id-only',
+        );
+
+        self::assertSame([], $decisionKeyOnly['sections']['mtf_symbols']);
+        self::assertSame([], $runIdOnly['sections']['orders']);
+        self::assertSame([], $runIdOnly['sections']['plan_orders']);
     }
 }

--- a/trading-app/tests/Front/Query/InvestigationQueryTest.php
+++ b/trading-app/tests/Front/Query/InvestigationQueryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Front\Query;
+
+use App\Front\Query\InvestigationQuery;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(InvestigationQuery::class)]
+final class InvestigationQueryTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE mtf_run_symbol (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id VARCHAR(80) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    execution_tf VARCHAR(10) NULL,
+    blocking_tf VARCHAR(10) NULL,
+    signal_side VARCHAR(10) NULL,
+    current_price NUMERIC NULL,
+    trading_decision VARCHAR(30) NULL,
+    error TEXT NULL,
+    context TEXT NULL,
+    created_at DATETIME NOT NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE entry_zone_live (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol VARCHAR(50) NOT NULL,
+    side VARCHAR(10) NOT NULL,
+    price_min NUMERIC NOT NULL,
+    price_max NUMERIC NOT NULL,
+    atr_pct_1m NUMERIC NULL,
+    vwap NUMERIC NULL,
+    volume_ratio NUMERIC NULL,
+    config_profile VARCHAR(80) NULL,
+    config_version VARCHAR(80) NULL,
+    valid_from DATETIME NULL,
+    valid_until DATETIME NULL,
+    created_at DATETIME NOT NULL,
+    status VARCHAR(30) NULL
+)
+SQL);
+    }
+
+    public function testInvestigationScopesMtfSymbolsToRequestedTimeWindowAndReadsEntryZoneAtr(): void
+    {
+        $this->connection->insert('mtf_run_symbol', [
+            'run_id' => 'run-in-window',
+            'symbol' => 'LINKUSDT',
+            'status' => 'VALID',
+            'execution_tf' => '1m',
+            'blocking_tf' => null,
+            'signal_side' => 'LONG',
+            'current_price' => '14.2',
+            'trading_decision' => 'LONG',
+            'error' => null,
+            'context' => '{}',
+            'created_at' => '2026-06-01 10:15:00',
+        ]);
+        $this->connection->insert('mtf_run_symbol', [
+            'run_id' => 'run-outside-window',
+            'symbol' => 'LINKUSDT',
+            'status' => 'VALID',
+            'execution_tf' => '1m',
+            'blocking_tf' => null,
+            'signal_side' => 'LONG',
+            'current_price' => '14.3',
+            'trading_decision' => 'LONG',
+            'error' => null,
+            'context' => '{}',
+            'created_at' => '2026-06-01 14:15:00',
+        ]);
+        $this->connection->insert('entry_zone_live', [
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'price_min' => '14.10',
+            'price_max' => '14.30',
+            'atr_pct_1m' => '0.0042',
+            'vwap' => '14.20',
+            'volume_ratio' => '1.1',
+            'config_profile' => 'scalper_micro',
+            'config_version' => 'test',
+            'valid_from' => '2026-06-01 10:00:00',
+            'valid_until' => '2026-06-01 10:05:00',
+            'created_at' => '2026-06-01 10:01:00',
+            'status' => 'active',
+        ]);
+
+        $result = (new InvestigationQuery($this->connection, sys_get_temp_dir()))->investigate(
+            'LINKUSDT',
+            '2026-06-01 10:00:00',
+            null,
+            null,
+        );
+
+        self::assertSame(['run-in-window'], array_column($result['sections']['mtf_symbols'], 'run_id'));
+        self::assertSame('0.0042', (string) $result['sections']['entry_zones'][0]['atr_pct_1m']);
+    }
+}

--- a/trading-app/tests/Front/Query/InvestigationQueryTest.php
+++ b/trading-app/tests/Front/Query/InvestigationQueryTest.php
@@ -90,6 +90,25 @@ CREATE TABLE futures_plan_order (
     updated_at DATETIME NOT NULL
 )
 SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE trade_lifecycle_event (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol VARCHAR(50) NOT NULL,
+    event_type VARCHAR(80) NOT NULL,
+    run_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    client_order_id VARCHAR(80) NULL,
+    side VARCHAR(10) NULL,
+    qty NUMERIC NULL,
+    price NUMERIC NULL,
+    timeframe VARCHAR(10) NULL,
+    config_profile VARCHAR(80) NULL,
+    config_version VARCHAR(80) NULL,
+    reason_code VARCHAR(80) NULL,
+    extra TEXT NULL,
+    happened_at DATETIME NOT NULL
+)
+SQL);
     }
 
     public function testInvestigationScopesMtfSymbolsToRequestedTimeWindowAndReadsEntryZoneAtr(): void
@@ -211,5 +230,34 @@ SQL);
         self::assertSame([], $decisionKeyOnly['sections']['mtf_symbols']);
         self::assertSame([], $runIdOnly['sections']['orders']);
         self::assertSame([], $runIdOnly['sections']['plan_orders']);
+    }
+
+    public function testDecisionKeyInvestigationFindsLifecycleRowsByOrderIds(): void
+    {
+        $this->connection->insert('trade_lifecycle_event', [
+            'symbol' => 'LINKUSDT',
+            'event_type' => 'order_submitted',
+            'run_id' => null,
+            'order_id' => null,
+            'client_order_id' => 'decision-client-order',
+            'side' => 'LONG',
+            'qty' => '1',
+            'price' => '14.2',
+            'timeframe' => '1m',
+            'config_profile' => 'scalper_micro',
+            'config_version' => 'test',
+            'reason_code' => null,
+            'extra' => '{}',
+            'happened_at' => '2026-06-01 10:15:00',
+        ]);
+
+        $result = (new InvestigationQuery($this->connection, sys_get_temp_dir()))->investigate(
+            null,
+            null,
+            'decision-client-order',
+            null,
+        );
+
+        self::assertSame(['decision-client-order'], array_column($result['sections']['lifecycle'], 'client_order_id'));
     }
 }

--- a/trading-app/tests/Front/Query/InvestigationQueryTest.php
+++ b/trading-app/tests/Front/Query/InvestigationQueryTest.php
@@ -91,6 +91,30 @@ CREATE TABLE futures_plan_order (
 )
 SQL);
         $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE order_intent (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    decision_key VARCHAR(255) NULL,
+    strategy_profile VARCHAR(80) NULL,
+    strategy_version VARCHAR(80) NULL,
+    symbol VARCHAR(50) NOT NULL,
+    timeframe VARCHAR(10) NULL,
+    side INTEGER NULL,
+    type VARCHAR(20) NULL,
+    status VARCHAR(30) NOT NULL,
+    price NUMERIC NULL,
+    size INTEGER NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    exchange_order_id VARCHAR(80) NULL,
+    failure_reason TEXT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    sent_at DATETIME NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
 CREATE TABLE trade_lifecycle_event (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     symbol VARCHAR(50) NOT NULL,
@@ -234,12 +258,33 @@ SQL);
 
     public function testDecisionKeyInvestigationFindsLifecycleRowsByOrderIds(): void
     {
+        $this->connection->insert('order_intent', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'decision_key' => 'decision-key',
+            'strategy_profile' => 'scalper_micro',
+            'strategy_version' => 'test',
+            'symbol' => 'LINKUSDT',
+            'timeframe' => '1m',
+            'side' => 1,
+            'type' => 'limit',
+            'status' => 'SENT',
+            'price' => '14.2',
+            'size' => 1,
+            'client_order_id' => 'decision-client-order',
+            'order_id' => null,
+            'exchange_order_id' => 'exchange-decision-order',
+            'failure_reason' => null,
+            'created_at' => '2026-06-01 10:00:00',
+            'updated_at' => '2026-06-01 10:01:00',
+            'sent_at' => '2026-06-01 10:01:00',
+        ]);
         $this->connection->insert('trade_lifecycle_event', [
             'symbol' => 'LINKUSDT',
             'event_type' => 'order_submitted',
             'run_id' => null,
-            'order_id' => null,
-            'client_order_id' => 'decision-client-order',
+            'order_id' => 'exchange-decision-order',
+            'client_order_id' => null,
             'side' => 'LONG',
             'qty' => '1',
             'price' => '14.2',
@@ -254,10 +299,10 @@ SQL);
         $result = (new InvestigationQuery($this->connection, sys_get_temp_dir()))->investigate(
             null,
             null,
-            'decision-client-order',
+            'decision-key',
             null,
         );
 
-        self::assertSame(['decision-client-order'], array_column($result['sections']['lifecycle'], 'client_order_id'));
+        self::assertSame(['exchange-decision-order'], array_column($result['sections']['lifecycle'], 'order_id'));
     }
 }

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -232,7 +232,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => 'active',
             'trigger_price' => '13.90',
@@ -275,7 +275,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => 'active',
             'trigger_price' => '13.90',
@@ -302,6 +302,56 @@ SQL);
         self::assertFalse($bySide['SHORT']['has_stop_loss']);
         self::assertSame(1, $view->criticalAlertCount);
         self::assertSame('SHORT', $view->alerts[0]->context['side']);
+    }
+
+    public function testProjectedNumericProtectionSideTwoMatchesShortPosition(): void
+    {
+        foreach (['LONG', 'SHORT'] as $side) {
+            $this->connection->insert('positions', [
+                'exchange' => 'bitmart',
+                'market_type' => 'perpetual',
+                'symbol' => 'LINKUSDT',
+                'side' => $side,
+                'size' => '42',
+                'avg_entry_price' => '14.25',
+                'leverage' => 8,
+                'unrealized_pnl' => '-3.10',
+                'status' => 'OPEN',
+                'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+                'updated_at' => '2026-06-01 10:00:00',
+            ]);
+        }
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 2,
+            'type' => 'stop_loss',
+            'status' => 'active',
+            'trigger_price' => '14.60',
+            'price' => '14.60',
+            'size' => 42,
+            'client_order_id' => 'short-sl-plan-order',
+            'order_id' => 'exchange-short-sl-plan-order',
+            'plan_type' => 'stop_loss',
+            'raw_data' => '{}',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        $bySide = [];
+        foreach ($view->positions as $position) {
+            $bySide[$position['side']] = $position;
+        }
+
+        self::assertFalse($bySide['LONG']['has_stop_loss']);
+        self::assertTrue($bySide['SHORT']['has_stop_loss']);
+        self::assertSame(1, $view->criticalAlertCount);
+        self::assertSame('LONG', $view->alerts[0]->context['side']);
     }
 
     public function testFailedOrderProtectionDoesNotSuppressMissingStopLossAlert(): void
@@ -367,7 +417,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => '1',
             'trigger_price' => '13.90',
@@ -427,7 +477,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => 'cancelled',
             'trigger_price' => '13.90',
@@ -468,7 +518,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => null,
             'trigger_price' => '13.90',
@@ -509,7 +559,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => 'cancelled',
             'trigger_price' => '13.90',
@@ -570,7 +620,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => 'active',
             'trigger_price' => '13.90',

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -229,7 +229,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 3,
+            'side' => 2,
             'type' => 'stop_loss',
             'status' => 'active',
             'trigger_price' => '13.90',
@@ -272,7 +272,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 3,
+            'side' => 2,
             'type' => 'stop_loss',
             'status' => 'active',
             'trigger_price' => '13.90',
@@ -330,6 +330,104 @@ SQL);
             'price' => '13.90',
             'client_order_id' => 'failed-sl-protection',
             'order_id' => 'exchange-failed-sl-protection',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertFalse($view->positions[0]['has_stop_loss']);
+        self::assertSame(1, $view->criticalAlertCount);
+    }
+
+    public function testNumericOpenPlanOrderStatusCanProtectPosition(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 2,
+            'type' => 'stop_loss',
+            'status' => '1',
+            'trigger_price' => '13.90',
+            'price' => '13.90',
+            'size' => 42,
+            'client_order_id' => 'numeric-open-sl-plan-order',
+            'order_id' => 'exchange-numeric-open-sl-plan-order',
+            'plan_type' => 'stop_loss',
+            'raw_data' => '{}',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertTrue($view->positions[0]['has_stop_loss']);
+        self::assertSame(0, $view->criticalAlertCount);
+    }
+
+    public function testSentOrderProtectionWithCancelledPlanDoesNotSuppressMissingStopLossAlert(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('order_intent', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 1,
+            'status' => 'SENT',
+            'updated_at' => '2026-06-01 09:59:00',
+        ]);
+        $this->connection->insert('order_protection', [
+            'order_intent_id' => 1,
+            'type' => 'stop_loss',
+            'price' => '13.90',
+            'client_order_id' => 'stale-sl-protection',
+            'order_id' => 'exchange-stale-sl-protection',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 2,
+            'type' => 'stop_loss',
+            'status' => 'cancelled',
+            'trigger_price' => '13.90',
+            'price' => '13.90',
+            'size' => 42,
+            'client_order_id' => 'stale-sl-protection',
+            'order_id' => 'exchange-stale-sl-protection',
+            'plan_type' => 'stop_loss',
+            'raw_data' => '{}',
             'updated_at' => '2026-06-01 10:01:00',
         ]);
 

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -88,6 +88,28 @@ CREATE TABLE symbol_execution_lock (
     released_at DATETIME NULL
 )
 SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE order_intent (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side INTEGER NULL,
+    status VARCHAR(30) NOT NULL,
+    updated_at DATETIME NOT NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE order_protection (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_intent_id INTEGER NOT NULL,
+    type VARCHAR(20) NOT NULL,
+    price NUMERIC NOT NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    updated_at DATETIME NOT NULL
+)
+SQL);
     }
 
     public function testOpenPositionWithoutStopLossProducesCriticalAlert(): void
@@ -207,7 +229,7 @@ SQL);
             'exchange' => 'bitmart',
             'market_type' => 'perpetual',
             'symbol' => 'LINKUSDT',
-            'side' => 2,
+            'side' => 3,
             'type' => 'stop_loss',
             'status' => 'active',
             'trigger_price' => '13.90',
@@ -227,5 +249,96 @@ SQL);
 
         self::assertTrue($view->positions[0]['has_stop_loss']);
         self::assertSame(0, $view->criticalAlertCount);
+    }
+
+    public function testStopLossProtectionMustMatchPositionSide(): void
+    {
+        foreach (['LONG', 'SHORT'] as $side) {
+            $this->connection->insert('positions', [
+                'exchange' => 'bitmart',
+                'market_type' => 'perpetual',
+                'symbol' => 'LINKUSDT',
+                'side' => $side,
+                'size' => '42',
+                'avg_entry_price' => '14.25',
+                'leverage' => 8,
+                'unrealized_pnl' => '-3.10',
+                'status' => 'OPEN',
+                'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+                'updated_at' => '2026-06-01 10:00:00',
+            ]);
+        }
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 3,
+            'type' => 'stop_loss',
+            'status' => 'active',
+            'trigger_price' => '13.90',
+            'price' => '13.90',
+            'size' => 42,
+            'client_order_id' => 'long-sl-plan-order',
+            'order_id' => 'exchange-long-sl-plan-order',
+            'plan_type' => 'stop_loss',
+            'raw_data' => '{}',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        $bySide = [];
+        foreach ($view->positions as $position) {
+            $bySide[$position['side']] = $position;
+        }
+
+        self::assertTrue($bySide['LONG']['has_stop_loss']);
+        self::assertFalse($bySide['SHORT']['has_stop_loss']);
+        self::assertSame(1, $view->criticalAlertCount);
+        self::assertSame('SHORT', $view->alerts[0]->context['side']);
+    }
+
+    public function testFailedOrderProtectionDoesNotSuppressMissingStopLossAlert(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('order_intent', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 1,
+            'status' => 'FAILED',
+            'updated_at' => '2026-06-01 09:59:00',
+        ]);
+        $this->connection->insert('order_protection', [
+            'order_intent_id' => 1,
+            'type' => 'stop_loss',
+            'price' => '13.90',
+            'client_order_id' => 'failed-sl-protection',
+            'order_id' => 'exchange-failed-sl-protection',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertFalse($view->positions[0]['has_stop_loss']);
+        self::assertSame(1, $view->criticalAlertCount);
     }
 }

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -139,4 +139,48 @@ SQL);
         self::assertSame('stale_symbol_lock', $view->alerts[0]->code);
         self::assertSame('BTCUSDT', $view->alerts[0]->symbol);
     }
+
+    public function testOpenOrdersIncludeSentAndExchangeNumericStatesInTotals(): void
+    {
+        foreach (['sent', '1', '2'] as $index => $status) {
+            $this->connection->insert('futures_order', [
+                'exchange' => 'bitmart',
+                'market_type' => 'perpetual',
+                'symbol' => 'ETHUSDT',
+                'side' => 1,
+                'type' => 'limit',
+                'status' => $status,
+                'price' => '3500',
+                'size' => 1,
+                'client_order_id' => 'order-' . $index,
+                'order_id' => 'exchange-order-' . $index,
+                'updated_at' => '2026-06-01 10:0' . $index . ':00',
+            ]);
+        }
+
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'ETHUSDT',
+            'side' => 1,
+            'type' => 'take_profit',
+            'status' => 'active',
+            'trigger_price' => '3600',
+            'price' => '3600',
+            'size' => 1,
+            'client_order_id' => 'plan-order',
+            'order_id' => 'exchange-plan-order',
+            'updated_at' => '2026-06-01 10:05:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertSame(3, $view->openOrderCount);
+        self::assertSame(1, $view->openPlanOrderCount);
+        self::assertSame(4, $view->openOrderTotalCount);
+        self::assertSame(4, $view->toArray()['open_order_total_count']);
+    }
 }

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -490,6 +490,48 @@ SQL);
         self::assertSame(0, $view->criticalAlertCount);
     }
 
+    public function testTerminalPlanOrderStatusWinsOverRawOpenState(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 2,
+            'type' => 'stop_loss',
+            'status' => 'cancelled',
+            'trigger_price' => '13.90',
+            'price' => '13.90',
+            'size' => 42,
+            'client_order_id' => 'cancelled-raw-state-sl-plan-order',
+            'order_id' => 'exchange-cancelled-raw-state-sl-plan-order',
+            'plan_type' => 'stop_loss',
+            'raw_data' => json_encode(['state' => 1], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertSame(0, $view->openPlanOrderCount);
+        self::assertFalse($view->positions[0]['has_stop_loss']);
+        self::assertSame(1, $view->criticalAlertCount);
+    }
+
     public function testStoredProtectionUsesParentIntentIdsToFindActivePlanOrder(): void
     {
         $this->connection->insert('positions', [
@@ -548,5 +590,62 @@ SQL);
 
         self::assertTrue($view->positions[0]['has_stop_loss']);
         self::assertSame(0, $view->criticalAlertCount);
+    }
+
+    public function testStoredProtectionDoesNotUseParentEntryOrderAsStopLoss(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('order_intent', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 1,
+            'status' => 'SENT',
+            'client_order_id' => 'entry-client-order',
+            'order_id' => null,
+            'exchange_order_id' => 'exchange-entry-order',
+            'updated_at' => '2026-06-01 09:59:00',
+        ]);
+        $this->connection->insert('order_protection', [
+            'order_intent_id' => 1,
+            'type' => 'stop_loss',
+            'price' => '13.90',
+            'client_order_id' => null,
+            'order_id' => null,
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+        $this->connection->insert('futures_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 1,
+            'type' => 'limit',
+            'status' => 'partially_filled',
+            'price' => '14.25',
+            'size' => 42,
+            'client_order_id' => 'entry-client-order',
+            'order_id' => 'exchange-entry-order',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertFalse($view->positions[0]['has_stop_loss']);
+        self::assertSame(1, $view->criticalAlertCount);
     }
 }

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -96,6 +96,9 @@ CREATE TABLE order_intent (
     symbol VARCHAR(50) NOT NULL,
     side INTEGER NULL,
     status VARCHAR(30) NOT NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    exchange_order_id VARCHAR(80) NULL,
     updated_at DATETIME NOT NULL
 )
 SQL);
@@ -322,6 +325,9 @@ SQL);
             'symbol' => 'LINKUSDT',
             'side' => 1,
             'status' => 'FAILED',
+            'client_order_id' => 'failed-entry-order',
+            'order_id' => null,
+            'exchange_order_id' => null,
             'updated_at' => '2026-06-01 09:59:00',
         ]);
         $this->connection->insert('order_protection', [
@@ -404,6 +410,9 @@ SQL);
             'symbol' => 'LINKUSDT',
             'side' => 1,
             'status' => 'SENT',
+            'client_order_id' => 'stale-entry-order',
+            'order_id' => null,
+            'exchange_order_id' => null,
             'updated_at' => '2026-06-01 09:59:00',
         ]);
         $this->connection->insert('order_protection', [
@@ -438,5 +447,106 @@ SQL);
 
         self::assertFalse($view->positions[0]['has_stop_loss']);
         self::assertSame(1, $view->criticalAlertCount);
+    }
+
+    public function testPlanOrderRawStateCanProtectPositionWhenStatusIsMissing(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 2,
+            'type' => 'stop_loss',
+            'status' => null,
+            'trigger_price' => '13.90',
+            'price' => '13.90',
+            'size' => 42,
+            'client_order_id' => 'raw-state-sl-plan-order',
+            'order_id' => 'exchange-raw-state-sl-plan-order',
+            'plan_type' => 'stop_loss',
+            'raw_data' => json_encode(['state' => 1], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertTrue($view->positions[0]['has_stop_loss']);
+        self::assertSame(0, $view->criticalAlertCount);
+    }
+
+    public function testStoredProtectionUsesParentIntentIdsToFindActivePlanOrder(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('order_intent', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 1,
+            'status' => 'SENT',
+            'client_order_id' => 'intent-client-order',
+            'order_id' => null,
+            'exchange_order_id' => 'exchange-intent-order',
+            'updated_at' => '2026-06-01 09:59:00',
+        ]);
+        $this->connection->insert('order_protection', [
+            'order_intent_id' => 1,
+            'type' => 'stop_loss',
+            'price' => '13.90',
+            'client_order_id' => null,
+            'order_id' => null,
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 2,
+            'type' => 'stop_loss',
+            'status' => 'active',
+            'trigger_price' => '13.90',
+            'price' => '13.90',
+            'size' => 42,
+            'client_order_id' => 'intent-client-order',
+            'order_id' => 'exchange-intent-order',
+            'plan_type' => 'stop_loss',
+            'raw_data' => '{}',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertTrue($view->positions[0]['has_stop_loss']);
+        self::assertSame(0, $view->criticalAlertCount);
     }
 }

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -69,6 +69,8 @@ CREATE TABLE futures_plan_order (
     size INTEGER NULL,
     client_order_id VARCHAR(80) NULL,
     order_id VARCHAR(80) NULL,
+    plan_type VARCHAR(20) NULL,
+    raw_data TEXT NOT NULL DEFAULT '{}',
     updated_at DATETIME NOT NULL
 )
 SQL);
@@ -170,6 +172,8 @@ SQL);
             'size' => 1,
             'client_order_id' => 'plan-order',
             'order_id' => 'exchange-plan-order',
+            'plan_type' => 'take_profit',
+            'raw_data' => '{}',
             'updated_at' => '2026-06-01 10:05:00',
         ]);
 
@@ -182,5 +186,46 @@ SQL);
         self::assertSame(1, $view->openPlanOrderCount);
         self::assertSame(4, $view->openOrderTotalCount);
         self::assertSame(4, $view->toArray()['open_order_total_count']);
+    }
+
+    public function testActiveStopLossPlanOrderSuppressesMissingStopLossAlert(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+        $this->connection->insert('futures_plan_order', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 2,
+            'type' => 'stop_loss',
+            'status' => 'active',
+            'trigger_price' => '13.90',
+            'price' => '13.90',
+            'size' => 42,
+            'client_order_id' => 'sl-plan-order',
+            'order_id' => 'exchange-sl-plan-order',
+            'plan_type' => 'stop_loss',
+            'raw_data' => '{}',
+            'updated_at' => '2026-06-01 10:01:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertTrue($view->positions[0]['has_stop_loss']);
+        self::assertSame(0, $view->criticalAlertCount);
     }
 }

--- a/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/RiskSummaryQueryTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Front\Query;
+
+use App\Front\Query\RiskSummaryQuery;
+use App\Front\ViewModel\FrontAlert;
+use App\Front\ViewModel\RiskSummaryView;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+#[CoversClass(RiskSummaryQuery::class)]
+#[CoversClass(RiskSummaryView::class)]
+#[CoversClass(FrontAlert::class)]
+final class RiskSummaryQueryTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE positions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side VARCHAR(10) NOT NULL,
+    size NUMERIC NULL,
+    avg_entry_price NUMERIC NULL,
+    leverage INTEGER NULL,
+    unrealized_pnl NUMERIC NULL,
+    status VARCHAR(16) NOT NULL,
+    payload TEXT NOT NULL,
+    updated_at DATETIME NOT NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE futures_order (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side INTEGER NULL,
+    type VARCHAR(20) NULL,
+    status VARCHAR(30) NULL,
+    price NUMERIC NULL,
+    size INTEGER NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    updated_at DATETIME NOT NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE futures_plan_order (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side INTEGER NULL,
+    type VARCHAR(20) NULL,
+    status VARCHAR(30) NULL,
+    trigger_price NUMERIC NULL,
+    price NUMERIC NULL,
+    size INTEGER NULL,
+    client_order_id VARCHAR(80) NULL,
+    order_id VARCHAR(80) NULL,
+    updated_at DATETIME NOT NULL
+)
+SQL);
+        $this->connection->executeStatement(<<<'SQL'
+CREATE TABLE symbol_execution_lock (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    status VARCHAR(24) NOT NULL,
+    owner_profile VARCHAR(80) NULL,
+    owner_decision_key VARCHAR(255) NULL,
+    locked_at DATETIME NOT NULL,
+    expires_at DATETIME NOT NULL,
+    released_at DATETIME NULL
+)
+SQL);
+    }
+
+    public function testOpenPositionWithoutStopLossProducesCriticalAlert(): void
+    {
+        $this->connection->insert('positions', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'LINKUSDT',
+            'side' => 'LONG',
+            'size' => '42',
+            'avg_entry_price' => '14.25',
+            'leverage' => 8,
+            'unrealized_pnl' => '-3.10',
+            'status' => 'OPEN',
+            'payload' => json_encode(['source' => 'exchange'], JSON_THROW_ON_ERROR),
+            'updated_at' => '2026-06-01 10:00:00',
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertSame(1, $view->openPositionCount);
+        self::assertSame(1, $view->criticalAlertCount);
+        self::assertSame('position_without_stop_loss', $view->alerts[0]->code);
+        self::assertSame('LINKUSDT', $view->alerts[0]->symbol);
+        self::assertStringContainsString('sans SL', $view->alerts[0]->message);
+    }
+
+    public function testExpiredExecutionLockIsReportedAsStale(): void
+    {
+        $this->connection->insert('symbol_execution_lock', [
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+            'symbol' => 'BTCUSDT',
+            'status' => 'ACTIVE',
+            'owner_profile' => 'scalper_micro',
+            'owner_decision_key' => 'decision-stale',
+            'locked_at' => '2026-06-01 09:30:00',
+            'expires_at' => '2026-06-01 09:45:00',
+            'released_at' => null,
+        ]);
+
+        $view = (new RiskSummaryQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:05:00 UTC'),
+        ))->getSummary();
+
+        self::assertSame(1, $view->staleLockCount);
+        self::assertSame('stale_symbol_lock', $view->alerts[0]->code);
+        self::assertSame('BTCUSDT', $view->alerts[0]->symbol);
+    }
+}

--- a/trading-app/tests/Front/Query/SystemHealthQueryTest.php
+++ b/trading-app/tests/Front/Query/SystemHealthQueryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Front\Query;
+
+use App\Front\Query\SystemHealthQuery;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+#[CoversClass(SystemHealthQuery::class)]
+final class SystemHealthQueryTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+
+        foreach (['messenger_messages_order_timeout', 'messenger_messages_mtf_projection', 'messenger_messages_mtf_decision', 'messenger_messages_failed'] as $table) {
+            $this->connection->executeStatement(sprintf(
+                'CREATE TABLE %s (id INTEGER PRIMARY KEY AUTOINCREMENT, queue_name VARCHAR(190) NOT NULL)',
+                $table,
+            ));
+        }
+    }
+
+    public function testQueuesReadConfiguredMessengerTransportTables(): void
+    {
+        $this->connection->insert('messenger_messages_mtf_decision', ['queue_name' => 'mtf_decision']);
+        $this->connection->insert('messenger_messages_mtf_decision', ['queue_name' => 'mtf_decision']);
+        $this->connection->insert('messenger_messages_order_timeout', ['queue_name' => 'order_timeout']);
+
+        $health = (new SystemHealthQuery(
+            $this->connection,
+            new MockClock('2026-06-01 10:00:00 UTC'),
+            sys_get_temp_dir(),
+        ))->health();
+
+        self::assertContains([
+            'queue_name' => 'mtf_decision',
+            'message_count' => 2,
+            'table_name' => 'messenger_messages_mtf_decision',
+        ], $health['queues']);
+        self::assertContains([
+            'queue_name' => 'order_timeout',
+            'message_count' => 1,
+            'table_name' => 'messenger_messages_order_timeout',
+        ], $health['queues']);
+    }
+}

--- a/trading-app/tests/Front/Query/TemporalSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/TemporalSummaryQueryTest.php
@@ -40,7 +40,7 @@ services:
     image: temporalio/ui:2.39.0
     container_name: temporal_ui
     ports:
-      - "8233:8080"
+      - "127.0.0.1:8233:8080"
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
   cron-symfony-mtf-workers:

--- a/trading-app/tests/Front/Query/TemporalSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/TemporalSummaryQueryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Front\Query;
+
+use App\Front\Query\TemporalSummaryQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TemporalSummaryQuery::class)]
+final class TemporalSummaryQueryTest extends TestCase
+{
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = sys_get_temp_dir() . '/tradingv3-temporal-test-' . bin2hex(random_bytes(4));
+        mkdir($this->projectDir . '/config', 0777, true);
+
+        file_put_contents($this->projectDir . '/config/mtf.yaml', <<<'YAML'
+mtf:
+  temporal:
+    address: '%env(TEMPORAL_ADDRESS)%'
+    namespace: '%env(TEMPORAL_NAMESPACE)%'
+    task_queue: 'mtf_minute_queue'
+    workflow_id: 'mtf-minute-workflow'
+YAML);
+
+        file_put_contents($this->projectDir . '/docker-compose.yml', <<<'YAML'
+services:
+  temporal:
+    image: temporalio/auto-setup:1.25
+    container_name: temporal_server
+    ports:
+      - "7233:7233"
+    environment:
+      - ENABLE_HTTP_API=true
+  temporal-ui:
+    image: temporalio/ui:2.39.0
+    container_name: temporal_ui
+    ports:
+      - "8233:8080"
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+  cron-symfony-mtf-workers:
+    container_name: cron_symfony_mtf_workers
+    environment:
+      - TEMPORAL_ADDRESS=temporal:7233
+      - TASK_QUEUE_NAME=cron_symfony_mtf_workers
+      - MTF_WORKERS_COUNT=4
+YAML);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->projectDir . '/config/mtf.yaml');
+        @unlink($this->projectDir . '/docker-compose.yml');
+        @rmdir($this->projectDir . '/config');
+        @rmdir($this->projectDir);
+    }
+
+    public function testSummaryExtractsTemporalConfigurationAndOperations(): void
+    {
+        $summary = (new TemporalSummaryQuery($this->projectDir))->summary();
+
+        self::assertSame('%env(TEMPORAL_ADDRESS)%', $summary['cluster']['address']);
+        self::assertSame('%env(TEMPORAL_NAMESPACE)%', $summary['cluster']['namespace']);
+        self::assertSame('mtf_minute_queue', $summary['cluster']['task_queue']);
+        self::assertSame('mtf-minute-workflow', $summary['cluster']['workflow_id']);
+        self::assertSame('http://localhost:8233', $summary['ui']['url']);
+
+        self::assertArrayHasKey('temporal', $summary['services']);
+        self::assertSame('temporal_server', $summary['services']['temporal']['container_name']);
+        self::assertSame('temporal_ui', $summary['services']['temporal-ui']['container_name']);
+
+        self::assertContains('mtf_minute_queue', $summary['task_queues']);
+        self::assertContains('cron_symfony_mtf_workers', $summary['task_queues']);
+        self::assertSame('4', $summary['workers'][0]['workers_count']);
+
+        self::assertNotEmpty($summary['admin_commands']);
+        self::assertStringContainsString('temporal operator cluster health', $summary['admin_commands'][0]['command']);
+    }
+}

--- a/trading-app/tests/Front/Query/TemporalSummaryQueryTest.php
+++ b/trading-app/tests/Front/Query/TemporalSummaryQueryTest.php
@@ -80,5 +80,7 @@ YAML);
 
         self::assertNotEmpty($summary['admin_commands']);
         self::assertStringContainsString('temporal operator cluster health', $summary['admin_commands'][0]['command']);
+        self::assertStringContainsString('--namespace default', $summary['admin_commands'][2]['command']);
+        self::assertStringNotContainsString('%env(TEMPORAL_NAMESPACE)%', $summary['admin_commands'][2]['command']);
     }
 }

--- a/trading-app/tests/Front/Security/OpsFrontAccessSubscriberTest.php
+++ b/trading-app/tests/Front/Security/OpsFrontAccessSubscriberTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Front\Security;
+
+use App\Front\Security\OpsFrontAccessSubscriber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+#[CoversClass(OpsFrontAccessSubscriber::class)]
+final class OpsFrontAccessSubscriberTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        foreach (['APP_ENV', 'OPS_FRONT_USER', 'OPS_FRONT_PASSWORD', 'OPS_FRONT_TOKEN'] as $key) {
+            unset($_ENV[$key], $_SERVER[$key]);
+            putenv($key);
+        }
+    }
+
+    public function testBlocksOpsFrontInProdWhenAccessIsNotConfigured(): void
+    {
+        $_SERVER['APP_ENV'] = 'prod';
+
+        $event = $this->eventFor(Request::create('/app/risk'));
+        (new OpsFrontAccessSubscriber())->guardOpsFront($event);
+
+        self::assertTrue($event->hasResponse());
+        self::assertSame(503, $event->getResponse()?->getStatusCode());
+    }
+
+    public function testAllowsOpsFrontWithConfiguredBearerToken(): void
+    {
+        $_SERVER['APP_ENV'] = 'prod';
+        $_SERVER['OPS_FRONT_TOKEN'] = 'secret-token';
+
+        $request = Request::create('/app/api/risk/summary');
+        $request->headers->set('Authorization', 'Bearer secret-token');
+        $event = $this->eventFor($request);
+
+        (new OpsFrontAccessSubscriber())->guardOpsFront($event);
+
+        self::assertFalse($event->hasResponse());
+    }
+
+    public function testBlocksOpsFrontWhenCredentialsAreWrong(): void
+    {
+        $_SERVER['APP_ENV'] = 'prod';
+        $_SERVER['OPS_FRONT_PASSWORD'] = 'secret-password';
+
+        $event = $this->eventFor(Request::create('/app'));
+        (new OpsFrontAccessSubscriber())->guardOpsFront($event);
+
+        self::assertTrue($event->hasResponse());
+        self::assertSame(401, $event->getResponse()?->getStatusCode());
+        self::assertSame('Basic realm="TradingV3 Ops"', $event->getResponse()?->headers->get('WWW-Authenticate'));
+    }
+
+    private function eventFor(Request $request): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createMock(KernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add a new Symfony/Twig ops console under /app with Cockpit, Risk Center, Decision Explorer, Investigation, System, Config, and Temporal screens.
- Add read-only DBAL query/view-model layer under src/Front plus local /front CSS and JS assets.
- Add Temporal dashboard at /app/temporal with cluster config, UI link, Docker services, workers, task queues, checks, admin commands, and JSON summary endpoint.

## Test Plan
- php bin/phpunit tests/Front --display-deprecations
- php bin/console lint:twig templates/front
- vendor/bin/phpstan analyse src/Front tests/Front
- DEFAULT_URI=http://localhost php bin/console debug:router | rg '/app'
- Kernel smoke test for /app, /app/risk, /app/decisions, /app/investigate, /app/system, /app/temporal, /app/config, and /app/api/temporal/summary

## Notes
- React is not required for these screens.
- out-of-zone-watcher/ remains untracked and is not part of this PR.