### PR TITLE
[codex] PR 03 — Runner extraction 1

### DIFF
--- a/docs/handbook/technical/runner-extraction.md
+++ b/docs/handbook/technical/runner-extraction.md
@@ -1,0 +1,136 @@
+# Runner extraction
+
+## Objectif PR03
+
+PR03 commence l'extraction du runner sans changer le comportement runtime.
+
+Le scope est volontairement limite a deux responsabilites deja presentes dans
+`MtfRunnerService` :
+
+- resolution de l'univers de symboles a traiter ;
+- filtrage des symboles occupes par positions ou ordres ouverts.
+
+`MtfRunnerService` reste l'orchestrateur principal. Les nouveaux services sont
+des delegations mecaniques qui conservent les memes entrees, sorties, logs et
+side effects que les blocs extraits.
+
+## Entrypoints conserves
+
+| Entrypoint | Statut PR03 |
+| --- | --- |
+| `php bin/console mtf:run` | Conserve. La commande construit toujours `MtfRunnerRequestDto` puis appelle `RunMtfCycleUseCase`. |
+| `POST /api/mtf/run` | Conserve. `RunnerController` garde le payload et la reponse existants. |
+| Temporal -> `/api/mtf/run` | Conserve. Aucun changement de schedule ou payload Temporal. |
+| Worker symboles `mtf:run-worker` | Conserve. Le worker continue d'appeler `MtfValidatorInterface` avec `--skip-open-filter` quand le runner a filtre en amont. |
+
+## Responsabilites actuelles du runner
+
+`MtfRunnerService` orchestre encore le cycle complet :
+
+1. creation du contexte exchange/market ;
+2. resolution des symboles ;
+3. synchronisation positions et ordres depuis l'exchange ;
+4. filtrage des symboles ayant une activite ouverte ;
+5. gestion des locks ;
+6. gestion des switches ;
+7. execution MTF sequentielle ou parallele ;
+8. projection Messenger des snapshots indicateurs ;
+9. recalcul TP/SL cadence ;
+10. enrichissement/reporting final.
+
+PR03 ne change pas l'ordre de ces etapes.
+
+## Ce que PR03 extrait
+
+### `App\Application\Runner\SymbolUniverseResolver`
+
+Responsabilite extraite depuis `MtfRunnerService::resolveSymbols()` :
+
+- normaliser les symboles fournis en entree ;
+- dedupliquer les symboles ;
+- charger les contrats actifs via `ContractRepository::allActiveSymbolNames()` quand aucun symbole n'est fourni ;
+- conserver le fallback legacy `BTCUSDT`, `ETHUSDT`, `ADAUSDT`, `SOLUSDT`, `DOTUSDT` ;
+- consommer la queue de switches via `MtfSwitchRepository::consumeSymbolsWithFutureExpiration()` ;
+- logger les memes avertissements et informations que le bloc historique.
+
+`MtfRunnerService::resolveSymbols()` reste disponible et delegue au nouveau
+service afin de preserver les appels existants.
+
+### `App\Application\Runner\OpenActivityFilter`
+
+Responsabilite extraite depuis
+`MtfRunnerService::filterSymbolsWithOpenOrdersOrPositions()` :
+
+- recuperer ou reutiliser les positions ouvertes ;
+- recuperer ou reutiliser les ordres ouverts ;
+- construire la liste des symboles avec activite ouverte ;
+- reactiver les switches des symboles redevenus inactifs ;
+- exclure les symboles occupes ;
+- renseigner `$excludedSymbols` avec les symboles exclus en majuscules ;
+- conserver les logs existants.
+
+`MtfRunnerService::filterSymbolsWithOpenOrdersOrPositions()` reste disponible et
+delegue au nouveau service.
+
+## Structure utilisee ensuite par MTF
+
+Apres resolution et filtrage, le runner transmet toujours une liste simple de
+symboles a `MtfValidatorService` :
+
+- en mode sequentiel, via `MtfRunRequestDto::symbols` ;
+- en mode parallele, via une `SplQueue` et la commande `mtf:run-worker`.
+
+Les resultats restent indexes par symbole dans `results`, avec les statuts
+`READY` ou `INVALID` derives de `MtfResultDto::isTradable`. PR03 ne modifie pas
+la structure de reponse ni les valeurs `READY` / `REJECTED` / `INVALID`.
+
+## Ce qui reste legacy dans PR03
+
+Les responsabilites suivantes restent dans `MtfRunnerService` :
+
+- synchronisation exchange complete ;
+- creation et mise a jour des entites `Position` ;
+- gestion des locks ;
+- extension/desactivation post-run des switches pour symboles exclus ;
+- execution parallele par `Process` ;
+- dispatch Messenger de projection indicateurs ;
+- recalcul TP/SL ;
+- reporting final et enrichissement de resultat.
+
+Les entrypoints Symfony, Temporal et worker ne sont pas extraits dans cette PR.
+
+## Hors-scope confirme
+
+PR03 ne branche pas `EffectiveTradingConfigResolver` au runtime, ne modifie pas
+les YAML strategie, ne change pas TradeEntry, EntryZone, Risk/Leverage, SL/TP,
+Temporal, les schedules, Bitmart, OKX ou Hyperliquid live.
+
+Aucun secret n'est ajoute.
+
+## Tests de non-regression
+
+Tests ajoutes :
+
+- `tests/Application/Runner/SymbolUniverseResolverTest.php`
+- `tests/Application/Runner/OpenActivityFilterTest.php`
+
+Ces tests couvrent :
+
+- normalisation et deduplication des symboles fournis ;
+- chargement des contrats actifs quand aucun symbole n'est fourni ;
+- fallback legacy quand la base et la queue ne retournent rien ;
+- consommation de la queue de switches ;
+- exclusion des symboles avec positions ou ordres ouverts ;
+- side effect de reactivation des switches inactifs.
+
+## Suite PR04
+
+PR04 pourra extraire les responsabilites suivantes, sans les melanger avec PR03 :
+
+- synchronisation exchange/tables ;
+- reporting final ;
+- assemblage de resultat ;
+- dispatch post-run.
+
+La validation MTF, TradeEntry, EntryZone, Risk/Leverage, SL/TP et ExecutionPort
+restent des PR separees du plan TradingCore canonique.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Donnees et persistance: technical/data.md
       - Configuration: technical/configuration.md
       - Effective trading config resolver: technical/effective-trading-config-resolver.md
+      - Runner extraction: technical/runner-extraction.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/Application/Runner/OpenActivityFilter.php
+++ b/trading-app/src/Application/Runner/OpenActivityFilter.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Runner;
+
+use App\Contract\Provider\MainProviderInterface;
+use App\MtfValidator\Repository\MtfSwitchRepository;
+use App\Provider\Context\ExchangeContext;
+use Psr\Log\LoggerInterface;
+
+final class OpenActivityFilter
+{
+    public function __construct(
+        private readonly MainProviderInterface $mainProvider,
+        private readonly MtfSwitchRepository $mtfSwitchRepository,
+        private readonly LoggerInterface $logger,
+        private readonly LoggerInterface $mtfLogger,
+    ) {
+    }
+
+    /**
+     * @param array<string> $symbols Liste des symboles à filtrer
+     * @param array<string> $excludedSymbols Référence pour retourner les symboles exclus
+     * @param array<int, object|array<string, mixed>>|null $openPositions Positions ouvertes préchargées
+     * @param array<int, object|array<string, mixed>>|null $openOrders Ordres ouverts préchargés
+     * @return array<string> Liste des symboles à traiter
+     */
+    public function filter(
+        array $symbols,
+        string $runId,
+        ExchangeContext $context,
+        array &$excludedSymbols = [],
+        ?array $openPositions = null,
+        ?array $openOrders = null,
+    ): array {
+        $excludedSymbols = [];
+        $provider = $this->mainProvider->forContext($context);
+        $accountProvider = $provider->getAccountProvider();
+        $orderProvider = $provider->getOrderProvider();
+
+        if (empty($symbols)) {
+            return $symbols;
+        }
+
+        $symbolsToProcess = [];
+
+        $openPositionSymbols = [];
+        try {
+            if ($openPositions === null) {
+                $openPositions = $accountProvider->getOpenPositions();
+                $this->mtfLogger->info('[MTF Runner] Fetched open positions', [
+                    'run_id' => $runId,
+                    'count' => count($openPositions),
+                ]);
+            } else {
+                $this->mtfLogger->info('[MTF Runner] Reusing prefetched open positions', [
+                    'run_id' => $runId,
+                    'count' => count($openPositions),
+                ]);
+            }
+
+            foreach ($openPositions as $position) {
+                $positionSymbol = strtoupper($this->extractSymbol($position));
+                if ($positionSymbol !== '' && !in_array($positionSymbol, $openPositionSymbols, true)) {
+                    $openPositionSymbols[] = $positionSymbol;
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->mtfLogger->warning('[MTF Runner] Failed to fetch open positions from exchange', [
+                'run_id' => $runId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        $openOrderSymbols = [];
+        try {
+            if ($openOrders === null) {
+                $openOrders = $orderProvider->getOpenOrders();
+                $this->mtfLogger->info('[MTF Runner] Fetched open orders', [
+                    'run_id' => $runId,
+                    'count' => count($openOrders),
+                ]);
+            } else {
+                $this->mtfLogger->info('[MTF Runner] Reusing prefetched open orders', [
+                    'run_id' => $runId,
+                    'count' => count($openOrders),
+                ]);
+            }
+
+            foreach ($openOrders as $order) {
+                $orderSymbol = strtoupper($this->extractSymbol($order));
+                if ($orderSymbol !== '' && !in_array($orderSymbol, $openOrderSymbols, true)) {
+                    $openOrderSymbols[] = $orderSymbol;
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->logger->warning('[MTF Runner] Failed to fetch open orders from exchange', [
+                'run_id' => $runId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        $symbolsWithActivity = array_unique(array_merge($openPositionSymbols, $openOrderSymbols));
+
+        try {
+            $reactivatedCount = $this->mtfSwitchRepository->reactivateSwitchesForInactiveSymbols($symbolsWithActivity);
+            if ($reactivatedCount > 0) {
+                $this->mtfLogger->info('[MTF Runner] Reactivated switches for inactive symbols', [
+                    'run_id' => $runId,
+                    'reactivated_count' => $reactivatedCount,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('[MTF Runner] Failed to reactivate switches for inactive symbols', [
+                'run_id' => $runId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        foreach ($symbols as $symbol) {
+            $symbolUpper = strtoupper($symbol);
+
+            if (in_array($symbolUpper, $symbolsWithActivity, true)) {
+                $excludedSymbols[] = $symbolUpper;
+            } else {
+                $symbolsToProcess[] = $symbol;
+            }
+        }
+
+        if (!empty($excludedSymbols)) {
+            $this->logger->info('[MTF Runner] Filtered symbols with open orders/positions', [
+                'run_id' => $runId,
+                'excluded_count' => count($excludedSymbols),
+                'excluded_symbols' => array_slice($excludedSymbols, 0, 10),
+                'remaining_count' => count($symbolsToProcess),
+            ]);
+        }
+
+        return $symbolsToProcess;
+    }
+
+    /**
+     * @param object|array<string, mixed> $payload
+     */
+    private function extractSymbol(object|array $payload): string
+    {
+        if (is_array($payload)) {
+            return is_string($payload['symbol'] ?? null) ? $payload['symbol'] : '';
+        }
+
+        return is_string($payload->symbol ?? null) ? $payload->symbol : '';
+    }
+}

--- a/trading-app/src/Application/Runner/OpenActivityFilter.php
+++ b/trading-app/src/Application/Runner/OpenActivityFilter.php
@@ -35,70 +35,82 @@ final class OpenActivityFilter
         ?array $openOrders = null,
     ): array {
         $excludedSymbols = [];
+
+        if (empty($symbols)) {
+            return $symbols;
+        }
+
         $provider = $this->mainProvider->forContext($context);
         $accountProvider = $provider->getAccountProvider();
         $orderProvider = $provider->getOrderProvider();
 
-        if (empty($symbols)) {
+        $hasAccountProvider = $accountProvider !== null || $openPositions !== null;
+        $hasOrderProvider = $orderProvider !== null || $openOrders !== null;
+
+        if (!$hasAccountProvider && !$hasOrderProvider) {
             return $symbols;
         }
 
         $symbolsToProcess = [];
 
         $openPositionSymbols = [];
-        try {
-            if ($openPositions === null) {
-                $openPositions = $accountProvider->getOpenPositions();
-                $this->mtfLogger->info('[MTF Runner] Fetched open positions', [
-                    'run_id' => $runId,
-                    'count' => count($openPositions),
-                ]);
-            } else {
-                $this->mtfLogger->info('[MTF Runner] Reusing prefetched open positions', [
-                    'run_id' => $runId,
-                    'count' => count($openPositions),
-                ]);
-            }
-
-            foreach ($openPositions as $position) {
-                $positionSymbol = strtoupper($this->extractSymbol($position));
-                if ($positionSymbol !== '' && !in_array($positionSymbol, $openPositionSymbols, true)) {
-                    $openPositionSymbols[] = $positionSymbol;
+        if ($accountProvider !== null || $openPositions !== null) {
+            try {
+                if ($openPositions === null && $accountProvider !== null) {
+                    $openPositions = $accountProvider->getOpenPositions();
+                    $this->mtfLogger->info('[MTF Runner] Fetched open positions', [
+                        'run_id' => $runId,
+                        'count' => count($openPositions),
+                    ]);
+                } elseif ($openPositions !== null) {
+                    $this->mtfLogger->info('[MTF Runner] Reusing prefetched open positions', [
+                        'run_id' => $runId,
+                        'count' => count($openPositions),
+                    ]);
                 }
+
+                foreach ($openPositions ?? [] as $position) {
+                    $positionSymbol = strtoupper($this->extractSymbol($position));
+                    if ($positionSymbol !== '' && !in_array($positionSymbol, $openPositionSymbols, true)) {
+                        $openPositionSymbols[] = $positionSymbol;
+                    }
+                }
+            } catch (\Throwable $e) {
+                $this->mtfLogger->warning('[MTF Runner] Failed to fetch open positions from exchange', [
+                    'run_id' => $runId,
+                    'error' => $e->getMessage(),
+                ]);
             }
-        } catch (\Throwable $e) {
-            $this->mtfLogger->warning('[MTF Runner] Failed to fetch open positions from exchange', [
-                'run_id' => $runId,
-                'error' => $e->getMessage(),
-            ]);
         }
 
         $openOrderSymbols = [];
-        try {
-            if ($openOrders === null) {
-                $openOrders = $orderProvider->getOpenOrders();
-                $this->mtfLogger->info('[MTF Runner] Fetched open orders', [
-                    'run_id' => $runId,
-                    'count' => count($openOrders),
-                ]);
-            } else {
-                $this->mtfLogger->info('[MTF Runner] Reusing prefetched open orders', [
-                    'run_id' => $runId,
-                    'count' => count($openOrders),
-                ]);
-            }
-
-            foreach ($openOrders as $order) {
-                $orderSymbol = strtoupper($this->extractSymbol($order));
-                if ($orderSymbol !== '' && !in_array($orderSymbol, $openOrderSymbols, true)) {
-                    $openOrderSymbols[] = $orderSymbol;
+        if ($orderProvider !== null || $openOrders !== null) {
+            try {
+                if ($openOrders === null && $orderProvider !== null) {
+                    $openOrders = $orderProvider->getOpenOrders();
+                    $this->mtfLogger->info('[MTF Runner] Fetched open orders', [
+                        'run_id' => $runId,
+                        'count' => count($openOrders),
+                    ]);
+                } elseif ($openOrders !== null) {
+                    $this->mtfLogger->info('[MTF Runner] Reusing prefetched open orders', [
+                        'run_id' => $runId,
+                        'count' => count($openOrders),
+                    ]);
                 }
+
+                foreach ($openOrders ?? [] as $order) {
+                    $orderSymbol = strtoupper($this->extractSymbol($order));
+                    if ($orderSymbol !== '' && !in_array($orderSymbol, $openOrderSymbols, true)) {
+                        $openOrderSymbols[] = $orderSymbol;
+                    }
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning('[MTF Runner] Failed to fetch open orders from exchange', [
+                    'run_id' => $runId,
+                    'error' => $e->getMessage(),
+                ]);
             }
-        } catch (\Throwable $e) {
-            $this->logger->warning('[MTF Runner] Failed to fetch open orders from exchange', [
-                'run_id' => $runId,
-                'error' => $e->getMessage(),
-            ]);
         }
 
         $symbolsWithActivity = array_unique(array_merge($openPositionSymbols, $openOrderSymbols));

--- a/trading-app/src/Application/Runner/SymbolUniverseResolver.php
+++ b/trading-app/src/Application/Runner/SymbolUniverseResolver.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Runner;
+
+use App\MtfValidator\Repository\MtfSwitchRepository;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Repository\ContractRepository;
+use Psr\Log\LoggerInterface;
+
+final class SymbolUniverseResolver
+{
+    private const FALLBACK_SYMBOLS = ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'SOLUSDT', 'DOTUSDT'];
+
+    public function __construct(
+        private readonly ContractRepository $contractRepository,
+        private readonly MtfSwitchRepository $mtfSwitchRepository,
+        private readonly LoggerInterface $logger,
+        private readonly LoggerInterface $mtfLogger,
+    ) {
+    }
+
+    /**
+     * @param array<string> $inputSymbols Liste des symboles fournis en entrée
+     * @return array<string> Liste des symboles à traiter
+     */
+    public function resolve(array $inputSymbols, ?string $profile = null, ?ExchangeContext $context = null): array
+    {
+        $symbols = [];
+
+        foreach ($inputSymbols as $symbol) {
+            if (is_string($symbol) && $symbol !== '') {
+                $symbols[] = strtoupper(trim($symbol));
+            }
+        }
+
+        $symbols = array_values(array_unique(array_filter($symbols)));
+
+        if (empty($symbols)) {
+            try {
+                $fetched = $this->contractRepository->allActiveSymbolNames([], false, $profile, $context);
+                if (!empty($fetched)) {
+                    $symbols = array_values(array_unique(array_map('strval', $fetched)));
+                }
+            } catch (\Throwable $e) {
+                $this->logger->warning('[MTF Runner] Failed to load active symbols, using fallback', [
+                    'error' => $e->getMessage(),
+                    'profile' => $profile,
+                ]);
+                $symbols = self::FALLBACK_SYMBOLS;
+            }
+        }
+
+        $queuedSymbols = $this->consumeSymbolsFromSwitchQueue();
+        if (!empty($queuedSymbols)) {
+            $symbols = array_values(array_unique(array_merge($symbols, $queuedSymbols)));
+            $this->mtfLogger->info('[MTF Runner] Added symbols from switch queue', [
+                'count' => count($queuedSymbols),
+            ]);
+        }
+
+        if (empty($symbols)) {
+            $symbols = self::FALLBACK_SYMBOLS;
+        }
+
+        return $symbols;
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function consumeSymbolsFromSwitchQueue(): array
+    {
+        try {
+            return $this->mtfSwitchRepository->consumeSymbolsWithFutureExpiration();
+        } catch (\Throwable $e) {
+            $this->logger->warning('[MTF Runner] Failed to consume symbols from switch queue', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+}

--- a/trading-app/src/Contract/Provider/MainProviderInterface.php
+++ b/trading-app/src/Contract/Provider/MainProviderInterface.php
@@ -24,15 +24,14 @@ interface MainProviderInterface
     /**
      * Retourne le provider d'ordres
      */
-    public function getOrderProvider(): OrderProviderInterface;
+    public function getOrderProvider(): ?OrderProviderInterface;
 
     /**
      * Retourne le provider de compte
      */
-    public function getAccountProvider(): AccountProviderInterface;
+    public function getAccountProvider(): ?AccountProviderInterface;
 
     public function getSystemProvider(): SystemProviderInterface;
 
     public function forContext(?ExchangeContext $context = null): self;
 }
-

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace App\MtfRunner\Service;
 
+use App\Application\Runner\OpenActivityFilter;
+use App\Application\Runner\SymbolUniverseResolver;
 use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
-use App\Contract\MtfValidator\Dto\MtfRunDto;
 use App\Contract\MtfValidator\Dto\MtfResultDto;
 use App\Contract\MtfValidator\MtfValidatorInterface;
 use App\Contract\Provider\MainProviderInterface;
@@ -22,9 +23,7 @@ use App\MtfRunner\Service\FuturesOrderSyncService;
 use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
 use App\MtfValidator\Repository\MtfLockRepository;
 use App\MtfValidator\Repository\MtfSwitchRepository;
-use App\MtfValidator\Service\Dto\SymbolResultDto;
 use App\Provider\Context\ExchangeContext;
-use App\Provider\Repository\ContractRepository;
 use App\Repository\PositionRepository;
 use App\Config\TradeEntryConfigProvider;
 use App\Config\TradeEntryModeContext;
@@ -55,7 +54,8 @@ use Symfony\Component\Process\Process;
 final class MtfRunnerService
 {
     public function __construct(
-        private readonly ContractRepository $contractRepository,
+        private readonly SymbolUniverseResolver $symbolUniverseResolver,
+        private readonly OpenActivityFilter $openActivityFilter,
         private readonly PositionRepository $positionRepository,
         private readonly MtfLockRepository $mtfLockRepository,
         private readonly MtfSwitchRepository $mtfSwitchRepository,
@@ -231,48 +231,7 @@ final class MtfRunnerService
      */
     public function resolveSymbols(array $inputSymbols, ?string $profile = null, ?ExchangeContext $context = null): array
     {
-        $symbols = [];
-
-        // Normaliser les symboles fournis
-        foreach ($inputSymbols as $symbol) {
-            if (is_string($symbol) && $symbol !== '') {
-                $symbols[] = strtoupper(trim($symbol));
-            }
-        }
-
-        $symbols = array_values(array_unique(array_filter($symbols)));
-
-        // Si aucun symbole fourni, récupérer depuis la base de données
-        if (empty($symbols)) {
-            try {
-                $fetched = $this->contractRepository->allActiveSymbolNames([], false, $profile, $context);
-                if (!empty($fetched)) {
-                    $symbols = array_values(array_unique(array_map('strval', $fetched)));
-                }
-            } catch (\Throwable $e) {
-                $this->logger->warning('[MTF Runner] Failed to load active symbols, using fallback', [
-                    'error' => $e->getMessage(),
-                    'profile' => $profile,
-                ]);
-                $symbols = ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'SOLUSDT', 'DOTUSDT'];
-            }
-        }
-
-        // Consommer les symboles depuis la queue des switches
-        $queuedSymbols = $this->consumeSymbolsFromSwitchQueue();
-        if (!empty($queuedSymbols)) {
-            $symbols = array_values(array_unique(array_merge($symbols, $queuedSymbols)));
-            $this->mtfLogger->info('[MTF Runner] Added symbols from switch queue', [
-                'count' => count($queuedSymbols),
-            ]);
-        }
-
-        // Fallback si toujours vide
-        if (empty($symbols)) {
-            $symbols = ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'SOLUSDT', 'DOTUSDT'];
-        }
-
-        return $symbols;
+        return $this->symbolUniverseResolver->resolve($inputSymbols, $profile, $context);
     }
 
     /**
@@ -295,122 +254,14 @@ final class MtfRunnerService
         ?array $openPositions = null,
         ?array $openOrders = null
     ): array {
-        $excludedSymbols = [];
-        $provider = $this->mainProvider->forContext($context);
-
-        $hasAccountProvider = $provider->getAccountProvider() !== null || $openPositions !== null;
-        $hasOrderProvider = $provider->getOrderProvider() !== null || $openOrders !== null;
-
-        if (empty($symbols) || (!$hasAccountProvider && !$hasOrderProvider)) {
-            return $symbols;
-        }
-
-        $symbolsToProcess = [];
-
-        // Récupérer les symboles avec positions ouvertes depuis l'exchange
-        $openPositionSymbols = [];
-        $accountProvider = $provider->getAccountProvider();
-        if ($accountProvider || $openPositions !== null) {
-            try {
-                if ($openPositions === null && $accountProvider) {
-                    $openPositions = $accountProvider->getOpenPositions();
-                    $this->mtfLogger->info('[MTF Runner] Fetched open positions', [
-                        'run_id' => $runId,
-                        'count' => count($openPositions),
-                    ]);
-                } elseif ($openPositions !== null) {
-                    $this->mtfLogger->info('[MTF Runner] Reusing prefetched open positions', [
-                        'run_id' => $runId,
-                        'count' => count($openPositions),
-                    ]);
-                }
-
-                foreach ($openPositions as $position) {
-                    $positionSymbol = strtoupper($position->symbol ?? '');
-                    if ($positionSymbol !== '' && !in_array($positionSymbol, $openPositionSymbols, true)) {
-                        $openPositionSymbols[] = $positionSymbol;
-                    }
-                }
-            } catch (\Throwable $e) {
-                $this->mtfLogger->warning('[MTF Runner] Failed to fetch open positions from exchange', [
-                    'run_id' => $runId,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
-
-        // Récupérer les symboles avec ordres ouverts depuis l'exchange
-        $openOrderSymbols = [];
-        $orderProvider = $provider->getOrderProvider();
-        if ($orderProvider || $openOrders !== null) {
-            try {
-                if ($openOrders === null && $orderProvider) {
-                    $openOrders = $orderProvider->getOpenOrders();
-                    $this->mtfLogger->info('[MTF Runner] Fetched open orders', [
-                        'run_id' => $runId,
-                        'count' => count($openOrders),
-                    ]);
-                } elseif ($openOrders !== null) {
-                    $this->mtfLogger->info('[MTF Runner] Reusing prefetched open orders', [
-                        'run_id' => $runId,
-                        'count' => count($openOrders),
-                    ]);
-                }
-
-                foreach ($openOrders as $order) {
-                    $orderSymbol = strtoupper($order->symbol ?? '');
-                    if ($orderSymbol !== '' && !in_array($orderSymbol, $openOrderSymbols, true)) {
-                        $openOrderSymbols[] = $orderSymbol;
-                    }
-                }
-            } catch (\Throwable $e) {
-                $this->logger->warning('[MTF Runner] Failed to fetch open orders from exchange', [
-                    'run_id' => $runId,
-                    'error' => $e->getMessage(),
-                ]);
-            }
-        }
-
-        // Combiner les symboles à exclure
-        $symbolsWithActivity = array_unique(array_merge($openPositionSymbols, $openOrderSymbols));
-
-        // Réactiver les switches des symboles qui n'ont plus d'ordres/positions ouverts
-        try {
-            $reactivatedCount = $this->mtfSwitchRepository->reactivateSwitchesForInactiveSymbols($symbolsWithActivity);
-            if ($reactivatedCount > 0) {
-                $this->mtfLogger->info('[MTF Runner] Reactivated switches for inactive symbols', [
-                    'run_id' => $runId,
-                    'reactivated_count' => $reactivatedCount,
-                ]);
-            }
-        } catch (\Throwable $e) {
-            $this->logger->error('[MTF Runner] Failed to reactivate switches for inactive symbols', [
-                'run_id' => $runId,
-                'error' => $e->getMessage(),
-            ]);
-        }
-
-        // Filtrer les symboles
-        foreach ($symbols as $symbol) {
-            $symbolUpper = strtoupper($symbol);
-
-            if (in_array($symbolUpper, $symbolsWithActivity, true)) {
-                $excludedSymbols[] = $symbolUpper;
-            } else {
-                $symbolsToProcess[] = $symbol;
-            }
-        }
-
-        if (!empty($excludedSymbols)) {
-            $this->logger->info('[MTF Runner] Filtered symbols with open orders/positions', [
-                'run_id' => $runId,
-                'excluded_count' => count($excludedSymbols),
-                'excluded_symbols' => array_slice($excludedSymbols, 0, 10),
-                'remaining_count' => count($symbolsToProcess),
-            ]);
-        }
-
-        return $symbolsToProcess;
+        return $this->openActivityFilter->filter(
+            $symbols,
+            $runId,
+            $context,
+            $excludedSymbols,
+            $openPositions,
+            $openOrders,
+        );
     }
 
     /**
@@ -1174,23 +1025,6 @@ final class MtfRunnerService
         $minute = (int) $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->format('i');
 
         return $minute % 3 === 0;
-    }
-
-    /**
-     * Consomme les symboles depuis la queue des switches
-     *
-     * @return array<string>
-     */
-    private function consumeSymbolsFromSwitchQueue(): array
-    {
-        try {
-            return $this->mtfSwitchRepository->consumeSymbolsWithFutureExpiration();
-        } catch (\Throwable $e) {
-            $this->logger->warning('[MTF Runner] Failed to consume symbols from switch queue', [
-                'error' => $e->getMessage(),
-            ]);
-            return [];
-        }
     }
 
     /**

--- a/trading-app/tests/Application/Runner/OpenActivityFilterTest.php
+++ b/trading-app/tests/Application/Runner/OpenActivityFilterTest.php
@@ -60,9 +60,9 @@ final class OpenActivityFilterTest extends TestCase
         $context = $this->legacyContext();
 
         $mainProvider = $this->createMock(MainProviderInterface::class);
-        $mainProvider->expects(self::once())->method('forContext')->with($context)->willReturnSelf();
-        $mainProvider->expects(self::once())->method('getAccountProvider')->willReturn($this->createMock(AccountProviderInterface::class));
-        $mainProvider->expects(self::once())->method('getOrderProvider')->willReturn($this->createMock(OrderProviderInterface::class));
+        $mainProvider->expects(self::never())->method('forContext');
+        $mainProvider->expects(self::never())->method('getAccountProvider');
+        $mainProvider->expects(self::never())->method('getOrderProvider');
 
         $switchRepository = $this->createMock(MtfSwitchRepository::class);
         $switchRepository->expects(self::never())->method('reactivateSwitchesForInactiveSymbols');
@@ -76,6 +76,32 @@ final class OpenActivityFilterTest extends TestCase
 
         $excludedSymbols = [];
         self::assertSame([], $filter->filter([], 'run-123', $context, $excludedSymbols));
+        self::assertSame([], $excludedSymbols);
+    }
+
+    public function testReturnsSymbolsUnchangedWhenNoProvidersAvailable(): void
+    {
+        $context = $this->legacyContext();
+        $symbols = ['BTCUSDT', 'ETHUSDT'];
+
+        $mainProvider = $this->createMock(MainProviderInterface::class);
+        $mainProvider->expects(self::once())->method('forContext')->with($context)->willReturnSelf();
+        $mainProvider->expects(self::once())->method('getAccountProvider')->willReturn(null);
+        $mainProvider->expects(self::once())->method('getOrderProvider')->willReturn(null);
+
+        $switchRepository = $this->createMock(MtfSwitchRepository::class);
+        $switchRepository->expects(self::never())->method('reactivateSwitchesForInactiveSymbols');
+
+        $filter = new OpenActivityFilter(
+            $mainProvider,
+            $switchRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $excludedSymbols = [];
+
+        self::assertSame($symbols, $filter->filter($symbols, 'run-123', $context, $excludedSymbols));
         self::assertSame([], $excludedSymbols);
     }
 

--- a/trading-app/tests/Application/Runner/OpenActivityFilterTest.php
+++ b/trading-app/tests/Application/Runner/OpenActivityFilterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Runner;
+
+use App\Application\Runner\OpenActivityFilter;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\MainProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\MtfValidator\Repository\MtfSwitchRepository;
+use App\Provider\Context\ExchangeContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+#[CoversClass(OpenActivityFilter::class)]
+final class OpenActivityFilterTest extends TestCase
+{
+    public function testFiltersSymbolsWithPrefetchedOpenPositionsOrOrdersAndReactivatesInactiveSwitches(): void
+    {
+        $context = $this->legacyContext();
+        $mainProvider = $this->createMock(MainProviderInterface::class);
+        $mainProvider->expects(self::once())->method('forContext')->with($context)->willReturnSelf();
+        $mainProvider->expects(self::once())->method('getAccountProvider')->willReturn($this->createMock(AccountProviderInterface::class));
+        $mainProvider->expects(self::once())->method('getOrderProvider')->willReturn($this->createMock(OrderProviderInterface::class));
+
+        $switchRepository = $this->createMock(MtfSwitchRepository::class);
+        $switchRepository
+            ->expects(self::once())
+            ->method('reactivateSwitchesForInactiveSymbols')
+            ->with(['BTCUSDT', 'ETHUSDT'])
+            ->willReturn(2);
+
+        $filter = new OpenActivityFilter(
+            $mainProvider,
+            $switchRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $excludedSymbols = [];
+        $remaining = $filter->filter(
+            ['btcusdt', 'adausdt', 'ETHUSDT'],
+            'run-123',
+            $context,
+            $excludedSymbols,
+            [(object) ['symbol' => 'btcusdt']],
+            [(object) ['symbol' => 'ethusdt']],
+        );
+
+        self::assertSame(['adausdt'], $remaining);
+        self::assertSame(['BTCUSDT', 'ETHUSDT'], $excludedSymbols);
+    }
+
+    public function testReturnsEmptySymbolListUnchangedWithoutReactivatingSwitches(): void
+    {
+        $context = $this->legacyContext();
+
+        $mainProvider = $this->createMock(MainProviderInterface::class);
+        $mainProvider->expects(self::once())->method('forContext')->with($context)->willReturnSelf();
+        $mainProvider->expects(self::once())->method('getAccountProvider')->willReturn($this->createMock(AccountProviderInterface::class));
+        $mainProvider->expects(self::once())->method('getOrderProvider')->willReturn($this->createMock(OrderProviderInterface::class));
+
+        $switchRepository = $this->createMock(MtfSwitchRepository::class);
+        $switchRepository->expects(self::never())->method('reactivateSwitchesForInactiveSymbols');
+
+        $filter = new OpenActivityFilter(
+            $mainProvider,
+            $switchRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $excludedSymbols = [];
+        self::assertSame([], $filter->filter([], 'run-123', $context, $excludedSymbols));
+        self::assertSame([], $excludedSymbols);
+    }
+
+    private function legacyContext(): ExchangeContext
+    {
+        return new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL);
+    }
+}

--- a/trading-app/tests/Application/Runner/SymbolUniverseResolverTest.php
+++ b/trading-app/tests/Application/Runner/SymbolUniverseResolverTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Runner;
+
+use App\Application\Runner\SymbolUniverseResolver;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\MtfValidator\Repository\MtfSwitchRepository;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Repository\ContractRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+#[CoversClass(SymbolUniverseResolver::class)]
+final class SymbolUniverseResolverTest extends TestCase
+{
+    public function testNormalizesProvidedSymbolsAndAppendsQueuedSymbols(): void
+    {
+        $contractRepository = $this->createMock(ContractRepository::class);
+        $contractRepository->expects(self::never())->method('allActiveSymbolNames');
+
+        $switchRepository = $this->createMock(MtfSwitchRepository::class);
+        $switchRepository
+            ->expects(self::once())
+            ->method('consumeSymbolsWithFutureExpiration')
+            ->willReturn(['solusdt', 'ETHUSDT']);
+
+        $resolver = new SymbolUniverseResolver(
+            $contractRepository,
+            $switchRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        self::assertSame(
+            ['BTCUSDT', 'ETHUSDT', 'solusdt'],
+            $resolver->resolve([' btcusdt ', 'ETHUSDT', 'btcusdt', ''], 'scalper', $this->legacyContext()),
+        );
+    }
+
+    public function testLoadsActiveSymbolsWhenNoInputSymbolsAreProvided(): void
+    {
+        $context = $this->legacyContext();
+
+        $contractRepository = $this->createMock(ContractRepository::class);
+        $contractRepository
+            ->expects(self::once())
+            ->method('allActiveSymbolNames')
+            ->with([], false, 'scalper_micro', $context)
+            ->willReturn(['BTCUSDT', 'ETHUSDT']);
+
+        $switchRepository = $this->createMock(MtfSwitchRepository::class);
+        $switchRepository
+            ->expects(self::once())
+            ->method('consumeSymbolsWithFutureExpiration')
+            ->willReturn([]);
+
+        $resolver = new SymbolUniverseResolver(
+            $contractRepository,
+            $switchRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        self::assertSame(['BTCUSDT', 'ETHUSDT'], $resolver->resolve([], 'scalper_micro', $context));
+    }
+
+    public function testFallsBackWhenContractRepositoryAndQueueReturnNoSymbols(): void
+    {
+        $contractRepository = $this->createMock(ContractRepository::class);
+        $contractRepository
+            ->expects(self::once())
+            ->method('allActiveSymbolNames')
+            ->willReturn([]);
+
+        $switchRepository = $this->createMock(MtfSwitchRepository::class);
+        $switchRepository
+            ->expects(self::once())
+            ->method('consumeSymbolsWithFutureExpiration')
+            ->willReturn([]);
+
+        $resolver = new SymbolUniverseResolver(
+            $contractRepository,
+            $switchRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        self::assertSame(
+            ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'SOLUSDT', 'DOTUSDT'],
+            $resolver->resolve([], null, $this->legacyContext()),
+        );
+    }
+
+    private function legacyContext(): ExchangeContext
+    {
+        return new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL);
+    }
+}


### PR DESCRIPTION
## Objectif

Commencer l’extraction du runner sans changement de comportement runtime.

Cette PR extrait uniquement la partie résolution/filtrage des symboles afin de préparer les prochaines étapes du TradingCore modulaire.

## Scope

- Extraction mécanique de responsabilités du runner liées à :
  - résolution de l’univers de symboles ;
  - filtrage des symboles non éligibles / occupés.
- Conservation des entrypoints existants :
  - `php bin/console mtf:run`
  - `POST /api/mtf/run`
  - Temporal -> `/api/mtf/run`
- Ajout de la documentation `runner-extraction`.
- Tests ciblés et checks de non-régression.

## Hors-scope

- Aucun changement MTF.
- Aucun changement TradeEntry.
- Aucun changement EntryZone.
- Aucun changement Risk/Leverage.
- Aucun changement SL/TP.
- Aucun branchement `EffectiveTradingConfigResolver`.
- Aucun changement Temporal.
- Aucun live OKX/Hyperliquid.
- Aucune suppression Bitmart.
- Aucun changement de stratégie YAML.

## Tests

- ✅ `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Application/Runner`
- ✅ `vendor/bin/phpstan analyse src/Application/Runner tests/Application/Runner --memory-limit=512M`
- ✅ `php bin/console lint:yaml config`
- ✅ `php bin/console lint:container`
- ✅ `php bin/console list mtf --raw | grep -E '^mtf:run\s'`
- ✅ `php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'`
- ✅ `python3 -m mkdocs build --strict`
- ✅ `git diff --check`

Checks informatifs hors scope large :

- ⚠️ `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Application/Runner tests/MtfRunner tests/MtfValidator` échoue sur dettes existantes `MtfValidator` hors PR03 : config YAML introuvable, `KERNEL_CLASS`, mocks de classes final, classe `HighConvictionValidation` absente, attentes existantes.
- ⚠️ `vendor/bin/phpstan analyse src/Application/Runner src/MtfRunner src/MtfValidator tests/Application/Runner --memory-limit=512M` échoue sur erreurs existantes dans `src/MtfRunner` / `src/MtfValidator`; le scope `src/Application/Runner` est OK.

## Risques

Le risque principal est de modifier involontairement la sélection des symboles ou les filtres de protection. Cette PR reste une extraction mécanique : `MtfRunnerService` garde les wrappers publics existants et délègue aux nouveaux services.

## Critères d’acceptation

- Aucun comportement runtime changé.
- Entrypoints préservés.
- Runner toujours fonctionnel.
- Sélection/filtrage symboles équivalents à l’existant.
- Documentation ajoutée.
