### PR TITLE
fix: align scalper_micro budget fixed_usdt with initial_margin (#132)

### DIFF
--- a/trading-app/config/app/trade_entry.scalper_micro.yaml
+++ b/trading-app/config/app/trade_entry.scalper_micro.yaml
@@ -132,7 +132,7 @@ trade_entry:
         fallback_taker: true
         budget:
             mode: fixed_or_available
-            fixed_usdt_if_available: 77
+            fixed_usdt_if_available: 50
         quantization:
             price_tick: from_exchange
             qty_step: from_exchange


### PR DESCRIPTION
## Context
Closes part of #132. `entry.budget.fixed_usdt_if_available` was 77 while `defaults.initial_margin_usdt` was 50, making real orders ~54% larger than the risk model expected.

## Change
`trade_entry.scalper_micro.yaml`: `entry.budget.fixed_usdt_if_available` 77 → 50

## Verification
```bash
docker-compose exec trading-app-php php bin/console mtf:run --workers=2 --dry-run=1
grep "budget_check\|initial_margin\|fixed_usdt" var/log/order-journey*.log
# Expected: initial_margin_usdt ≈ fixed_usdt_if_available ≈ 50, écart < 5%
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)