### PR TITLE
[codex] PR 04 — Runner extraction 2

### DIFF
--- a/docs/handbook/technical/runner-extraction.md
+++ b/docs/handbook/technical/runner-extraction.md
@@ -1,22 +1,29 @@
 # Runner extraction
 
-## Objectif PR03
+## Objectif
 
-PR03 commence l'extraction du runner sans changer le comportement runtime.
+Les PR Runner amincissent progressivement `MtfRunnerService` sans changer le
+comportement runtime.
 
-Le scope est volontairement limite a deux responsabilites deja presentes dans
-`MtfRunnerService` :
+Le runner reste l'orchestrateur principal des entrypoints existants. Chaque PR
+extrait uniquement des blocs deja presents, avec les memes entrees, sorties,
+logs et side effects.
+
+## PR03 - extraction symboles et activite ouverte
+
+PR03 a extrait mecaniquement deux responsabilites :
 
 - resolution de l'univers de symboles a traiter ;
 - filtrage des symboles occupes par positions ou ordres ouverts.
 
-`MtfRunnerService` reste l'orchestrateur principal. Les nouveaux services sont
-des delegations mecaniques qui conservent les memes entrees, sorties, logs et
-side effects que les blocs extraits.
+Services ajoutes :
+
+- `App\Application\Runner\SymbolUniverseResolver` ;
+- `App\Application\Runner\OpenActivityFilter`.
 
 ## Entrypoints conserves
 
-| Entrypoint | Statut PR03 |
+| Entrypoint | Statut |
 | --- | --- |
 | `php bin/console mtf:run` | Conserve. La commande construit toujours `MtfRunnerRequestDto` puis appelle `RunMtfCycleUseCase`. |
 | `POST /api/mtf/run` | Conserve. `RunnerController` garde le payload et la reponse existants. |
@@ -38,7 +45,7 @@ side effects que les blocs extraits.
 9. recalcul TP/SL cadence ;
 10. enrichissement/reporting final.
 
-PR03 ne change pas l'ordre de ces etapes.
+Les PR03 et PR04 ne changent pas l'ordre de ces etapes.
 
 ## Ce que PR03 extrait
 
@@ -72,6 +79,57 @@ Responsabilite extraite depuis
 `MtfRunnerService::filterSymbolsWithOpenOrdersOrPositions()` reste disponible et
 delegue au nouveau service.
 
+## PR04 - sync exchange, projection post-run et resultat
+
+PR04 poursuit l'extraction sans changer le comportement runtime ni la structure
+JSON retournee par `/api/mtf/run`.
+
+Services ajoutes :
+
+- `App\Application\Runner\ExchangeStateSynchronizer` ;
+- `App\Application\Runner\PostRunProjectionDispatcher` ;
+- `App\Application\Runner\RunResultAssembler`.
+
+### `App\Application\Runner\ExchangeStateSynchronizer`
+
+Responsabilite extraite depuis `MtfRunnerService::syncTables()` :
+
+- resoudre les providers via `MainProviderInterface::forContext()` ;
+- conserver le guard legacy quand les providers account et order sont absents ;
+- synchroniser les positions ouvertes dans `positions` via
+  `PositionRepository::findOneBySymbolSide()` puis `upsert()` ;
+- reutiliser `OrderProviderInterface::getOpenOrders()`, qui conserve le chemin
+  existant de synchronisation des ordres cote provider/FuturesOrderSyncService ;
+- retourner le meme tableau `open_positions` / `open_orders` ;
+- conserver les logs et catches existants.
+
+`MtfRunnerService::syncTables()` reste disponible et delegue au nouveau service.
+
+### `App\Application\Runner\PostRunProjectionDispatcher`
+
+Responsabilite extraite autour du dispatch post-run :
+
+- resoudre les timeframes depuis `current_tf` ou `MtfValidatorInterface::getListTimeframe()` ;
+- filtrer les resultats de symboles en ignorant l'entree synthetique `FINAL` ;
+- publier le meme `IndicatorSnapshotPersistRequestMessage` ;
+- conserver `run_id`, profil, timestamp UTC, exchange et market type ;
+- conserver les conditions de non-dispatch quand il n'y a pas de timeframe ou de symbole.
+
+Aucun transport Messenger, queue ou handler n'est modifie.
+
+### `App\Application\Runner\RunResultAssembler`
+
+Responsabilite extraite autour de l'enrichissement et de la reponse finale :
+
+- deleguer l'enrichissement existant a `MtfRunResultEnricher` ;
+- assembler la reponse avec les memes clefs :
+  `summary`, `results`, `errors`, `summary_by_tf`, `rejected_by`,
+  `last_validated`, `orders_placed`, `performance` ;
+- conserver les compteurs, timings, resultats par symbole, raisons de rejet et
+  ordres places/ignores.
+
+La structure de reponse `/api/mtf/run` reste inchangee.
+
 ## Structure utilisee ensuite par MTF
 
 Apres resolution et filtrage, le runner transmet toujours une liste simple de
@@ -84,37 +142,40 @@ Les resultats restent indexes par symbole dans `results`, avec les statuts
 `READY` ou `INVALID` derives de `MtfResultDto::isTradable`. PR03 ne modifie pas
 la structure de reponse ni les valeurs `READY` / `REJECTED` / `INVALID`.
 
-## Ce qui reste legacy dans PR03
+PR04 ne change pas cette structure.
+
+## Ce qui reste dans `MtfRunnerService`
 
 Les responsabilites suivantes restent dans `MtfRunnerService` :
 
-- synchronisation exchange complete ;
-- creation et mise a jour des entites `Position` ;
 - gestion des locks ;
 - extension/desactivation post-run des switches pour symboles exclus ;
 - execution parallele par `Process` ;
-- dispatch Messenger de projection indicateurs ;
 - recalcul TP/SL ;
-- reporting final et enrichissement de resultat.
+- construction du contexte exchange/market ;
+- construction de `MtfRunRequestDto` pour l'execution sequentielle ;
+- aggregation des workers paralleles ;
+- creation de la commande `mtf:run-worker`.
 
 Les entrypoints Symfony, Temporal et worker ne sont pas extraits dans cette PR.
 
 ## Hors-scope confirme
 
-PR03 ne branche pas `EffectiveTradingConfigResolver` au runtime, ne modifie pas
-les YAML strategie, ne change pas TradeEntry, EntryZone, Risk/Leverage, SL/TP,
-Temporal, les schedules, Bitmart, OKX ou Hyperliquid live.
+PR03 et PR04 ne branchent pas `EffectiveTradingConfigResolver` au runtime, ne
+modifient pas les YAML strategie, ne changent pas TradeEntry, EntryZone,
+Risk/Leverage, SL/TP, Temporal, les schedules, Bitmart, OKX ou Hyperliquid
+live.
 
 Aucun secret n'est ajoute.
 
 ## Tests de non-regression
 
-Tests ajoutes :
+Tests PR03 :
 
 - `tests/Application/Runner/SymbolUniverseResolverTest.php`
 - `tests/Application/Runner/OpenActivityFilterTest.php`
 
-Ces tests couvrent :
+Ils couvrent :
 
 - normalisation et deduplication des symboles fournis ;
 - chargement des contrats actifs quand aucun symbole n'est fourni ;
@@ -123,14 +184,42 @@ Ces tests couvrent :
 - exclusion des symboles avec positions ou ordres ouverts ;
 - side effect de reactivation des switches inactifs.
 
-## Suite PR04
+Tests PR04 :
 
-PR04 pourra extraire les responsabilites suivantes, sans les melanger avec PR03 :
+- `tests/Application/Runner/ExchangeStateSynchronizerTest.php`
+- `tests/Application/Runner/PostRunProjectionDispatcherTest.php`
+- `tests/Application/Runner/RunResultAssemblerTest.php`
 
-- synchronisation exchange/tables ;
-- reporting final ;
-- assemblage de resultat ;
-- dispatch post-run.
+Ils couvrent :
+
+- absence de providers account/order sans sync ni erreur ;
+- synchronisation positions et retour des ordres ouverts ;
+- payload `IndicatorSnapshotPersistRequestMessage` ;
+- absence de dispatch quand aucun symbole reel n'est present ;
+- assemblage final avec la structure de reponse existante.
+
+## Suite PR05
+
+PR05 doit traiter les DTOs MTF / TradeCandidate sans melanger cette etape avec
+la validation strategique ou l'execution :
+
+- stabiliser un DTO explicite entre MTF et TradeEntry ;
+- rendre visibles profil, instrument, side, execution timeframe, raisons de
+  rejet et metadata ;
+- conserver les valeurs READY / REJECTED et le comportement de validation ;
+- ne pas modifier TradeEntry, EntryZone, Risk/Leverage, SL/TP ou ExecutionPort
+  dans la meme PR.
 
 La validation MTF, TradeEntry, EntryZone, Risk/Leverage, SL/TP et ExecutionPort
 restent des PR separees du plan TradingCore canonique.
+
+## Garantie runtime
+
+PR04 reste une extraction mecanique :
+
+- aucun entrypoint n'est modifie ;
+- aucun schedule Temporal n'est modifie ;
+- aucune strategie YAML n'est modifiee ;
+- aucun exchange live OKX/Hyperliquid n'est active ;
+- Bitmart reste legacy runtime ;
+- la reponse `/api/mtf/run` conserve les memes clefs et payloads.

--- a/trading-app/src/Application/Runner/ExchangeStateSynchronizer.php
+++ b/trading-app/src/Application/Runner/ExchangeStateSynchronizer.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Runner;
+
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\Dto\PositionDto;
+use App\Contract\Provider\MainProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Entity\Position;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\PositionRepository;
+use Psr\Log\LoggerInterface;
+
+final class ExchangeStateSynchronizer
+{
+    public function __construct(
+        private readonly MainProviderInterface $mainProvider,
+        private readonly PositionRepository $positionRepository,
+        private readonly LoggerInterface $logger,
+        private readonly LoggerInterface $positionsLogger,
+    ) {
+    }
+
+    /**
+     * Synchronise les tables depuis l'exchange.
+     *
+     * @return array{open_positions: array<int, mixed>, open_orders: array<int, mixed>}
+     */
+    public function sync(ExchangeContext $context): array
+    {
+        $openPositions = [];
+        $openOrders = [];
+
+        try {
+            $provider = $this->mainProvider->forContext($context);
+            $accountProvider = $provider->getAccountProvider();
+            $orderProvider = $provider->getOrderProvider();
+
+            if (!$accountProvider && !$orderProvider) {
+                $this->positionsLogger->warning('[MTF Runner] Cannot sync tables: missing providers');
+
+                return [
+                    'open_positions' => $openPositions,
+                    'open_orders' => $openOrders,
+                ];
+            }
+
+            if ($accountProvider) {
+                $openPositions = $this->syncPositions($accountProvider, $context);
+            }
+
+            if ($orderProvider) {
+                $openOrders = $this->syncOrders($orderProvider);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('[MTF Runner] Failed to sync tables', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+        }
+
+        return [
+            'open_positions' => $openPositions,
+            'open_orders' => $openOrders,
+        ];
+    }
+
+    /**
+     * Synchronise les positions depuis l'exchange vers la table positions.
+     *
+     * @return array<int, mixed>
+     */
+    private function syncPositions(AccountProviderInterface $accountProvider, ExchangeContext $context): array
+    {
+        $openPositions = [];
+
+        try {
+            /** @var array<int, PositionDto> $openPositions */
+            $openPositions = $accountProvider->getOpenPositions();
+            $this->positionsLogger->info('[MTF Runner] Syncing positions', [
+                'count' => count($openPositions),
+            ]);
+
+            foreach ($openPositions as $positionDto) {
+                try {
+                    $symbol = strtoupper($positionDto->symbol);
+                    $side = strtoupper($positionDto->side->value);
+
+                    $position = $this->positionRepository->findOneBySymbolSide($symbol, $side, $context);
+                    if (!$position) {
+                        $position = new Position($symbol, $side, $context->exchange, $context->marketType);
+                    }
+
+                    $position->setSize($positionDto->size->__toString());
+                    $position->setAvgEntryPrice($positionDto->entryPrice->__toString());
+                    $position->setLeverage((int) $positionDto->leverage->__toString());
+                    $position->setUnrealizedPnl($positionDto->unrealizedPnl->__toString());
+                    $position->setStatus('OPEN');
+                    $position->mergePayload([
+                        'exchange' => $context->exchange->value,
+                        'market_type' => $context->marketType->value,
+                        'mark_price' => $positionDto->markPrice->__toString(),
+                        'margin' => $positionDto->margin->__toString(),
+                        'realized_pnl' => $positionDto->realizedPnl->__toString(),
+                    ]);
+
+                    $this->positionRepository->upsert($position);
+                } catch (\Throwable $e) {
+                    $this->logger->error('[MTF Runner] Failed to sync position', [
+                        'symbol' => $positionDto->symbol ?? 'unknown',
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('[MTF Runner] Failed to sync positions', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $openPositions;
+    }
+
+    /**
+     * Synchronise les ordres depuis l'exchange vers futures_order et futures_order_trade.
+     *
+     * @return array<int, mixed>
+     */
+    private function syncOrders(OrderProviderInterface $orderProvider): array
+    {
+        $openOrders = [];
+
+        try {
+            $openOrders = $orderProvider->getOpenOrders();
+            $this->positionsLogger->info('[MTF Runner] Syncing orders via provider', [
+                'count' => count($openOrders),
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->error('[MTF Runner] Failed to sync orders', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $openOrders;
+    }
+}

--- a/trading-app/src/Application/Runner/PostRunProjectionDispatcher.php
+++ b/trading-app/src/Application/Runner/PostRunProjectionDispatcher.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Runner;
+
+use App\Contract\MtfValidator\MtfValidatorInterface;
+use App\Indicator\Message\IndicatorSnapshotPersistRequestMessage;
+use App\MtfRunner\Dto\MtfRunnerRequestDto;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class PostRunProjectionDispatcher
+{
+    public function __construct(
+        private readonly MtfValidatorInterface $mtfValidator,
+        private readonly MessageBusInterface $messageBus,
+        private readonly ClockInterface $clock,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $results
+     */
+    public function dispatch(array $results, MtfRunnerRequestDto $request, string $runId): void
+    {
+        $timeframes = $this->resolveTimeframes($request);
+        if ($timeframes === []) {
+            return;
+        }
+
+        $symbols = [];
+        foreach (array_keys($results) as $symbol) {
+            if (!\is_string($symbol) || $symbol === '' || strtoupper($symbol) === 'FINAL') {
+                continue;
+            }
+            $symbols[] = strtoupper($symbol);
+        }
+
+        if ($symbols === []) {
+            return;
+        }
+
+        try {
+            $this->messageBus->dispatch(new IndicatorSnapshotPersistRequestMessage(
+                $symbols,
+                $timeframes,
+                $runId,
+                $request->profile,
+                $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+                $request->exchange?->value ?? 'bitmart',
+                $request->marketType?->value ?? 'perpetual',
+            ));
+
+            $this->logger->debug('[MTF Runner] Indicator persistence dispatched', [
+                'run_id' => $runId,
+                'exchange' => $request->exchange?->value ?? 'bitmart',
+                'market_type' => $request->marketType?->value ?? 'perpetual',
+                'symbols_count' => count($symbols),
+                'timeframes' => $timeframes,
+            ]);
+        } catch (\Throwable $exception) {
+            $this->logger->warning('[MTF Runner] Failed to dispatch indicator persistence job', [
+                'run_id' => $runId,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveTimeframes(MtfRunnerRequestDto $request): array
+    {
+        if (\is_string($request->currentTf) && $request->currentTf !== '') {
+            return [$request->currentTf];
+        }
+
+        return $this->mtfValidator->getListTimeframe($request->profile);
+    }
+}

--- a/trading-app/src/Application/Runner/RunResultAssembler.php
+++ b/trading-app/src/Application/Runner/RunResultAssembler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Runner;
+
+use App\MtfRunner\Application\Result\MtfRunResultEnricher;
+
+final class RunResultAssembler
+{
+    public function __construct(
+        private readonly MtfRunResultEnricher $resultEnricher,
+    ) {
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $results
+     * @return array{
+     *     summary_by_tf: array<string, array<string>>,
+     *     rejected_by: array<string>,
+     *     last_validated: array<int, array{symbol: string, side: mixed, timeframe: string|null}>,
+     *     orders_placed: array{count: array<string, int>, orders: array<int|string, mixed>}
+     * }
+     */
+    public function enrich(array $results): array
+    {
+        return $this->resultEnricher->enrich($results);
+    }
+
+    /**
+     * @param array<string, mixed> $runnerResult
+     * @param array<string, mixed> $results
+     * @param array{
+     *     summary_by_tf: array<string, array<string>>,
+     *     rejected_by: array<string>,
+     *     last_validated: array<int, array{symbol: string, side: mixed, timeframe: string|null}>,
+     *     orders_placed: array{count: array<string, int>, orders: array<int|string, mixed>}
+     * } $enriched
+     * @param array<string, mixed> $performanceReport
+     * @return array{
+     *     summary: mixed,
+     *     results: array<string, mixed>,
+     *     errors: mixed,
+     *     summary_by_tf: array<string, array<string>>,
+     *     rejected_by: array<string>,
+     *     last_validated: array<int, array{symbol: string, side: mixed, timeframe: string|null}>,
+     *     orders_placed: array{count: array<string, int>, orders: array<int|string, mixed>},
+     *     performance: array<string, mixed>
+     * }
+     */
+    public function assemble(array $runnerResult, array $results, array $enriched, array $performanceReport): array
+    {
+        return [
+            'summary' => $runnerResult['summary'] ?? [],
+            'results' => $results,
+            'errors' => $runnerResult['errors'] ?? [],
+            'summary_by_tf' => $enriched['summary_by_tf'],
+            'rejected_by' => $enriched['rejected_by'],
+            'last_validated' => $enriched['last_validated'],
+            'orders_placed' => $enriched['orders_placed'],
+            'performance' => $performanceReport,
+        ];
+    }
+}

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\MtfRunner\Service;
 
+use App\Application\Runner\ExchangeStateSynchronizer;
 use App\Application\Runner\OpenActivityFilter;
+use App\Application\Runner\PostRunProjectionDispatcher;
+use App\Application\Runner\RunResultAssembler;
 use App\Application\Runner\SymbolUniverseResolver;
 use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
 use App\Contract\MtfValidator\Dto\MtfResultDto;
@@ -15,23 +18,17 @@ use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Common\Enum\OrderSide;
 use App\Common\Enum\PositionSide;
-use App\Entity\Position;
 use App\MtfRunner\Dto\MtfRunnerRequestDto as RunnerRequestDto;
-use App\MtfRunner\Application\Projection\IndicatorSnapshotPersistenceDispatcher;
-use App\MtfRunner\Application\Result\MtfRunResultEnricher;
-use App\MtfRunner\Service\FuturesOrderSyncService;
 use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
 use App\MtfValidator\Repository\MtfLockRepository;
 use App\MtfValidator\Repository\MtfSwitchRepository;
 use App\Provider\Context\ExchangeContext;
-use App\Repository\PositionRepository;
 use App\Config\TradeEntryConfigProvider;
 use App\Config\TradeEntryModeContext;
 use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
 use App\TradeEntry\Service\TpSlTwoTargetsService;
 use App\TradeEntry\Types\Side as EntrySide;
 use App\MtfValidator\Service\PerformanceProfiler;
-use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
@@ -56,19 +53,17 @@ final class MtfRunnerService
     public function __construct(
         private readonly SymbolUniverseResolver $symbolUniverseResolver,
         private readonly OpenActivityFilter $openActivityFilter,
-        private readonly PositionRepository $positionRepository,
+        private readonly ExchangeStateSynchronizer $exchangeStateSynchronizer,
+        private readonly PostRunProjectionDispatcher $postRunProjectionDispatcher,
+        private readonly RunResultAssembler $runResultAssembler,
         private readonly MtfLockRepository $mtfLockRepository,
         private readonly MtfSwitchRepository $mtfSwitchRepository,
-        private readonly FuturesOrderSyncService $futuresOrderSyncService,
         private readonly MtfValidatorInterface $mtfValidator,
         private readonly MainProviderInterface $mainProvider,
-        private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
         private readonly LoggerInterface $mtfLogger,
         private readonly LoggerInterface $positionsLogger,
         private readonly TradeDecisionDispatcherInterface $tradeDecisionDispatcher,
-        private readonly IndicatorSnapshotPersistenceDispatcher $indicatorSnapshotPersistenceDispatcher,
-        private readonly MtfRunResultEnricher $resultEnricher,
         #[Autowire('%kernel.project_dir%')]
         private readonly string $projectDir,
         private readonly ClockInterface $clock,
@@ -156,7 +151,7 @@ final class MtfRunnerService
                 : $this->runSequential($symbols, $request, $context);
             $profiler->increment('runner', 'mtf_execution', microtime(true) - $execStart);
 
-            $this->indicatorSnapshotPersistenceDispatcher->dispatch($result['results'] ?? [], $request, $runId);
+            $this->postRunProjectionDispatcher->dispatch($result['results'] ?? [], $request, $runId);
 
             // 8. Mettre à jour les switches pour les symboles exclus (après traitement)
             if (!empty($excludedSymbols)) {
@@ -184,7 +179,7 @@ final class MtfRunnerService
             // 10. Post-processing : enrichir les résultats
             $postProcessStart = microtime(true);
             $results = $result['results'] ?? [];
-            $enriched = $this->resultEnricher->enrich($results);
+            $enriched = $this->runResultAssembler->enrich($results);
             $profiler->increment('runner', 'post_processing', microtime(true) - $postProcessStart);
 
             $executionTime = microtime(true) - $startTime;
@@ -197,16 +192,7 @@ final class MtfRunnerService
                 'performance' => $performanceReport,
             ]);
 
-            return [
-                'summary' => $result['summary'] ?? [],
-                'results' => $results,
-                'errors' => $result['errors'] ?? [],
-                'summary_by_tf' => $enriched['summary_by_tf'],
-                'rejected_by' => $enriched['rejected_by'],
-                'last_validated' => $enriched['last_validated'],
-                'orders_placed' => $enriched['orders_placed'],
-                'performance' => $performanceReport,
-            ];
+            return $this->runResultAssembler->assemble($result, $results, $enriched, $performanceReport);
 
         } catch (\Throwable $e) {
             $this->logger->error('[MTF Runner] Execution failed', [
@@ -352,120 +338,7 @@ final class MtfRunnerService
      */
     public function syncTables(ExchangeContext $context): array
     {
-        $openPositions = [];
-        $openOrders = [];
-
-        try {
-            $provider = $this->mainProvider->forContext($context);
-            $accountProvider = $provider->getAccountProvider();
-            $orderProvider = $provider->getOrderProvider();
-
-            if (!$accountProvider && !$orderProvider) {
-                $this->positionsLogger->warning('[MTF Runner] Cannot sync tables: missing providers');
-                return [
-                    'open_positions' => $openPositions,
-                    'open_orders' => $openOrders,
-                ];
-            }
-
-            // 1. Synchroniser les positions
-            if ($accountProvider) {
-                $openPositions = $this->syncPositions($accountProvider, $context);
-            }
-
-            // 2. Synchroniser les ordres
-            if ($orderProvider) {
-                $openOrders = $this->syncOrders($orderProvider);
-            }
-
-        } catch (\Throwable $e) {
-            $this->logger->error('[MTF Runner] Failed to sync tables', [
-                'error' => $e->getMessage(),
-                'trace' => $e->getTraceAsString(),
-            ]);
-        }
-
-        return [
-            'open_positions' => $openPositions,
-            'open_orders' => $openOrders,
-        ];
-    }
-
-    /**
-     * Synchronise les positions depuis l'exchange vers la table positions
-     */
-    private function syncPositions($accountProvider, ExchangeContext $context): array
-    {
-        $openPositions = [];
-
-        try {
-            $openPositions = $accountProvider->getOpenPositions();
-            $this->positionsLogger->info('[MTF Runner] Syncing positions', [
-                'count' => count($openPositions),
-            ]);
-
-            foreach ($openPositions as $positionDto) {
-                try {
-                    $symbol = strtoupper($positionDto->symbol);
-                    $side = strtoupper($positionDto->side->value);
-
-                    // Chercher ou créer la position
-                    $position = $this->positionRepository->findOneBySymbolSide($symbol, $side, $context);
-                    if (!$position) {
-                        $position = new Position($symbol, $side, $context->exchange, $context->marketType);
-                    }
-
-                    // Mettre à jour les données
-                    $position->setSize($positionDto->size->__toString());
-                    $position->setAvgEntryPrice($positionDto->entryPrice->__toString());
-                    $position->setLeverage((int)$positionDto->leverage->__toString());
-                    $position->setUnrealizedPnl($positionDto->unrealizedPnl->__toString());
-                    $position->setStatus('OPEN');
-                    $position->mergePayload([
-                        'exchange' => $context->exchange->value,
-                        'market_type' => $context->marketType->value,
-                        'mark_price' => $positionDto->markPrice->__toString(),
-                        'margin' => $positionDto->margin->__toString(),
-                        'realized_pnl' => $positionDto->realizedPnl->__toString(),
-                    ]);
-
-                    $this->positionRepository->upsert($position);
-                } catch (\Throwable $e) {
-                    $this->logger->error('[MTF Runner] Failed to sync position', [
-                        'symbol' => $positionDto->symbol ?? 'unknown',
-                        'error' => $e->getMessage(),
-                    ]);
-                }
-            }
-        } catch (\Throwable $e) {
-            $this->logger->error('[MTF Runner] Failed to sync positions', [
-                'error' => $e->getMessage(),
-            ]);
-        }
-
-        return $openPositions;
-    }
-
-    /**
-     * Synchronise les ordres depuis l'exchange vers futures_order et futures_order_trade
-     */
-    private function syncOrders($orderProvider): array
-    {
-        $openOrders = [];
-
-        try {
-            $openOrders = $orderProvider->getOpenOrders();
-            // getOpenOrders() synchronise déjà les ordres via FuturesOrderSyncService
-            $this->positionsLogger->info('[MTF Runner] Syncing orders via provider', [
-                'count' => count($openOrders),
-            ]);
-        } catch (\Throwable $e) {
-            $this->logger->error('[MTF Runner] Failed to sync orders', [
-                'error' => $e->getMessage(),
-            ]);
-        }
-
-        return $openOrders;
+        return $this->exchangeStateSynchronizer->sync($context);
     }
 
     /**

--- a/trading-app/tests/Application/Runner/ExchangeStateSynchronizerTest.php
+++ b/trading-app/tests/Application/Runner/ExchangeStateSynchronizerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Runner;
+
+use App\Application\Runner\ExchangeStateSynchronizer;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderStatus;
+use App\Common\Enum\OrderType;
+use App\Common\Enum\PositionSide;
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\PositionDto;
+use App\Contract\Provider\MainProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Entity\Position;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\PositionRepository;
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+#[CoversClass(ExchangeStateSynchronizer::class)]
+final class ExchangeStateSynchronizerTest extends TestCase
+{
+    public function testReturnsEmptyListsWhenProvidersAreMissing(): void
+    {
+        $context = $this->legacyContext();
+
+        $mainProvider = $this->createMock(MainProviderInterface::class);
+        $mainProvider->expects(self::once())->method('forContext')->with($context)->willReturnSelf();
+        $mainProvider->expects(self::once())->method('getAccountProvider')->willReturn(null);
+        $mainProvider->expects(self::once())->method('getOrderProvider')->willReturn(null);
+
+        $positionRepository = $this->createMock(PositionRepository::class);
+        $positionRepository->expects(self::never())->method('upsert');
+
+        $synchronizer = new ExchangeStateSynchronizer(
+            $mainProvider,
+            $positionRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        self::assertSame(
+            ['open_positions' => [], 'open_orders' => []],
+            $synchronizer->sync($context),
+        );
+    }
+
+    public function testSynchronizesPositionsAndReturnsOpenOrders(): void
+    {
+        $context = $this->legacyContext();
+        $positionDto = $this->positionDto();
+        $orderDto = $this->orderDto();
+
+        $accountProvider = $this->createMock(AccountProviderInterface::class);
+        $accountProvider->expects(self::once())->method('getOpenPositions')->willReturn([$positionDto]);
+
+        $orderProvider = $this->createMock(OrderProviderInterface::class);
+        $orderProvider->expects(self::once())->method('getOpenOrders')->willReturn([$orderDto]);
+
+        $mainProvider = $this->createMock(MainProviderInterface::class);
+        $mainProvider->expects(self::once())->method('forContext')->with($context)->willReturnSelf();
+        $mainProvider->expects(self::once())->method('getAccountProvider')->willReturn($accountProvider);
+        $mainProvider->expects(self::once())->method('getOrderProvider')->willReturn($orderProvider);
+
+        $positionRepository = $this->createMock(PositionRepository::class);
+        $positionRepository
+            ->expects(self::once())
+            ->method('findOneBySymbolSide')
+            ->with('BTCUSDT', 'LONG', $context)
+            ->willReturn(null);
+        $positionRepository
+            ->expects(self::once())
+            ->method('upsert')
+            ->with(self::callback(static function (Position $position): bool {
+                return $position->getSymbol() === 'BTCUSDT'
+                    && $position->getSide() === 'LONG'
+                    && $position->getSize() === '12'
+                    && $position->getAvgEntryPrice() === '42000'
+                    && $position->getLeverage() === 3
+                    && $position->getUnrealizedPnl() === '7.5'
+                    && $position->getPayload()['exchange'] === 'bitmart'
+                    && $position->getPayload()['market_type'] === 'perpetual'
+                    && $position->getPayload()['mark_price'] === '42100';
+            }));
+
+        $synchronizer = new ExchangeStateSynchronizer(
+            $mainProvider,
+            $positionRepository,
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        self::assertSame(
+            ['open_positions' => [$positionDto], 'open_orders' => [$orderDto]],
+            $synchronizer->sync($context),
+        );
+    }
+
+    private function legacyContext(): ExchangeContext
+    {
+        return new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL);
+    }
+
+    private function positionDto(): PositionDto
+    {
+        return new PositionDto(
+            symbol: 'btcusdt',
+            side: PositionSide::LONG,
+            size: BigDecimal::of('12'),
+            entryPrice: BigDecimal::of('42000'),
+            markPrice: BigDecimal::of('42100'),
+            unrealizedPnl: BigDecimal::of('7.5'),
+            realizedPnl: BigDecimal::of('1.25'),
+            margin: BigDecimal::of('140'),
+            leverage: BigDecimal::of('3'),
+            openedAt: new \DateTimeImmutable('2025-01-01 00:00:00 UTC'),
+        );
+    }
+
+    private function orderDto(): OrderDto
+    {
+        return new OrderDto(
+            orderId: 'order-1',
+            symbol: 'ETHUSDT',
+            side: OrderSide::BUY,
+            type: OrderType::LIMIT,
+            status: OrderStatus::PENDING,
+            quantity: BigDecimal::of('1'),
+            price: BigDecimal::of('3000'),
+            stopPrice: null,
+            filledQuantity: BigDecimal::of('0'),
+            remainingQuantity: BigDecimal::of('1'),
+            averagePrice: null,
+            createdAt: new \DateTimeImmutable('2025-01-01 00:00:00 UTC'),
+        );
+    }
+}

--- a/trading-app/tests/Application/Runner/PostRunProjectionDispatcherTest.php
+++ b/trading-app/tests/Application/Runner/PostRunProjectionDispatcherTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Runner;
+
+use App\Application\Runner\PostRunProjectionDispatcher;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Contract\MtfValidator\MtfValidatorInterface;
+use App\Indicator\Message\IndicatorSnapshotPersistRequestMessage;
+use App\MtfRunner\Dto\MtfRunnerRequestDto;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(PostRunProjectionDispatcher::class)]
+final class PostRunProjectionDispatcherTest extends TestCase
+{
+    public function testDispatchesIndicatorPersistenceMessageWithResolvedSymbolsAndTimeframes(): void
+    {
+        $request = new MtfRunnerRequestDto(
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            profile: 'scalper_micro',
+        );
+
+        $mtfValidator = $this->createMock(MtfValidatorInterface::class);
+        $mtfValidator->expects(self::once())->method('getListTimeframe')->with('scalper_micro')->willReturn(['5m', '1m']);
+
+        $clock = $this->createMock(ClockInterface::class);
+        $clock->expects(self::once())->method('now')->willReturn(new \DateTimeImmutable('2025-12-04 08:12:21 Europe/Paris'));
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(static function (object $message): bool {
+                self::assertInstanceOf(IndicatorSnapshotPersistRequestMessage::class, $message);
+                self::assertSame(['BTCUSDT', 'ETHUSDT'], $message->symbols);
+                self::assertSame(['5m', '1m'], $message->timeframes);
+                self::assertSame('run-123', $message->runId);
+                self::assertSame('scalper_micro', $message->profile);
+                self::assertSame('2025-12-04 07:12:21', $message->requestedAt);
+                self::assertSame('bitmart', $message->exchange);
+                self::assertSame('perpetual', $message->marketType);
+
+                return true;
+            }))
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $dispatcher = new PostRunProjectionDispatcher(
+            $mtfValidator,
+            $messageBus,
+            $clock,
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $dispatcher->dispatch(
+            [
+                'btcusdt' => ['status' => 'READY'],
+                'FINAL' => ['status' => 'completed'],
+                'ETHUSDT' => ['status' => 'INVALID'],
+            ],
+            $request,
+            'run-123',
+        );
+    }
+
+    public function testDoesNotDispatchWhenThereAreNoSymbolResults(): void
+    {
+        $mtfValidator = $this->createMock(MtfValidatorInterface::class);
+        $mtfValidator->expects(self::once())->method('getListTimeframe')->willReturn(['1m']);
+
+        $messageBus = $this->createMock(MessageBusInterface::class);
+        $messageBus->expects(self::never())->method('dispatch');
+
+        $dispatcher = new PostRunProjectionDispatcher(
+            $mtfValidator,
+            $messageBus,
+            $this->createMock(ClockInterface::class),
+            $this->createMock(LoggerInterface::class),
+        );
+
+        $dispatcher->dispatch(['FINAL' => ['status' => 'completed']], new MtfRunnerRequestDto(profile: 'scalper'), 'run-123');
+    }
+}

--- a/trading-app/tests/Application/Runner/RunResultAssemblerTest.php
+++ b/trading-app/tests/Application/Runner/RunResultAssemblerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Runner;
+
+use App\Application\Runner\RunResultAssembler;
+use App\MtfRunner\Application\Result\MtfRunResultEnricher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RunResultAssembler::class)]
+final class RunResultAssemblerTest extends TestCase
+{
+    public function testAssemblesFinalResponseWithExistingShape(): void
+    {
+        $assembler = new RunResultAssembler(new MtfRunResultEnricher());
+
+        $runnerResult = [
+            'summary' => ['status' => 'completed'],
+            'results' => [
+                'BTCUSDT' => ['status' => 'SUCCESS', 'execution_tf' => '1m', 'signal_side' => 'LONG'],
+                'ETHUSDT' => ['status' => 'INVALID', 'failed_timeframe' => '5m'],
+            ],
+            'errors' => ['worker warning'],
+        ];
+        $results = $runnerResult['results'];
+        $enriched = $assembler->enrich($results);
+        $performanceReport = ['runner' => ['mtf_execution' => 1.25]];
+
+        self::assertSame(
+            [
+                'summary' => ['status' => 'completed'],
+                'results' => $results,
+                'errors' => ['worker warning'],
+                'summary_by_tf' => [
+                    '1m' => ['BTCUSDT'],
+                    '5m' => ['ETHUSDT'],
+                    '15m' => [],
+                    '1h' => [],
+                    '4h' => [],
+                ],
+                'rejected_by' => ['ETHUSDT'],
+                'last_validated' => [
+                    ['symbol' => 'BTCUSDT', 'side' => 'LONG', 'timeframe' => 'READY'],
+                ],
+                'orders_placed' => [
+                    'count' => ['total' => 0, 'submitted' => 0, 'pending' => 0, 'protection_failed' => 0, 'simulated' => 0],
+                    'orders' => [],
+                ],
+                'performance' => $performanceReport,
+            ],
+            $assembler->assemble($runnerResult, $results, $enriched, $performanceReport),
+        );
+    }
+}


### PR DESCRIPTION
## Objectif

Continuer l’extraction du runner sans changement de comportement runtime.

Cette PR fait suite à PR 03 et extrait mécaniquement les responsabilités liées à la synchronisation exchange, à la projection post-run et à l’assemblage/reporting du résultat.

## Scope

- Extraction de services applicatifs fins autour de :
  - synchronisation exchange ;
  - projection post-run ;
  - assemblage / reporting du résultat.
- Conservation des entrypoints existants :
  - `php bin/console mtf:run`
  - `POST /api/mtf/run`
  - Temporal -> `/api/mtf/run`
- Mise à jour de `docs/handbook/technical/runner-extraction.md`.
- Tests ciblés de non-régression.

## Hors-scope

- Aucun changement MTF.
- Aucun changement TradeEntry.
- Aucun changement EntryZone.
- Aucun changement Risk/Leverage.
- Aucun changement SL/TP.
- Aucun branchement `EffectiveTradingConfigResolver`.
- Aucun changement Temporal.
- Aucun live OKX/Hyperliquid.
- Aucune suppression Bitmart.
- Aucun changement de stratégie YAML.
- Aucun changement de structure de réponse `/api/mtf/run`.

## Tests

- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Application/Runner`
- `vendor/bin/phpstan analyse src/Application/Runner tests/Application/Runner --memory-limit=512M`
- `php bin/console lint:yaml config`
- `php bin/console lint:container`
- `php bin/console list mtf --raw | grep -E '^mtf:run\s'`
- `php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Risques

Le risque principal est de modifier involontairement la structure de réponse `/api/mtf/run` ou les side effects de synchronisation/projection. Cette PR reste une extraction mécanique.

## Critères d’acceptation

- Aucun comportement runtime changé.
- Entrypoints préservés.
- MtfRunnerService reste orchestrateur.
- Sync/projection/reporting délégués sans changement.
- Structure de réponse préservée.
- Documentation mise à jour.

## Notes

- PHPStan additionnel sur `src/MtfRunner/Service/MtfRunnerService.php` échoue sur dette legacy de typage hors périmètre (`array` non génériques, dead catch, nullsafe provider).
- Le périmètre `src/Application/Runner tests/Application/Runner` est propre.
