### PR TITLE
feat: fees-aware TP calculation and raise r_multiple (#132)

### DIFF
--- a/trading-app/config/app/trade_entry.regular.yaml
+++ b/trading-app/config/app/trade_entry.regular.yaml
@@ -15,6 +15,13 @@ meta:
     created_at: '2025-10-05'
 
 trade_entry:
+    # ============================
+    # FEES
+    # ============================
+    fees:
+        maker_rate: 0.0005
+        taker_rate: 0.0005
+
     # ======== DEFAULTS (Paramètres par défaut pour TradeEntry) ========
     # Clés déplacées depuis mtf_validations.yaml (section defaults)
     defaults:

--- a/trading-app/config/app/trade_entry.scalper.yaml
+++ b/trading-app/config/app/trade_entry.scalper.yaml
@@ -13,6 +13,13 @@ meta:
 trade_entry:
 
     # ============================
+    # FEES
+    # ============================
+    fees:
+        maker_rate: 0.0005
+        taker_rate: 0.0005
+
+    # ============================
     # DEFAULTS
     # ============================
     defaults:
@@ -24,8 +31,8 @@ trade_entry:
             '1m': 4
 
         # --- R-MULTIPLE corrigé (1.2 → 1.5)
-        r_multiple: 1.3              # Ratio R attendu sur le trade
-        tp1_r: 1.0                   # TP1 déclenché à 1R
+        r_multiple: 1.8              # Ratio R attendu sur le trade
+        tp1_r: 1.4                   # TP1 déclenché à 1R
 
         # --- STOP LOSS
         stop_from: 'pivot'             # Stop basé sur ATR dynamique

--- a/trading-app/config/app/trade_entry.scalper_micro.yaml
+++ b/trading-app/config/app/trade_entry.scalper_micro.yaml
@@ -20,6 +20,13 @@ meta:
 trade_entry:
 
     # ============================
+    # FEES
+    # ============================
+    fees:
+        maker_rate: 0.0005
+        taker_rate: 0.0005
+
+    # ============================
     # DEFAULTS
     # ============================
     defaults:
@@ -27,8 +34,8 @@ trade_entry:
         risk_pct_percent: 0.4             # 0.4 % du capital par trade
         initial_margin_usdt: 50.0        # budget relevé pour passer les min_size des contrats
         fallback_account_balance: 0.0
-        r_multiple: 1.3                  # TP resserré (profil micro)
-        tp1_r: 1.2
+        r_multiple: 1.8                  # TP resserré (profil micro)
+        tp1_r: 1.5
 
         # --- Stop Loss ---
         stop_from: 'atr'

--- a/trading-app/src/Config/TradeEntryConfig.php
+++ b/trading-app/src/Config/TradeEntryConfig.php
@@ -66,6 +66,14 @@ class TradeEntryConfig
         return $this->config['market_entry'] ?? [];
     }
 
+    public function getFees(): array
+    {
+        return $this->config['fees'] ?? [
+            'maker_rate' => 0.0,
+            'taker_rate' => 0.0,
+        ];
+    }
+
     public function getFallbackEndOfZoneConfig(): \App\TradeEntry\Dto\FallbackEndOfZoneConfig
     {
         $block = (array)($this->config['fallback_end_of_zone'] ?? []);

--- a/trading-app/src/TradeEntry/Builder/TradeEntryRequestBuilder.php
+++ b/trading-app/src/TradeEntry/Builder/TradeEntryRequestBuilder.php
@@ -216,6 +216,10 @@ final class TradeEntryRequestBuilder
             $leverageExchangeCap = null;
         }
 
+        $fees = $config->getFees();
+        $makerRate = (float)($fees['maker_rate'] ?? 0.0);
+        $takerRate = (float)($fees['taker_rate'] ?? 0.0);
+
         return new TradeEntryRequest(
             symbol: $symbol,
             side: $sideEnum,
@@ -247,6 +251,8 @@ final class TradeEntryRequestBuilder
             leverageMultiplier: 1.0,
             leverageExchangeCap: $leverageExchangeCap,
             exchangeContext: $exchangeContext,
+            makerRate: $makerRate,
+            takerRate: $takerRate,
         );
     }
 

--- a/trading-app/src/TradeEntry/Controller/TradeEntryController.php
+++ b/trading-app/src/TradeEntry/Controller/TradeEntryController.php
@@ -89,6 +89,7 @@ final class TradeEntryController extends AbstractController
                 $stopFallback = 'atr';
             }
 
+            $fees = $config->getFees();
             $requestDto = new TradeEntryRequest(
                 symbol: (string)$data['symbol'],
                 side: $side,
@@ -108,6 +109,8 @@ final class TradeEntryController extends AbstractController
                 atrK: isset($data['atr_k']) ? (float)$data['atr_k'] : (float)($defaults['atr_k'] ?? 1.5),
                 marketMaxSpreadPct: $marketSpread,
                 leverageExchangeCap: $leverageExchangeCap,
+                makerRate: (float)($fees['maker_rate'] ?? 0.0),
+                takerRate: (float)($fees['taker_rate'] ?? 0.0),
             );
 
             $result = $this->service->buildAndExecute($requestDto, mode: $mode);

--- a/trading-app/src/TradeEntry/Dto/TradeEntryRequest.php
+++ b/trading-app/src/TradeEntry/Dto/TradeEntryRequest.php
@@ -39,5 +39,7 @@ final class TradeEntryRequest
         public readonly float $leverageMultiplier = 1.0,
         public readonly ?float $leverageExchangeCap = null,
         public readonly ?ExchangeContext $exchangeContext = null,
+        public readonly float $makerRate = 0.0,
+        public readonly float $takerRate = 0.0,
     ) {}
 }

--- a/trading-app/src/TradeEntry/OrderPlan/OrderPlanBuilder.php
+++ b/trading-app/src/TradeEntry/OrderPlan/OrderPlanBuilder.php
@@ -549,7 +549,10 @@ final class OrderPlanBuilder
         ]);
 
         // --- TAKE PROFIT : R-multiple puis « snap » sur pivot avec garde en R ---
-        $tpTheoretical = $this->tpc->fromRMultiple($entry, $stop, $req->side, (float)$req->rMultiple, $precision);
+        $tpTheoretical = $this->tpc->fromRMultipleWithFees(
+            $entry, $stop, $req->side, (float)$req->rMultiple,
+            $req->makerRate, $req->takerRate, $precision
+        );
 
         $pivotLevels = \is_array($pre->pivotLevels) && !empty($pre->pivotLevels) ? $pre->pivotLevels : null;
         if ($pivotLevels === null) {
@@ -607,6 +610,7 @@ final class OrderPlanBuilder
             'r_theoretical' => $rTheoretical,
             'r_effective' => round($rEffective, 3),
             'aligned_on_pivot' => $pickedFromPivot,
+            'expected_fee_usdt' => $entry * $contractSize * ($req->makerRate + $req->takerRate) * $sizeContracts,
             'decision_key' => $decisionKey,
         ]);
 

--- a/trading-app/src/TradeEntry/RiskSizer/TakeProfitCalculator.php
+++ b/trading-app/src/TradeEntry/RiskSizer/TakeProfitCalculator.php
@@ -40,6 +40,33 @@ final class TakeProfitCalculator
     }
 
     /**
+     * TP = entry ± R * multiple + fee offset (maker+taker round-trip).
+     * Uses directional rounding: floor for Long, ceil for Short (same as fromRMultiple).
+     */
+    public function fromRMultipleWithFees(
+        float $entry,
+        float $stop,
+        Side $side,
+        float $rMultiple,
+        float $makerRate,
+        float $takerRate,
+        int $pricePrecision
+    ): float {
+        $rMultiple = max(0.0, $rMultiple);
+        $riskUnit  = abs($entry - $stop);
+        if ($riskUnit <= 0.0 || $rMultiple === 0.0) {
+            return TickQuantizer::quantize($entry, $pricePrecision);
+        }
+        $feeOffset = $entry * ($makerRate + $takerRate);
+        $raw = $side === Side::Long
+            ? $entry + $rMultiple * $riskUnit + $feeOffset
+            : $entry - $rMultiple * $riskUnit - $feeOffset;
+        return $side === Side::Long
+            ? TickQuantizer::quantize($raw, $pricePrecision)
+            : TickQuantizer::quantizeUp($raw, $pricePrecision);
+    }
+
+    /**
      * Aligne le TP sur un niveau pivot (R1/R2/R3... ou S1/S2/S3...) cohérent :
      *  - pour un Long : chercher la résistance >= baseTP, sinon garder baseTP
      *  - pour un Short: chercher le support   <= baseTP, sinon garder baseTP

--- a/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
+++ b/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
@@ -475,17 +475,17 @@ final class TpSlTwoTargetsService
 
         // Fallback: 2R depuis SL si aucun pivot valide trouvé
         if ($tp2 === null || !$tp2Found) {
-            $tp2 = $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, 2.0, $precision);
+            $tp2 = $this->tpc->fromRMultipleWithFees($entryPrice, $stop, $req->side, 2.0, $makerRate, $takerRate, $precision);
             // Garantir que TP2 est significativement différent de TP1
             if ($req->side === EntrySide::Long) {
                 if ($tp2 <= $tp1 + $minDiffFromTp1) {
                     // Utiliser un multiple plus élevé ou forcer un écart minimal
-                    $tp2 = max($tp1 + $minDiffFromTp1, $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, 2.5, $precision));
+                    $tp2 = max($tp1 + $minDiffFromTp1, $this->tpc->fromRMultipleWithFees($entryPrice, $stop, $req->side, 2.5, $makerRate, $takerRate, $precision));
                     $tp2 = \App\TradeEntry\Pricing\TickQuantizer::quantizeUp($tp2, $precision);
                 }
             } else {
                 if ($tp2 >= $tp1 - $minDiffFromTp1) {
-                    $tp2 = min($tp1 - $minDiffFromTp1, $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, 2.5, $precision));
+                    $tp2 = min($tp1 - $minDiffFromTp1, $this->tpc->fromRMultipleWithFees($entryPrice, $stop, $req->side, 2.5, $makerRate, $takerRate, $precision));
                     $tp2 = \App\TradeEntry\Pricing\TickQuantizer::quantize($tp2, $precision);
                 }
             }

--- a/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
+++ b/trading-app/src/TradeEntry/Service/TpSlTwoTargetsService.php
@@ -140,6 +140,9 @@ final class TpSlTwoTargetsService
         $pivotSlMinKeepRatio = isset($defaults['pivot_sl_min_keep_ratio']) ? (float)$defaults['pivot_sl_min_keep_ratio'] : null;
         $rMultiple = (float)($req->rMultiple ?? ($defaults['r_multiple'] ?? 2.0));
         $slFullByDefault = (bool)($defaults['sl_full_size'] ?? true);
+        $fees = $config->getFees();
+        $makerRate = (float)($fees['maker_rate'] ?? 0.0);
+        $takerRate = (float)($fees['taker_rate'] ?? 0.0);
 
         // Stop par pivot si disponible, sinon par risque
         if (!empty($pivotLevels)) {
@@ -180,7 +183,7 @@ final class TpSlTwoTargetsService
         $currentPrice = (float)($pre->markPrice ?? $pre->bestAsk ?? $pre->bestBid ?? $entryPrice);
 
         // TP1 = mécanique actuelle (R multiple aligné pivots si dispo)
-        $tp1Base = $this->tpc->fromRMultiple($entryPrice, $stop, $req->side, $rMultiple, $precision);
+        $tp1Base = $this->tpc->fromRMultipleWithFees($entryPrice, $stop, $req->side, $rMultiple, $makerRate, $takerRate, $precision);
         $tp1 = $tp1Base;
         if (!empty($pivotLevels) && $rMultiple > 0.0) {
             $tp1 = $this->tpc->alignTakeProfitWithPivot(

--- a/trading-app/tests/TradeEntry/RiskSizer/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradeEntry/RiskSizer/TakeProfitCalculatorTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradeEntry\RiskSizer;
+
+use App\TradeEntry\RiskSizer\TakeProfitCalculator;
+use App\TradeEntry\Types\Side;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+final class TakeProfitCalculatorTest extends TestCase
+{
+    private TakeProfitCalculator $calculator;
+
+    protected function setUp(): void
+    {
+        $this->calculator = new TakeProfitCalculator(new NullLogger());
+    }
+
+    public function testFromRMultipleWithFeesLong(): void
+    {
+        // entry=100, stop=95 → riskUnit=5, feeOffset=100*(0.0005+0.0005)=0.1
+        // TP = 100 + 1.8*5 + 0.1 = 109.1
+        $result = $this->calculator->fromRMultipleWithFees(
+            100.0, 95.0, Side::Long, 1.8, 0.0005, 0.0005, 2
+        );
+        $this->assertSame(109.1, $result);
+    }
+
+    public function testFromRMultipleWithFeesShort(): void
+    {
+        // entry=100, stop=105 → riskUnit=5, feeOffset=0.1
+        // TP = 100 - 1.8*5 - 0.1 = 90.9
+        $result = $this->calculator->fromRMultipleWithFees(
+            100.0, 105.0, Side::Short, 1.8, 0.0005, 0.0005, 2
+        );
+        $this->assertSame(90.9, $result);
+    }
+
+    public function testFromRMultipleWithFeesZeroRMultiple(): void
+    {
+        // When rMultiple is 0, returns entry price (safe no-op, mirrors fromRMultiple behaviour)
+        $result = $this->calculator->fromRMultipleWithFees(
+            100.0, 95.0, Side::Long, 0.0, 0.0005, 0.0005, 2
+        );
+        $this->assertSame(100.0, $result);
+    }
+
+    public function testFromRMultipleWithFeesEntryEqualsStop(): void
+    {
+        // riskUnit = 0 → safe no-op: returns entry price (not fee-inflated entry)
+        $result = $this->calculator->fromRMultipleWithFees(
+            100.0, 100.0, Side::Long, 1.8, 0.0005, 0.0005, 2
+        );
+        $this->assertSame(100.0, $result);
+    }
+
+    public function testFromRMultipleWithFeesZeroFees(): void
+    {
+        // With zero fees, result should equal fromRMultiple for the same inputs
+        $withFees = $this->calculator->fromRMultipleWithFees(
+            100.0, 95.0, Side::Long, 1.8, 0.0, 0.0, 2
+        );
+        $withoutFees = $this->calculator->fromRMultiple(
+            100.0, 95.0, Side::Long, 1.8, 2
+        );
+        $this->assertSame($withoutFees, $withFees);
+    }
+}


### PR DESCRIPTION
## Context
Closes part of #132. The take-profit calculation was ignoring entry/exit fees (~0.1% round-trip on Bitmart), leading to under-estimated TP targets. Additionally, `r_multiple` was too conservative at 1.3.

## Changes
- Add `fees.maker_rate/taker_rate: 0.0005` block to all 3 profile YAML files
- Raise `r_multiple` 1.3→1.8 in `scalper_micro` and `scalper` (regular stays at 2.0)
- Raise `tp1_r` 1.2→1.5 (micro) and 1.0→1.4 (scalper)
- Add `TradeEntryConfig::getFees()` accessor with safe fallback defaults
- Add `makerRate`/`takerRate` to `TradeEntryRequest` (default 0.0, backward-compatible)
- Populate fees in `TradeEntryRequestBuilder` from profile config
- Wire `TakeProfitCalculator::fromRMultipleWithFees()` with directional rounding and riskUnit==0 guard
- Log `expected_fee_usdt` in order journey logs
- 5 unit tests covering Long, Short, zero rMultiple, zero riskUnit, zero fees

## Verification
```bash
docker-compose exec trading-app-php php bin/phpunit tests/TradeEntry/RiskSizer/TakeProfitCalculatorTest.php
docker-compose exec trading-app-php php bin/console mtf:run --workers=2 --dry-run=1
grep "expected_fee_usdt" var/log/order-journey*.log
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)