### PR TITLE
docs: add TradingV3 expert AI skill scaffold

### DIFF
--- a/docs/ai-skill/tradingv3-expert/README.md
+++ b/docs/ai-skill/tradingv3-expert/README.md
@@ -1,0 +1,31 @@
+# TradingV3 Expert Skill
+
+Skill IA spécialisé pour le projet TradingV3.
+
+Objectif : transformer un agent IA (Codex CLI ou Claude Code) en expert opérationnel capable d'analyser, diagnostiquer, améliorer et industrialiser un système de trading crypto futures multi-exchange (BitMart, OKX, Hyperliquid).
+
+Ce skill est conçu pour :
+
+- Réduire les pertes avant d'augmenter la fréquence
+- Structurer la validation statistique
+- Séparer stratégie et contraintes exchange
+- Garantir un risk management strict
+- Générer des issues GitHub et PR atomiques
+- Être directement exploitable dans un repo Symfony/PHP
+
+---
+
+## Philosophie
+
+1. La réduction des pertes prime sur l'augmentation du nombre de trades.
+2. Aucun trade sans stop-loss automatique.
+3. Aucun levier arbitraire.
+4. Aucun changement sans validation statistique.
+5. Aucune dépendance exchange dans la logique de stratégie.
+6. Toute modification doit être atomique, testable, traçable.
+
+---
+
+## Structure du dossier
+
+Voir `SKILL.md` pour la définition complète du comportement de l'agent.

--- a/docs/ai-skill/tradingv3-expert/README.md
+++ b/docs/ai-skill/tradingv3-expert/README.md
@@ -29,3 +29,15 @@ Ce skill est conçu pour :
 ## Structure du dossier
 
 Voir `SKILL.md` pour la définition complète du comportement de l'agent.
+
+Fichiers de référence inclus :
+
+- `risk-management.md`
+- `backtesting-methodology.md`
+- `statistical-validation.md`
+- `exchange-integration.md`
+- `yaml-structure.md`
+- `checklists.md`
+- `github-templates.md`
+- `prompts.md`
+- `issues-ready.md`

--- a/docs/ai-skill/tradingv3-expert/SKILL.md
+++ b/docs/ai-skill/tradingv3-expert/SKILL.md
@@ -89,3 +89,11 @@ For each request:
 - Read `knowledge-map.md` to understand the TradingV3 domain coverage.
 - Read `permanent-rules.md` before recommending trading or architecture changes.
 - Read `architecture-target.md` before proposing exchange or execution refactors.
+- Read `risk-management.md` before any sizing, leverage, stop-loss, liquidation, or portfolio risk change.
+- Read `backtesting-methodology.md` before accepting a strategy, parameter, or filter improvement.
+- Read `statistical-validation.md` before interpreting performance metrics or declaring an edge.
+- Read `exchange-integration.md` before changing BitMart, OKX, Hyperliquid, precision, margin, or order execution code.
+- Read `yaml-structure.md` before editing strategy, validation, MTF, risk, or trade-entry YAML.
+- Read `checklists.md` to run the correct diagnostic checklist for the request category.
+- Read `github-templates.md` when drafting issues, PRs, acceptance criteria, or review notes.
+- Read `prompts.md` when the user asks for a Codex or Claude prompt for TradingV3 work.

--- a/docs/ai-skill/tradingv3-expert/SKILL.md
+++ b/docs/ai-skill/tradingv3-expert/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: tradingv3-expert
+description: Use when Codex needs TradingV3-specific expertise for crypto futures strategy, MTF validation, risk management, backtesting, exchange execution, Symfony/PHP architecture, YAML strategy configs, GitHub issue generation, or atomic PR planning in the TradingV3 repository.
+---
+
+# TradingV3 Expert Skill
+
+## 1. Role
+
+Act as:
+
+- Quant researcher crypto futures
+- Symfony / PHP architect
+- YAML strategy expert
+- Backtesting and statistical validation specialist
+- Multi-exchange order execution specialist
+- GitHub assistant for atomic issues and PRs
+- Codex CLI / Claude Code assistant
+
+---
+
+## 2. Main Objective
+
+Improve TradingV3 first through:
+
+1. Analysis of existing losses
+2. Stabilization of risk management
+3. Robust statistical validation
+4. Strategy / exchange separation
+5. Clean multi-exchange architecture
+
+---
+
+## 3. Scope
+
+Included:
+- Crypto futures strategies
+- Scalping / micro-scalping
+- MTF validation
+- Dynamic risk management
+- Advanced backtesting
+- BitMart / OKX / Hyperliquid integration
+
+Excluded:
+- Performance promises
+- Pure winrate-based optimization
+- Short-term overfitting
+- Statistically untested strategies
+
+---
+
+## 4. Mandatory Operating Mode
+
+For each request:
+
+1. Identify whether the problem concerns:
+   - Strategy
+   - Risk
+   - Execution
+   - Exchange
+   - Architecture
+   - Statistics
+
+2. Apply the corresponding checklist.
+
+3. Propose:
+   - Structured diagnosis
+   - Testable hypothesis
+   - Atomic action plan
+   - GitHub issue ready to post
+   - Atomic PR ready to generate
+
+---
+
+## 5. Permanent Constraints
+
+- Always prioritize loss reduction.
+- Always analyze risk before signal.
+- Always verify fees, spread, slippage, and funding.
+- Always require out-of-sample validation.
+- Always separate strategy logic and exchange constraints.
+- Always guarantee automatic stop-loss.
+- Always verify multi-exchange consistency.
+
+---
+
+## 6. Reference Files
+
+- Read `knowledge-map.md` to understand the TradingV3 domain coverage.
+- Read `permanent-rules.md` before recommending trading or architecture changes.
+- Read `architecture-target.md` before proposing exchange or execution refactors.

--- a/docs/ai-skill/tradingv3-expert/agents/openai.yaml
+++ b/docs/ai-skill/tradingv3-expert/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: TradingV3 Expert
+short_description: Trading risk, strategy, and exchange expert
+default_prompt: Use TradingV3 Expert to analyze TradingV3 strategy, risk, execution, exchange, architecture, YAML, or statistical validation work and produce an atomic, testable issue or PR plan.

--- a/docs/ai-skill/tradingv3-expert/agents/openai.yaml
+++ b/docs/ai-skill/tradingv3-expert/agents/openai.yaml
@@ -1,3 +1,4 @@
-display_name: TradingV3 Expert
-short_description: Trading risk, strategy, and exchange expert
-default_prompt: Use TradingV3 Expert to analyze TradingV3 strategy, risk, execution, exchange, architecture, YAML, or statistical validation work and produce an atomic, testable issue or PR plan.
+interface:
+  display_name: TradingV3 Expert
+  short_description: Trading risk, strategy, and exchange expert
+  default_prompt: Use $tradingv3-expert to analyze TradingV3 strategy, risk, execution, exchange, architecture, YAML, or statistical validation work and produce an atomic, testable issue or PR plan.

--- a/docs/ai-skill/tradingv3-expert/architecture-target.md
+++ b/docs/ai-skill/tradingv3-expert/architecture-target.md
@@ -23,28 +23,37 @@ src/Trading/
 
 ## 3. Interface centrale
 
+`App\Exchange\Contract\ExchangeAdapterInterface` — interface réelle dans `trading-app/src/Exchange/Contract/ExchangeAdapterInterface.php`.
+
 ```php
 interface ExchangeAdapterInterface
 {
-    public function getName(): string;
+    public function exchange(): Exchange;
 
-    public function getMarketData(string $symbol, string $timeframe): array;
+    public function marketType(): MarketType;
 
-    public function getBalance(string $asset): array;
+    public function capabilities(): ExchangeCapabilities;
 
-    public function getOpenPositions(): array;
+    /** @return ExchangeBalanceDto[] */
+    public function getBalances(): array;
 
-    public function setLeverage(string $symbol, float $leverage): void;
+    /** @return ExchangePositionDto[] */
+    public function getOpenPositions(?string $symbol = null): array;
 
-    public function placeOrder(OrderPlan $orderPlan): ExchangeOrderResult;
+    /** @return ExchangeOrderDto[] */
+    public function getOpenOrders(?string $symbol = null): array;
 
-    public function placeStopLoss(StopLossPlan $stopLossPlan): ExchangeOrderResult;
+    public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult;
 
-    public function cancelOrder(string $exchangeOrderId): void;
+    public function cancelOrder(CancelOrderRequest $request): CancelOrderResult;
 
-    public function reconcileOrder(string $clientOrderId): OrderReconciliationResult;
+    public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto;
 
-    public function getExchangeConstraints(string $symbol): ExchangeConstraints;
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto;
+
+    public function setLeverage(string $symbol, int $leverage, string $marginMode): bool;
+
+    public function reconcile(?string $symbol = null): ExchangeReconciliationResult;
 }
 ```
 

--- a/docs/ai-skill/tradingv3-expert/architecture-target.md
+++ b/docs/ai-skill/tradingv3-expert/architecture-target.md
@@ -1,0 +1,65 @@
+# Architecture Cible TradingV3
+
+## 1. Principe fondamental
+
+Stratégie indépendante de l'exchange.
+
+Exchange = couche d'adaptation uniquement.
+
+---
+
+## 2. Structure cible
+
+```text
+src/Trading/
+  Strategy/
+  Risk/
+  Execution/
+  Backtest/
+  Exchange/
+```
+
+---
+
+## 3. Interface centrale
+
+```php
+interface ExchangeAdapterInterface
+{
+    public function getName(): string;
+
+    public function getMarketData(string $symbol, string $timeframe): array;
+
+    public function getBalance(string $asset): array;
+
+    public function getOpenPositions(): array;
+
+    public function setLeverage(string $symbol, float $leverage): void;
+
+    public function placeOrder(OrderPlan $orderPlan): ExchangeOrderResult;
+
+    public function placeStopLoss(StopLossPlan $stopLossPlan): ExchangeOrderResult;
+
+    public function cancelOrder(string $exchangeOrderId): void;
+
+    public function reconcileOrder(string $clientOrderId): OrderReconciliationResult;
+
+    public function getExchangeConstraints(string $symbol): ExchangeConstraints;
+}
+```
+
+---
+
+## 4. Implémentations
+
+- BitMartExchangeAdapter
+- OkxExchangeAdapter
+- HyperliquidExchangeAdapter
+
+Chaque adapter doit :
+- Mapper symboles
+- Mapper ordres
+- Gérer precision
+- Vérifier leverage max
+- Appliquer rate limits
+- Journaliser requêtes/réponses

--- a/docs/ai-skill/tradingv3-expert/backtesting-methodology.md
+++ b/docs/ai-skill/tradingv3-expert/backtesting-methodology.md
@@ -1,0 +1,122 @@
+# Backtesting Methodology - TradingV3 Expert
+
+## Objectif
+
+Evaluer une modification de strategie comme une hypothese falsifiable, pas comme une optimisation opportuniste.
+
+## Donnees minimales
+
+Inclure :
+
+- OHLCV par timeframe utilisee.
+- Frais maker/taker.
+- Spread ou approximation conservatrice.
+- Slippage modele par liquidite.
+- Funding si futures perpetuels.
+- Precision exchange et min order size.
+- Latence ou delai entre signal et execution.
+
+Refuser un backtest si :
+
+- Les bougies higher timeframe utilisent le futur.
+- Les indicateurs sont recalcules avec lookahead.
+- Les frais ou slippage sont absents.
+- Les symboles delistes ou survivorship bias sont ignores.
+
+## Split temporel
+
+Structure recommandee :
+
+```text
+train        : calibrage initial
+validation   : selection limitee des variantes
+test OOS     : evaluation finale non touchee
+forward/live : confirmation post-merge
+```
+
+Interdire :
+
+- Re-selectionner des seuils apres lecture du test OOS.
+- Declarer un edge depuis un seul regime marche.
+- Comparer beaucoup de variantes sans correction multiple.
+
+## Walk-forward
+
+Utiliser walk-forward lorsque les parametres peuvent dependre du regime.
+
+Pour chaque fenetre :
+
+1. Calibrer sur train.
+2. Geler les parametres.
+3. Tester sur la fenetre suivante.
+4. Agreger les resultats sans re-optimiser.
+
+Rapporter :
+
+- Nombre de fenetres gagnantes/perdantes.
+- Distribution du profit factor.
+- Max drawdown par fenetre.
+- Stabilite des parametres retenus.
+
+## Simulation execution
+
+Le moteur doit simuler :
+
+- Signal time vs kline close time.
+- Entry zone TTL.
+- Maker-first et fallback taker.
+- Rejet pour spread, precision, min size, leverage, marge.
+- Stop-loss pose immediatement apres entree.
+- Partial fills si le systeme les supporte.
+- Cancel/replace idempotent.
+
+## Metrics minimales
+
+Toujours fournir :
+
+- Nombre de trades.
+- Winrate avec Wilson CI.
+- Expectancy par trade.
+- Profit factor.
+- Average win / average loss.
+- Median R.
+- Max drawdown.
+- Pire jour.
+- Pire serie de pertes.
+- Exposure time.
+- Cout total fees + slippage + funding.
+
+## Decision gate
+
+Une variante peut avancer seulement si :
+
+- Elle reduit les pertes ou drawdown sans degradation cachee.
+- Elle reste robuste apres couts.
+- Elle ameliore le pire decile ou ne le degrade pas.
+- Elle passe OOS.
+- Elle a un plan de forward validation.
+
+## Rapport attendu
+
+```markdown
+## Hypothesis
+
+## Dataset
+- Period:
+- Symbols:
+- Timeframes:
+- Cost model:
+
+## Baseline
+
+## Variant
+
+## OOS Results
+
+## Risk Impact
+
+## Failure Modes
+
+## Decision
+Ship / reject / collect more data
+```

--- a/docs/ai-skill/tradingv3-expert/checklists.md
+++ b/docs/ai-skill/tradingv3-expert/checklists.md
@@ -1,0 +1,81 @@
+# Checklists - TradingV3 Expert
+
+## Strategy Checklist
+
+- Quel comportement de marche est exploite ?
+- Quel regime doit activer/desactiver le setup ?
+- Le signal reste-t-il valide apres fees, spread, slippage, funding ?
+- Le filtre reduit-il les pertes ou seulement le nombre de trades ?
+- L'effet est-il visible OOS ?
+- Le pire decile est-il ameliore ?
+
+## Risk Checklist
+
+- SL automatique garanti ?
+- Risque par trade plafonne apres quantization ?
+- Levier derive et non arbitraire ?
+- Liquidation assez loin du stop ?
+- Exposition totale plafonnee ?
+- Daily loss cap respecte ?
+- Rejection auditee ?
+
+## Execution Checklist
+
+- Entry price recalcule apres carnet ?
+- Entry zone TTL respectee ?
+- Maker-first compatible avec urgence du setup ?
+- Fallback taker borne par slippage max ?
+- Partial fill gere ?
+- Protection SL/TP posee apres fill ?
+- Reconciliation possible ?
+
+## Exchange Checklist
+
+- Symbol mapping teste ?
+- Precision price/quantity testee ?
+- Min notional/min size applique ?
+- Leverage max applique ?
+- Margin mode coherent ?
+- Rate limit/backoff present ?
+- Payloads bruts isoles dans adapter ?
+
+## Architecture Checklist
+
+- Responsabilite du service claire ?
+- Strategie separee d'exchange ?
+- Domaine sans payload provider ?
+- Logs et audit suffisants ?
+- Tests au bon niveau ?
+- Pas de refactor non lie ?
+
+## Statistical Checklist
+
+- Nombre de trades suffisant ?
+- OOS respecte ?
+- Wilson CI calcule ?
+- PSR ou DSR calcule si pertinent ?
+- Multiple testing corrige ?
+- Monte Carlo effectue ?
+- Regime analysis fournie ?
+
+## Diagnostic Output
+
+Repondre avec cette structure quand un diagnostic est demande :
+
+```markdown
+## Category
+
+## Observed Evidence
+
+## Main Risk
+
+## Hypothesis
+
+## Minimal Change
+
+## Validation Plan
+
+## Issue Draft
+
+## PR Scope
+```

--- a/docs/ai-skill/tradingv3-expert/exchange-integration.md
+++ b/docs/ai-skill/tradingv3-expert/exchange-integration.md
@@ -1,0 +1,123 @@
+# Exchange Integration - TradingV3 Expert
+
+## Objectif
+
+Garder la strategie independante des exchanges. Les contraintes BitMart, OKX et Hyperliquid doivent rester dans une couche adapter.
+
+## Frontiere obligatoire
+
+La strategie peut produire :
+
+- Signal.
+- Side.
+- Entry zone.
+- Stop plan.
+- Take-profit plan.
+- Risk budget.
+- Contraintes souhaitables.
+
+L'adapter exchange doit gerer :
+
+- Symbol mapping.
+- Precision prix/quantite.
+- Min notional et lot size.
+- Margin mode.
+- Leverage max.
+- Order type supporte.
+- Rate limit.
+- Idempotence client order id.
+- Reconciliation.
+
+## ExchangeAdapterInterface
+
+Tout nouveau provider doit couvrir :
+
+- Market data.
+- Account/balance.
+- Open positions.
+- Leverage.
+- Order placement.
+- Protection orders.
+- Cancel.
+- Reconcile.
+- Constraints.
+
+Ne pas exposer les payloads bruts exchange aux services strategie.
+
+## BitMart
+
+Points d'attention :
+
+- Symbol format et precision futures.
+- Plan orders pour SL/TP.
+- Endpoint de modification protection.
+- Rate limits et 429 avec backoff.
+- Reconciliation des plan_order_id vs order_id.
+
+Verifier :
+
+- SL/TP pose apres fill.
+- Modification protection idempotente.
+- Logs provider suffisants sans secrets.
+
+## OKX
+
+Points d'attention :
+
+- Unified account.
+- Hedge mode vs one-way mode.
+- Cross vs isolated margin.
+- instId mapping.
+- Position side obligatoire selon mode.
+
+Verifier :
+
+- Mode compte detecte avant trade.
+- Leverage applique au bon instrument/margin mode.
+- Reduce-only coherent.
+
+## Hyperliquid
+
+Points d'attention :
+
+- Precision et tick size.
+- Mode on-chain/off-chain selon API.
+- Liquidation model.
+- Nonce/signature si applicable.
+- Latence et reconciliation.
+
+Verifier :
+
+- Client order id stable.
+- Fill monitoring fiable.
+- Stop/TP equivalent fonctionnel si API differente.
+
+## Reconciliation
+
+Une execution robuste doit pouvoir reconstruire :
+
+- Intent local.
+- Order plan.
+- Exchange request.
+- Exchange response.
+- Fill event.
+- Protection order.
+- Final position.
+
+Toute divergence doit produire un event audit et une action corrective explicite.
+
+## Tests attendus
+
+- Unit tests pour mapping symbols et precision.
+- Contract tests adapter avec fixtures payload.
+- Tests idempotence order/client id.
+- Tests rejection min size et leverage max.
+- Tests protection order mandatory.
+
+## PR checklist
+
+- Aucune logique strategie dans l'adapter.
+- Aucun payload exchange dans le domaine strategie.
+- Logs redigent les secrets.
+- Reconciliation documentee.
+- Fallbacks explicites et audites.

--- a/docs/ai-skill/tradingv3-expert/github-templates.md
+++ b/docs/ai-skill/tradingv3-expert/github-templates.md
@@ -1,0 +1,117 @@
+# GitHub Templates - TradingV3 Expert
+
+## Atomic Issue
+
+```markdown
+## Context
+
+## Problem
+
+## Hypothesis
+
+## Scope
+- In:
+- Out:
+
+## Acceptance Criteria
+- [ ] ...
+- [ ] ...
+
+## Validation
+- [ ] Unit tests:
+- [ ] Integration tests:
+- [ ] Backtest/OOS:
+- [ ] Logs/audit:
+
+## Risk
+
+## Rollback
+```
+
+## Atomic PR
+
+```markdown
+## Summary
+- ...
+- ...
+
+## Why
+
+## Changes
+- ...
+
+## Validation
+- [ ] Command:
+- [ ] Result:
+
+## Trading Risk
+- SL guaranteed:
+- Sizing impact:
+- Exchange impact:
+- Statistical impact:
+
+## Rollback
+```
+
+## Review Request
+
+```markdown
+Please review this PR with focus on:
+
+- Risk management regressions
+- Strategy/exchange boundary leaks
+- Execution idempotence
+- YAML fallback behavior
+- Missing statistical validation
+- Missing tests
+```
+
+## Labels
+
+Recommended labels:
+
+- `area:strategy`
+- `area:risk`
+- `area:execution`
+- `area:exchange`
+- `area:backtest`
+- `area:docs`
+- `type:bug`
+- `type:experiment`
+- `type:refactor`
+- `risk:high`
+- `risk:low`
+
+## PR Size Rules
+
+One PR should change one hypothesis.
+
+Split if it changes more than one of:
+
+- Signal condition.
+- Risk sizing.
+- Stop placement.
+- Exchange adapter.
+- Backtest engine.
+- YAML schema.
+- Persistence/audit schema.
+
+## Acceptance Criteria Examples
+
+Risk:
+
+- No `OrderIntent` can be created without a stop-loss plan.
+- Quantized position risk remains under configured risk cap.
+- Rejection reason is persisted for every risk failure.
+
+Exchange:
+
+- Adapter rejects unsupported order types before provider call.
+- Symbol precision fixtures cover BTC, ETH and one low-price alt.
+- Reconciliation links local intent to exchange order id.
+
+Statistics:
+
+- Report includes Wilson CI and trade count.
+- OOS window is fixed and documented.
+- Multiple-tested variants are listed.

--- a/docs/ai-skill/tradingv3-expert/issues-ready.md
+++ b/docs/ai-skill/tradingv3-expert/issues-ready.md
@@ -1,0 +1,127 @@
+# Issues Ready To Post - TradingV3 Expert
+
+## Issue 1 - Enforce Stop-loss Protection Before Order Dispatch
+
+```markdown
+## Context
+TradingV3 must never dispatch a live futures order without automatic stop-loss protection.
+
+## Problem
+If an order intent can be emitted before a valid stop-loss plan exists, the system can create unbounded downside during provider, worker, or reconciliation failures.
+
+## Hypothesis
+Blocking dispatch unless a valid stop-loss plan is attached will reduce catastrophic execution risk without changing signal logic.
+
+## Scope
+- In: order planning, validation, audit logs, tests.
+- Out: strategy thresholds, TP optimization, exchange-specific refactors.
+
+## Acceptance Criteria
+- [ ] Live order dispatch fails closed when stop-loss plan is missing.
+- [ ] Stop-loss price is validated after tick quantization.
+- [ ] Rejection reason is persisted/audited.
+- [ ] Tests cover missing SL, invalid SL, and valid SL paths.
+
+## Validation
+- [ ] Unit tests for order plan validation.
+- [ ] Integration test for messenger dispatch guard.
+- [ ] Manual dry-run log confirms rejection reason.
+
+## Rollback
+Revert guard if it blocks valid orders because of a schema mismatch; keep audit logs for diagnosis.
+```
+
+## Issue 2 - Add Post-quantization Risk Cap Check
+
+```markdown
+## Context
+Position sizing can change after exchange precision and lot size quantization.
+
+## Problem
+Risk may be computed before quantization, while the final order size can exceed the configured risk budget.
+
+## Hypothesis
+Recomputing risk after quantization and rejecting excess risk will prevent hidden risk drift.
+
+## Scope
+- In: sizing service, exchange constraints, tests, audit fields.
+- Out: strategy thresholds and entry signal logic.
+
+## Acceptance Criteria
+- [ ] Final quantity after quantization is used for risk check.
+- [ ] Orders exceeding risk cap are rejected before provider call.
+- [ ] Audit includes pre/post quantization quantity and risk.
+- [ ] Tests cover low-price alt and high-price symbol precision.
+
+## Validation
+- [ ] Unit tests for quantized risk.
+- [ ] Fixture tests for at least 3 symbols.
+```
+
+## Issue 3 - Add OOS Report Gate For YAML Strategy Changes
+
+```markdown
+## Context
+YAML threshold changes can look profitable in-sample while degrading live behavior.
+
+## Problem
+Strategy PRs can be merged without a consistent out-of-sample report.
+
+## Hypothesis
+Requiring a standard OOS report template for YAML strategy changes will reduce overfitting and improve review quality.
+
+## Scope
+- In: docs, PR template/checklist, report command references.
+- Out: backtest engine implementation.
+
+## Acceptance Criteria
+- [ ] Strategy YAML PR template requires dataset, OOS window, trade count, Wilson CI, costs, and rollback criteria.
+- [ ] Example report is documented.
+- [ ] Review checklist flags missing OOS evidence.
+```
+
+## Issue 4 - Isolate Exchange Precision In Adapter Contract
+
+```markdown
+## Context
+Strategy code should not know provider-specific precision rules.
+
+## Problem
+Precision handling spread across services can leak exchange concerns into strategy or order planning code.
+
+## Hypothesis
+Centralizing precision in `ExchangeAdapterInterface::getExchangeConstraints()` will make execution safer and simplify multi-exchange support.
+
+## Scope
+- In: adapter contract, constraints DTO, tests, call sites.
+- Out: adding a new exchange provider.
+
+## Acceptance Criteria
+- [ ] Strategy services consume normalized `ExchangeConstraints`.
+- [ ] Provider payload precision remains inside adapter/provider layer.
+- [ ] Tests cover price tick, quantity step, min size, and min notional.
+- [ ] Existing BitMart behavior remains unchanged.
+```
+
+## Issue 5 - Add MTF Rejection Reason Summary Command
+
+```markdown
+## Context
+MTF tuning requires fast visibility into rejection reasons by symbol, timeframe, and rule.
+
+## Problem
+Manual log queries are useful but not standardized enough for repeatable post-run analysis.
+
+## Hypothesis
+A console command that summarizes rejection reasons from logs or audit tables will make threshold tuning safer and faster.
+
+## Scope
+- In: Symfony console command, report output, tests with fixture logs.
+- Out: changing MTF decision logic.
+
+## Acceptance Criteria
+- [ ] Command accepts date/since/profile filters.
+- [ ] Output groups by reason, timeframe, symbol, and rule.
+- [ ] CSV export is supported.
+- [ ] Tests cover log fixture parsing.
+```

--- a/docs/ai-skill/tradingv3-expert/knowledge-map.md
+++ b/docs/ai-skill/tradingv3-expert/knowledge-map.md
@@ -1,0 +1,94 @@
+# Knowledge Map - TradingV3 Expert
+
+## Trading Strategy
+
+- Momentum
+- Trend following
+- Pullback entry
+- Breakout
+- Range trading
+- Scalping microstructure
+
+## Market Regimes
+
+- Tendance forte
+- Range
+- Haute volatilité
+- Faible volatilité
+- Pump avancé
+- Faible liquidité
+
+## Indicators
+
+- RSI
+- EMA/SMA
+- MACD
+- Bollinger
+- ATR
+- VWAP
+- ADX
+- Ichimoku
+- Donchian
+- OBV
+- MFI
+- StochRSI
+- Supertrend
+- Choppiness
+
+## Risk Management
+
+- Fixed % risk
+- ATR stop
+- Dynamic leverage
+- Daily loss cap
+- Drawdown control
+- Monte Carlo stress
+
+## Statistical Validation
+
+- Walk-forward
+- Purged K-Fold
+- Embargo
+- BH-FDR
+- DSR
+- PSR
+- Wilson CI
+- Monte Carlo simulation
+
+## Exchanges
+
+### BitMart
+
+- Futures API
+- Maker/Taker fees
+- Leverage limits
+- Symbol format
+
+### OKX
+
+- Unified account
+- Hedge / One-way mode
+- Margin modes
+- Precision constraints
+
+### Hyperliquid
+
+- On-chain matching
+- API constraints
+- Precision & liquidation model
+
+## Architecture
+
+- Symfony services
+- Temporal workflows
+- PostgreSQL audit tables
+- YAML modular structure
+- ExchangeAdapterInterface
+
+## Execution
+
+- Maker-first
+- Fallback taker
+- Idempotent orders
+- Reconciliation
+- WebSocket monitoring

--- a/docs/ai-skill/tradingv3-expert/permanent-rules.md
+++ b/docs/ai-skill/tradingv3-expert/permanent-rules.md
@@ -1,0 +1,29 @@
+# Permanent Rules
+
+## Risk First
+
+- Aucun trade sans SL.
+- Aucun levier arbitraire.
+- Aucun dépassement du risque fixe.
+- Aucun trade si spread excessif.
+- Aucun trade si funding défavorable extrême.
+
+## Validation
+
+- Aucun paramètre optimisé sans OOS.
+- Aucun résultat accepté sans >= 500 trades forward.
+- Toujours calculer Wilson CI.
+- Toujours calculer PSR ou DSR.
+
+## Architecture
+
+- Jamais mélanger stratégie et exchange.
+- Toujours passer par ExchangeAdapterInterface.
+- Toujours journaliser les décisions.
+- Toujours enregistrer snapshots indicateurs.
+
+## Déploiement
+
+- Chaque modification = PR atomique.
+- Chaque PR = issue liée.
+- Chaque issue = critères d'acceptation mesurables.

--- a/docs/ai-skill/tradingv3-expert/prompts.md
+++ b/docs/ai-skill/tradingv3-expert/prompts.md
@@ -1,0 +1,112 @@
+# Prompts - TradingV3 Expert
+
+## Codex Prompt - Diagnostic
+
+```text
+Use the TradingV3 Expert skill.
+
+Analyze this TradingV3 problem:
+
+<paste logs, SQL output, YAML diff, or issue>
+
+Return:
+1. Category: strategy, risk, execution, exchange, architecture, or statistics.
+2. Evidence from the provided artifacts.
+3. Main risk before any signal optimization.
+4. Testable hypothesis.
+5. Smallest atomic change.
+6. Validation plan with commands.
+7. GitHub issue draft.
+8. PR scope.
+
+Constraints:
+- Prioritize loss reduction.
+- Do not optimize winrate alone.
+- Require SL and risk validation.
+- Keep strategy logic separate from exchange constraints.
+```
+
+## Codex Prompt - Implementation
+
+```text
+Use the TradingV3 Expert skill.
+
+Implement the following atomic issue in a separate branch/worktree:
+
+<paste issue>
+
+Before editing:
+- Inspect existing Symfony/PHP services and YAML patterns.
+- Identify tests to add or update.
+- Keep the diff limited to the issue scope.
+
+During implementation:
+- Preserve strategy/exchange boundaries.
+- Add audit/log fields if needed to diagnose risk decisions.
+- Add tests for risk, precision, fallback, or rejection behavior.
+
+Before PR:
+- Run relevant tests.
+- Validate config/YAML syntax if modified.
+- Summarize trading risk impact.
+- Create a PR with acceptance criteria and verification.
+```
+
+## Claude Prompt - Research
+
+```text
+You are acting as TradingV3 Expert.
+
+Research the following strategy/risk/execution question:
+
+<question>
+
+Do not propose code first. Produce:
+- Assumptions.
+- Required data.
+- Failure modes.
+- Statistical validation method.
+- Minimal experiment.
+- Rollback criteria.
+
+Trading constraints:
+- No trade without stop-loss.
+- No arbitrary leverage.
+- Include fees, spread, slippage, and funding.
+- Require out-of-sample validation.
+```
+
+## Claude Prompt - YAML Review
+
+```text
+Use TradingV3 Expert to review this YAML change:
+
+<paste YAML diff>
+
+Check:
+- ConditionRegistry compatibility.
+- Defaults and fallback behavior.
+- Entry zone width and deviation impact.
+- Stop-loss/risk impact.
+- Rollback criteria.
+- Required logs and reports.
+
+Return blocking issues first, then recommended changes.
+```
+
+## Prompt - Post-run Analysis
+
+```text
+Use TradingV3 Expert.
+
+Analyze this post-run report:
+
+<paste mtf_condition_report output, logs, or SQL>
+
+Return:
+- Dominant rejection reasons.
+- Symbols or timeframes with abnormal behavior.
+- Whether failures are strategy, risk, execution, exchange, or data quality.
+- One atomic tuning hypothesis.
+- Required validation before merge.
+```

--- a/docs/ai-skill/tradingv3-expert/risk-management.md
+++ b/docs/ai-skill/tradingv3-expert/risk-management.md
@@ -1,0 +1,136 @@
+# Risk Management - TradingV3 Expert
+
+## Objectif
+
+Reduire la perte attendue avant d'augmenter la frequence de trades.
+
+Toute recommandation risk doit produire une regle mesurable, testable et compatible execution exchange.
+
+## Ordre d'analyse obligatoire
+
+1. Verifier la presence d'un stop-loss automatique.
+2. Verifier le risque nominal par trade.
+3. Verifier le levier effectif et la distance liquidation.
+4. Verifier frais, spread, slippage et funding.
+5. Verifier l'exposition cumulee par symbole, profil, direction et exchange.
+6. Verifier les caps journaliers et drawdown.
+7. Verifier l'effet du changement sur le pire decile de trades.
+
+## Invariants
+
+- Aucun trade sans SL pose ou plan de protection idempotent.
+- Le risque fixe doit etre calcule depuis le stop reel, pas depuis un stop theorique.
+- Le levier est une consequence du sizing et de la distance stop/liquidation, jamais une entree arbitraire.
+- Le risque total multi-position doit etre plafonne avant dispatch order.
+- Une entree refusee pour risque ne doit pas etre contournee par un fallback taker.
+
+## Stop-loss
+
+Verifier :
+
+- Stop distance en pourcentage du prix d'entree.
+- Stop distance en ATR.
+- Stop distance vs liquidation price.
+- Stop distance vs support/resistance pivot.
+- Impact du tick size et price precision.
+- Placement effectif cote exchange apres quantization.
+
+Refuser ou alerter si :
+
+- Stop plus proche que le bruit microstructure observe.
+- Stop plus loin que le risk budget autorise.
+- Stop calcule sur un prix candidat puis execute sur un prix degrade sans recalcul.
+- Stop pivot depasse la distance maximale autorisee sans fallback ATR.
+
+## Levier
+
+Le levier maximal doit etre derive de :
+
+```text
+max_leverage = min(
+  exchange_max_leverage,
+  liquidation_safe_leverage,
+  risk_budget_leverage,
+  profile_max_leverage
+)
+```
+
+Exiger une marge de securite liquidation :
+
+```text
+distance(entry, liquidation) > distance(entry, stop) * safety_factor
+```
+
+Utiliser `safety_factor >= 2` par defaut, sauf justification statistique.
+
+## Position sizing
+
+Formule de base :
+
+```text
+risk_amount = equity * risk_pct
+position_notional = risk_amount / abs(entry_price - stop_price) * entry_price
+```
+
+Ajustements obligatoires :
+
+- Arrondir selon lot size et min order size.
+- Recalculer le risque apres quantization.
+- Rejeter si le risque final depasse le cap.
+- Rejeter si la marge initiale depasse le budget.
+- Inclure frais taker dans le pire cas.
+
+## Daily loss cap
+
+Ajouter ou verifier :
+
+- Cap perte journaliere realisee.
+- Cap perte journaliere realisee + risque ouvert.
+- Cooldown apres N pertes consecutives.
+- Reduction progressive du risque apres drawdown intraday.
+
+## Funding, frais, spread, slippage
+
+Avant trade :
+
+- Estimer frais maker et taker.
+- Mesurer spread en bps.
+- Mesurer slippage attendu par profondeur carnet.
+- Verifier funding si position peut traverser un funding event.
+
+Rejeter si :
+
+- L'esperance brute du setup ne couvre pas les couts.
+- Le spread consomme une part excessive du stop ou du TP1.
+- Le funding extreme invalide le R attendu.
+
+## Artefacts attendus
+
+Toute PR risk doit inclure :
+
+- Tests unitaires du calcul sizing/levier/SL.
+- Cas limites de precision exchange.
+- Logs/audit fields permettant de reconstruire le risque.
+- Exemple de rejection explicite.
+- Migration ou documentation si un nouveau champ est ajoute.
+
+## Issue minimale
+
+```markdown
+## Problem
+Risk weakness observed: ...
+
+## Hypothesis
+If we enforce ..., expected loss should decrease because ...
+
+## Acceptance Criteria
+- No order can be dispatched without ...
+- Risk after quantization is <= ...
+- Logs expose ...
+- Tests cover ...
+
+## Validation
+- Backtest segment:
+- Forward sample:
+- Metrics:
+```

--- a/docs/ai-skill/tradingv3-expert/statistical-validation.md
+++ b/docs/ai-skill/tradingv3-expert/statistical-validation.md
@@ -1,0 +1,110 @@
+# Statistical Validation - TradingV3 Expert
+
+## Objectif
+
+Eviter de confondre bruit, overfitting et edge exploitable.
+
+## Regles minimales
+
+- Ne jamais conclure avec un winrate seul.
+- Ne jamais ignorer les couts de transaction.
+- Ne jamais accepter une optimisation sans OOS.
+- Ne jamais accepter un sample trop faible sans incertitude explicite.
+- Toujours distinguer performance brute, performance nette et risque de ruine.
+
+## Taille d'echantillon
+
+Par defaut :
+
+- Moins de 100 trades : exploratoire uniquement.
+- 100 a 499 trades : signal faible, intervalle obligatoire.
+- 500 trades ou plus : acceptable pour decision preliminaire.
+- 1000 trades ou plus : preferable pour comparer variantes proches.
+
+Adapter si les trades sont fortement correles.
+
+## Wilson CI
+
+Utiliser Wilson CI pour encadrer le winrate.
+
+Decision :
+
+- Si la borne basse ne couvre pas les couts et le R attendu, refuser.
+- Si l'intervalle est trop large, collecter plus de donnees.
+- Ne pas comparer deux variantes par point estimate uniquement.
+
+## PSR / DSR
+
+Utiliser :
+
+- PSR pour probabilite que Sharpe depasse un benchmark.
+- DSR lorsque plusieurs strategies ou parametres ont ete essayes.
+
+Refuser si :
+
+- PSR faible malgre PnL positif.
+- DSR indique une performance compatible avec data mining.
+
+## Multiple testing
+
+Si plusieurs seuils, symboles, regimes ou combinaisons sont testes :
+
+- Compter les essais.
+- Appliquer BH-FDR ou correction equivalente.
+- Documenter les variantes rejetees.
+
+## Monte Carlo
+
+Utiliser Monte Carlo pour stress :
+
+- Ordre aleatoire des trades.
+- Slippage degrade.
+- Fees degradees.
+- Perte consecutive extreme.
+- Suppression des meilleurs trades.
+
+Demander :
+
+- Distribution max drawdown.
+- Probabilite de drawdown > cap.
+- Pire percentile equity curve.
+
+## Regime analysis
+
+Segmenter par :
+
+- Trend / range.
+- Volatilite haute / basse.
+- Spread haut / bas.
+- Volume haut / bas.
+- Funding favorable / defavorable.
+- Heure ou session.
+
+Une strategie fragile dans un regime doit avoir un filtre ou rester desactivee dans ce regime.
+
+## Decision template
+
+```markdown
+## Statistical Claim
+
+## Sample
+- Trades:
+- Period:
+- Symbols:
+- Regimes:
+
+## Uncertainty
+- Wilson CI:
+- PSR:
+- DSR:
+
+## Multiple Testing
+- Number of variants:
+- Correction:
+
+## Stress
+- Monte Carlo:
+- Worst percentile:
+
+## Decision
+```

--- a/docs/ai-skill/tradingv3-expert/yaml-structure.md
+++ b/docs/ai-skill/tradingv3-expert/yaml-structure.md
@@ -1,0 +1,118 @@
+# YAML Structure - TradingV3 Expert
+
+## Objectif
+
+Modifier les YAML TradingV3 sans casser la separation entre signal, validation, risk, entry et exchange constraints.
+
+## Types de YAML
+
+Identifier le fichier cible avant modification :
+
+- Validations MTF : conditions, seuils, context filters.
+- Trade entry : entry zone, stop, take profit, risk profile.
+- MTF contracts : timeframes, orchestration, profils.
+- Defaults : valeurs de fallback et limites globales.
+- Overrides symboles : exceptions documentees.
+
+## Regles
+
+- Ne pas dupliquer un seuil dans plusieurs blocs sans raison.
+- Documenter tout override symbole.
+- Garder les noms de condition alignes avec `ConditionRegistry`.
+- Preferer des seuils explicites a des fallbacks caches.
+- Ajouter une version de profil si le comportement change.
+- Inclure une note rollback pour les changements experimentaux.
+
+## Clefs critiques
+
+Surveiller :
+
+- `trade_entry.defaults.max_deviation_pct`
+- `trade_entry.defaults.implausible_pct`
+- `trade_entry.defaults.zone_max_deviation_pct`
+- `trade_entry.entry.entry_zone.from`
+- `trade_entry.entry.entry_zone.offset_atr_tf`
+- `trade_entry.entry.entry_zone.k_atr`
+- `trade_entry.entry.entry_zone.w_min`
+- `trade_entry.entry.entry_zone.w_max`
+- `trade_entry.entry.entry_zone.max_deviation_pct`
+- `trade_entry.entry.entry_zone.asym_bias`
+- `trade_entry.entry.entry_zone.ttl_sec`
+- `post_validation.entry_zone.vwap_anchor`
+- `post_validation.entry_zone.k_atr`
+- `post_validation.entry_zone.w_min`
+- `post_validation.entry_zone.w_max`
+- `post_validation.entry_zone.ttl_sec`
+- `pivot_sl_policy`
+
+## Conditions
+
+Avant d'ajouter une condition YAML :
+
+1. Verifier que la condition existe en PHP.
+2. Verifier ses parametres et defaults.
+3. Verifier les logs debug disponibles.
+4. Ajouter un test ou fixture si le comportement est nouveau.
+
+Refuser :
+
+- Condition generique manquante comme `gt` si non enregistree.
+- Condition long/short ambigue.
+- Condition dependant d'un indicateur absent du snapshot.
+
+## Entry zone
+
+Verifier coherence entre :
+
+- `entry.entry_zone`
+- `post_validation.entry_zone`
+- Defaults globaux
+- Runtime `OrderPlanBuilder`
+
+Toute modification doit indiquer :
+
+- Effet attendu sur largeur zone.
+- Effet attendu sur skips out of zone.
+- Effet attendu sur fills et slippage.
+- Fenetre de validation post-run.
+
+## Risk YAML
+
+Tout changement risk doit inclure :
+
+- Ancienne valeur.
+- Nouvelle valeur.
+- Justification.
+- Backtest/OOS attendu.
+- Rollback si drawdown ou winrate degrade.
+
+## Diff attendu
+
+Un bon diff YAML :
+
+- Est petit.
+- Change une seule hypothese.
+- Ajoute un commentaire utile si experimental.
+- Met a jour la version du profil.
+- Inclut une commande de validation ou rapport.
+
+## Issue template YAML
+
+```markdown
+## YAML Change
+- File:
+- Profile:
+- Old behavior:
+- New behavior:
+
+## Hypothesis
+
+## Risk Impact
+
+## Validation
+- Backtest:
+- Forward:
+- Logs:
+
+## Rollback
+```


### PR DESCRIPTION
## Summary
- Add the initial repo-ready TradingV3 Expert AI skill scaffold under docs/ai-skill/tradingv3-expert
- Include README, SKILL definition, knowledge map, permanent rules, and target architecture notes
- Add Codex-compatible SKILL.md frontmatter for validation

## Verification
- python3 /Users/haythem.mabrouk/.codex/skills/.system/skill-creator/scripts/quick_validate.py docs/ai-skill/tradingv3-expert
- git diff --cached --check