### PR TITLE
[codex] PR 01 effective trading config resolver

### DIFF
--- a/.github/workflows/trading-core-config.yml
+++ b/.github/workflows/trading-core-config.yml
@@ -1,0 +1,93 @@
+name: Trading Core Config Checks
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/trading-core-config.yml'
+      - 'trading-app/src/TradingCore/Config/**'
+      - 'trading-app/tests/TradingCore/Config/**'
+      - 'trading-app/config/**'
+      - 'config_file/**'
+      - 'docs/handbook/technical/**'
+      - 'mkdocs.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/trading-core-config.yml'
+      - 'trading-app/src/TradingCore/Config/**'
+      - 'trading-app/tests/TradingCore/Config/**'
+      - 'trading-app/config/**'
+      - 'config_file/**'
+      - 'docs/handbook/technical/**'
+      - 'mkdocs.yml'
+
+jobs:
+  trading-core-config:
+    name: Trading Core Config
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: trading-app
+
+    env:
+      APP_ENV: test
+      DEFAULT_URI: 'http://localhost'
+      DATABASE_URL: 'postgresql://postgres:postgres@127.0.0.1:5432/trading_test?serverVersion=16&charset=utf8'
+      REDIS_URL: 'redis://127.0.0.1:6379'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: redis, pdo_pgsql, intl, opcache
+          coverage: none
+          tools: composer:v2
+
+      - name: Validate composer
+        run: composer validate --no-check-publish
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: PHPUnit TradingCore Config
+        run: vendor/bin/phpunit --bootstrap vendor/autoload.php tests/TradingCore/Config
+
+      - name: PHPStan TradingCore Config
+        run: vendor/bin/phpstan analyse src/TradingCore/Config tests/TradingCore/Config --memory-limit=512M
+
+      - name: Lint YAML config
+        run: php bin/console lint:yaml config
+
+      - name: Lint Symfony container
+        run: php bin/console lint:container
+
+      - name: Check mtf:run command still exists
+        run: php bin/console list mtf --raw | grep -E '^mtf:run\s'
+
+      - name: Check /api/mtf/run route still exists
+        run: php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install MkDocs dependencies
+        working-directory: .
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-docs.txt ]; then
+            python -m pip install -r requirements-docs.txt
+          else
+            python -m pip install mkdocs mkdocs-material pymdown-extensions
+          fi
+
+      - name: Build MkDocs strict
+        working-directory: .
+        run: python -m mkdocs build --strict

--- a/docs/handbook/technical/effective-trading-config-resolver.md
+++ b/docs/handbook/technical/effective-trading-config-resolver.md
@@ -1,0 +1,82 @@
+# Effective Trading Config Resolver
+
+## Objectif
+
+`EffectiveTradingConfigResolver` introduit une resolution de configuration en couches pour le futur TradingCore modulaire, sans changer le runtime actuel.
+
+L'ordre de resolution est deterministe :
+
+```text
+base
+< mode
+< exchange
+< mode_exchange
+< env
+= effective config
+```
+
+Exemple :
+
+```text
+config/trading/base.yaml
+config/trading/mode/scalper.yaml
+config/trading/exchange/okx.yaml
+config/trading/mode_exchange/scalper.okx.yaml
+config/trading/env/dev.yaml
+```
+
+## Statut runtime
+
+Cette PR ne branche pas encore le resolver sur `mtf:run`, `POST /api/mtf/run`, TradeEntry, Temporal ou les gateways exchange.
+
+Les fichiers sous `trading-app/config/trading/` sont des references inactives. Ils documentent la cible et gardent les protections suivantes :
+
+- `dry_run: true` ;
+- `live_enabled: false` ;
+- `runtime_check_required: true` pour OKX et Hyperliquid ;
+- Bitmart reste marque legacy tant que le runtime actuel en depend.
+
+## Couches
+
+- `base.yaml` est obligatoire.
+- `mode/{mode}.yaml` est optionnel.
+- `exchange/{exchange}.yaml` est optionnel.
+- `mode_exchange/{mode}.{exchange}.yaml` est optionnel.
+- `env/{env}.yaml` est optionnel.
+
+Une couche optionnelle absente est ignoree et exposee dans `missing_optional_layers`. Une couche obligatoire absente leve `TradingConfigException`.
+
+## YAML historiques actuellement utilises
+
+Regular :
+
+- TradeEntry : `trading-app/config/app/trade_entry.regular.yaml`
+- Validations MTF : `trading-app/src/MtfValidator/config/validations.regular.yaml`
+- Contrats MTF : fallback `trading-app/config/app/mtf_contracts.yaml`
+
+Scalper :
+
+- TradeEntry : `trading-app/config/app/trade_entry.scalper.yaml`
+- Validations MTF : `trading-app/src/MtfValidator/config/validations.scalper.yaml`
+- Contrats MTF : fallback `trading-app/config/app/mtf_contracts.yaml`
+
+Scalper micro :
+
+- TradeEntry : `trading-app/config/app/trade_entry.scalper_micro.yaml`
+- Validations MTF : `trading-app/src/MtfValidator/config/validations.scalper_micro.yaml`
+- Contrats MTF : `trading-app/config/app/mtf_contracts.scalper_micro.yaml`
+
+Crash existe aussi comme profil historique, mais il n'est pas dans le scope de la PR 01 :
+
+- TradeEntry : `trading-app/config/app/trade_entry.crash.yaml`
+- Validations MTF : `trading-app/src/MtfValidator/config/validations.crash.yaml`
+
+## Chargement actuel
+
+Le runtime actuel charge encore les YAML via les providers historiques :
+
+- `App\Config\TradeEntryConfigProvider`
+- `App\Config\MtfValidationConfigProvider`
+- `App\Config\MtfContractsConfigProvider`
+
+Le nouveau resolver reste donc une brique preparatoire. Les PR suivantes pourront comparer puis brancher progressivement la config effective sans modifier les strategies dans cette PR.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
       - Interfaces et commandes: technical/interfaces.md
       - Donnees et persistance: technical/data.md
       - Configuration: technical/configuration.md
+      - Effective trading config resolver: technical/effective-trading-config-resolver.md
       - Templates clés environnement: technical/environment-key-templates.md
       - Temporal workers: technical/temporal.md
       - Frontend et Ops: technical/frontend.md

--- a/trading-app/config/trading/base.yaml
+++ b/trading-app/config/trading/base.yaml
@@ -1,0 +1,24 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  config_schema: effective_trading_config.v1
+  runtime_status: inactive_reference
+  exchange: fake
+  market_type: perpetual
+  execution:
+    dry_run: true
+    live_enabled: false
+    runtime_check_required: true
+    require_stop_loss: true
+  risk:
+    source: legacy_runtime_config
+  leverage:
+    policy: derived_from_risk_and_stop
+  entry_zone:
+    source: legacy_trade_entry_config
+  fees:
+    source: exchange_layer_or_legacy_runtime_config
+
+compatibility:
+  bitmart_legacy_runtime_kept: true
+  current_runtime_unchanged: true

--- a/trading-app/config/trading/env/dev.yaml
+++ b/trading-app/config/trading/env/dev.yaml
@@ -1,0 +1,7 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  env: dev
+  execution:
+    dry_run: true
+    live_enabled: false

--- a/trading-app/config/trading/env/prod.yaml
+++ b/trading-app/config/trading/env/prod.yaml
@@ -1,0 +1,8 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  env: prod
+  execution:
+    dry_run: true
+    live_enabled: false
+    runtime_check_required: true

--- a/trading-app/config/trading/exchange/bitmart.yaml
+++ b/trading-app/config/trading/exchange/bitmart.yaml
@@ -1,0 +1,19 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  exchange: bitmart
+  exchange_status: legacy_runtime_only
+  execution:
+    dry_run: true
+    live_enabled: false
+
+compatibility:
+  legacy_runtime_dependency: true
+  env_template_keys:
+    - BITMART_API_KEY
+    - BITMART_SECRET_KEY
+    - BITMART_API_MEMO
+    - BITMART_BASE_URL
+    - BITMART_PRIVATE_API_URL
+    - BITMART_PUBLIC_API_URL
+    - BITMART_WS_PRIVATE_URL

--- a/trading-app/config/trading/exchange/fake.yaml
+++ b/trading-app/config/trading/exchange/fake.yaml
@@ -1,0 +1,15 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  exchange: fake
+  exchange_status: paper_only
+  execution:
+    dry_run: true
+    live_enabled: false
+
+compatibility:
+  env_template_keys:
+    - FAKE_EXCHANGE_ENABLED
+    - FAKE_EXCHANGE_INITIAL_BALANCE_USDT
+    - FAKE_EXCHANGE_FEES_ENABLED
+    - FAKE_EXCHANGE_SLIPPAGE_BPS

--- a/trading-app/config/trading/exchange/hyperliquid.yaml
+++ b/trading-app/config/trading/exchange/hyperliquid.yaml
@@ -1,0 +1,18 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  exchange: hyperliquid
+  exchange_status: dry_run_runtime_check_only
+  execution:
+    dry_run: true
+    live_enabled: false
+    runtime_check_required: true
+
+compatibility:
+  env_template_keys:
+    - HYPERLIQUID_ENV
+    - HYPERLIQUID_PRIVATE_KEY
+    - HYPERLIQUID_ACCOUNT_ADDRESS
+    - HYPERLIQUID_API_BASE_URI
+    - HYPERLIQUID_WS_URI
+    - HYPERLIQUID_MAINNET_ENABLED

--- a/trading-app/config/trading/exchange/okx.yaml
+++ b/trading-app/config/trading/exchange/okx.yaml
@@ -1,0 +1,21 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  exchange: okx
+  exchange_status: dry_run_runtime_check_only
+  execution:
+    dry_run: true
+    live_enabled: false
+    runtime_check_required: true
+
+compatibility:
+  env_template_keys:
+    - OKX_ENV
+    - OKX_API_KEY
+    - OKX_API_SECRET
+    - OKX_API_PASSPHRASE
+    - OKX_API_BASE_URI
+    - OKX_WS_PUBLIC_URI
+    - OKX_WS_PRIVATE_URI
+    - OKX_DEMO_TRADING_ENABLED
+    - OKX_LIVE_ENABLED

--- a/trading-app/config/trading/mode/regular.yaml
+++ b/trading-app/config/trading/mode/regular.yaml
@@ -1,0 +1,9 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  profile: regular
+
+compatibility:
+  trade_entry_config: config/app/trade_entry.regular.yaml
+  mtf_validation_config: src/MtfValidator/config/validations.regular.yaml
+  mtf_contracts_config: config/app/mtf_contracts.yaml

--- a/trading-app/config/trading/mode/scalper.yaml
+++ b/trading-app/config/trading/mode/scalper.yaml
@@ -1,0 +1,9 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  profile: scalper
+
+compatibility:
+  trade_entry_config: config/app/trade_entry.scalper.yaml
+  mtf_validation_config: src/MtfValidator/config/validations.scalper.yaml
+  mtf_contracts_config: config/app/mtf_contracts.yaml

--- a/trading-app/config/trading/mode/scalper_micro.yaml
+++ b/trading-app/config/trading/mode/scalper_micro.yaml
@@ -1,0 +1,9 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  profile: scalper_micro
+
+compatibility:
+  trade_entry_config: config/app/trade_entry.scalper_micro.yaml
+  mtf_validation_config: src/MtfValidator/config/validations.scalper_micro.yaml
+  mtf_contracts_config: config/app/mtf_contracts.scalper_micro.yaml

--- a/trading-app/config/trading/mode_exchange/scalper.okx.yaml
+++ b/trading-app/config/trading/mode_exchange/scalper.okx.yaml
@@ -1,0 +1,12 @@
+version: '0.1.0-effective-config-bootstrap'
+
+trading:
+  profile: scalper
+  exchange: okx
+  execution:
+    dry_run: true
+    live_enabled: false
+    runtime_check_required: true
+
+compatibility:
+  reason: future_profile_exchange_override_placeholder

--- a/trading-app/src/TradingCore/Config/EffectiveTradingConfigResolver.php
+++ b/trading-app/src/TradingCore/Config/EffectiveTradingConfigResolver.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradingCore\Config;
+
+use Psr\Log\LoggerInterface;
+
+final readonly class EffectiveTradingConfigResolver
+{
+    public function __construct(
+        private ?TradingConfigLayerLoader $loader = null,
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    /**
+     * Resolves trading configuration as:
+     * base < mode < exchange < mode_exchange < env.
+     *
+     * @return array{
+     *     config: array<string, mixed>,
+     *     layers: list<array{type: string, name: string, path: string, required: bool}>,
+     *     missing_optional_layers: list<array{type: string, name: string, path: string, required: bool}>
+     * }
+     */
+    public function resolve(string $mode, string $exchange, string $env): array
+    {
+        $loader = $this->loader ?? new TradingConfigLayerLoader();
+
+        $candidates = [
+            ['layer' => $loader->loadBase(), 'missing' => null],
+            ['layer' => $loader->loadMode($mode), 'missing' => $loader->describeOptional('mode', $mode)],
+            ['layer' => $loader->loadExchange($exchange), 'missing' => $loader->describeOptional('exchange', $exchange)],
+            ['layer' => $loader->loadModeExchange($mode, $exchange), 'missing' => $loader->describeOptional('mode_exchange', sprintf('%s.%s', $mode, $exchange))],
+            ['layer' => $loader->loadEnv($env), 'missing' => $loader->describeOptional('env', $env)],
+        ];
+
+        $effectiveConfig = [];
+        $usedLayers = [];
+        $missingOptionalLayers = [];
+
+        foreach ($candidates as $candidate) {
+            $layer = $candidate['layer'];
+            if ($layer instanceof TradingConfigLayer) {
+                $effectiveConfig = $this->mergeConfig($effectiveConfig, $layer->config);
+                $usedLayers[] = $layer->toLogContext();
+                continue;
+            }
+
+            if (is_array($candidate['missing'])) {
+                $missingOptionalLayers[] = $candidate['missing'];
+            }
+        }
+
+        $this->logger?->info('trading_config.effective_resolved', [
+            'mode' => $mode,
+            'exchange' => $exchange,
+            'env' => $env,
+            'layers' => $usedLayers,
+            'missing_optional_layers' => $missingOptionalLayers,
+        ]);
+
+        return [
+            'config' => $effectiveConfig,
+            'layers' => $usedLayers,
+            'missing_optional_layers' => $missingOptionalLayers,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $base
+     * @param array<string, mixed> $override
+     * @return array<string, mixed>
+     */
+    private function mergeConfig(array $base, array $override): array
+    {
+        foreach ($override as $key => $value) {
+            if (
+                array_key_exists($key, $base)
+                && is_array($base[$key])
+                && is_array($value)
+                && $this->isAssociative($base[$key])
+                && $this->isAssociative($value)
+            ) {
+                /** @var array<string, mixed> $baseValue */
+                $baseValue = $base[$key];
+                /** @var array<string, mixed> $overrideValue */
+                $overrideValue = $value;
+                $base[$key] = $this->mergeConfig($baseValue, $overrideValue);
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function isAssociative(array $value): bool
+    {
+        return $value === [] || array_keys($value) !== range(0, count($value) - 1);
+    }
+}

--- a/trading-app/src/TradingCore/Config/Exception/TradingConfigException.php
+++ b/trading-app/src/TradingCore/Config/Exception/TradingConfigException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradingCore\Config\Exception;
+
+final class TradingConfigException extends \RuntimeException
+{
+}

--- a/trading-app/src/TradingCore/Config/TradingConfigLayer.php
+++ b/trading-app/src/TradingCore/Config/TradingConfigLayer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradingCore\Config;
+
+final readonly class TradingConfigLayer
+{
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function __construct(
+        public string $type,
+        public string $name,
+        public string $path,
+        public bool $required,
+        public array $config,
+    ) {
+    }
+
+    /**
+     * @return array{type: string, name: string, path: string, required: bool}
+     */
+    public function toLogContext(): array
+    {
+        return [
+            'type' => $this->type,
+            'name' => $this->name,
+            'path' => $this->path,
+            'required' => $this->required,
+        ];
+    }
+}

--- a/trading-app/src/TradingCore/Config/TradingConfigLayerLoader.php
+++ b/trading-app/src/TradingCore/Config/TradingConfigLayerLoader.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradingCore\Config;
+
+use App\TradingCore\Config\Exception\TradingConfigException;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+final readonly class TradingConfigLayerLoader
+{
+    public function __construct(
+        private ?string $configRoot = null,
+    ) {
+    }
+
+    public function loadBase(): TradingConfigLayer
+    {
+        return $this->load('base', 'base', 'base.yaml', true);
+    }
+
+    public function loadMode(string $mode): ?TradingConfigLayer
+    {
+        return $this->load('mode', $mode, sprintf('mode/%s.yaml', $mode), false);
+    }
+
+    public function loadExchange(string $exchange): ?TradingConfigLayer
+    {
+        return $this->load('exchange', $exchange, sprintf('exchange/%s.yaml', $exchange), false);
+    }
+
+    public function loadModeExchange(string $mode, string $exchange): ?TradingConfigLayer
+    {
+        $name = sprintf('%s.%s', $mode, $exchange);
+
+        return $this->load('mode_exchange', $name, sprintf('mode_exchange/%s.yaml', $name), false);
+    }
+
+    public function loadEnv(string $env): ?TradingConfigLayer
+    {
+        return $this->load('env', $env, sprintf('env/%s.yaml', $env), false);
+    }
+
+    /**
+     * @return array{type: string, name: string, path: string, required: bool}
+     */
+    public function describeOptional(string $type, string $name): array
+    {
+        return [
+            'type' => $type,
+            'name' => $name,
+            'path' => $this->pathFor($this->relativePathFor($type, $name)),
+            'required' => false,
+        ];
+    }
+
+    private function load(string $type, string $name, string $relativePath, bool $required): ?TradingConfigLayer
+    {
+        $path = $this->pathFor($relativePath);
+
+        if (!is_file($path)) {
+            if ($required) {
+                throw new TradingConfigException(sprintf(
+                    'Required trading config layer "%s" is missing: %s',
+                    $type,
+                    $path,
+                ));
+            }
+
+            return null;
+        }
+
+        try {
+            $parsed = Yaml::parseFile($path);
+        } catch (ParseException $exception) {
+            throw new TradingConfigException(sprintf(
+                'Trading config layer "%s" could not be parsed: %s',
+                $type,
+                $path,
+            ), previous: $exception);
+        }
+
+        if (!is_array($parsed) || array_is_list($parsed)) {
+            throw new TradingConfigException(sprintf(
+                'Trading config layer "%s" must contain a YAML mapping: %s',
+                $type,
+                $path,
+            ));
+        }
+
+        /** @var array<string, mixed> $parsed */
+        return new TradingConfigLayer($type, $name, $path, $required, $parsed);
+    }
+
+    private function pathFor(string $relativePath): string
+    {
+        return rtrim($this->root(), '/') . '/' . ltrim($relativePath, '/');
+    }
+
+    private function root(): string
+    {
+        return $this->configRoot ?? dirname(__DIR__, 3) . '/config/trading';
+    }
+
+    private function relativePathFor(string $type, string $name): string
+    {
+        return match ($type) {
+            'mode' => sprintf('mode/%s.yaml', $name),
+            'exchange' => sprintf('exchange/%s.yaml', $name),
+            'mode_exchange' => sprintf('mode_exchange/%s.yaml', $name),
+            'env' => sprintf('env/%s.yaml', $name),
+            default => sprintf('%s.yaml', $name),
+        };
+    }
+}

--- a/trading-app/src/TradingCore/Config/TradingConfigLayerLoader.php
+++ b/trading-app/src/TradingCore/Config/TradingConfigLayerLoader.php
@@ -47,6 +47,8 @@ final readonly class TradingConfigLayerLoader
      */
     public function describeOptional(string $type, string $name): array
     {
+        $this->assertSafeLayerName($type, $name);
+
         return [
             'type' => $type,
             'name' => $name,
@@ -57,6 +59,8 @@ final readonly class TradingConfigLayerLoader
 
     private function load(string $type, string $name, string $relativePath, bool $required): ?TradingConfigLayer
     {
+        $this->assertSafeLayerName($type, $name);
+
         $path = $this->pathFor($relativePath);
 
         if (!is_file($path)) {
@@ -112,5 +116,22 @@ final readonly class TradingConfigLayerLoader
             'env' => sprintf('env/%s.yaml', $name),
             default => sprintf('%s.yaml', $name),
         };
+    }
+
+    private function assertSafeLayerName(string $type, string $name): void
+    {
+        $pattern = $type === 'mode_exchange'
+            ? '/^[a-z0-9][a-z0-9_-]*(?:\.[a-z0-9][a-z0-9_-]*)+$/'
+            : '/^[a-z0-9][a-z0-9_-]*$/';
+
+        if (preg_match($pattern, $name) === 1) {
+            return;
+        }
+
+        throw new TradingConfigException(sprintf(
+            'Invalid trading config layer name for "%s": "%s"',
+            $type,
+            $name,
+        ));
     }
 }

--- a/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
+++ b/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
@@ -9,7 +9,6 @@ use App\TradingCore\Config\Exception\TradingConfigException;
 use App\TradingCore\Config\TradingConfigLayer;
 use App\TradingCore\Config\TradingConfigLayerLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(EffectiveTradingConfigResolver::class)]
@@ -169,6 +168,41 @@ YAML);
         $this->expectExceptionMessage('must contain a YAML mapping');
 
         $this->resolver()->resolve('regular', 'fake', 'dev');
+    }
+
+    public function testRejectsUnsafeLayerNamesBeforeReadingOptionalFiles(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  execution:
+    dry_run: true
+YAML);
+        $this->writeYaml('../services.yaml', <<<YAML
+services:
+  escaped: true
+YAML);
+
+        $this->expectException(TradingConfigException::class);
+        $this->expectExceptionMessage('Invalid trading config layer name');
+
+        $this->resolver()->resolve('../../services', 'fake', 'dev');
+    }
+
+    public function testAllowsSafeSlugLayerNames(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  execution:
+    dry_run: true
+YAML);
+        $this->writeYaml('mode/scalper_micro.yaml', <<<YAML
+trading:
+  profile: scalper_micro
+YAML);
+
+        $resolved = $this->resolver()->resolve('scalper_micro', 'fake', 'dev');
+
+        self::assertSame('scalper_micro', $resolved['config']['trading']['profile']);
     }
 
     private function resolver(): EffectiveTradingConfigResolver

--- a/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
+++ b/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Config;
+
+use App\TradingCore\Config\EffectiveTradingConfigResolver;
+use App\TradingCore\Config\Exception\TradingConfigException;
+use App\TradingCore\Config\TradingConfigLayer;
+use App\TradingCore\Config\TradingConfigLayerLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EffectiveTradingConfigResolver::class)]
+#[CoversClass(TradingConfigLayer::class)]
+#[CoversClass(TradingConfigLayerLoader::class)]
+#[CoversClass(TradingConfigException::class)]
+final class EffectiveTradingConfigResolverTest extends TestCase
+{
+    private string $configRoot;
+
+    protected function setUp(): void
+    {
+        $this->configRoot = sys_get_temp_dir() . '/trading-config-' . bin2hex(random_bytes(6));
+        mkdir($this->configRoot . '/mode', 0777, true);
+        mkdir($this->configRoot . '/exchange', 0777, true);
+        mkdir($this->configRoot . '/mode_exchange', 0777, true);
+        mkdir($this->configRoot . '/env', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->configRoot);
+    }
+
+    public function testMergesBaseAndModeLayers(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  market_type: perpetual
+  risk:
+    max_leverage: 3
+  execution:
+    dry_run: true
+YAML);
+        $this->writeYaml('mode/scalper.yaml', <<<YAML
+trading:
+  profile: scalper
+  risk:
+    risk_pct_percent: 2.5
+YAML);
+
+        $resolved = $this->resolver()->resolve('scalper', 'missing-exchange', 'missing-env');
+
+        self::assertSame('scalper', $resolved['config']['trading']['profile']);
+        self::assertSame('perpetual', $resolved['config']['trading']['market_type']);
+        self::assertSame(3, $resolved['config']['trading']['risk']['max_leverage']);
+        self::assertSame(2.5, $resolved['config']['trading']['risk']['risk_pct_percent']);
+        self::assertSame(['base', 'mode'], array_column($resolved['layers'], 'type'));
+    }
+
+    public function testMergesBaseModeAndExchangeLayers(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  execution:
+    dry_run: true
+  fees:
+    maker_rate: 0.0002
+YAML);
+        $this->writeYaml('mode/regular.yaml', <<<YAML
+trading:
+  profile: regular
+YAML);
+        $this->writeYaml('exchange/okx.yaml', <<<YAML
+trading:
+  exchange: okx
+  fees:
+    taker_rate: 0.0005
+YAML);
+
+        $resolved = $this->resolver()->resolve('regular', 'okx', 'missing-env');
+
+        self::assertSame('okx', $resolved['config']['trading']['exchange']);
+        self::assertSame(0.0002, $resolved['config']['trading']['fees']['maker_rate']);
+        self::assertSame(0.0005, $resolved['config']['trading']['fees']['taker_rate']);
+        self::assertSame(['base', 'mode', 'exchange'], array_column($resolved['layers'], 'type'));
+    }
+
+    public function testMergesAllLayersWithDeterministicOverridePriority(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  profile: base
+  exchange: bitmart
+  execution:
+    dry_run: true
+    live_enabled: false
+  risk:
+    max_leverage: 2
+    risk_pct_percent: 1
+YAML);
+        $this->writeYaml('mode/scalper.yaml', <<<YAML
+trading:
+  profile: scalper
+  risk:
+    max_leverage: 4
+YAML);
+        $this->writeYaml('exchange/okx.yaml', <<<YAML
+trading:
+  exchange: okx
+  risk:
+    max_leverage: 5
+YAML);
+        $this->writeYaml('mode_exchange/scalper.okx.yaml', <<<YAML
+trading:
+  risk:
+    max_leverage: 6
+YAML);
+        $this->writeYaml('env/dev.yaml', <<<YAML
+trading:
+  env: dev
+  execution:
+    dry_run: true
+  risk:
+    risk_pct_percent: 0.5
+YAML);
+
+        $resolved = $this->resolver()->resolve('scalper', 'okx', 'dev');
+
+        self::assertSame('scalper', $resolved['config']['trading']['profile']);
+        self::assertSame('okx', $resolved['config']['trading']['exchange']);
+        self::assertSame('dev', $resolved['config']['trading']['env']);
+        self::assertSame(6, $resolved['config']['trading']['risk']['max_leverage']);
+        self::assertSame(0.5, $resolved['config']['trading']['risk']['risk_pct_percent']);
+        self::assertTrue($resolved['config']['trading']['execution']['dry_run']);
+        self::assertFalse($resolved['config']['trading']['execution']['live_enabled']);
+        self::assertSame(['base', 'mode', 'exchange', 'mode_exchange', 'env'], array_column($resolved['layers'], 'type'));
+    }
+
+    public function testThrowsClearErrorWhenBaseLayerIsMissing(): void
+    {
+        $this->expectException(TradingConfigException::class);
+        $this->expectExceptionMessage('Required trading config layer "base" is missing');
+
+        $this->resolver()->resolve('scalper', 'okx', 'dev');
+    }
+
+    public function testIgnoresMissingOptionalLayers(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  execution:
+    dry_run: true
+YAML);
+
+        $resolved = $this->resolver()->resolve('scalper_micro', 'fake', 'prod');
+
+        self::assertSame(['base'], array_column($resolved['layers'], 'type'));
+        self::assertSame(['mode', 'exchange', 'mode_exchange', 'env'], array_column($resolved['missing_optional_layers'], 'type'));
+    }
+
+    public function testRejectsNonMappingYamlFiles(): void
+    {
+        $this->writeYaml('base.yaml', '- not-a-map');
+
+        $this->expectException(TradingConfigException::class);
+        $this->expectExceptionMessage('must contain a YAML mapping');
+
+        $this->resolver()->resolve('regular', 'fake', 'dev');
+    }
+
+    private function resolver(): EffectiveTradingConfigResolver
+    {
+        return new EffectiveTradingConfigResolver(new TradingConfigLayerLoader($this->configRoot));
+    }
+
+    private function writeYaml(string $relativePath, string $contents): void
+    {
+        $path = $this->configRoot . '/' . $relativePath;
+        $directory = dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($path, $contents . "\n");
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        self::assertIsArray($entries);
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/trading-app/tests/TradingCore/Config/EnvironmentTemplateTest.php
+++ b/trading-app/tests/TradingCore/Config/EnvironmentTemplateTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Config;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class EnvironmentTemplateTest extends TestCase
+{
+    public function testEnvironmentTemplatesDoNotContainSecretValues(): void
+    {
+        foreach (['dev.env', 'prod.env'] as $template) {
+            $path = dirname(__DIR__, 4) . '/config_file/' . $template;
+            self::assertFileExists($path);
+
+            $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            self::assertIsArray($lines);
+
+            foreach ($lines as $line) {
+                $trimmed = trim($line);
+                if ($trimmed === '' || str_starts_with($trimmed, '#')) {
+                    continue;
+                }
+
+                self::assertMatchesRegularExpression('/^[A-Z0-9_]+=$/', $trimmed, sprintf(
+                    '%s must only contain empty KEY= template entries; got "%s"',
+                    $template,
+                    $trimmed,
+                ));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Objectif

Introduire un resolver de configuration effective TradingCore sans brancher le runtime existant.

## Scope

- Ajout de `EffectiveTradingConfigResolver`, `TradingConfigLayerLoader`, `TradingConfigLayer` et `TradingConfigException`.
- Ajout des couches inactives `config/trading/{base,mode,exchange,mode_exchange,env}`.
- Ajout de tests unitaires sur le merge, les priorites, les couches optionnelles et la base obligatoire.
- Ajout d’un test garantissant que `config_file/dev.env` et `config_file/prod.env` restent des templates `KEY=`.
- Documentation courte du resolver et de la cartographie YAML historique.

## Hors-scope

- Aucun branchement sur `mtf:run`, `/api/mtf/run`, Temporal, TradeEntry ou les gateways exchange.
- Aucun changement de strategie, EntryZone, levier, SL/TP ou comportement live.
- Bitmart reste legacy runtime; OKX/Hyperliquid restent dry-run/runtime-check.
- Aucun secret ajoute.

## Tests

- `cd trading-app && vendor/bin/phpunit --bootstrap vendor/autoload.php tests/TradingCore/Config`
- `cd trading-app && vendor/bin/phpstan analyse src/TradingCore/Config tests/TradingCore/Config --memory-limit=512M`
- `cd trading-app && APP_ENV=test APP_SECRET=test DEFAULT_URI=http://localhost DATABASE_URL="sqlite:///%kernel.project_dir%/var/test.db" LOCK_DSN=flock REDIS_HOST=127.0.0.1 REDIS_PORT=6379 MESSENGER_TRANSPORT_DSN="doctrine://default?queue_name=test" php bin/console lint:yaml config`
- `cd trading-app && APP_ENV=test APP_SECRET=test DEFAULT_URI=http://localhost DATABASE_URL="sqlite:///%kernel.project_dir%/var/test.db" LOCK_DSN=flock REDIS_HOST=127.0.0.1 REDIS_PORT=6379 MESSENGER_TRANSPORT_DSN="doctrine://default?queue_name=test" php bin/console lint:container`
- `python3 -m mkdocs build --strict`

## Notes

- `lint:container` emet une depreciation existante sur `EntryZoneStatsCommand`, mais sort en succes.
- `phpstan analyse` complet reste hors scope: le depot contient deja des erreurs existantes; le perimetre ajoute est propre.
