### PR TITLE
[codex] PR 02 exchange readiness matrix

### DIFF
--- a/docs/handbook/technical/exchange-readiness-consolidation.md
+++ b/docs/handbook/technical/exchange-readiness-consolidation.md
@@ -1,0 +1,128 @@
+# Exchange readiness consolidation
+
+## Objectif
+
+Cette page consolide l'état exchange après :
+
+- PR #129, `feat: add exchange profile runtime schedules` ;
+- PR #141, architecture cible TradingCore ;
+- PR #142, `EffectiveTradingConfigResolver` et couches `config/trading/*`.
+
+Elle ne branche pas la config effective au runtime et ne rend aucun nouvel exchange prêt au live. Elle sert à distinguer ce qui existe déjà, ce qui est partiel, ce qui manque, ce qui est interdit en live et ce qui doit être validé avant toute activation.
+
+## Sources vérifiées
+
+- `trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php`
+- `trading-app/src/Command/ExchangeRuntimeCheckCommand.php`
+- `cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py`
+- `cron_symfony_mtf_workers/README.md`
+- `docs/handbook/technical/exchange-readiness-matrix.md`
+- `docs/handbook/technical/exchange-runtime-gates.md`
+- `docs/handbook/technical/exchange-schedule-policy.md`
+- `trading-app/config/trading/exchange/*.yaml`
+- `trading-app/config/trading/env/dev.yaml`
+- `trading-app/config/trading/env/prod.yaml`
+- `config_file/dev.env`
+- `config_file/prod.env`
+- adapters `FakeExchangeAdapter`, `OkxExchangeAdapter`, `HyperliquidExchangeAdapter`, `BitmartExchangeAdapter`
+- registries `ExchangeAdapterRegistry` et `ExchangeProviderRegistry`
+
+## Déjà présent via PR #129
+
+| Élément | Statut |
+|---|---|
+| `MtfRunnerRequestDto` accepte l'enum `Exchange` | Présent. `Exchange::tryFrom()` accepte `bitmart`, `binance`, `fake`, `hyperliquid`, `okx`. |
+| Payload Temporal explicite | Présent. Le script générique envoie `exchange`, `market_type`, `mtf_profile`, `workers`, `dry_run`. |
+| Schedule manager exchange/profile | Présent dans `manage_exchange_profile_schedule.py`. |
+| Defaults dry-run | Présents. `dry_run=true` est le défaut, y compris Bitmart. |
+| Guardrails live | Présents. `dry_run=false` exige `Schedule ready: yes`, credentials `ok` et `Live trading: enabled`, sauf bypass explicite. |
+| Commande runtime-check | Présente : `php bin/console app:exchange:runtime-check <exchange> <market_type>`. |
+| Docs runtime matrix | Présentes dans le README Temporal et les pages handbook existantes. |
+
+## Présent mais partiel
+
+| Élément | État partiel |
+|---|---|
+| Adapters OKX/Hyperliquid | Présents, avec REST private/public, order placement/cancel, balance, positions et reconciliation REST. Ils restent dry-run/runtime-check, pas live. |
+| Provider bundles OKX/Hyperliquid/Fake | Manquants dans `ExchangeProviderRegistry`. Le registry ne déclare que Bitmart perpetual/spot. |
+| WebSocket OKX | Normalizer privé présent, mais pas de client privé réel ; l'adapter n'annonce pas `supportsWebSocketPrivate`. |
+| WebSocket Hyperliquid | URI/config présents, mais pas de client WS privé ; l'adapter n'annonce pas `supportsWebSocketPrivate`. |
+| Fake/Paper | Adapter, state store, matching engine et WS fake présents. Le provider bundle MTF reste manquant. |
+| TradingCore config PR #142 | Couches YAML présentes, mais non branchées au runtime MTF/TradeEntry. |
+| Bitmart reconciliation | Runtime legacy présent ; la méthode adapter indique encore `legacy_bitmart_reconciliation_not_wired_yet` pour son résultat direct. |
+
+## Manquant
+
+- Provider bundles `fake::perpetual`, `okx::perpetual` et `hyperliquid::perpetual`.
+- Branchement runtime de `EffectiveTradingConfigResolver`.
+- Validation réelle `app:exchange:runtime-check` avec credentials et endpoints exchange.
+- Clients WebSocket privés OKX/Hyperliquid utilisables en runtime.
+- Validation SL/TP attach/reconciliation de bout en bout sur OKX/Hyperliquid.
+- Politique de live explicite par PR dédiée.
+- Inventaire de retrait Bitmart et migration des dépendances legacy.
+
+## Interdit en live
+
+- OKX live.
+- Hyperliquid live.
+- Tout schedule `dry_run=false` OKX/Hyperliquid.
+- Toute activation live par simple présence de credentials.
+- Suppression de Bitmart dans cette PR.
+- Branchement de `EffectiveTradingConfigResolver` au runtime dans cette PR.
+- Modification de `mtf:run`, `POST /api/mtf/run`, Temporal runtime, TradeEntry, EntryZone, Risk/Leverage, SL/TP ou YAML stratégie.
+
+## Matrice exchange
+
+| Exchange | Statut cible | Statut runtime actuel | Dry-run autorisé | Live autorisé | Adapter présent | Provider bundle présent | Credentials attendus | Runtime-check disponible | WebSocket public | WebSocket privé | Order placement | Order cancel | Position fetch | Balance fetch | SL/TP attach | Reconciliation | Audit/logging | Temporal schedule | Risques | Prochaines actions |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Fake/Paper | Target test gateway | Partiel : adapter simulation présent, provider MTF manquant | Oui | Non | Oui, `FakeExchangeAdapter` | Non | `FAKE_EXCHANGE_ENABLED`, `FAKE_EXCHANGE_INITIAL_BALANCE_USDT`, `FAKE_EXCHANGE_FEES_ENABLED`, `FAKE_EXCHANGE_SLIPPAGE_BPS` | Oui, mais `Schedule ready` reste bloqué tant que le provider bundle manque | Non requis ; simulation locale | Oui côté fake/capability | Oui, simulé | Oui, simulé | Oui, simulé | Oui, simulé | Oui, simulé via capabilities | Oui, simulée | Partiel via events/projections | Oui avec `manage_exchange_profile_schedule.py`, simulation/dry-run seulement | Confusion possible entre adapter prêt et pipeline MTF prêt | Ajouter le provider bundle fake ou clarifier le bypass simulation ; valider un run dry-run complet sans Bitmart |
+| OKX | Target gateway, dry-run only | Partiel : adapter REST présent, provider MTF manquant | Oui, après runtime-check ou schedule dry-run avec warning | Non | Oui, `OkxExchangeAdapter` | Non | `OKX_ENV`, `OKX_API_KEY`, `OKX_API_SECRET`, `OKX_API_PASSPHRASE`, `OKX_API_BASE_URI`, `OKX_WS_PUBLIC_URI`, `OKX_WS_PRIVATE_URI`, `OKX_DEMO_TRADING_ENABLED`, `OKX_LIVE_ENABLED` | Oui | Config/REST public présents ; client WS public non consolidé | Normalizer présent, client privé manquant, capability false | Implémenté REST, à garder dry-run/demo uniquement | Implémenté REST | Implémenté REST | Implémenté REST | Pas attaché sur entrée ; trigger orders disponibles mais workflow à valider | REST snapshot présent | Partiel via events/reconciliation | Oui, dry-run seulement | `OKX_DEMO_TRADING_ENABLED` ou credentials peuvent donner une fausse impression de readiness | Ajouter provider bundle, client WS privé, validation SL/TP/reconciliation, puis PR live séparée si besoin |
+| Hyperliquid | Target gateway, dry-run only | Partiel : adapter REST présent, provider MTF manquant | Oui, après runtime-check ou schedule dry-run avec warning | Non | Oui, `HyperliquidExchangeAdapter` | Non | `HYPERLIQUID_ENV`, `HYPERLIQUID_PRIVATE_KEY`, `HYPERLIQUID_ACCOUNT_ADDRESS`, `HYPERLIQUID_API_BASE_URI`, `HYPERLIQUID_WS_URI`, `HYPERLIQUID_MAINNET_ENABLED` | Oui | Config URI présente ; pas de client WS runtime consolidé | Manquant, capability false | Implémenté au niveau adapter, mais le client par défaut ne signe pas le live | Implémenté au niveau adapter | Implémenté REST info | Implémenté REST info | Pas attaché sur entrée ; trigger/protection à valider selon modèle Hyperliquid | REST snapshot présent | Partiel via events/reconciliation | Oui, dry-run seulement | Client par défaut indique que le signing live n'est pas activé ; modèle USDC/symboles différent | Ajouter provider bundle, client signé non-live/testnet, WS ou équivalent, validation protections/reconciliation |
+| Bitmart | Legacy runtime only, to remove later | Présent, historique | Oui si déjà supporté | Legacy uniquement ; pas cible future | Oui, `BitmartExchangeAdapter` | Oui, perpetual et spot legacy | `BITMART_API_KEY`, `BITMART_SECRET_KEY`, `BITMART_API_MEMO`, `BITMART_BASE_URL`, `BITMART_PRIVATE_API_URL`, `BITMART_PUBLIC_API_URL`, `BITMART_WS_PRIVATE_URL` | Oui | Oui, legacy | Oui, legacy | Oui, legacy | Oui, legacy | Oui, legacy | Oui, legacy | Oui, legacy | Partiel/direct adapter legacy ; service reconciliation disponible | Oui, legacy logs existants | Oui, legacy et dry-run par défaut dans le nouveau script | Dépendances runtime encore fortes ; ne pas le supprimer trop tôt | Inventorier les dépendances Bitmart, maintenir compatibilité, retirer seulement par PR dédiée |
+
+## Config TradingCore PR #142
+
+| Fichier | Décision de consolidation |
+|---|---|
+| `config/trading/exchange/fake.yaml` | Confirme `paper_only`, `dry_run: true`, `live_enabled: false`. Fake/Paper est la gateway de sécurité. |
+| `config/trading/exchange/okx.yaml` | Confirme `dry_run_runtime_check_only`, `runtime_check_required: true`, `live_enabled: false`. OKX n'est pas live-ready. |
+| `config/trading/exchange/hyperliquid.yaml` | Confirme `dry_run_runtime_check_only`, `runtime_check_required: true`, `live_enabled: false`. Hyperliquid n'est pas live-ready. |
+| `config/trading/exchange/bitmart.yaml` | Confirme `legacy_runtime_only` et `legacy_runtime_dependency: true`. Bitmart reste à conserver. |
+| `config/trading/env/dev.yaml` | Dev reste `dry_run: true`, `live_enabled: false`. |
+| `config/trading/env/prod.yaml` | Prod reste `dry_run: true`, `live_enabled: false`, `runtime_check_required: true`. |
+| `config_file/dev.env` et `config_file/prod.env` | Listent les clés attendues sans secrets. Les clés OKX/Hyperliquid/Fake existent, Bitmart reste listé en legacy. |
+
+Ces configs ne changent pas le runtime aujourd'hui. Elles documentent la cible de résolution effective et les clés d'environnement attendues.
+
+## À valider avant live
+
+Avant toute PR live OKX ou Hyperliquid :
+
+1. Fake/Paper doit exécuter un dry-run complet et auditable.
+2. Le provider bundle de l'exchange cible doit être déclaré et testé.
+3. `app:exchange:runtime-check <exchange> perpetual` doit sortir `Schedule ready: yes`.
+4. Les credentials doivent être présents hors Git et validés.
+5. Les flags live doivent rester désactivés jusqu'à PR dédiée.
+6. Le WebSocket privé, ou un mécanisme équivalent, doit prouver les ordres, fills et positions.
+7. `balance fetch` et `position fetch` doivent être validés sur environnement non-live.
+8. `order placement` et `order cancel` doivent être validés en dry-run/demo/testnet.
+9. SL/TP attach et reconciliation doivent être prouvés sur traces.
+10. L'audit minimal doit couvrir décisions, rejets, ordres, fills, protections et reconciliation.
+11. Les schedules Temporal doivent rester explicites : `exchange`, `market_type`, `mtf_profile`, `dry_run`.
+12. Une procédure de rollback vers Fake/Paper doit être documentée.
+
+## Décision PR 02
+
+PR 02 est une consolidation documentaire. Elle ne doit pas :
+
+- modifier `mtf:run` ;
+- modifier `POST /api/mtf/run` ;
+- modifier le runtime Temporal ;
+- activer OKX live ;
+- activer Hyperliquid live ;
+- supprimer Bitmart ;
+- brancher `EffectiveTradingConfigResolver` au runtime ;
+- modifier TradeEntry, EntryZone, Risk/Leverage, SL/TP ;
+- changer les YAML stratégie `regular`, `scalper` ou `scalper_micro`.
+
+La prochaine étape technique sûre est de faire passer Fake/Paper au statut de gateway de sécurité réellement runnable par le pipeline MTF, puis seulement ensuite de traiter OKX/Hyperliquid en dry-run/runtime-check.

--- a/docs/handbook/technical/exchange-readiness-matrix.md
+++ b/docs/handbook/technical/exchange-readiness-matrix.md
@@ -1,0 +1,141 @@
+# Exchange readiness matrix
+
+## Objectif
+
+Cette page définit l’état de readiness des gateways exchange dans TradingV3.
+
+Elle ne rend aucun exchange prêt au live. Elle sert à éviter les confusions entre :
+
+- ce qui existe déjà dans le code ;
+- ce qui est utilisable en dry-run ;
+- ce qui reste legacy ;
+- ce qui est interdit avant validation runtime.
+
+## Statuts canoniques
+
+| Statut | Sens |
+|---|---|
+| `target_test_gateway` | Gateway de test/simulation utilisable pour valider le pipeline sans live. |
+| `target_dry_run_only` | Gateway cible future, mais uniquement dry-run/runtime-check pour l’instant. |
+| `legacy_runtime_only` | Présent parce que le runtime historique en dépend encore, mais à retirer plus tard. |
+| `not_ready` | Ne doit pas être utilisé par le runtime. |
+
+## Matrice synthétique
+
+| Exchange | Statut cible | Runtime actuel | Dry-run autorisé | Live autorisé | Rôle |
+|---|---|---:|---:|---:|---|
+| Fake / Paper | `target_test_gateway` | À valider | Oui | Non | Gateway de sécurité pour tests, simulation, replay, OrderPlan et ExecutionPort. |
+| OKX | `target_dry_run_only` | À valider | Oui, après runtime-check | Non | Gateway cible future, jamais live tant que la readiness complète n’est pas prouvée. |
+| Hyperliquid | `target_dry_run_only` | À valider | Oui, après runtime-check | Non | Gateway cible future, jamais live tant que la readiness complète n’est pas prouvée. |
+| Bitmart | `legacy_runtime_only` | Oui, historique | Oui si déjà supporté | Legacy uniquement | À conserver tant que le runtime en dépend, puis retirer par PR dédiée. |
+
+## Matrice détaillée
+
+| Capability | Fake / Paper | OKX | Hyperliquid | Bitmart legacy |
+|---|---|---|---|---|
+| Adapter présent | À valider | À valider | À valider | Historique |
+| Provider bundle présent | À valider | À valider | À valider | Historique |
+| Credentials attendus | Non, sauf paramètres de simulation | Oui | Oui | Oui tant que legacy |
+| Runtime-check obligatoire | Oui | Oui | Oui | Oui si maintenu |
+| WebSocket public | Non requis au début | À valider | À valider | Historique |
+| WebSocket privé | Non requis au début | Bloquant avant live | Bloquant avant live | Historique |
+| Balance fetch | Simulé | Bloquant avant live | Bloquant avant live | Historique |
+| Position fetch | Simulé | Bloquant avant live | Bloquant avant live | Historique |
+| Order placement | Simulé | Dry-run uniquement | Dry-run uniquement | Legacy |
+| Order cancel | Simulé | Dry-run uniquement | Dry-run uniquement | Legacy |
+| SL/TP attach | Simulé et vérifiable | Bloquant avant live | Bloquant avant live | Obligatoire |
+| Liquidation guard | Testable | Bloquant avant live | Bloquant avant live | Obligatoire |
+| Reconciliation | Testable | Bloquant avant live | Bloquant avant live | Obligatoire |
+| Audit/logging | Obligatoire | Obligatoire | Obligatoire | Obligatoire |
+| Temporal schedule | Simulation seulement | Dry-run seulement | Dry-run seulement | Legacy uniquement |
+
+## Fake / Paper
+
+Fake / Paper doit devenir la gateway de sécurité canonique.
+
+Elle doit permettre de valider :
+
+- `OrderPlan` ;
+- `ExecutionPort` ;
+- idempotence ;
+- SL obligatoire ;
+- liquidation guard ;
+- audit minimal ;
+- dry-run ;
+- backtesting/replay ;
+- compatibilité des entrypoints `mtf:run` et `POST /api/mtf/run`.
+
+Fake / Paper doit être disponible avant toute expérimentation sérieuse OKX ou Hyperliquid.
+
+## OKX
+
+OKX est une gateway cible, mais son statut reste `target_dry_run_only`.
+
+OKX ne doit pas passer live tant que les points suivants ne sont pas prouvés :
+
+- credentials présents et valides ;
+- runtime-check OK ;
+- WebSocket privé OK ;
+- balance fetch OK ;
+- position fetch OK ;
+- order placement dry-run OK ;
+- order cancel dry-run OK ;
+- SL/TP attach testé ;
+- reconciliation testée ;
+- audit minimal complet ;
+- schedule Temporal explicitement autorisé ;
+- fallback Fake/Paper disponible.
+
+## Hyperliquid
+
+Hyperliquid est une gateway cible, mais son statut reste `target_dry_run_only`.
+
+Hyperliquid ne doit pas passer live tant que les points suivants ne sont pas prouvés :
+
+- credentials présents et valides ;
+- runtime-check OK ;
+- WebSocket public/privé ou mécanisme équivalent validé ;
+- balance fetch OK ;
+- position fetch OK ;
+- order placement dry-run OK ;
+- order cancel dry-run OK ;
+- SL/TP attach ou équivalent testé ;
+- liquidation guard adapté au modèle Hyperliquid ;
+- reconciliation testée ;
+- audit minimal complet ;
+- schedule Temporal explicitement autorisé ;
+- fallback Fake/Paper disponible.
+
+## Bitmart legacy
+
+Bitmart reste `legacy_runtime_only`.
+
+Règles :
+
+- ne pas supprimer Bitmart dans les PRs de préparation ;
+- ne pas prendre Bitmart comme modèle cible pour les DTOs métier ;
+- ne pas baser la future architecture TradingCore sur les payloads Bitmart ;
+- retirer Bitmart uniquement après inventaire et PR dédiée ;
+- ne pas casser le runtime existant tant qu’il dépend de Bitmart.
+
+## Règles de décision
+
+Un exchange peut être déclaré candidat au live uniquement si :
+
+1. Fake/Paper est stable ;
+2. la config effective est résolue et auditée ;
+3. les runtime gates sont toutes vertes ;
+4. les schedules sont explicitement autorisés ;
+5. le dry-run a produit des traces exploitables ;
+6. `position_trade_analysis` ou une source équivalente permet de mesurer les résultats ;
+7. aucun invariant trading n’est cassé.
+
+## Invariants
+
+- Aucune position sans stop-loss automatique immédiatement attaché.
+- Aucun levier arbitraire : le levier doit rester dérivé du risque, du stop et des caps exchange.
+- Aucune bascule live sans runtime-check OK.
+- OKX/Hyperliquid restent dry-run jusqu’à validation explicite.
+- Fake/Paper doit rester disponible comme filet de sécurité.
+- Bitmart reste legacy tant que le runtime en dépend.
+- Aucune EntryZone ne doit être desserrée sans preuve PnL nette.

--- a/docs/handbook/technical/exchange-runtime-gates.md
+++ b/docs/handbook/technical/exchange-runtime-gates.md
@@ -1,0 +1,143 @@
+# Exchange runtime gates
+
+## Objectif
+
+Cette page définit les gates minimales avant qu’un exchange puisse être utilisé par un flux runtime.
+
+Elle s’applique aux gateways cibles :
+
+- Fake / Paper ;
+- OKX ;
+- Hyperliquid ;
+- Bitmart legacy tant qu’il reste en runtime.
+
+## Principe
+
+Un exchange ne doit jamais être activé en live par simple présence d’un adapter, d’un provider ou de credentials.
+
+La bascule live doit être explicite, testée et traçable.
+
+## Gates obligatoires avant tout live
+
+| Gate | Description | Bloquant live |
+|---|---|---:|
+| Credentials présents | Les clés nécessaires sont disponibles hors Git. | Oui |
+| Credentials valides | Le runtime-check peut authentifier l’exchange. | Oui |
+| Exchange explicitement autorisé | L’exchange est listé dans la config effective. | Oui |
+| Market type explicitement autorisé | Le couple exchange/market type est supporté. | Oui |
+| Dry-run validé | Les opérations critiques ont été testées sans live. | Oui |
+| Runtime-check OK | La commande ou le service runtime-check confirme la disponibilité. | Oui |
+| WebSocket privé OK | Les événements ordres/positions sont observables. | Oui pour live |
+| Balance fetch OK | Le solde disponible est lisible. | Oui |
+| Position fetch OK | Les positions ouvertes sont lisibles. | Oui |
+| Order placement OK | Le placement d’ordre est validé en dry-run ou environnement test. | Oui |
+| Order cancel OK | L’annulation est validée. | Oui |
+| SL attaché | Le stop-loss automatique est attaché immédiatement. | Oui |
+| TP/SL reconciliation | Les protections sont relues et reconciliées. | Oui |
+| Liquidation guard OK | Le risque de liquidation est contrôlé. | Oui |
+| Idempotence OK | Pas de double ordre pour la même décision. | Oui |
+| Audit minimal OK | Les décisions, rejets, ordres et protections sont journalisés. | Oui |
+| Temporal schedule autorisé | Le schedule déclare explicitement exchange/profile/mode. | Oui |
+| Fallback Fake/Paper disponible | Possibilité de revenir à une exécution non-live. | Oui |
+
+## Gates par environnement
+
+### Dev
+
+Dev doit rester permissif pour l’expérimentation, mais sans live implicite.
+
+Règles :
+
+- Fake/Paper autorisé ;
+- OKX dry-run autorisé si runtime-check OK ;
+- Hyperliquid dry-run autorisé si runtime-check OK ;
+- Bitmart legacy seulement si nécessaire ;
+- live interdit par défaut.
+
+### Prod
+
+Prod doit être strict.
+
+Règles :
+
+- aucun live sans validation explicite ;
+- aucun live OKX/Hyperliquid dans les PRs de préparation ;
+- aucun schedule live sans readiness complète ;
+- toute activation live doit être une PR dédiée ;
+- toute activation live doit être réversible.
+
+## Gates spécifiques OKX
+
+OKX reste `dry-run only` tant que les gates suivantes ne sont pas toutes validées :
+
+- `OKX_API_KEY` présent hors Git ;
+- `OKX_API_SECRET` présent hors Git ;
+- `OKX_API_PASSPHRASE` présent hors Git ;
+- environnement demo/sandbox clarifié ;
+- API base URI validée ;
+- WebSocket public validé ;
+- WebSocket privé validé ;
+- balance fetch validé ;
+- position fetch validé ;
+- order placement dry-run validé ;
+- order cancel dry-run validé ;
+- SL/TP attach validé ;
+- reconciliation validée ;
+- audit complet.
+
+## Gates spécifiques Hyperliquid
+
+Hyperliquid reste `dry-run only` tant que les gates suivantes ne sont pas toutes validées :
+
+- clé privée présente hors Git ;
+- account address présent hors Git ;
+- environnement mainnet/testnet clarifié ;
+- API base URI validée ;
+- WebSocket ou mécanisme équivalent validé ;
+- balance fetch validé ;
+- position fetch validé ;
+- order placement dry-run validé ;
+- order cancel dry-run validé ;
+- SL/TP ou mécanisme de protection équivalent validé ;
+- liquidation guard adapté ;
+- reconciliation validée ;
+- audit complet.
+
+## Gates spécifiques Fake / Paper
+
+Fake/Paper ne doit jamais envoyer d’ordre live.
+
+Il doit valider :
+
+- construction d’un `OrderPlan` ;
+- idempotence ;
+- SL obligatoire ;
+- TP/SL simulated attach ;
+- liquidation guard ;
+- frais simulés ;
+- slippage simulé ;
+- audit ;
+- replay/backtesting.
+
+## Gates spécifiques Bitmart legacy
+
+Bitmart reste uniquement `legacy_runtime_only`.
+
+Règles :
+
+- ne pas supprimer tant que le runtime dépend de lui ;
+- ne pas ajouter de nouvelle logique cible basée sur Bitmart ;
+- ne pas utiliser Bitmart comme modèle des DTOs TradingCore ;
+- inventorier ses dépendances avant suppression ;
+- retirer uniquement par PR dédiée.
+
+## Anti-patterns interdits
+
+- Passer OKX live parce que les credentials existent.
+- Passer Hyperliquid live parce que l’adapter compile.
+- Ajouter un schedule Temporal live sans readiness complète.
+- Brancher un exchange au runtime sans audit.
+- Ouvrir une position sans SL attaché.
+- Changer le levier pour compenser un problème d’exécution.
+- Supprimer Bitmart avant Fake/Paper stable.
+- Desserrer les EntryZones pour augmenter la fréquence sans preuve PnL nette.

--- a/docs/handbook/technical/exchange-runtime-gates.md
+++ b/docs/handbook/technical/exchange-runtime-gates.md
@@ -22,7 +22,7 @@ La bascule live doit être explicite, testée et traçable.
 | Gate | Description | Bloquant live |
 |---|---|---:|
 | Credentials présents | Les clés nécessaires sont disponibles hors Git. | Oui |
-| Credentials valides | Le runtime-check peut authentifier l’exchange. | Oui |
+| Credentials valides | Les clés sont non vides (vérification de présence uniquement). `app:exchange:runtime-check` n’effectue pas de sonde REST ; la validité réelle doit être confirmée séparément par un appel authentifié. | Oui |
 | Exchange explicitement autorisé | L’exchange est listé dans la config effective. | Oui |
 | Market type explicitement autorisé | Le couple exchange/market type est supporté. | Oui |
 | Dry-run validé | Les opérations critiques ont été testées sans live. | Oui |

--- a/docs/handbook/technical/exchange-schedule-policy.md
+++ b/docs/handbook/technical/exchange-schedule-policy.md
@@ -1,0 +1,154 @@
+# Exchange schedule policy
+
+## Objectif
+
+Cette page définit la politique des schedules Temporal par exchange, market type et profil.
+
+Elle évite qu’un nouveau schedule rende OKX ou Hyperliquid live avant validation complète.
+
+## Règle générale
+
+Un schedule doit déclarer explicitement :
+
+- exchange ;
+- market type ;
+- profil ;
+- mode dry-run ou live ;
+- cadence ;
+- garde-fous rate limits ;
+- audit attendu ;
+- statut readiness.
+
+## Statuts schedule
+
+| Statut | Sens |
+|---|---|
+| `simulation_allowed` | Autorisé seulement avec Fake/Paper. |
+| `dry_run_allowed` | Autorisé sans ordre live, après runtime-check. |
+| `legacy_allowed` | Autorisé uniquement parce que le runtime historique en dépend. |
+| `live_forbidden` | Interdit en live. |
+| `live_candidate` | Potentiellement live plus tard, après PR dédiée. |
+
+## Politique par exchange
+
+| Exchange | Schedule simulation | Schedule dry-run | Schedule live | Commentaire |
+|---|---:|---:|---:|---|
+| Fake / Paper | Oui | Oui | Non | Filet de sécurité et gateway de test. |
+| OKX | Oui via Fake/Paper | Oui après runtime-check | Non | Live interdit dans les PRs de préparation. |
+| Hyperliquid | Oui via Fake/Paper | Oui après runtime-check | Non | Live interdit dans les PRs de préparation. |
+| Bitmart legacy | Non cible | Legacy seulement | Legacy seulement | À retirer plus tard, sans casser l’existant. |
+
+## Cadence
+
+La cadence 1 minute est sensible.
+
+Avant d’autoriser une cadence 1m pour un exchange/profil, il faut valider :
+
+- rate limits exchange ;
+- coûts de requêtes REST ;
+- WebSocket privé stable ;
+- idempotence ;
+- lock cross-profile ;
+- audit complet ;
+- dry-run stable ;
+- absence de double soumission ;
+- SL attaché immédiatement ;
+- logs exploitables.
+
+## Format cible de déclaration
+
+Un schedule devrait pouvoir être décrit ainsi :
+
+```yaml
+exchange: okx
+market_type: perpetual
+profile: scalper
+mode: dry_run
+cadence: "*/1 * * * *"
+runtime_check_required: true
+live_enabled: false
+audit_required: true
+fallback_gateway: fake
+```
+
+Ce format est indicatif pour la documentation. Il ne branche aucun runtime dans cette PR.
+
+## Fake / Paper
+
+Fake/Paper est autorisé pour :
+
+- simulation ;
+- dry-run ;
+- validation d’OrderPlan ;
+- validation d’ExecutionPort ;
+- replay ;
+- backtesting ;
+- contrôle des invariants.
+
+Fake/Paper ne doit jamais envoyer d’ordre live.
+
+## OKX
+
+OKX peut avoir des schedules dry-run seulement si :
+
+- runtime-check OK ;
+- credentials disponibles hors Git ;
+- dry-run explicitement activé ;
+- live explicitement désactivé ;
+- audit actif ;
+- Fake/Paper disponible comme fallback.
+
+OKX live est interdit tant qu’une PR dédiée de readiness live n’a pas été validée.
+
+## Hyperliquid
+
+Hyperliquid peut avoir des schedules dry-run seulement si :
+
+- runtime-check OK ;
+- credentials disponibles hors Git ;
+- environnement test/mainnet clarifié ;
+- dry-run explicitement activé ;
+- live explicitement désactivé ;
+- audit actif ;
+- Fake/Paper disponible comme fallback.
+
+Hyperliquid live est interdit tant qu’une PR dédiée de readiness live n’a pas été validée.
+
+## Bitmart legacy
+
+Bitmart peut rester schedulé uniquement si le runtime historique en dépend encore.
+
+Règles :
+
+- ne pas créer de nouveaux schedules Bitmart comme cible future ;
+- documenter les schedules legacy existants ;
+- retirer Bitmart après inventaire ;
+- ne pas casser `mtf:run`, `POST /api/mtf/run` ou Temporal pendant la transition.
+
+## Gates avant ajout d’un nouveau schedule
+
+Avant tout nouveau schedule, vérifier :
+
+1. la gateway est listée dans la readiness matrix ;
+2. le runtime-check est disponible ;
+3. l’exchange n’est pas live par défaut ;
+4. le profil est explicitement autorisé ;
+5. la cadence est justifiée ;
+6. les rate limits sont connus ;
+7. l’audit minimal est actif ;
+8. Fake/Paper fallback existe ;
+9. la PR reste atomique ;
+10. les invariants trading ne sont pas cassés.
+
+## Hors-scope des PRs de préparation
+
+Les PRs de préparation ne doivent pas :
+
+- créer de schedule live OKX ;
+- créer de schedule live Hyperliquid ;
+- augmenter la cadence pour chercher plus de trades ;
+- contourner le runtime-check ;
+- désactiver le dry-run ;
+- modifier les stratégies pour forcer des trades ;
+- desserrer les EntryZones ;
+- modifier le levier.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,9 @@ nav:
       - Donnees et persistance: technical/data.md
       - Configuration: technical/configuration.md
       - Effective trading config resolver: technical/effective-trading-config-resolver.md
+      - Exchange readiness matrix: technical/exchange-readiness-matrix.md
+      - Exchange runtime gates: technical/exchange-runtime-gates.md
+      - Exchange schedule policy: technical/exchange-schedule-policy.md
       - Templates clés environnement: technical/environment-key-templates.md
       - Temporal workers: technical/temporal.md
       - Frontend et Ops: technical/frontend.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Donnees et persistance: technical/data.md
       - Configuration: technical/configuration.md
       - Effective trading config resolver: technical/effective-trading-config-resolver.md
+      - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md
       - Exchange schedule policy: technical/exchange-schedule-policy.md


### PR DESCRIPTION
## Objectif

Documenter la readiness exchange avant toute extension runtime.

Cette PR établit la matrice de préparation pour :

- Fake / Paper exchange ;
- OKX ;
- Hyperliquid ;
- Bitmart legacy.

## Scope

- Ajout de `docs/handbook/technical/exchange-readiness-matrix.md`.
- Ajout de `docs/handbook/technical/exchange-runtime-gates.md`.
- Ajout de `docs/handbook/technical/exchange-schedule-policy.md`.
- Ajout des pages dans `mkdocs.yml`.

## Décisions documentées

- Fake / Paper = gateway de test cible.
- OKX = gateway cible, dry-run only.
- Hyperliquid = gateway cible, dry-run only.
- Bitmart = legacy runtime only, à retirer plus tard par PR dédiée.

## Hors-scope

- Aucun changement runtime.
- Aucun branchement d’exchange.
- Aucun changement `mtf:run`.
- Aucun changement `POST /api/mtf/run`.
- Aucun changement Temporal.
- Aucun changement TradeEntry.
- Aucun changement EntryZone.
- Aucun changement Risk / Leverage.
- Aucun changement SL/TP.
- Aucun changement YAML stratégie.
- Aucun secret ajouté.

## Checks à lancer

- `cd trading-app && php bin/console lint:yaml config`
- `cd trading-app && php bin/console lint:container`
- `cd trading-app && php bin/console list mtf --raw | grep -E '^mtf:run\s'`
- `cd trading-app && php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'`
- `python3 -m mkdocs build --strict`

## Notes

Cette PR est documentation only. Elle ne rend pas OKX ou Hyperliquid prêts au trading réel.
