### PR TITLE
feat: configurable limit order TTL per profile (#132)

### DIFF
--- a/trading-app/config/app/trade_entry.crash.yaml
+++ b/trading-app/config/app/trade_entry.crash.yaml
@@ -164,6 +164,8 @@ trade_entry:
     entry:
         prefer_maker: true
         fallback_taker: true
+        limit_order_ttl_sec: 120
+        cancel_after_timeout_sec: 150
 
         budget:
             mode: fixed_or_available

--- a/trading-app/config/app/trade_entry.regular.yaml
+++ b/trading-app/config/app/trade_entry.regular.yaml
@@ -152,6 +152,8 @@ trade_entry:
     entry:
         prefer_maker: true
         fallback_taker: true
+        limit_order_ttl_sec: 90
+        cancel_after_timeout_sec: 120
         budget:
             mode: fixed_or_available
             fixed_usdt_if_available: 30       # utilise 30 USDT si dispo, sinon solde dispo

--- a/trading-app/config/app/trade_entry.scalper.yaml
+++ b/trading-app/config/app/trade_entry.scalper.yaml
@@ -152,6 +152,8 @@ trade_entry:
     entry:
         prefer_maker: true     # Préférence maker-only
         fallback_taker: true   # Autorise fallback en taker
+        limit_order_ttl_sec: 45
+        cancel_after_timeout_sec: 75
 
         budget:
             mode: fixed_or_available          # Utilise budget fixe ou solde dispo

--- a/trading-app/config/app/trade_entry.scalper_micro.yaml
+++ b/trading-app/config/app/trade_entry.scalper_micro.yaml
@@ -130,6 +130,8 @@ trade_entry:
     entry:
         prefer_maker: true
         fallback_taker: true
+        limit_order_ttl_sec: 30
+        cancel_after_timeout_sec: 60
         budget:
             mode: fixed_or_available
             fixed_usdt_if_available: 50

--- a/trading-app/src/Config/TradeEntryConfig.php
+++ b/trading-app/src/Config/TradeEntryConfig.php
@@ -68,9 +68,13 @@ class TradeEntryConfig
 
     public function getLimitOrderTtlSec(): int
     {
-        return (int) ($this->config['entry']['limit_order_ttl_sec'] ?? 60);
+        return (int) ($this->config['entry']['limit_order_ttl_sec'] ?? 120);
     }
 
+    /**
+     * Reserved for future use: exchange-side cancel-after timeout.
+     * The Bitmart dead-man switch is currently disabled (set to 0) in ExecutionBox.
+     */
     public function getCancelAfterTimeoutSec(): int
     {
         return (int) ($this->config['entry']['cancel_after_timeout_sec'] ?? 90);

--- a/trading-app/src/Config/TradeEntryConfig.php
+++ b/trading-app/src/Config/TradeEntryConfig.php
@@ -66,6 +66,16 @@ class TradeEntryConfig
         return $this->config['market_entry'] ?? [];
     }
 
+    public function getLimitOrderTtlSec(): int
+    {
+        return (int) ($this->config['entry']['limit_order_ttl_sec'] ?? 60);
+    }
+
+    public function getCancelAfterTimeoutSec(): int
+    {
+        return (int) ($this->config['entry']['cancel_after_timeout_sec'] ?? 90);
+    }
+
     public function getTpSlRecalcConfig(): array
     {
         return $this->config['tp_sl_recalc'] ?? [

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -176,8 +176,9 @@ final class ExecutionBox
         $cancelAfterTimeout = null;   // valeur envoyée au provider (0 => désarmement exchange)
         $watchWindowSec = null;       // fenêtre locale de surveillance/fallback
         if ($plan->orderType !== 'market') {
-            // Fenêtre locale forcée à 120 secondes
-            $watchWindowSec = 120;
+            // Fenêtre locale basée sur le profil (sinon 120s par défaut)
+            $profileConfig = $this->tradeEntryConfigResolver->resolve($mode);
+            $watchWindowSec = $profileConfig->getLimitOrderTtlSec();
             // Désarmer le dead-man côté exchange (éviter le cap 60s)
             $orderPayload['cancel_after_timeout'] = 0; // 0 => disable cancel-all-after
         }
@@ -262,6 +263,7 @@ final class ExecutionBox
                             tries: 0,
                             decisionKey: $decisionKey,
                             lifecycleContext: $contextSnapshot,
+                            mode: $mode,
                         ),
                         [new DelayStamp(self::LIMIT_WATCH_INITIAL_DELAY_MS)] // premier poll dans 5s
                     );

--- a/trading-app/src/TradeEntry/Execution/ExecutionBox.php
+++ b/trading-app/src/TradeEntry/Execution/ExecutionBox.php
@@ -250,8 +250,7 @@ final class ExecutionBox
             if ($plan->orderType !== 'market') {
                 try {
                     // Utiliser la fenêtre locale forcée si définie, sinon fallback sur 60s
-                    $watchSec = $watchWindowSec ?? ($cancelAfterTimeout ?? 60);
-                    if ($watchSec <= 0) { $watchSec = 60; }
+                    $watchSec = ($watchWindowSec !== null && $watchWindowSec > 0) ? $watchWindowSec : 120;
                     $contextSnapshot = $this->watchLifecycleContext($contextBuilder, $plan->exchangeContext);
                     $this->bus->dispatch(
                         new LimitFillWatchMessage(

--- a/trading-app/src/TradeEntry/Message/LimitFillWatchMessage.php
+++ b/trading-app/src/TradeEntry/Message/LimitFillWatchMessage.php
@@ -16,5 +16,6 @@ final class LimitFillWatchMessage
         /** @var array<string,mixed>|null */
         public readonly ?array $lifecycleContext = null,
         public readonly bool $cancelIssued = false,
+        public readonly ?string $mode = null,
     ) {}
 }

--- a/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
@@ -267,6 +267,7 @@ final class LimitFillWatchMessageHandler
                 decisionKey: $message->decisionKey,
                 lifecycleContext: $message->lifecycleContext,
                 cancelIssued: $cancelIssued,
+                mode: $message->mode,
             ),
             [new DelayStamp(self::POLL_DELAY_MS)]
         );

--- a/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
@@ -267,7 +267,7 @@ final class LimitFillWatchMessageHandler
                 decisionKey: $message->decisionKey,
                 lifecycleContext: $message->lifecycleContext,
                 cancelIssued: $cancelIssued,
-                mode: $message->mode,
+                mode: $message->mode ?? null,
             ),
             [new DelayStamp(self::POLL_DELAY_MS)]
         );


### PR DESCRIPTION
## Context
Closes part of #132. Limit order TTL was hardcoded at 120s in `ExecutionBox`. A 1m signal becomes invalid in 30-45s — orders filled beyond that run in the wrong context.

## Changes
- Add `limit_order_ttl_sec` / `cancel_after_timeout_sec` to all 4 profile YAML files
  - scalper_micro: 30s / 60s
  - scalper: 45s / 75s
  - regular: 90s / 120s
  - crash: 120s / 150s (crash mode needs longer fill windows)
- Add `TradeEntryConfig::getLimitOrderTtlSec()` (fallback: 120s to preserve old behavior)
- Add `TradeEntryConfig::getCancelAfterTimeoutSec()` (reserved — exchange dead-man switch currently disabled)
- `ExecutionBox`: reads `getLimitOrderTtlSec()` from profile config instead of hardcoded 120s
- Add optional `mode` field to `LimitFillWatchMessage` (backward-compatible)
- `LimitFillWatchMessageHandler`: forwards `mode` on re-dispatch

## Verification
```bash
# Restart worker after config change
docker-compose restart trading-app-messenger-order-timeout

# Dry-run and check TTL in logs
docker-compose exec trading-app-php php bin/console mtf:run --workers=2 --dry-run=0
grep "cancel_after\|limit_order_ttl\|order_expired" var/log/order-journey*.log
# Expected: cancelAfterSec=30 for scalper_micro
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)