### PR TITLE
[codex] PR 06 — EntryZone module

### DIFF
--- a/docs/handbook/technical/entry-zone-module.md
+++ b/docs/handbook/technical/entry-zone-module.md
@@ -1,0 +1,184 @@
+# EntryZone module
+
+## Objectif
+
+PR06 introduit un module `App\TradingCore\Entry` explicite, testable et
+auditable pour documenter la frontiere EntryZone.
+
+Cette PR est volontairement preparatoire. Elle ne branche pas le nouveau module
+au runtime TradeEntry et ne modifie pas les seuils existants.
+
+## Role de l'EntryZone
+
+L'EntryZone represente la fenetre de prix dans laquelle une entree peut rester
+coherente avec le signal MTF et le contexte de marche.
+
+La logique runtime existante couvre notamment :
+
+- le choix d'un pivot, le plus souvent VWAP ou SMA21 ;
+- une largeur derivee de l'ATR ;
+- les bornes `w_min` et `w_max` ;
+- le TTL de la zone ;
+- la quantification aux pas exchange ;
+- le test du prix candidat dans la zone ;
+- le calcul `zone_dev_pct` ;
+- la comparaison a `zone_max_dev_pct` ;
+- la raison de rejet, notamment `zone_far_from_market`,
+  `entry_not_within_zone` et `skipped_out_of_zone`.
+
+## Ce que PR06 ajoute
+
+Nouveau namespace :
+
+```text
+App\TradingCore\Entry
+```
+
+DTOs et enum :
+
+- `Dto\EntryZoneRequest` ;
+- `Dto\EntryZone` ;
+- `Dto\EntryZoneDecision` ;
+- `Enum\EntryZoneStatus`.
+
+Services et mapper :
+
+- `Service\EntryZoneCalculator` ;
+- `Service\EntryZoneGuard` ;
+- `Mapper\LegacyEntryZoneMapper`.
+
+Le calculateur pur formalise :
+
+- `center` depuis VWAP ou prix de reference ;
+- demi-largeur ATR via `k_atr` ou `offset_k` ;
+- clamp par `w_min` et `w_max` ;
+- quantification optionnelle par `tick_size` ;
+- metadata de profil, exchange, market type, direction, timeframe,
+  spread et slippage.
+
+Le guard formalise :
+
+- acceptation si le prix candidat est dans la zone ;
+- calcul `zone_dev_pct` contre le prix de reference ;
+- normalisation de `zone_max_dev_pct` quand une valeur percentuelle legacy est
+  fournie ;
+- conservation de `reason_if_rejected`.
+
+Le mapper legacy permet de lire `App\TradeEntry\Dto\EntryZone` sans changer les
+bornes, le TTL ou les metadata.
+
+## Ce qui reste legacy
+
+Les chemins runtime restent inchanges :
+
+```text
+TradingDecisionHandler
+  -> TradeEntryRequestBuilder
+  -> TradeEntryService
+  -> BuildOrderPlan
+  -> App\TradeEntry\EntryZone\EntryZoneCalculator
+  -> OrderPlanBuilder
+```
+
+Les classes suivantes restent la source effective du runtime :
+
+- `App\TradeEntry\EntryZone\EntryZoneCalculator` ;
+- `App\TradeEntry\EntryZone\EntryZoneFilters` ;
+- `App\TradeEntry\Dto\EntryZone` ;
+- `App\TradeEntry\Workflow\BuildOrderPlan` ;
+- `App\TradeEntry\OrderPlan\OrderPlanBuilder` ;
+- `App\TradeEntry\Service\TradeEntryService`.
+
+PR06 ne remplace pas ces classes dans le flux d'execution.
+
+## Metriques a logger
+
+Le module cible rend explicites les champs qui doivent rester auditables :
+
+| Champ | Usage |
+| --- | --- |
+| `entry_price` | Prix candidat ou prix final d'entree. |
+| `zone_low` | Borne basse de la zone. |
+| `zone_high` | Borne haute de la zone. |
+| `zone_dev_pct` | Distance relative entre la zone et le prix de reference. |
+| `zone_max_dev_pct` | Seuil runtime autorise. |
+| `spread_bps` | Spread observe si disponible. |
+| `slippage_bps` | Slippage estime si disponible. |
+| `reason_if_rejected` | Raison de rejet normalisee. |
+
+Ces champs ne sont pas rebranches dans PR06. Ils documentent le contrat cible
+pour les extractions suivantes.
+
+## Pourquoi aucun desserrage
+
+Le risque principal est d'augmenter le nombre de trades en modifiant
+involontairement les zones d'entree.
+
+PR06 ne modifie pas :
+
+- les YAML `trade_entry*.yaml` ;
+- `w_min` ;
+- `w_max` ;
+- `zone_max_deviation_pct` ;
+- `max_deviation_pct` ;
+- la selection du pivot runtime ;
+- les conditions MTF ;
+- les decisions READY / REJECTED.
+
+Toute optimisation ou modification de seuil doit attendre une baseline
+analytics et un backtest net.
+
+## Lien avec analytics et backtesting
+
+Le module `TradingCore\Entry` prepare les prochaines etapes :
+
+- consommer `TradeCandidate.entryContext` ;
+- exposer une decision EntryZone stable pour Risk / Leverage ;
+- fournir un contrat plus simple au futur module SLTP ;
+- rendre `zone_dev_pct`, `zone_max_dev_pct` et `reason_if_rejected`
+  comparables entre live, dry-run, replay et backtesting.
+
+Le branchement runtime devra etre traite dans une PR separee avec tests de
+non-regression sur `TradeEntry`, `OrderPlan` et le payload `/api/mtf/run`.
+
+## Tests
+
+Tests ajoutes :
+
+- `tests/TradingCore/Entry/EntryZoneCalculatorTest.php` ;
+- `tests/TradingCore/Entry/EntryZoneGuardTest.php` ;
+- `tests/TradingCore/Entry/LegacyEntryZoneMapperTest.php`.
+
+Ils couvrent :
+
+- calcul d'une zone autour du pivot VWAP ;
+- respect de `w_min` ;
+- respect de `w_max` ;
+- quantification par `tick_size` ;
+- calcul de `zone_dev_pct` ;
+- acceptation d'un prix dans la zone ;
+- rejet d'un prix hors zone sans desserrer `zone_max_dev_pct` ;
+- conservation de `reason_if_rejected` ;
+- mapping legacy sans changement de bornes ni metadata.
+
+## Non branche dans PR06
+
+PR06 ne branche pas :
+
+- `EntryZoneRequest` dans `TradingDecisionHandler` ;
+- `EntryZoneCalculator` TradingCore dans `BuildOrderPlan` ;
+- `EntryZoneGuard` dans `OrderPlanBuilder` ;
+- `LegacyEntryZoneMapper` dans `TradeEntryService` ;
+- `EffectiveTradingConfigResolver` dans le runtime.
+
+PR06 ne modifie pas :
+
+- `mtf:run` ;
+- `POST /api/mtf/run` ;
+- Temporal ;
+- les schedules ;
+- les regles MTF ;
+- Risk / Leverage ;
+- SL / TP ;
+- ExecutionPort ;
+- Bitmart, OKX ou Hyperliquid live.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Effective trading config resolver: technical/effective-trading-config-resolver.md
       - Runner extraction: technical/runner-extraction.md
       - DTOs MTF et TradeCandidate: technical/mtf-dtos-and-trade-candidate.md
+      - EntryZone module: technical/entry-zone-module.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/TradingCore/Entry/Dto/EntryZone.php
+++ b/trading-app/src/TradingCore/Entry/Dto/EntryZone.php
@@ -23,6 +23,31 @@ final readonly class EntryZone
 
     public function contains(float $price): bool
     {
-        return $price >= $this->low && $price <= $this->high;
+        if ($price >= $this->low && $price <= $this->high) {
+            return true;
+        }
+
+        $tolerance = $this->metadata['outside_tolerance_pct'] ?? null;
+        if (!\is_numeric($tolerance)) {
+            return false;
+        }
+
+        $tolerance = (float)$tolerance;
+        if ($tolerance <= 0.0 || $price <= 0.0) {
+            return false;
+        }
+        if ($tolerance > 1.0) {
+            $tolerance *= 0.01;
+        }
+        $tolerance = min($tolerance, 1.0);
+
+        if ($price > $this->high) {
+            return (($price - $this->high) / $price) <= $tolerance;
+        }
+        if ($price < $this->low) {
+            return (($this->low - $price) / $price) <= $tolerance;
+        }
+
+        return false;
     }
 }

--- a/trading-app/src/TradingCore/Entry/Dto/EntryZone.php
+++ b/trading-app/src/TradingCore/Entry/Dto/EntryZone.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Entry\Dto;
+
+final readonly class EntryZone
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public float $low,
+        public float $high,
+        public float $center,
+        public float $widthPct,
+        public ?int $ttlSec,
+        public ?\DateTimeImmutable $expiresAt,
+        public string $source,
+        public ?float $atrUsed,
+        public bool $quantized,
+        public array $metadata = [],
+    ) {}
+
+    public function contains(float $price): bool
+    {
+        return $price >= $this->low && $price <= $this->high;
+    }
+}

--- a/trading-app/src/TradingCore/Entry/Dto/EntryZoneDecision.php
+++ b/trading-app/src/TradingCore/Entry/Dto/EntryZoneDecision.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Entry\Dto;
+
+use App\TradingCore\Entry\Enum\EntryZoneStatus;
+
+final readonly class EntryZoneDecision
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public EntryZoneStatus $status,
+        public EntryZone $entryZone,
+        public float $candidatePrice,
+        public ?float $zoneDevPct,
+        public ?float $zoneMaxDevPct,
+        public ?string $reasonIfRejected,
+        public array $metadata = [],
+    ) {}
+}

--- a/trading-app/src/TradingCore/Entry/Dto/EntryZoneRequest.php
+++ b/trading-app/src/TradingCore/Entry/Dto/EntryZoneRequest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Entry\Dto;
+
+final readonly class EntryZoneRequest
+{
+    public ?string $instrument;
+
+    /**
+     * @param array<string,mixed> $config
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $symbol,
+        ?string $instrument,
+        public string $profile,
+        public string $exchange,
+        public string $marketType,
+        public string $direction,
+        public string $executionTimeframe,
+        public float $referencePrice,
+        public float $currentPrice,
+        public ?float $vwap,
+        public ?float $atr,
+        public ?float $tickSize,
+        public ?float $spreadBps,
+        public ?float $slippageBps,
+        public array $config = [],
+        public array $metadata = [],
+    ) {
+        $this->instrument = $instrument ?? $symbol;
+    }
+}

--- a/trading-app/src/TradingCore/Entry/Enum/EntryZoneStatus.php
+++ b/trading-app/src/TradingCore/Entry/Enum/EntryZoneStatus.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Entry\Enum;
+
+enum EntryZoneStatus: string
+{
+    case Accepted = 'accepted';
+    case Rejected = 'rejected';
+}

--- a/trading-app/src/TradingCore/Entry/Mapper/LegacyEntryZoneMapper.php
+++ b/trading-app/src/TradingCore/Entry/Mapper/LegacyEntryZoneMapper.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Entry\Mapper;
+
+use App\TradeEntry\Dto\EntryZone as LegacyEntryZone;
+use App\TradingCore\Entry\Dto\EntryZone;
+
+final class LegacyEntryZoneMapper
+{
+    public function fromLegacy(LegacyEntryZone $legacy): EntryZone
+    {
+        $center = ($legacy->min + $legacy->max) / 2;
+        $metadata = $legacy->getMetadata();
+        $widthPct = isset($metadata['width_pct']) && \is_numeric($metadata['width_pct'])
+            ? (float)$metadata['width_pct']
+            : ($center > 0.0 ? ($legacy->max - $legacy->min) / $center : 0.0);
+        $source = isset($metadata['pivot_source']) && \is_string($metadata['pivot_source'])
+            ? (string)$metadata['pivot_source']
+            : 'legacy';
+        $atrUsed = isset($metadata['atr']) && \is_numeric($metadata['atr']) ? (float)$metadata['atr'] : null;
+        $expiresAt = null;
+        if ($legacy->createdAt !== null && $legacy->ttlSec !== null) {
+            $expiresAt = $legacy->createdAt->modify(sprintf('+%d seconds', $legacy->ttlSec));
+        }
+
+        return new EntryZone(
+            low: $legacy->min,
+            high: $legacy->max,
+            center: $center,
+            widthPct: $widthPct,
+            ttlSec: $legacy->ttlSec,
+            expiresAt: $expiresAt,
+            source: $source,
+            atrUsed: $atrUsed,
+            quantized: (bool)($metadata['quantized'] ?? false),
+            metadata: $metadata + [
+                'legacy_rationale' => $legacy->rationale,
+            ],
+        );
+    }
+}

--- a/trading-app/src/TradingCore/Entry/Service/EntryZoneCalculator.php
+++ b/trading-app/src/TradingCore/Entry/Service/EntryZoneCalculator.php
@@ -85,12 +85,11 @@ final class EntryZoneCalculator
 
     private function resolveSource(EntryZoneRequest $request): string
     {
-        $anchor = $request->config['anchor'] ?? $request->config['from'] ?? null;
-        if (\is_string($anchor) && trim($anchor) !== '') {
-            return strtolower(trim($anchor));
+        if ($request->vwap !== null && \is_finite($request->vwap) && $request->vwap > 0.0) {
+            return 'vwap';
         }
 
-        return $request->vwap !== null ? 'vwap' : 'reference_price';
+        return $request->referencePrice > 0.0 ? 'reference_price' : 'current_price';
     }
 
     /**

--- a/trading-app/src/TradingCore/Entry/Service/EntryZoneCalculator.php
+++ b/trading-app/src/TradingCore/Entry/Service/EntryZoneCalculator.php
@@ -25,6 +25,7 @@ final class EntryZoneCalculator
             ?? self::DEFAULT_W_MAX;
         $ttlSec = $this->intConfig($request->config, 'ttl_sec') ?? self::DEFAULT_TTL_SEC;
         $quantize = (bool)($request->config['quantize_to_exchange_step'] ?? false);
+        $outsideTolerancePct = $this->floatConfig($request->config, 'outside_tolerance_pct');
 
         $halfFromAtr = $request->atr !== null && \is_finite($request->atr) && $request->atr > 0.0
             ? $request->atr * $kAtr
@@ -70,6 +71,7 @@ final class EntryZoneCalculator
                 'k_atr' => $kAtr,
                 'w_min' => $wMin,
                 'w_max' => $wMax,
+                'outside_tolerance_pct' => $outsideTolerancePct,
             ],
         );
     }

--- a/trading-app/src/TradingCore/Entry/Service/EntryZoneCalculator.php
+++ b/trading-app/src/TradingCore/Entry/Service/EntryZoneCalculator.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Entry\Service;
+
+use App\TradingCore\Entry\Dto\EntryZone;
+use App\TradingCore\Entry\Dto\EntryZoneRequest;
+
+final class EntryZoneCalculator
+{
+    private const DEFAULT_K_ATR = 0.35;
+    private const DEFAULT_W_MIN = 0.0005;
+    private const DEFAULT_W_MAX = 0.0100;
+    private const DEFAULT_TTL_SEC = 240;
+
+    public function calculate(EntryZoneRequest $request): EntryZone
+    {
+        $center = $this->resolveCenter($request);
+        $kAtr = $this->floatConfig($request->config, 'k_atr')
+            ?? $this->floatConfig($request->config, 'offset_k')
+            ?? self::DEFAULT_K_ATR;
+        $wMin = $this->floatConfig($request->config, 'w_min') ?? self::DEFAULT_W_MIN;
+        $wMax = $this->floatConfig($request->config, 'w_max')
+            ?? $this->floatConfig($request->config, 'max_deviation_pct')
+            ?? self::DEFAULT_W_MAX;
+        $ttlSec = $this->intConfig($request->config, 'ttl_sec') ?? self::DEFAULT_TTL_SEC;
+        $quantize = (bool)($request->config['quantize_to_exchange_step'] ?? false);
+
+        $halfFromAtr = $request->atr !== null && \is_finite($request->atr) && $request->atr > 0.0
+            ? $request->atr * $kAtr
+            : 0.0;
+        $minHalf = $center * $wMin;
+        $maxHalf = $center * $wMax;
+        $half = min(max($halfFromAtr, $minHalf), $maxHalf);
+
+        $low = $center - $half;
+        $high = $center + $half;
+        $wasQuantized = false;
+        if ($quantize && $request->tickSize !== null && $request->tickSize > 0.0) {
+            $low = $this->quantizeDown($low, $request->tickSize);
+            $high = $this->quantizeUp($high, $request->tickSize);
+            $wasQuantized = true;
+        }
+
+        $widthPct = $center > 0.0 ? ($high - $low) / $center : 0.0;
+        $expiresAt = $ttlSec > 0 ? (new \DateTimeImmutable())->modify(sprintf('+%d seconds', $ttlSec)) : null;
+
+        return new EntryZone(
+            low: $low,
+            high: $high,
+            center: $center,
+            widthPct: $widthPct,
+            ttlSec: $ttlSec,
+            expiresAt: $expiresAt,
+            source: $this->resolveSource($request),
+            atrUsed: $request->atr,
+            quantized: $wasQuantized,
+            metadata: $request->metadata + [
+                'symbol' => $request->symbol,
+                'instrument' => $request->instrument,
+                'profile' => $request->profile,
+                'exchange' => $request->exchange,
+                'market_type' => $request->marketType,
+                'direction' => $request->direction,
+                'execution_timeframe' => $request->executionTimeframe,
+                'reference_price' => $request->referencePrice,
+                'current_price' => $request->currentPrice,
+                'spread_bps' => $request->spreadBps,
+                'slippage_bps' => $request->slippageBps,
+                'k_atr' => $kAtr,
+                'w_min' => $wMin,
+                'w_max' => $wMax,
+            ],
+        );
+    }
+
+    private function resolveCenter(EntryZoneRequest $request): float
+    {
+        if ($request->vwap !== null && \is_finite($request->vwap) && $request->vwap > 0.0) {
+            return $request->vwap;
+        }
+
+        return $request->referencePrice > 0.0 ? $request->referencePrice : $request->currentPrice;
+    }
+
+    private function resolveSource(EntryZoneRequest $request): string
+    {
+        $anchor = $request->config['anchor'] ?? $request->config['from'] ?? null;
+        if (\is_string($anchor) && trim($anchor) !== '') {
+            return strtolower(trim($anchor));
+        }
+
+        return $request->vwap !== null ? 'vwap' : 'reference_price';
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    private function floatConfig(array $config, string $key): ?float
+    {
+        return isset($config[$key]) && \is_numeric($config[$key]) ? (float)$config[$key] : null;
+    }
+
+    /**
+     * @param array<string,mixed> $config
+     */
+    private function intConfig(array $config, string $key): ?int
+    {
+        return isset($config[$key]) && \is_numeric($config[$key]) ? max(0, (int)$config[$key]) : null;
+    }
+
+    private function quantizeDown(float $price, float $tickSize): float
+    {
+        return $this->normalizePrecision(floor($price / $tickSize) * $tickSize, $tickSize);
+    }
+
+    private function quantizeUp(float $price, float $tickSize): float
+    {
+        return $this->normalizePrecision(ceil($price / $tickSize) * $tickSize, $tickSize);
+    }
+
+    private function normalizePrecision(float $price, float $tickSize): float
+    {
+        $decimals = 0;
+        $tick = rtrim(rtrim(sprintf('%.12F', $tickSize), '0'), '.');
+        if (str_contains($tick, '.')) {
+            $decimals = strlen(substr(strrchr($tick, '.'), 1));
+        }
+
+        return round($price, $decimals);
+    }
+}

--- a/trading-app/src/TradingCore/Entry/Service/EntryZoneGuard.php
+++ b/trading-app/src/TradingCore/Entry/Service/EntryZoneGuard.php
@@ -22,8 +22,9 @@ final class EntryZoneGuard
     ): EntryZoneDecision {
         $normalizedZoneMax = $zoneMaxDevPct !== null ? $this->normalizePercent($zoneMaxDevPct) : null;
         $zoneDevPct = $this->computeZoneDeviation($referencePrice, $entryZone);
-        $accepted = $entryZone->contains($candidatePrice)
-            && ($normalizedZoneMax === null || $zoneDevPct === null || $zoneDevPct <= $normalizedZoneMax);
+        $isInsideZone = $entryZone->contains($candidatePrice);
+        $isWithinDeviation = $normalizedZoneMax === null || $zoneDevPct === null || $zoneDevPct <= $normalizedZoneMax;
+        $accepted = $isInsideZone && $isWithinDeviation;
 
         return new EntryZoneDecision(
             status: $accepted ? EntryZoneStatus::Accepted : EntryZoneStatus::Rejected,
@@ -31,9 +32,18 @@ final class EntryZoneGuard
             candidatePrice: $candidatePrice,
             zoneDevPct: $zoneDevPct,
             zoneMaxDevPct: $normalizedZoneMax,
-            reasonIfRejected: $accepted ? null : ($reasonIfRejected ?? 'entry_not_within_zone'),
+            reasonIfRejected: $accepted ? null : ($reasonIfRejected ?? $this->defaultRejectedReason($isInsideZone, $isWithinDeviation)),
             metadata: $metadata,
         );
+    }
+
+    private function defaultRejectedReason(bool $isInsideZone, bool $isWithinDeviation): string
+    {
+        if ($isInsideZone && !$isWithinDeviation) {
+            return 'zone_far_from_market';
+        }
+
+        return 'entry_not_within_zone';
     }
 
     private function computeZoneDeviation(?float $referencePrice, EntryZone $entryZone): ?float

--- a/trading-app/src/TradingCore/Entry/Service/EntryZoneGuard.php
+++ b/trading-app/src/TradingCore/Entry/Service/EntryZoneGuard.php
@@ -39,7 +39,7 @@ final class EntryZoneGuard
 
     private function defaultRejectedReason(bool $isInsideZone, bool $isWithinDeviation): string
     {
-        if ($isInsideZone && !$isWithinDeviation) {
+        if (!$isWithinDeviation) {
             return 'zone_far_from_market';
         }
 

--- a/trading-app/src/TradingCore/Entry/Service/EntryZoneGuard.php
+++ b/trading-app/src/TradingCore/Entry/Service/EntryZoneGuard.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Entry\Service;
+
+use App\TradingCore\Entry\Dto\EntryZone;
+use App\TradingCore\Entry\Dto\EntryZoneDecision;
+use App\TradingCore\Entry\Enum\EntryZoneStatus;
+
+final class EntryZoneGuard
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function decide(
+        EntryZone $entryZone,
+        float $candidatePrice,
+        ?float $referencePrice,
+        ?float $zoneMaxDevPct,
+        ?string $reasonIfRejected = null,
+        array $metadata = [],
+    ): EntryZoneDecision {
+        $normalizedZoneMax = $zoneMaxDevPct !== null ? $this->normalizePercent($zoneMaxDevPct) : null;
+        $zoneDevPct = $this->computeZoneDeviation($referencePrice, $entryZone);
+        $accepted = $entryZone->contains($candidatePrice)
+            && ($normalizedZoneMax === null || $zoneDevPct === null || $zoneDevPct <= $normalizedZoneMax);
+
+        return new EntryZoneDecision(
+            status: $accepted ? EntryZoneStatus::Accepted : EntryZoneStatus::Rejected,
+            entryZone: $entryZone,
+            candidatePrice: $candidatePrice,
+            zoneDevPct: $zoneDevPct,
+            zoneMaxDevPct: $normalizedZoneMax,
+            reasonIfRejected: $accepted ? null : ($reasonIfRejected ?? 'entry_not_within_zone'),
+            metadata: $metadata,
+        );
+    }
+
+    private function computeZoneDeviation(?float $referencePrice, EntryZone $entryZone): ?float
+    {
+        if ($referencePrice === null || $referencePrice <= 0.0) {
+            return null;
+        }
+
+        return max(
+            abs($entryZone->low - $referencePrice),
+            abs($entryZone->high - $referencePrice),
+        ) / $referencePrice;
+    }
+
+    private function normalizePercent(float $value): float
+    {
+        $value = max(0.0, $value);
+        if ($value > 1.0) {
+            $value *= 0.01;
+        }
+
+        return min($value, 1.0);
+    }
+}

--- a/trading-app/tests/TradingCore/Entry/EntryZoneCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Entry/EntryZoneCalculatorTest.php
@@ -3,12 +3,15 @@ declare(strict_types=1);
 
 namespace App\Tests\TradingCore\Entry;
 
+use App\TradingCore\Entry\Dto\EntryZone;
 use App\TradingCore\Entry\Dto\EntryZoneRequest;
 use App\TradingCore\Entry\Service\EntryZoneCalculator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(EntryZoneCalculator::class)]
+#[CoversClass(EntryZoneRequest::class)]
+#[CoversClass(EntryZone::class)]
 final class EntryZoneCalculatorTest extends TestCase
 {
     public function testCalculatesZoneAroundVwapPivot(): void

--- a/trading-app/tests/TradingCore/Entry/EntryZoneCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Entry/EntryZoneCalculatorTest.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Entry;
+
+use App\TradingCore\Entry\Dto\EntryZoneRequest;
+use App\TradingCore\Entry\Service\EntryZoneCalculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EntryZoneCalculator::class)]
+final class EntryZoneCalculatorTest extends TestCase
+{
+    public function testCalculatesZoneAroundVwapPivot(): void
+    {
+        $calculator = new EntryZoneCalculator();
+
+        $zone = $calculator->calculate(new EntryZoneRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            executionTimeframe: '1m',
+            referencePrice: 100.0,
+            currentPrice: 100.2,
+            vwap: 100.0,
+            atr: 1.0,
+            tickSize: null,
+            spreadBps: 4.0,
+            slippageBps: null,
+            config: [
+                'anchor' => 'vwap',
+                'k_atr' => 0.5,
+                'w_min' => 0.001,
+                'w_max' => 0.01,
+                'ttl_sec' => 180,
+            ],
+            metadata: ['decision_key' => 'decision-1'],
+        ));
+
+        self::assertSame(99.5, $zone->low);
+        self::assertSame(100.5, $zone->high);
+        self::assertSame(100.0, $zone->center);
+        self::assertEqualsWithDelta(0.01, $zone->widthPct, 1e-12);
+        self::assertSame(180, $zone->ttlSec);
+        self::assertSame('vwap', $zone->source);
+        self::assertSame(1.0, $zone->atrUsed);
+        self::assertFalse($zone->quantized);
+        self::assertSame('decision-1', $zone->metadata['decision_key']);
+    }
+
+    public function testRespectsMinimumWidthWithoutChangingConfig(): void
+    {
+        $calculator = new EntryZoneCalculator();
+        $config = [
+            'anchor' => 'vwap',
+            'k_atr' => 0.1,
+            'w_min' => 0.002,
+            'w_max' => 0.01,
+            'ttl_sec' => 240,
+        ];
+
+        $zone = $calculator->calculate(new EntryZoneRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'short',
+            executionTimeframe: '5m',
+            referencePrice: 100.0,
+            currentPrice: 100.0,
+            vwap: 100.0,
+            atr: 0.5,
+            tickSize: null,
+            spreadBps: null,
+            slippageBps: null,
+            config: $config,
+        ));
+
+        self::assertSame(99.8, $zone->low);
+        self::assertSame(100.2, $zone->high);
+        self::assertSame($config, [
+            'anchor' => 'vwap',
+            'k_atr' => 0.1,
+            'w_min' => 0.002,
+            'w_max' => 0.01,
+            'ttl_sec' => 240,
+        ]);
+    }
+
+    public function testRespectsMaximumWidth(): void
+    {
+        $calculator = new EntryZoneCalculator();
+
+        $zone = $calculator->calculate(new EntryZoneRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            executionTimeframe: '1m',
+            referencePrice: 100.0,
+            currentPrice: 100.0,
+            vwap: 100.0,
+            atr: 100.0,
+            tickSize: null,
+            spreadBps: null,
+            slippageBps: null,
+            config: [
+                'anchor' => 'vwap',
+                'k_atr' => 0.5,
+                'w_min' => 0.001,
+                'w_max' => 0.003,
+                'ttl_sec' => 240,
+            ],
+        ));
+
+        self::assertSame(99.7, $zone->low);
+        self::assertSame(100.3, $zone->high);
+        self::assertEqualsWithDelta(0.006, $zone->widthPct, 1e-12);
+    }
+
+    public function testQuantizesZoneBoundsWhenTickSizeIsAvailable(): void
+    {
+        $calculator = new EntryZoneCalculator();
+
+        $zone = $calculator->calculate(new EntryZoneRequest(
+            symbol: 'XRPUSDT',
+            instrument: null,
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            executionTimeframe: '5m',
+            referencePrice: 100.0,
+            currentPrice: 100.0,
+            vwap: 100.0,
+            atr: 0.37,
+            tickSize: 0.05,
+            spreadBps: null,
+            slippageBps: null,
+            config: [
+                'anchor' => 'vwap',
+                'k_atr' => 1.0,
+                'w_min' => 0.001,
+                'w_max' => 0.01,
+                'ttl_sec' => 120,
+                'quantize_to_exchange_step' => true,
+            ],
+        ));
+
+        self::assertSame(99.6, $zone->low);
+        self::assertSame(100.4, $zone->high);
+        self::assertTrue($zone->quantized);
+    }
+}

--- a/trading-app/tests/TradingCore/Entry/EntryZoneCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Entry/EntryZoneCalculatorTest.php
@@ -160,4 +160,35 @@ final class EntryZoneCalculatorTest extends TestCase
         self::assertSame(100.4, $zone->high);
         self::assertTrue($zone->quantized);
     }
+
+    public function testPropagatesOutsideToleranceFromConfigIntoMetadata(): void
+    {
+        $calculator = new EntryZoneCalculator();
+
+        $zone = $calculator->calculate(new EntryZoneRequest(
+            symbol: 'DOGEUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            executionTimeframe: '1m',
+            referencePrice: 100.0,
+            currentPrice: 100.0,
+            vwap: 100.0,
+            atr: 1.0,
+            tickSize: null,
+            spreadBps: null,
+            slippageBps: null,
+            config: [
+                'k_atr' => 0.5,
+                'w_min' => 0.001,
+                'w_max' => 0.01,
+                'outside_tolerance_pct' => 0.012,
+            ],
+        ));
+
+        self::assertSame(0.012, $zone->metadata['outside_tolerance_pct']);
+        self::assertTrue($zone->contains(101.5));
+    }
 }

--- a/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
+++ b/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Entry;
+
+use App\TradingCore\Entry\Dto\EntryZone;
+use App\TradingCore\Entry\Enum\EntryZoneStatus;
+use App\TradingCore\Entry\Service\EntryZoneGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EntryZoneGuard::class)]
+final class EntryZoneGuardTest extends TestCase
+{
+    public function testAcceptsCandidateInsideZone(): void
+    {
+        $guard = new EntryZoneGuard();
+        $zone = new EntryZone(
+            low: 99.0,
+            high: 101.0,
+            center: 100.0,
+            widthPct: 0.02,
+            ttlSec: 180,
+            expiresAt: null,
+            source: 'vwap',
+            atrUsed: 1.0,
+            quantized: false,
+        );
+
+        $decision = $guard->decide(
+            entryZone: $zone,
+            candidatePrice: 100.5,
+            referencePrice: 100.0,
+            zoneMaxDevPct: 0.03,
+        );
+
+        self::assertSame(EntryZoneStatus::Accepted, $decision->status);
+        self::assertSame($zone, $decision->entryZone);
+        self::assertSame(100.5, $decision->candidatePrice);
+        self::assertSame(0.01, $decision->zoneDevPct);
+        self::assertSame(0.03, $decision->zoneMaxDevPct);
+        self::assertNull($decision->reasonIfRejected);
+    }
+
+    public function testRejectsCandidateOutsideZoneWithoutRelaxingThreshold(): void
+    {
+        $guard = new EntryZoneGuard();
+        $zone = new EntryZone(
+            low: 90.0,
+            high: 91.0,
+            center: 90.5,
+            widthPct: 0.011049723756906077,
+            ttlSec: 180,
+            expiresAt: null,
+            source: 'vwap',
+            atrUsed: 1.0,
+            quantized: false,
+        );
+
+        $decision = $guard->decide(
+            entryZone: $zone,
+            candidatePrice: 100.0,
+            referencePrice: 100.0,
+            zoneMaxDevPct: 0.05,
+            reasonIfRejected: 'zone_far_from_market',
+            metadata: ['decision_key' => 'decision-2'],
+        );
+
+        self::assertSame(EntryZoneStatus::Rejected, $decision->status);
+        self::assertSame(0.10, $decision->zoneDevPct);
+        self::assertSame(0.05, $decision->zoneMaxDevPct);
+        self::assertSame('zone_far_from_market', $decision->reasonIfRejected);
+        self::assertSame('decision-2', $decision->metadata['decision_key']);
+    }
+
+    public function testNormalizesPercentThresholdButDoesNotChangeSemanticValue(): void
+    {
+        $guard = new EntryZoneGuard();
+        $zone = new EntryZone(
+            low: 99.0,
+            high: 101.0,
+            center: 100.0,
+            widthPct: 0.02,
+            ttlSec: 180,
+            expiresAt: null,
+            source: 'vwap',
+            atrUsed: 1.0,
+            quantized: false,
+        );
+
+        $decision = $guard->decide(
+            entryZone: $zone,
+            candidatePrice: 100.0,
+            referencePrice: 100.0,
+            zoneMaxDevPct: 3.0,
+        );
+
+        self::assertSame(EntryZoneStatus::Accepted, $decision->status);
+        self::assertSame(0.03, $decision->zoneMaxDevPct);
+    }
+}

--- a/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
+++ b/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
@@ -135,6 +135,32 @@ final class EntryZoneGuardTest extends TestCase
         self::assertSame('zone_far_from_market', $decision->reasonIfRejected);
     }
 
+    public function testDefaultsToFarFromMarketReasonWhenBothContainmentAndDeviationFail(): void
+    {
+        $guard = new EntryZoneGuard();
+        $zone = new EntryZone(
+            low: 90.0,
+            high: 91.0,
+            center: 90.5,
+            widthPct: 0.011049723756906077,
+            ttlSec: 180,
+            expiresAt: null,
+            source: 'vwap',
+            atrUsed: 1.0,
+            quantized: false,
+        );
+
+        $decision = $guard->decide(
+            entryZone: $zone,
+            candidatePrice: 100.0,
+            referencePrice: 100.0,
+            zoneMaxDevPct: 0.05,
+        );
+
+        self::assertSame(EntryZoneStatus::Rejected, $decision->status);
+        self::assertSame('zone_far_from_market', $decision->reasonIfRejected);
+    }
+
     public function testAcceptsCandidateInsideLegacyOutsideTolerance(): void
     {
         $guard = new EntryZoneGuard();

--- a/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
+++ b/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 namespace App\Tests\TradingCore\Entry;
 
 use App\TradingCore\Entry\Dto\EntryZone;
+use App\TradingCore\Entry\Dto\EntryZoneDecision;
 use App\TradingCore\Entry\Enum\EntryZoneStatus;
 use App\TradingCore\Entry\Service\EntryZoneGuard;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(EntryZoneGuard::class)]
+#[CoversClass(EntryZone::class)]
+#[CoversClass(EntryZoneDecision::class)]
+#[CoversClass(EntryZoneStatus::class)]
 final class EntryZoneGuardTest extends TestCase
 {
     public function testAcceptsCandidateInsideZone(): void
@@ -103,6 +107,59 @@ final class EntryZoneGuardTest extends TestCase
         self::assertEqualsWithDelta(1.02, $decision->zoneDevPct, 1e-12);
         self::assertSame(0.05, $decision->zoneMaxDevPct);
         self::assertSame('zone_far_from_market', $decision->reasonIfRejected);
+    }
+
+    public function testDefaultsToFarFromMarketReasonWhenZoneDeviationFails(): void
+    {
+        $guard = new EntryZoneGuard();
+        $zone = new EntryZone(
+            low: 100.0,
+            high: 101.0,
+            center: 100.5,
+            widthPct: 0.01,
+            ttlSec: 180,
+            expiresAt: null,
+            source: 'vwap',
+            atrUsed: 1.0,
+            quantized: false,
+        );
+
+        $decision = $guard->decide(
+            entryZone: $zone,
+            candidatePrice: 100.5,
+            referencePrice: 50.0,
+            zoneMaxDevPct: 0.05,
+        );
+
+        self::assertSame(EntryZoneStatus::Rejected, $decision->status);
+        self::assertSame('zone_far_from_market', $decision->reasonIfRejected);
+    }
+
+    public function testAcceptsCandidateInsideLegacyOutsideTolerance(): void
+    {
+        $guard = new EntryZoneGuard();
+        $zone = new EntryZone(
+            low: 99.0,
+            high: 101.0,
+            center: 100.0,
+            widthPct: 0.02,
+            ttlSec: 180,
+            expiresAt: null,
+            source: 'vwap',
+            atrUsed: 1.0,
+            quantized: false,
+            metadata: ['outside_tolerance_pct' => 0.012],
+        );
+
+        $decision = $guard->decide(
+            entryZone: $zone,
+            candidatePrice: 101.5,
+            referencePrice: 100.0,
+            zoneMaxDevPct: 0.03,
+        );
+
+        self::assertSame(EntryZoneStatus::Accepted, $decision->status);
+        self::assertNull($decision->reasonIfRejected);
     }
 
     public function testNormalizesPercentThresholdButDoesNotChangeSemanticValue(): void

--- a/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
+++ b/trading-app/tests/TradingCore/Entry/EntryZoneGuardTest.php
@@ -37,7 +37,7 @@ final class EntryZoneGuardTest extends TestCase
         self::assertSame(EntryZoneStatus::Accepted, $decision->status);
         self::assertSame($zone, $decision->entryZone);
         self::assertSame(100.5, $decision->candidatePrice);
-        self::assertSame(0.01, $decision->zoneDevPct);
+        self::assertEqualsWithDelta(0.01, $decision->zoneDevPct, 1e-12);
         self::assertSame(0.03, $decision->zoneMaxDevPct);
         self::assertNull($decision->reasonIfRejected);
     }
@@ -67,10 +67,42 @@ final class EntryZoneGuardTest extends TestCase
         );
 
         self::assertSame(EntryZoneStatus::Rejected, $decision->status);
-        self::assertSame(0.10, $decision->zoneDevPct);
+        self::assertEqualsWithDelta(0.10, $decision->zoneDevPct, 1e-12);
         self::assertSame(0.05, $decision->zoneMaxDevPct);
         self::assertSame('zone_far_from_market', $decision->reasonIfRejected);
         self::assertSame('decision-2', $decision->metadata['decision_key']);
+    }
+
+    public function testRejectsCandidateBecauseZoneIsTooFarFromMarketEvenThoughPriceIsInsideZone(): void
+    {
+        $guard = new EntryZoneGuard();
+        $zone = new EntryZone(
+            low: 100.0,
+            high: 101.0,
+            center: 100.5,
+            widthPct: 0.01,
+            ttlSec: 180,
+            expiresAt: null,
+            source: 'vwap',
+            atrUsed: 1.0,
+            quantized: false,
+        );
+
+        // candidatePrice is inside zone bounds — contains() returns true.
+        // But the zone is anchored around 100–101 while the market reference is 50.
+        // zoneDevPct = max(|100-50|, |101-50|) / 50 = 51/50 = 1.02, which exceeds zoneMaxDevPct=0.05.
+        $decision = $guard->decide(
+            entryZone: $zone,
+            candidatePrice: 100.5,
+            referencePrice: 50.0,
+            zoneMaxDevPct: 0.05,
+            reasonIfRejected: 'zone_far_from_market',
+        );
+
+        self::assertSame(EntryZoneStatus::Rejected, $decision->status);
+        self::assertEqualsWithDelta(1.02, $decision->zoneDevPct, 1e-12);
+        self::assertSame(0.05, $decision->zoneMaxDevPct);
+        self::assertSame('zone_far_from_market', $decision->reasonIfRejected);
     }
 
     public function testNormalizesPercentThresholdButDoesNotChangeSemanticValue(): void

--- a/trading-app/tests/TradingCore/Entry/LegacyEntryZoneMapperTest.php
+++ b/trading-app/tests/TradingCore/Entry/LegacyEntryZoneMapperTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 namespace App\Tests\TradingCore\Entry;
 
 use App\TradeEntry\Dto\EntryZone as LegacyEntryZone;
+use App\TradingCore\Entry\Dto\EntryZone;
 use App\TradingCore\Entry\Mapper\LegacyEntryZoneMapper;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(LegacyEntryZoneMapper::class)]
+#[CoversClass(EntryZone::class)]
+#[CoversClass(LegacyEntryZone::class)]
 final class LegacyEntryZoneMapperTest extends TestCase
 {
     public function testMapsLegacyEntryZoneWithoutChangingBoundsOrMetadata(): void

--- a/trading-app/tests/TradingCore/Entry/LegacyEntryZoneMapperTest.php
+++ b/trading-app/tests/TradingCore/Entry/LegacyEntryZoneMapperTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Entry;
+
+use App\TradeEntry\Dto\EntryZone as LegacyEntryZone;
+use App\TradingCore\Entry\Mapper\LegacyEntryZoneMapper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LegacyEntryZoneMapper::class)]
+final class LegacyEntryZoneMapperTest extends TestCase
+{
+    public function testMapsLegacyEntryZoneWithoutChangingBoundsOrMetadata(): void
+    {
+        $legacy = new LegacyEntryZone(
+            min: 99.0,
+            max: 101.0,
+            rationale: 'vwap@1m',
+            createdAt: new \DateTimeImmutable('2026-06-15T10:00:00+00:00'),
+            ttlSec: 180,
+            metadata: [
+                'pivot' => 100.0,
+                'pivot_source' => 'vwap',
+                'atr' => 1.5,
+                'width_pct' => 0.02,
+            ],
+        );
+
+        $zone = (new LegacyEntryZoneMapper())->fromLegacy($legacy);
+
+        self::assertSame(99.0, $zone->low);
+        self::assertSame(101.0, $zone->high);
+        self::assertSame(100.0, $zone->center);
+        self::assertSame(0.02, $zone->widthPct);
+        self::assertSame(180, $zone->ttlSec);
+        self::assertSame('2026-06-15T10:03:00+00:00', $zone->expiresAt?->format(\DateTimeInterface::ATOM));
+        self::assertSame('vwap', $zone->source);
+        self::assertSame(1.5, $zone->atrUsed);
+        self::assertFalse($zone->quantized);
+        self::assertSame('vwap@1m', $zone->metadata['legacy_rationale']);
+        self::assertSame(100.0, $zone->metadata['pivot']);
+    }
+}


### PR DESCRIPTION
## Objectif

Introduire un module EntryZone explicite, testable et auditable.

Cette PR prépare les futures extractions Risk/Leverage, SLTP et OrderPlan, sans modifier les seuils, sans desserrer les zones et sans changer le comportement runtime.

## Scope

- Ajout de DTOs / services EntryZone.
- Ajout de tests unitaires sur le calcul et les décisions EntryZone.
- Documentation du module EntryZone.
- Aucun branchement runtime TradeEntry dans cette PR.

## Hors-scope

- Aucun changement `mtf:run`.
- Aucun changement `POST /api/mtf/run`.
- Aucun changement Temporal.
- Aucun changement règles MTF.
- Aucun changement READY / REJECTED.
- Aucun changement Risk/Leverage.
- Aucun changement SL/TP.
- Aucun branchement `EffectiveTradingConfigResolver`.
- Aucun live OKX/Hyperliquid.
- Aucune suppression Bitmart.
- Aucun changement YAML stratégie.
- Aucun desserrage EntryZone.
- Aucun changement `zone_max_dev_pct`.
- Aucun objectif d’augmentation du nombre de trades.

## Tests

- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision tests/Application/Runner`
- `vendor/bin/phpstan analyse src/TradingCore/Entry src/TradingCore/Mtf src/TradingCore/Decision tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision --memory-limit=512M`
- `php bin/console lint:yaml config`
- `php bin/console lint:container`
- `php bin/console list mtf --raw | grep -E '^mtf:run\s'`
- `php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Notes de validation

`lint:container` passe avec un warning PHP 8.4 existant sur `EntryZoneStatsCommand::$name`. `mkdocs build --strict` passe avec une info existante sur `technical/trading-platform-architecture-decision.md` hors nav.

## Risques

Le risque principal est de modifier involontairement les zones d’entrée et donc le taux de trades. Cette PR reste une formalisation préparatoire : le nouveau module n’est pas branché dans `TradeEntry`.

## Critères d’acceptation

- Module EntryZone ajouté.
- Tests EntryZone ajoutés.
- Aucune valeur de zone modifiée.
- Aucun desserrage.
- Entrypoints préservés.
- Aucun comportement runtime changé.
- Documentation ajoutée.
