### PR TITLE
feat: add guards to prevent unsafe TP/SL recalculation (#132)

### DIFF
--- a/trading-app/config/app/trade_entry.regular.yaml
+++ b/trading-app/config/app/trade_entry.regular.yaml
@@ -184,3 +184,11 @@ trade_entry:
             Transforme un signal validé (MTF) en plans d'exécution sûrs, traçables et idempotents.
             Sélection dynamique 1m vs 5m, calcul du dernier prix (WS->REST->K-line),
             sizing, levier, orchestration, état, tests, observabilité.
+
+    # ============================
+    # TP/SL RECALCULATION GUARDS
+    # ============================
+    tp_sl_recalc:
+        min_position_age_sec: 180
+        tp_proximity_skip_pct: 0.003
+        skip_if_tp_partially_filled: true

--- a/trading-app/config/app/trade_entry.scalper.yaml
+++ b/trading-app/config/app/trade_entry.scalper.yaml
@@ -187,3 +187,11 @@ trade_entry:
 
         meta: >
             EntryZone resserrée, plus précise, moins permissive, cohérente avec le scalping pro.
+
+    # ============================
+    # TP/SL RECALCULATION GUARDS
+    # ============================
+    tp_sl_recalc:
+        min_position_age_sec: 180
+        tp_proximity_skip_pct: 0.003
+        skip_if_tp_partially_filled: true

--- a/trading-app/config/app/trade_entry.scalper_micro.yaml
+++ b/trading-app/config/app/trade_entry.scalper_micro.yaml
@@ -164,3 +164,11 @@ trade_entry:
             max_attempts: 3
         meta: >
             Zone d'entrée courte, pure micro-structure autour de VWAP 1m (1m/5m).
+
+    # ============================
+    # TP/SL RECALCULATION GUARDS
+    # ============================
+    tp_sl_recalc:
+        min_position_age_sec: 180
+        tp_proximity_skip_pct: 0.003
+        skip_if_tp_partially_filled: true

--- a/trading-app/src/Config/TradeEntryConfig.php
+++ b/trading-app/src/Config/TradeEntryConfig.php
@@ -66,6 +66,15 @@ class TradeEntryConfig
         return $this->config['market_entry'] ?? [];
     }
 
+    public function getTpSlRecalcConfig(): array
+    {
+        return $this->config['tp_sl_recalc'] ?? [
+            'min_position_age_sec' => 0,
+            'tp_proximity_skip_pct' => 0.0,
+            'skip_if_tp_partially_filled' => false,
+        ];
+    }
+
     public function getFees(): array
     {
         return $this->config['fees'] ?? [

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -994,6 +994,13 @@ final class MtfRunnerService
                 return;
             }
 
+            // Charger la config des guards une seule fois pour toutes les positions
+            $recalcConfig = $this->tradeEntryConfigProvider !== null && $this->tradeEntryModeContext !== null
+                ? $this->tradeEntryConfigProvider
+                    ->getConfigForMode($this->tradeEntryModeContext->resolve(null))
+                    ->getTpSlRecalcConfig()
+                : ['min_position_age_sec' => 0, 'tp_proximity_skip_pct' => 0.0, 'skip_if_tp_partially_filled' => false];
+
             // Récupérer toutes les positions ouvertes
             $openPositions = $accountProvider->getOpenPositions();
             $this->positionsLogger->info('[MTF Runner] TP/SL recalculation: checking positions', [
@@ -1067,13 +1074,6 @@ final class MtfRunnerService
                         continue;
                     }
 
-                    // Guards configurables par profil
-                    $recalcConfig = $this->tradeEntryConfigProvider !== null && $this->tradeEntryModeContext !== null
-                        ? $this->tradeEntryConfigProvider
-                            ->getConfigForMode($this->tradeEntryModeContext->resolve(null))
-                            ->getTpSlRecalcConfig()
-                        : ['min_position_age_sec' => 0, 'tp_proximity_skip_pct' => 0.0, 'skip_if_tp_partially_filled' => false];
-
                     // Guard 1 — Âge minimum de la position
                     $positionAgeSec = time() - $position->openedAt->getTimestamp();
                     if ($positionAgeSec < $recalcConfig['min_position_age_sec']) {
@@ -1088,14 +1088,14 @@ final class MtfRunnerService
                     // Guard 2 — TP trop proche du prix courant
                     $existingTp = reset($tpOrders) ?: null;
                     $currentPrice = (float)$position->markPrice->__toString();
-                    if ($existingTp !== null && $recalcConfig['tp_proximity_skip_pct'] > 0.0 && $currentPrice > 0.0) {
+                    if ($existingTp !== null && $recalcConfig['tp_proximity_skip_pct'] > 0.0 && $currentPrice > 0.0 && $existingTp->price !== null) {
                         $tpPrice = (float)$existingTp->price->__toString();
                         $proximity = abs($currentPrice - $tpPrice) / $currentPrice;
                         if ($proximity < $recalcConfig['tp_proximity_skip_pct']) {
                             $this->positionsLogger->info('tp_sl_recalc_skipped', [
                                 'symbol' => $symbol,
                                 'reason' => 'tp_too_close',
-                                'proximity_pct' => $proximity,
+                                'proximity_ratio' => $proximity,
                             ]);
                             continue;
                         }

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -26,6 +26,8 @@ use App\MtfValidator\Service\Dto\SymbolResultDto;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Repository\ContractRepository;
 use App\Repository\PositionRepository;
+use App\Config\TradeEntryConfigProvider;
+use App\Config\TradeEntryModeContext;
 use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
 use App\TradeEntry\Service\TpSlTwoTargetsService;
 use App\TradeEntry\Types\Side as EntrySide;
@@ -71,6 +73,8 @@ final class MtfRunnerService
         private readonly string $projectDir,
         private readonly ClockInterface $clock,
         private readonly ?TpSlTwoTargetsService $tpSlService = null,
+        private readonly ?TradeEntryConfigProvider $tradeEntryConfigProvider = null,
+        private readonly ?TradeEntryModeContext $tradeEntryModeContext = null,
     ) {
     }
 
@@ -1061,6 +1065,52 @@ final class MtfRunnerService
                             'reason' => count($tpOrders) === 0 ? 'no_tp_orders' : 'multiple_tp_orders',
                         ]);
                         continue;
+                    }
+
+                    // Guards configurables par profil
+                    $recalcConfig = $this->tradeEntryConfigProvider !== null && $this->tradeEntryModeContext !== null
+                        ? $this->tradeEntryConfigProvider
+                            ->getConfigForMode($this->tradeEntryModeContext->resolve(null))
+                            ->getTpSlRecalcConfig()
+                        : ['min_position_age_sec' => 0, 'tp_proximity_skip_pct' => 0.0, 'skip_if_tp_partially_filled' => false];
+
+                    // Guard 1 — Âge minimum de la position
+                    $positionAgeSec = time() - $position->openedAt->getTimestamp();
+                    if ($positionAgeSec < $recalcConfig['min_position_age_sec']) {
+                        $this->positionsLogger->info('tp_sl_recalc_skipped', [
+                            'symbol' => $symbol,
+                            'reason' => 'position_too_young',
+                            'age_sec' => $positionAgeSec,
+                        ]);
+                        continue;
+                    }
+
+                    // Guard 2 — TP trop proche du prix courant
+                    $existingTp = reset($tpOrders) ?: null;
+                    $currentPrice = (float)$position->markPrice->__toString();
+                    if ($existingTp !== null && $recalcConfig['tp_proximity_skip_pct'] > 0.0 && $currentPrice > 0.0) {
+                        $tpPrice = (float)$existingTp->price->__toString();
+                        $proximity = abs($currentPrice - $tpPrice) / $currentPrice;
+                        if ($proximity < $recalcConfig['tp_proximity_skip_pct']) {
+                            $this->positionsLogger->info('tp_sl_recalc_skipped', [
+                                'symbol' => $symbol,
+                                'reason' => 'tp_too_close',
+                                'proximity_pct' => $proximity,
+                            ]);
+                            continue;
+                        }
+                    }
+
+                    // Guard 3 — TP partiellement fillé
+                    if ($recalcConfig['skip_if_tp_partially_filled'] && $existingTp !== null) {
+                        if ($existingTp->filledQuantity->isGreaterThan(0)) {
+                            $this->positionsLogger->info('tp_sl_recalc_skipped', [
+                                'symbol' => $symbol,
+                                'reason' => 'tp_partially_filled',
+                                'filled_qty' => (float)$existingTp->filledQuantity->__toString(),
+                            ]);
+                            continue;
+                        }
                     }
 
                     // Recalculer les TP/SL

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -1075,7 +1075,7 @@ final class MtfRunnerService
                     }
 
                     // Guard 1 — Âge minimum de la position
-                    $positionAgeSec = time() - $position->openedAt->getTimestamp();
+                    $positionAgeSec = $this->clock->now()->getTimestamp() - $position->openedAt->getTimestamp();
                     if ($positionAgeSec < $recalcConfig['min_position_age_sec']) {
                         $this->positionsLogger->info('tp_sl_recalc_skipped', [
                             'symbol' => $symbol,


### PR DESCRIPTION
## Context
Closes part of #132. `processTpSlRecalculation()` was cancelling and recreating TP/SL orders every 3 minutes with no safety checks, converting winning trades into losers (e.g., cancelling a TP order that was 0.1% away from being hit).

## Changes
- Add `tp_sl_recalc` config block to all 3 profile YAML files (scalper_micro, scalper, regular)
- Add `TradeEntryConfig::getTpSlRecalcConfig()` with safe defaults (all guards disabled = backward-compatible)
- Inject `TradeEntryConfigProvider` + `TradeEntryModeContext` into `MtfRunnerService` (nullable, backward-compatible)
- Add 3 guards in `processTpSlRecalculation()`:
  1. **Age guard**: skip if position age < `min_position_age_sec` (180s)
  2. **Proximity guard**: skip if existing TP within `tp_proximity_skip_pct` of mark price (0.3%)
  3. **Partial fill guard**: skip if existing TP has been partially filled
- Config loaded once before the position loop (not per-position)
- Null-safe check on `$existingTp->price` for PHPStan compliance
- Guards log `tp_sl_recalc_skipped` with `reason` for observability

## Verification
```bash
docker-compose exec trading-app-php php bin/console mtf:run --workers=2 --dry-run=1
grep "tp_sl_recalc_skipped" var/log/mtf-$(date +%Y-%m-%d).log
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)