### PR TITLE
[codex] PR 07 — Risk / Leverage module

### DIFF
--- a/docs/handbook/technical/risk-and-leverage-module.md
+++ b/docs/handbook/technical/risk-and-leverage-module.md
@@ -1,0 +1,237 @@
+# Risk / Leverage module
+
+## Objectif
+
+PR07 introduit un module `App\TradingCore\Risk` explicite, testable et
+preparatoire.
+
+Cette PR ne branche pas le module dans `TradeEntry`, ne modifie pas les YAML et
+ne change pas le comportement runtime. Elle formalise les contrats cibles pour
+le calcul du risque, de la taille de position et du levier derive du stop.
+
+## Source de verite actuelle
+
+Le runtime legacy utilise encore le flux suivant :
+
+```text
+TradingDecisionHandler
+  -> TradeEntryRequestBuilder
+  -> TradeEntryRequest
+  -> OrderPlanBuilder
+  -> DynamicLeverageService
+  -> ExecutionBox / ExchangeExecutionService
+```
+
+La source effective du risque pour la taille de position est actuellement :
+
+```text
+trade_entry.defaults.risk_pct_percent
+  -> TradeEntryRequestBuilder
+  -> TradeEntryRequest::riskPct
+  -> OrderPlanBuilder
+```
+
+`OrderPlanBuilder` calcule ensuite :
+
+```text
+available_budget = min(initial_margin_usdt, preflight.available_usdt)
+risk_usdt = available_budget * TradeEntryRequest::riskPct
+size = floor(risk_usdt / (stop_distance * contract_size))
+```
+
+`risk.fixed_risk_pct` existe dans certains YAML historiques, mais il n'est pas
+la source branchee du runtime TradeEntry actuel pour la taille de position.
+Le nouveau `RiskConfigInterpreter` documente donc cette ambiguite au lieu de la
+masquer.
+
+## Champs legacy
+
+| Champ | Statut PR07 | Interpretation |
+| --- | --- | --- |
+| `defaults.risk_pct_percent` | Source runtime actuelle | Converti en ratio dans `TradeEntryRequestBuilder`, puis utilise par `OrderPlanBuilder`. |
+| `risk.fixed_risk_pct` | Canonical cible / non branche runtime | Champ explicite du module cible. A documenter comme non effectif tant que TradeEntry n'est pas migre. |
+| `defaults.initial_margin_usdt` | Runtime actuel | Budget nominal borne par le solde disponible preflight. |
+| `defaults.fallback_account_balance` | Runtime actuel partiel | Utilise seulement si `initial_margin_usdt <= 0`, pour reconstruire une marge initiale de fallback. |
+| `defaults.stop_from` | Runtime actuel | Peut etre `risk`, `atr` ou `pivot` selon profil. |
+| `defaults.atr_k` | Runtime actuel | Utilise pour le stop ATR et pour les approximations de levier dans certains contextes MTF. |
+| `leverage.exchange_cap` | Runtime actuel | Cap config en plus des caps exchange preflight. |
+| `leverage.per_symbol_caps` | Runtime actuel | Caps regex par symbole dans `DynamicLeverageService`. |
+| `defaults.timeframe_multipliers` | Runtime actuel | Multiplicateur applique au levier dynamique dans `DynamicLeverageService`. |
+| `leverage.timeframe_multipliers` | Runtime actuel | Multiplicateur applique plus tard a la taille et au levier dans les couches execution. |
+| `leverage.confidence_multiplier` | Documente / peu ou pas branche | Garde pour contrat cible, sans effet PR07. |
+| `leverage.conviction` | Documente / peu ou pas branche | Garde pour contrat cible, sans effet PR07. |
+| `leverage.max_loss_pct` | Runtime execution | Cappe le multiplicateur de timeframe via taille max autorisee au SL. |
+| `leverage.rounding.mode` | Runtime actuel | `ceil`, `floor` ou `round` selon etape. |
+
+## Formule cible
+
+Le module cible rend explicite :
+
+```text
+effective_risk_pct = fixed_risk_pct ou legacy risk_pct_percent
+risk_usdt = capital_base * effective_risk_pct
+stop_pct = abs(entry_price - stop_price) / entry_price, ou stop_pct fourni
+position_notional = risk_usdt / stop_pct
+quantity = position_notional / entry_price
+raw_leverage = risk_pct / stop_pct
+final_leverage = raw_leverage
+  * timeframe_multiplier
+  * liquidity_multiplier
+  puis caps, floor et rounding
+```
+
+Dans le module pur, `fixed_risk_pct` est le champ canonique quand il est fourni.
+Le mapper legacy peut cependant choisir de ne pas le passer au calcul tant que
+le runtime reste base sur `defaults.risk_pct_percent`.
+Dans PR07, `RiskConfigInterpreter` marque explicitement les requetes issues du
+runtime legacy pour que `PositionSizer` preserve `defaults.risk_pct_percent`
+quand les deux champs sont presents.
+
+## Formule actuelle si differente
+
+Le calcul live actuel contient des etapes supplementaires :
+
+- le stop peut venir du risque, de l'ATR ou d'un pivot ;
+- un stop pivot trop loin peut fallback vers ATR ou risk ;
+- une garde minimale de distance stop a 0.5 % peut elargir le stop ;
+- la taille est quantifiee et bornee par `minVolume`, `maxVolume` et
+  `marketMaxVolume` ;
+- le levier peut etre ajuste ensuite pour rapprocher la marge initiale de la
+  marge cible ;
+- les couches execution peuvent encore appliquer `leverage.timeframe_multipliers`
+  et `max_loss_pct`.
+
+PR07 ne deplace pas ces etapes.
+
+## Caps de levier
+
+Le nouveau `LeverageCapResolver` formalise les caps suivants :
+
+```text
+exchange_cap
+profile_cap
+symbol_cap
+```
+
+Le runtime actuel applique principalement :
+
+- cap preflight exchange via `PreflightReport::maxLeverage` ;
+- `TradeEntryRequest::leverageExchangeCap`, issu de `leverage.exchange_cap` ;
+- `leverage.exchange_cap` dans `DynamicLeverageService` ;
+- caps regex `leverage.per_symbol_caps` ;
+- `floor` ;
+- min/max exchange ;
+- rounding.
+
+`profile_cap` est present dans le contrat cible pour les futures configs
+effectives, mais il n'est pas branche dans PR07.
+
+## max_loss_pct
+
+`leverage.max_loss_pct` n'est pas applique au `raw_leverage` dans le plan
+initial.
+
+Il intervient plus tard dans `ExecutionBox` et `ExchangeExecutionService` pour
+limiter le multiplicateur de timeframe :
+
+```text
+max_loss_usdt = initial_margin_usdt * max_loss_pct
+risk_per_contract = abs(entry - stop) * contract_size
+max_size_allowed = floor(max_loss_usdt / risk_per_contract)
+effective_multiplier = min(tf_multiplier, max_size_allowed / plan.size)
+```
+
+Le module PR07 le transporte et genere un warning pour rappeler qu'il s'agit
+d'un cap execution-time, pas d'un composant du `raw_leverage`.
+
+## Liquidation guard
+
+Le guard live actuel (`App\TradeEntry\Policy\LiquidationGuard`) verifie surtout
+que la distance entre entry et stop n'est pas nulle. La formule exacte de
+liquidation reste a brancher.
+
+PR07 ne modifie pas ce guard. La suite logique est PR08, qui doit traiter SLTP
+et `LiquidationGuard` avec un contrat dedie.
+
+## Contraintes avant branchement live
+
+Avant de brancher ce module dans `TradeEntry`, il faudra :
+
+- comparer les resultats du module avec les plans legacy sur un echantillon de
+  decisions ;
+- verifier que `defaults.risk_pct_percent` et `risk.fixed_risk_pct` ne creent
+  pas deux sources contradictoires ;
+- decider explicitement si le runtime migre vers `risk.fixed_risk_pct` ou garde
+  `defaults.risk_pct_percent` comme source effective ;
+- couvrir les ajustements de marge de `OrderPlanBuilder` ;
+- couvrir les multipliers execution et `max_loss_pct` ;
+- verifier que le levier final ne peut pas augmenter par rapport au legacy ;
+- conserver les checks `mtf:run`, `/api/mtf/run`, container lint et mkdocs.
+
+## Ajouts PR07
+
+Namespace ajoute :
+
+```text
+App\TradingCore\Risk
+```
+
+DTOs et enum :
+
+- `Dto\RiskCalculationRequest` ;
+- `Dto\RiskCalculationResult` ;
+- `Dto\LeverageCalculationRequest` ;
+- `Dto\LeverageCalculationResult` ;
+- `Enum\RiskSource`.
+
+Services :
+
+- `Service\PositionSizer` ;
+- `Service\LeverageCalculator` ;
+- `Service\RiskConfigInterpreter` ;
+- `Service\LeverageCapResolver`.
+
+## Non branche dans PR07
+
+PR07 ne branche pas :
+
+- `PositionSizer` TradingCore dans `OrderPlanBuilder` ;
+- `LeverageCalculator` TradingCore dans `DynamicLeverageService` ;
+- `RiskConfigInterpreter` dans `TradeEntryRequestBuilder` ;
+- `EffectiveTradingConfigResolver` dans le runtime ;
+- `LiquidationGuard` cible.
+
+PR07 ne modifie pas :
+
+- `mtf:run` ;
+- `POST /api/mtf/run` ;
+- Temporal ;
+- les schedules ;
+- les regles MTF ;
+- les decisions `READY` / `REJECTED` ;
+- EntryZone ;
+- SL / TP ;
+- ExecutionPort ;
+- les valeurs risk/leverage dans les YAML ;
+- Bitmart, OKX ou Hyperliquid live.
+
+## Tests
+
+Tests ajoutes :
+
+- `tests/TradingCore/Risk/RiskConfigInterpreterTest.php` ;
+- `tests/TradingCore/Risk/PositionSizerTest.php` ;
+- `tests/TradingCore/Risk/LeverageCalculatorTest.php`.
+
+Ils couvrent :
+
+- source runtime legacy `defaults.risk_pct_percent` ;
+- fallback `risk.fixed_risk_pct` si la source legacy est absente ;
+- warning quand deux champs de risque coexistent ;
+- sizing depuis `risk_usdt / stop_pct` ;
+- rejet d'un `stop_pct` nul ;
+- levier brut `risk_pct / stop_pct` ;
+- caps exchange/profil/symbole ;
+- floor et rounding ;
+- representation de `max_loss_pct` sans changer le calcul initial ;
+- absence de levier arbitraire sans stop valide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
       - Runner extraction: technical/runner-extraction.md
       - DTOs MTF et TradeCandidate: technical/mtf-dtos-and-trade-candidate.md
       - EntryZone module: technical/entry-zone-module.md
+      - Risk / Leverage module: technical/risk-and-leverage-module.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/TradingCore/Risk/Dto/LeverageCalculationRequest.php
+++ b/trading-app/src/TradingCore/Risk/Dto/LeverageCalculationRequest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Dto;
+
+final readonly class LeverageCalculationRequest
+{
+    public string $instrument;
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $symbol,
+        ?string $instrument,
+        public string $profile,
+        public string $exchange,
+        public string $marketType,
+        public ?float $stopPct,
+        public ?float $riskPct,
+        public ?float $rawLeverage,
+        public ?float $exchangeCap,
+        public ?float $symbolCap,
+        public ?float $profileCap,
+        public ?float $timeframeMultiplier,
+        public ?float $liquidityMultiplier,
+        public ?float $maxLossPct,
+        public ?float $floor = null,
+        public int $minLeverage = 1,
+        public int $maxLeverage = 100,
+        public string $roundingMode = 'ceil',
+        public array $metadata = [],
+    ) {
+        $this->instrument = $instrument ?? $symbol;
+    }
+}

--- a/trading-app/src/TradingCore/Risk/Dto/LeverageCalculationResult.php
+++ b/trading-app/src/TradingCore/Risk/Dto/LeverageCalculationResult.php
@@ -6,7 +6,7 @@ namespace App\TradingCore\Risk\Dto;
 final readonly class LeverageCalculationResult
 {
     /**
-     * @param list<string> $capsApplied
+     * @param list<string> $capsApplied Caps that were configured and positive (not limited to those that actually reduced leverage).
      * @param list<string> $warnings
      * @param array<string,mixed> $metadata
      */
@@ -15,7 +15,6 @@ final readonly class LeverageCalculationResult
         public float $cappedLeverage,
         public int $finalLeverage,
         public array $capsApplied,
-        public int $roundedLeverage,
         public array $warnings = [],
         public array $metadata = [],
     ) {}

--- a/trading-app/src/TradingCore/Risk/Dto/LeverageCalculationResult.php
+++ b/trading-app/src/TradingCore/Risk/Dto/LeverageCalculationResult.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Dto;
+
+final readonly class LeverageCalculationResult
+{
+    /**
+     * @param list<string> $capsApplied
+     * @param list<string> $warnings
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public float $rawLeverage,
+        public float $cappedLeverage,
+        public int $finalLeverage,
+        public array $capsApplied,
+        public int $roundedLeverage,
+        public array $warnings = [],
+        public array $metadata = [],
+    ) {}
+}

--- a/trading-app/src/TradingCore/Risk/Dto/RiskCalculationRequest.php
+++ b/trading-app/src/TradingCore/Risk/Dto/RiskCalculationRequest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Dto;
+
+final readonly class RiskCalculationRequest
+{
+    public string $instrument;
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $symbol,
+        ?string $instrument,
+        public string $profile,
+        public string $exchange,
+        public string $marketType,
+        public ?float $equity,
+        public ?float $availableBalance,
+        public float $entryPrice,
+        public ?float $stopPrice,
+        public ?float $stopPct,
+        public ?float $fixedRiskPct,
+        public ?float $riskPctPercentLegacy,
+        public ?float $initialMarginUsdt,
+        public ?float $fallbackAccountBalance = null,
+        public array $metadata = [],
+    ) {
+        $this->instrument = $instrument ?? $symbol;
+    }
+}

--- a/trading-app/src/TradingCore/Risk/Dto/RiskCalculationResult.php
+++ b/trading-app/src/TradingCore/Risk/Dto/RiskCalculationResult.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Dto;
+
+use App\TradingCore\Risk\Enum\RiskSource;
+
+final readonly class RiskCalculationResult
+{
+    /**
+     * @param list<string> $warnings
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public float $effectiveRiskPct,
+        public RiskSource $riskSource,
+        public float $riskUsdt,
+        public float $stopPct,
+        public float $positionNotional,
+        public ?float $quantity,
+        public array $warnings = [],
+        public array $metadata = [],
+    ) {}
+}

--- a/trading-app/src/TradingCore/Risk/Enum/RiskSource.php
+++ b/trading-app/src/TradingCore/Risk/Enum/RiskSource.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Enum;
+
+enum RiskSource: string
+{
+    case FixedRiskPct = 'fixed_risk_pct';
+    case RiskPctPercentLegacy = 'risk_pct_percent_legacy';
+    case RequestRiskPct = 'request_risk_pct';
+}

--- a/trading-app/src/TradingCore/Risk/Enum/RiskSource.php
+++ b/trading-app/src/TradingCore/Risk/Enum/RiskSource.php
@@ -7,5 +7,6 @@ enum RiskSource: string
 {
     case FixedRiskPct = 'fixed_risk_pct';
     case RiskPctPercentLegacy = 'risk_pct_percent_legacy';
+    // Reserved for per-request override (not wired in PR07 — no handler in PositionSizer yet).
     case RequestRiskPct = 'request_risk_pct';
 }

--- a/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
+++ b/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
@@ -37,6 +37,9 @@ final class LeverageCalculator
         $rounded = max(1, $rounded);
         $rounded = max($request->minLeverage, $rounded);
         $rounded = min($request->maxLeverage, $rounded);
+        // Prevent ceil/round from pushing above a fractional float cap (e.g. cap=5.5, ceil→6).
+        $rounded = min($rounded, (int)floor($cappedLeverage));
+        $rounded = max(max(1, $request->minLeverage), $rounded);
 
         if ($request->maxLossPct !== null && \is_finite($request->maxLossPct) && $request->maxLossPct > 0.0) {
             $warnings[] = 'maxLossPct is represented for execution-time size/leverage capping; it is not applied to raw leverage in this preparatory module.';

--- a/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
+++ b/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
@@ -46,7 +46,6 @@ final class LeverageCalculator
             cappedLeverage: $cappedLeverage,
             finalLeverage: $rounded,
             capsApplied: $capsApplied,
-            roundedLeverage: $rounded,
             warnings: $warnings,
             metadata: [
                 'timeframe_multiplier' => $timeframeMultiplier,

--- a/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
+++ b/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
@@ -37,9 +37,13 @@ final class LeverageCalculator
         $rounded = max(1, $rounded);
         $rounded = max($request->minLeverage, $rounded);
         $rounded = min($request->maxLeverage, $rounded);
-        // Prevent ceil/round from pushing above a fractional float cap (e.g. cap=5.5, ceil→6).
-        $rounded = min($rounded, (int)floor($cappedLeverage));
-        $rounded = max(max(1, $request->minLeverage), $rounded);
+        // Prevent ceil/round from pushing above a fractional float cap, but only when a cap
+        // actually reduced the leverage (cappedLeverage < preCapLeverage).
+        // When no cap was binding, cappedLeverage equals the raw leverage and the rounding
+        // mode must be respected as-is (e.g. rawLeverage=1.5, ceil→2 must stay 2).
+        if ($cappedLeverage < $preCapLeverage && $rounded > (int)floor($cappedLeverage)) {
+            $rounded = max(max(1, $request->minLeverage), (int)floor($cappedLeverage));
+        }
 
         if ($request->maxLossPct !== null && \is_finite($request->maxLossPct) && $request->maxLossPct > 0.0) {
             $warnings[] = 'maxLossPct is represented for execution-time size/leverage capping; it is not applied to raw leverage in this preparatory module.';

--- a/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
+++ b/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
@@ -37,13 +37,16 @@ final class LeverageCalculator
         $rounded = max(1, $rounded);
         $rounded = max($request->minLeverage, $rounded);
         $rounded = min($request->maxLeverage, $rounded);
-        // Prevent ceil/round from pushing above a fractional float cap, but only when a cap
-        // actually reduced the leverage (cappedLeverage < preCapLeverage).
-        // When no cap was binding, cappedLeverage equals the raw leverage and the rounding
-        // mode must be respected as-is (e.g. rawLeverage=1.5, ceil→2 must stay 2).
-        if ($cappedLeverage < $preCapLeverage && $rounded > (int)floor($cappedLeverage)) {
-            $rounded = max(max(1, $request->minLeverage), (int)floor($cappedLeverage));
+        // Enforce integer compliance against each configured float cap.
+        // Checking individual cap values (not cappedLeverage vs preCapLeverage) handles both
+        // the "cap reduced leverage" case and the "raw leverage exactly equals a fractional cap"
+        // edge case (e.g. rawLeverage=5.5, exchangeCap=5.5 → ceil=6 must be clamped to 5).
+        foreach ([$request->exchangeCap, $request->profileCap, $request->symbolCap] as $cap) {
+            if ($cap !== null && \is_finite($cap) && $cap > 0.0 && $rounded > $cap) {
+                $rounded = (int)floor($cap);
+            }
         }
+        $rounded = max(max(1, $request->minLeverage), $rounded);
 
         if ($request->maxLossPct !== null && \is_finite($request->maxLossPct) && $request->maxLossPct > 0.0) {
             $warnings[] = 'maxLossPct is represented for execution-time size/leverage capping; it is not applied to raw leverage in this preparatory module.';

--- a/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
+++ b/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Service;
+
+use App\TradingCore\Risk\Dto\LeverageCalculationRequest;
+use App\TradingCore\Risk\Dto\LeverageCalculationResult;
+
+final class LeverageCalculator
+{
+    public function __construct(private readonly LeverageCapResolver $capResolver) {}
+
+    public function calculate(LeverageCalculationRequest $request): LeverageCalculationResult
+    {
+        $warnings = [];
+        $rawLeverage = $this->resolveRawLeverage($request);
+
+        $timeframeMultiplier = $this->positiveMultiplierOrDefault($request->timeframeMultiplier);
+        $liquidityMultiplier = $this->positiveMultiplierOrDefault($request->liquidityMultiplier);
+        $preCapLeverage = $rawLeverage * $timeframeMultiplier * $liquidityMultiplier;
+
+        [$cappedLeverage, $capsApplied] = $this->capResolver->applyCaps(
+            leverage: $preCapLeverage,
+            exchangeCap: $request->exchangeCap,
+            profileCap: $request->profileCap,
+            symbolCap: $request->symbolCap,
+        );
+
+        $bounded = min(max($cappedLeverage, (float)$request->minLeverage), (float)$request->maxLeverage);
+
+        if ($request->floor !== null && \is_finite($request->floor) && $request->floor > 0.0) {
+            $bounded = max($bounded, $request->floor);
+        }
+
+        $rounded = $this->round($bounded, $request->roundingMode);
+        $rounded = max(1, $rounded);
+        $rounded = max($request->minLeverage, $rounded);
+        $rounded = min($request->maxLeverage, $rounded);
+
+        if ($request->maxLossPct !== null && \is_finite($request->maxLossPct) && $request->maxLossPct > 0.0) {
+            $warnings[] = 'maxLossPct is represented for execution-time size/leverage capping; it is not applied to raw leverage in this preparatory module.';
+        }
+
+        return new LeverageCalculationResult(
+            rawLeverage: $rawLeverage,
+            cappedLeverage: $cappedLeverage,
+            finalLeverage: $rounded,
+            capsApplied: $capsApplied,
+            roundedLeverage: $rounded,
+            warnings: $warnings,
+            metadata: [
+                'timeframe_multiplier' => $timeframeMultiplier,
+                'liquidity_multiplier' => $liquidityMultiplier,
+                'pre_cap_leverage' => $preCapLeverage,
+                'floor' => $request->floor,
+                'rounding_mode' => $request->roundingMode,
+            ],
+        );
+    }
+
+    private function resolveRawLeverage(LeverageCalculationRequest $request): float
+    {
+        if ($request->rawLeverage !== null) {
+            if ($request->rawLeverage <= 0.0 || !\is_finite($request->rawLeverage)) {
+                throw new \InvalidArgumentException('rawLeverage must be positive');
+            }
+
+            return $request->rawLeverage;
+        }
+
+        if ($request->stopPct === null || $request->stopPct <= 0.0 || !\is_finite($request->stopPct)) {
+            throw new \InvalidArgumentException('stopPct must be positive');
+        }
+        if ($request->riskPct === null || $request->riskPct <= 0.0 || !\is_finite($request->riskPct)) {
+            throw new \InvalidArgumentException('riskPct must be positive');
+        }
+
+        return $request->riskPct / $request->stopPct;
+    }
+
+    private function positiveMultiplierOrDefault(?float $multiplier): float
+    {
+        if ($multiplier === null || !\is_finite($multiplier) || $multiplier <= 0.0) {
+            return 1.0;
+        }
+
+        return $multiplier;
+    }
+
+    private function round(float $value, string $mode): int
+    {
+        return match (strtolower($mode)) {
+            'floor' => (int)floor($value),
+            'round' => (int)round($value),
+            default => (int)ceil($value),
+        };
+    }
+}

--- a/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
+++ b/trading-app/src/TradingCore/Risk/Service/LeverageCalculator.php
@@ -29,7 +29,8 @@ final class LeverageCalculator
         $bounded = min(max($cappedLeverage, (float)$request->minLeverage), (float)$request->maxLeverage);
 
         if ($request->floor !== null && \is_finite($request->floor) && $request->floor > 0.0) {
-            $bounded = max($bounded, $request->floor);
+            // Floor cannot bypass exchange/profile/symbol caps: cap it to cappedLeverage first.
+            $bounded = max($bounded, min($request->floor, $cappedLeverage));
         }
 
         $rounded = $this->round($bounded, $request->roundingMode);

--- a/trading-app/src/TradingCore/Risk/Service/LeverageCapResolver.php
+++ b/trading-app/src/TradingCore/Risk/Service/LeverageCapResolver.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Service;
+
+final class LeverageCapResolver
+{
+    /**
+     * @return array{0:float,1:list<string>}
+     */
+    public function applyCaps(
+        float $leverage,
+        ?float $exchangeCap,
+        ?float $profileCap,
+        ?float $symbolCap,
+    ): array {
+        $capsApplied = [];
+        $capped = $leverage;
+
+        if ($exchangeCap !== null && \is_finite($exchangeCap) && $exchangeCap > 0.0) {
+            $capsApplied[] = 'exchange_cap';
+            $capped = min($capped, $exchangeCap);
+        }
+        if ($profileCap !== null && \is_finite($profileCap) && $profileCap > 0.0) {
+            $capsApplied[] = 'profile_cap';
+            $capped = min($capped, $profileCap);
+        }
+        if ($symbolCap !== null && \is_finite($symbolCap) && $symbolCap > 0.0) {
+            $capsApplied[] = 'symbol_cap';
+            $capped = min($capped, $symbolCap);
+        }
+
+        return [$capped, $capsApplied];
+    }
+}

--- a/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
+++ b/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
@@ -68,12 +68,13 @@ final class PositionSizer
         if (
             $legacyRuntimeSource === RiskSource::RiskPctPercentLegacy
             && $request->riskPctPercentLegacy !== null
-            && $request->riskPctPercentLegacy > 0.0
         ) {
-            if ($request->fixedRiskPct !== null && $request->fixedRiskPct > 0.0) {
+            if ($request->riskPctPercentLegacy > 0.0 && $request->fixedRiskPct !== null && $request->fixedRiskPct > 0.0) {
                 $warnings[] = 'Preserving legacy runtime risk source from defaults.risk_pct_percent; risk.fixed_risk_pct is carried for audit only.';
             }
-
+            // Return even when zero — the caller's positivity check rejects it, matching the
+            // legacy TradeEntryRequestBuilder which returns null when riskPct <= 0 (never falls
+            // through to fixedRiskPct).
             return [$request->riskPctPercentLegacy, RiskSource::RiskPctPercentLegacy, $warnings];
         }
 

--- a/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
+++ b/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
@@ -110,7 +110,12 @@ final class PositionSizer
             // Mirrors TradeEntryRequestBuilder: initialMargin = fallbackCapital * riskPct.
             // Caller applies effectiveRiskPct again → riskUsdt = balance * riskPct².
             // All current YAML configs set fallback_account_balance: 0.0 so this path is unreachable in production.
-            return $request->fallbackAccountBalance * $riskPct;
+            $syntheticMargin = $request->fallbackAccountBalance * $riskPct;
+            if ($request->availableBalance !== null) {
+                return min($syntheticMargin, max(0.0, $request->availableBalance));
+            }
+
+            return $syntheticMargin;
         }
 
         if ($request->availableBalance !== null && $request->availableBalance > 0.0) {

--- a/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
+++ b/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
@@ -98,8 +98,9 @@ final class PositionSizer
     {
         $initialMargin = $request->initialMarginUsdt;
         if ($initialMargin !== null && $initialMargin > 0.0) {
-            if ($request->availableBalance !== null && $request->availableBalance > 0.0) {
-                return min($initialMargin, $request->availableBalance);
+            if ($request->availableBalance !== null) {
+                // Honor an explicit zero balance: min(margin, 0.0) = 0.0 → caller throws.
+                return min($initialMargin, max(0.0, $request->availableBalance));
             }
 
             return $initialMargin;

--- a/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
+++ b/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
@@ -106,6 +106,9 @@ final class PositionSizer
         }
 
         if ($request->fallbackAccountBalance !== null && $request->fallbackAccountBalance > 0.0) {
+            // Mirrors TradeEntryRequestBuilder: initialMargin = fallbackCapital * riskPct.
+            // Caller applies effectiveRiskPct again → riskUsdt = balance * riskPct².
+            // All current YAML configs set fallback_account_balance: 0.0 so this path is unreachable in production.
             return $request->fallbackAccountBalance * $riskPct;
         }
 

--- a/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
+++ b/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
@@ -118,8 +118,9 @@ final class PositionSizer
             return $syntheticMargin;
         }
 
-        if ($request->availableBalance !== null && $request->availableBalance > 0.0) {
-            return $request->availableBalance;
+        if ($request->availableBalance !== null) {
+            // Honor explicit zero — no spendable budget → capitalBase = 0 → caller rejects.
+            return max(0.0, $request->availableBalance);
         }
 
         return $request->equity !== null && $request->equity > 0.0 ? $request->equity : 0.0;

--- a/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
+++ b/trading-app/src/TradingCore/Risk/Service/PositionSizer.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Service;
+
+use App\TradingCore\Risk\Dto\RiskCalculationRequest;
+use App\TradingCore\Risk\Dto\RiskCalculationResult;
+use App\TradingCore\Risk\Enum\RiskSource;
+
+final class PositionSizer
+{
+    public function calculate(RiskCalculationRequest $request): RiskCalculationResult
+    {
+        $stopPct = $this->resolveStopPct($request);
+        if ($stopPct <= 0.0 || !\is_finite($stopPct)) {
+            throw new \InvalidArgumentException('stopPct must be positive');
+        }
+
+        [$effectiveRiskPct, $riskSource, $warnings] = $this->resolveRiskPct($request);
+        if ($effectiveRiskPct <= 0.0 || !\is_finite($effectiveRiskPct)) {
+            throw new \InvalidArgumentException('effective risk pct must be positive');
+        }
+
+        $capitalBase = $this->resolveCapitalBase($request, $effectiveRiskPct);
+        if ($capitalBase <= 0.0 || !\is_finite($capitalBase)) {
+            throw new \InvalidArgumentException('capital base must be positive');
+        }
+
+        $riskUsdt = $capitalBase * $effectiveRiskPct;
+        $positionNotional = $riskUsdt / $stopPct;
+        $quantity = $request->entryPrice > 0.0 ? $positionNotional / $request->entryPrice : null;
+
+        return new RiskCalculationResult(
+            effectiveRiskPct: $effectiveRiskPct,
+            riskSource: $riskSource,
+            riskUsdt: $riskUsdt,
+            stopPct: $stopPct,
+            positionNotional: $positionNotional,
+            quantity: $quantity,
+            warnings: $warnings,
+            metadata: [
+                'capital_base_usdt' => $capitalBase,
+                'runtime_note' => 'Legacy TradeEntry currently sizes contracts from riskUsdt / stop distance, then exchange volume clamps are applied in OrderPlanBuilder.',
+            ],
+        );
+    }
+
+    private function resolveStopPct(RiskCalculationRequest $request): float
+    {
+        if ($request->stopPct !== null) {
+            return $request->stopPct;
+        }
+
+        if ($request->stopPrice !== null && $request->entryPrice > 0.0) {
+            return abs($request->entryPrice - $request->stopPrice) / $request->entryPrice;
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * @return array{0:float,1:RiskSource,2:list<string>}
+     */
+    private function resolveRiskPct(RiskCalculationRequest $request): array
+    {
+        $warnings = [];
+        $legacyRuntimeSource = $request->metadata['legacy_runtime_risk_source'] ?? null;
+        if (
+            $legacyRuntimeSource === RiskSource::RiskPctPercentLegacy
+            && $request->riskPctPercentLegacy !== null
+            && $request->riskPctPercentLegacy > 0.0
+        ) {
+            if ($request->fixedRiskPct !== null && $request->fixedRiskPct > 0.0) {
+                $warnings[] = 'Preserving legacy runtime risk source from defaults.risk_pct_percent; risk.fixed_risk_pct is carried for audit only.';
+            }
+
+            return [$request->riskPctPercentLegacy, RiskSource::RiskPctPercentLegacy, $warnings];
+        }
+
+        if ($request->fixedRiskPct !== null && $request->fixedRiskPct > 0.0) {
+            if ($request->riskPctPercentLegacy !== null && $request->riskPctPercentLegacy > 0.0) {
+                $warnings[] = 'Both fixedRiskPct and legacy riskPctPercent are present; fixedRiskPct is the canonical module source.';
+            }
+
+            return [$request->fixedRiskPct, RiskSource::FixedRiskPct, $warnings];
+        }
+
+        if ($request->riskPctPercentLegacy !== null && $request->riskPctPercentLegacy > 0.0) {
+            $warnings[] = 'Using legacy defaults.risk_pct_percent because fixedRiskPct is absent.';
+
+            return [$request->riskPctPercentLegacy, RiskSource::RiskPctPercentLegacy, $warnings];
+        }
+
+        throw new \InvalidArgumentException('risk pct source is required');
+    }
+
+    private function resolveCapitalBase(RiskCalculationRequest $request, float $riskPct): float
+    {
+        $initialMargin = $request->initialMarginUsdt;
+        if ($initialMargin !== null && $initialMargin > 0.0) {
+            if ($request->availableBalance !== null && $request->availableBalance > 0.0) {
+                return min($initialMargin, $request->availableBalance);
+            }
+
+            return $initialMargin;
+        }
+
+        if ($request->fallbackAccountBalance !== null && $request->fallbackAccountBalance > 0.0) {
+            return $request->fallbackAccountBalance * $riskPct;
+        }
+
+        if ($request->availableBalance !== null && $request->availableBalance > 0.0) {
+            return $request->availableBalance;
+        }
+
+        return $request->equity !== null && $request->equity > 0.0 ? $request->equity : 0.0;
+    }
+}

--- a/trading-app/src/TradingCore/Risk/Service/RiskConfigInterpreter.php
+++ b/trading-app/src/TradingCore/Risk/Service/RiskConfigInterpreter.php
@@ -77,6 +77,12 @@ final class RiskConfigInterpreter
         );
     }
 
+    /**
+     * Normalizes a percent-or-fraction value to a fraction.
+     * Values > 1.0 are treated as percentage (e.g. 5.0 → 0.05).
+     * Values ≤ 1.0 are assumed to already be fractions (e.g. 0.05 stays 0.05).
+     * All YAML fixed_risk_pct values in this codebase are > 1.0; never use sub-1 values to mean sub-1%.
+     */
     public function normalizePercent(float $value): float
     {
         $value = max(0.0, $value);

--- a/trading-app/src/TradingCore/Risk/Service/RiskConfigInterpreter.php
+++ b/trading-app/src/TradingCore/Risk/Service/RiskConfigInterpreter.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Risk\Service;
+
+use App\TradingCore\Risk\Dto\RiskCalculationRequest;
+use App\TradingCore\Risk\Enum\RiskSource;
+
+final class RiskConfigInterpreter
+{
+    /**
+     * @param array<string,mixed> $defaults Legacy trade_entry.defaults block.
+     * @param array<string,mixed> $risk Legacy trade_entry.risk block.
+     */
+    public function fromLegacyTradeEntryConfig(
+        string $symbol,
+        string $profile,
+        string $exchange,
+        string $marketType,
+        float $entryPrice,
+        ?float $stopPct,
+        array $defaults,
+        array $risk,
+        ?string $instrument = null,
+        ?float $equity = null,
+        ?float $availableBalance = null,
+        ?float $stopPrice = null,
+    ): RiskCalculationRequest {
+        $warnings = [];
+
+        $legacyRiskPct = null;
+        if (isset($defaults['risk_pct_percent']) && is_numeric($defaults['risk_pct_percent'])) {
+            $legacyRiskPct = $this->normalizeLegacyPercent((float)$defaults['risk_pct_percent']);
+        }
+
+        $fixedRiskPct = null;
+        if (isset($risk['fixed_risk_pct']) && is_numeric($risk['fixed_risk_pct'])) {
+            $fixedRiskPct = $this->normalizePercent((float)$risk['fixed_risk_pct']);
+        }
+
+        $runtimeSource = null;
+        if ($legacyRiskPct !== null) {
+            $runtimeSource = RiskSource::RiskPctPercentLegacy;
+            if ($fixedRiskPct !== null) {
+                $warnings[] = 'risk.fixed_risk_pct is configured but legacy TradeEntry runtime derives TradeEntryRequest::riskPct from defaults.risk_pct_percent.';
+            }
+        } elseif ($fixedRiskPct !== null) {
+            $runtimeSource = RiskSource::FixedRiskPct;
+        }
+
+        $initialMargin = isset($defaults['initial_margin_usdt']) && is_numeric($defaults['initial_margin_usdt'])
+            ? (float)$defaults['initial_margin_usdt']
+            : null;
+        $fallbackAccountBalance = isset($defaults['fallback_account_balance']) && is_numeric($defaults['fallback_account_balance'])
+            ? (float)$defaults['fallback_account_balance']
+            : null;
+
+        return new RiskCalculationRequest(
+            symbol: $symbol,
+            instrument: $instrument,
+            profile: $profile,
+            exchange: $exchange,
+            marketType: $marketType,
+            equity: $equity,
+            availableBalance: $availableBalance,
+            entryPrice: $entryPrice,
+            stopPrice: $stopPrice,
+            stopPct: $stopPct,
+            fixedRiskPct: $fixedRiskPct,
+            riskPctPercentLegacy: $legacyRiskPct,
+            initialMarginUsdt: $initialMargin,
+            fallbackAccountBalance: $fallbackAccountBalance,
+            metadata: [
+                'legacy_runtime_risk_source' => $runtimeSource,
+                'warnings' => $warnings,
+            ],
+        );
+    }
+
+    public function normalizePercent(float $value): float
+    {
+        $value = max(0.0, $value);
+        if ($value > 1.0) {
+            $value *= 0.01;
+        }
+
+        return min($value, 1.0);
+    }
+
+    private function normalizeLegacyPercent(float $value): float
+    {
+        $value = max(0.0, $value);
+
+        return min($value * 0.01, 1.0);
+    }
+}

--- a/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
@@ -141,6 +141,40 @@ final class LeverageCalculatorTest extends TestCase
         self::assertSame(5, $result->finalLeverage);
     }
 
+    public function testCeilRoundingIsPreservedWhenNoCapsReducedLeverage(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        // rawLeverage = 0.04/0.02 = 2.0 — exchange cap is 100 (not binding).
+        // ceil(2.0) = 2 must NOT be clipped to floor(2.0) = 2 (no-op here).
+        // More critically: fractional raw = 1.5, cap = 100 → ceil(1.5) must stay 2.
+        $result = $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.02,
+            riskPct: 0.03,
+            rawLeverage: null,
+            exchangeCap: 100.0,
+            symbolCap: null,
+            profileCap: null,
+            timeframeMultiplier: 1.0,
+            liquidityMultiplier: null,
+            maxLossPct: null,
+            floor: null,
+            minLeverage: 1,
+            maxLeverage: 100,
+            roundingMode: 'ceil',
+        ));
+
+        // rawLeverage = 0.03/0.02 = 1.5, exchangeCap not binding → ceil(1.5) = 2
+        self::assertSame(1.5, $result->rawLeverage);
+        self::assertSame(1.5, $result->cappedLeverage);
+        self::assertSame(2, $result->finalLeverage);
+    }
+
     public function testFloorDoesNotInventLeverageWithoutPositiveRawInput(): void
     {
         $calculator = new LeverageCalculator(new LeverageCapResolver());

--- a/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
@@ -77,6 +77,39 @@ final class LeverageCalculatorTest extends TestCase
         self::assertSame(['exchange_cap', 'profile_cap', 'symbol_cap'], $result->capsApplied);
     }
 
+    public function testFloorCannotBypassExchangeOrProfileOrSymbolCaps(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        // rawLeverage = 0.2/0.01 = 20, cappedLeverage = min(20, 5) = 5
+        // floor = 10 > exchangeCap = 5 — must NOT raise finalLeverage above 5
+        $result = $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.01,
+            riskPct: 0.2,
+            rawLeverage: null,
+            exchangeCap: 5.0,
+            symbolCap: null,
+            profileCap: null,
+            timeframeMultiplier: 1.0,
+            liquidityMultiplier: null,
+            maxLossPct: null,
+            floor: 10.0,
+            minLeverage: 1,
+            maxLeverage: 100,
+            roundingMode: 'ceil',
+        ));
+
+        self::assertSame(20.0, $result->rawLeverage);
+        self::assertSame(5.0, $result->cappedLeverage);
+        self::assertSame(5, $result->finalLeverage);
+        self::assertContains('exchange_cap', $result->capsApplied);
+    }
+
     public function testFloorDoesNotInventLeverageWithoutPositiveRawInput(): void
     {
         $calculator = new LeverageCalculator(new LeverageCapResolver());

--- a/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
@@ -110,6 +110,37 @@ final class LeverageCalculatorTest extends TestCase
         self::assertContains('exchange_cap', $result->capsApplied);
     }
 
+    public function testCeilRoundingCannotExceedFractionalFloatCap(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        // exchangeCap = 5.5 (fractional), rawLeverage >> cap → cappedLeverage = 5.5
+        // ceil(5.5) = 6 would exceed the cap — finalLeverage must be floor(5.5) = 5
+        $result = $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.01,
+            riskPct: 0.5,
+            rawLeverage: null,
+            exchangeCap: 5.5,
+            symbolCap: null,
+            profileCap: null,
+            timeframeMultiplier: 1.0,
+            liquidityMultiplier: null,
+            maxLossPct: null,
+            floor: null,
+            minLeverage: 1,
+            maxLeverage: 100,
+            roundingMode: 'ceil',
+        ));
+
+        self::assertSame(5.5, $result->cappedLeverage);
+        self::assertSame(5, $result->finalLeverage);
+    }
+
     public function testFloorDoesNotInventLeverageWithoutPositiveRawInput(): void
     {
         $calculator = new LeverageCalculator(new LeverageCapResolver());

--- a/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
@@ -141,6 +141,39 @@ final class LeverageCalculatorTest extends TestCase
         self::assertSame(5, $result->finalLeverage);
     }
 
+    public function testCeilRoundingCannotExceedCapWhenRawLeverageEqualsCapExactly(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        // rawLeverage = riskPct/stopPct = 0.055/0.01 = 5.5, exchangeCap = 5.5
+        // cappedLeverage = preCapLeverage = 5.5 (cap not "reducing" but still binding)
+        // ceil(5.5) = 6 must be clamped to floor(5.5) = 5
+        $result = $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.01,
+            riskPct: 0.055,
+            rawLeverage: null,
+            exchangeCap: 5.5,
+            symbolCap: null,
+            profileCap: null,
+            timeframeMultiplier: 1.0,
+            liquidityMultiplier: null,
+            maxLossPct: null,
+            floor: null,
+            minLeverage: 1,
+            maxLeverage: 100,
+            roundingMode: 'ceil',
+        ));
+
+        self::assertSame(5.5, $result->rawLeverage);
+        self::assertSame(5.5, $result->cappedLeverage);
+        self::assertSame(5, $result->finalLeverage);
+    }
+
     public function testCeilRoundingIsPreservedWhenNoCapsReducedLeverage(): void
     {
         $calculator = new LeverageCalculator(new LeverageCapResolver());

--- a/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
@@ -43,7 +43,6 @@ final class LeverageCalculatorTest extends TestCase
 
         self::assertSame(2.0, $result->rawLeverage);
         self::assertSame(2.0, $result->cappedLeverage);
-        self::assertSame(2, $result->roundedLeverage);
         self::assertSame(2, $result->finalLeverage);
     }
 
@@ -74,7 +73,6 @@ final class LeverageCalculatorTest extends TestCase
 
         self::assertSame(10.0, $result->rawLeverage);
         self::assertSame(5.0, $result->cappedLeverage);
-        self::assertSame(5, $result->roundedLeverage);
         self::assertSame(5, $result->finalLeverage);
         self::assertSame(['exchange_cap', 'profile_cap', 'symbol_cap'], $result->capsApplied);
     }

--- a/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
+++ b/trading-app/tests/TradingCore/Risk/LeverageCalculatorTest.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Risk;
+
+use App\TradingCore\Risk\Dto\LeverageCalculationRequest;
+use App\TradingCore\Risk\Dto\LeverageCalculationResult;
+use App\TradingCore\Risk\Service\LeverageCalculator;
+use App\TradingCore\Risk\Service\LeverageCapResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LeverageCalculator::class)]
+#[CoversClass(LeverageCapResolver::class)]
+#[CoversClass(LeverageCalculationRequest::class)]
+#[CoversClass(LeverageCalculationResult::class)]
+final class LeverageCalculatorTest extends TestCase
+{
+    public function testRawLeverageIsDerivedFromRiskPctAndStopPct(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        $result = $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.02,
+            riskPct: 0.04,
+            rawLeverage: null,
+            exchangeCap: 100.0,
+            symbolCap: null,
+            profileCap: null,
+            timeframeMultiplier: 1.0,
+            liquidityMultiplier: null,
+            maxLossPct: null,
+            floor: 1.0,
+            minLeverage: 1,
+            maxLeverage: 100,
+            roundingMode: 'ceil',
+        ));
+
+        self::assertSame(2.0, $result->rawLeverage);
+        self::assertSame(2.0, $result->cappedLeverage);
+        self::assertSame(2, $result->roundedLeverage);
+        self::assertSame(2, $result->finalLeverage);
+    }
+
+    public function testAppliesExchangeProfileSymbolCapsFloorAndRounding(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        $result = $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'NVDAXUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.01,
+            riskPct: 0.1,
+            rawLeverage: null,
+            exchangeCap: 20.0,
+            symbolCap: 5.0,
+            profileCap: 8.0,
+            timeframeMultiplier: 1.25,
+            liquidityMultiplier: 1.0,
+            maxLossPct: null,
+            floor: 2.0,
+            minLeverage: 1,
+            maxLeverage: 100,
+            roundingMode: 'floor',
+        ));
+
+        self::assertSame(10.0, $result->rawLeverage);
+        self::assertSame(5.0, $result->cappedLeverage);
+        self::assertSame(5, $result->roundedLeverage);
+        self::assertSame(5, $result->finalLeverage);
+        self::assertSame(['exchange_cap', 'profile_cap', 'symbol_cap'], $result->capsApplied);
+    }
+
+    public function testFloorDoesNotInventLeverageWithoutPositiveRawInput(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stopPct must be positive');
+
+        $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.0,
+            riskPct: 0.02,
+            rawLeverage: null,
+            exchangeCap: 20.0,
+            symbolCap: null,
+            profileCap: null,
+            timeframeMultiplier: 1.0,
+            liquidityMultiplier: null,
+            maxLossPct: null,
+            floor: 2.0,
+            minLeverage: 1,
+            maxLeverage: 20,
+            roundingMode: 'ceil',
+        ));
+    }
+
+    public function testDocumentsMaxLossPctAsExecutionTimeCapWarning(): void
+    {
+        $calculator = new LeverageCalculator(new LeverageCapResolver());
+
+        $result = $calculator->calculate(new LeverageCalculationRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            stopPct: 0.01,
+            riskPct: 0.02,
+            rawLeverage: null,
+            exchangeCap: 20.0,
+            symbolCap: null,
+            profileCap: null,
+            timeframeMultiplier: 1.0,
+            liquidityMultiplier: null,
+            maxLossPct: 0.004,
+            floor: 1.0,
+            minLeverage: 1,
+            maxLeverage: 20,
+            roundingMode: 'ceil',
+        ));
+
+        self::assertContains('maxLossPct is represented for execution-time size/leverage capping; it is not applied to raw leverage in this preparatory module.', $result->warnings);
+    }
+}

--- a/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
+++ b/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
@@ -121,6 +121,32 @@ final class PositionSizerTest extends TestCase
         ));
     }
 
+    public function testRejectsWhenAvailableBalanceIsZeroAndEquityIsPositive(): void
+    {
+        $sizer = new PositionSizer();
+
+        // No initialMarginUsdt, no fallbackAccountBalance — falls to the availableBalance/equity
+        // branch. availableBalance=0.0 must block sizing even when equity is positive.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('capital base must be positive');
+
+        $sizer->calculate(new RiskCalculationRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            equity: 500.0,
+            availableBalance: 0.0,
+            entryPrice: 100.0,
+            stopPrice: null,
+            stopPct: 0.02,
+            fixedRiskPct: null,
+            riskPctPercentLegacy: 0.004,
+            initialMarginUsdt: null,
+        ));
+    }
+
     public function testFallbackCapitalPathCappsToAvailableBalance(): void
     {
         $sizer = new PositionSizer();

--- a/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
+++ b/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Risk;
+
+use App\TradingCore\Risk\Dto\RiskCalculationRequest;
+use App\TradingCore\Risk\Dto\RiskCalculationResult;
+use App\TradingCore\Risk\Enum\RiskSource;
+use App\TradingCore\Risk\Service\PositionSizer;
+use App\TradingCore\Risk\Service\RiskConfigInterpreter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PositionSizer::class)]
+#[CoversClass(RiskConfigInterpreter::class)]
+#[CoversClass(RiskCalculationRequest::class)]
+#[CoversClass(RiskCalculationResult::class)]
+#[CoversClass(RiskSource::class)]
+final class PositionSizerTest extends TestCase
+{
+    public function testCalculatesPositionFromLegacyRuntimeRiskPctAndStopPct(): void
+    {
+        $sizer = new PositionSizer();
+
+        $result = $sizer->calculate(new RiskCalculationRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            equity: null,
+            availableBalance: 100.0,
+            entryPrice: 100.0,
+            stopPrice: null,
+            stopPct: 0.02,
+            fixedRiskPct: null,
+            riskPctPercentLegacy: 0.004,
+            initialMarginUsdt: 50.0,
+        ));
+
+        self::assertSame(0.004, $result->effectiveRiskPct);
+        self::assertSame(RiskSource::RiskPctPercentLegacy, $result->riskSource);
+        self::assertSame(0.2, $result->riskUsdt);
+        self::assertSame(0.02, $result->stopPct);
+        self::assertSame(10.0, $result->positionNotional);
+        self::assertSame(0.1, $result->quantity);
+    }
+
+    public function testRejectsZeroOrNegativeStopPct(): void
+    {
+        $sizer = new PositionSizer();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stopPct must be positive');
+
+        $sizer->calculate(new RiskCalculationRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            equity: null,
+            availableBalance: 100.0,
+            entryPrice: 100.0,
+            stopPrice: null,
+            stopPct: 0.0,
+            fixedRiskPct: null,
+            riskPctPercentLegacy: 0.01,
+            initialMarginUsdt: 50.0,
+        ));
+    }
+
+    public function testWarnsWhenCanonicalAndLegacyRiskFieldsAreBothPresent(): void
+    {
+        $sizer = new PositionSizer();
+
+        $result = $sizer->calculate(new RiskCalculationRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            equity: null,
+            availableBalance: 200.0,
+            entryPrice: 20.0,
+            stopPrice: null,
+            stopPct: 0.05,
+            fixedRiskPct: 0.02,
+            riskPctPercentLegacy: 0.01,
+            initialMarginUsdt: 100.0,
+        ));
+
+        self::assertSame(0.02, $result->effectiveRiskPct);
+        self::assertSame(RiskSource::FixedRiskPct, $result->riskSource);
+        self::assertContains('Both fixedRiskPct and legacy riskPctPercent are present; fixedRiskPct is the canonical module source.', $result->warnings);
+    }
+
+    public function testPreservesLegacyRuntimeRiskSourceWhenRequestComesFromInterpreter(): void
+    {
+        $interpreter = new RiskConfigInterpreter();
+        $sizer = new PositionSizer();
+
+        $request = $interpreter->fromLegacyTradeEntryConfig(
+            symbol: 'BTCUSDT',
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            entryPrice: 100.0,
+            stopPct: 0.02,
+            defaults: [
+                'risk_pct_percent' => 0.4,
+                'initial_margin_usdt' => 50.0,
+            ],
+            risk: [
+                'fixed_risk_pct' => 5.0,
+            ],
+            availableBalance: 100.0,
+        );
+
+        $result = $sizer->calculate($request);
+
+        self::assertSame(0.004, $result->effectiveRiskPct);
+        self::assertSame(RiskSource::RiskPctPercentLegacy, $result->riskSource);
+        self::assertContains('Preserving legacy runtime risk source from defaults.risk_pct_percent; risk.fixed_risk_pct is carried for audit only.', $result->warnings);
+    }
+}

--- a/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
+++ b/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
@@ -95,6 +95,32 @@ final class PositionSizerTest extends TestCase
         self::assertContains('Both fixedRiskPct and legacy riskPctPercent are present; fixedRiskPct is the canonical module source.', $result->warnings);
     }
 
+    public function testRejectsPositionWhenAvailableBalanceIsExplicitlyZero(): void
+    {
+        $sizer = new PositionSizer();
+
+        // availableBalance=0.0 explicitly means "no budget" and must be honored,
+        // not silently ignored in favour of initialMarginUsdt.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('capital base must be positive');
+
+        $sizer->calculate(new RiskCalculationRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            equity: null,
+            availableBalance: 0.0,
+            entryPrice: 100.0,
+            stopPrice: null,
+            stopPct: 0.02,
+            fixedRiskPct: null,
+            riskPctPercentLegacy: 0.004,
+            initialMarginUsdt: 50.0,
+        ));
+    }
+
     public function testSizesFallbackCapitalUsingLegacyDoubleRiskPctPattern(): void
     {
         $sizer = new PositionSizer();

--- a/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
+++ b/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
@@ -121,6 +121,33 @@ final class PositionSizerTest extends TestCase
         ));
     }
 
+    public function testFallbackCapitalPathCappsToAvailableBalance(): void
+    {
+        $sizer = new PositionSizer();
+
+        // syntheticMargin = 1000 * 0.004 = 4.0, availableBalance = 1.0
+        // capitalBase = min(4.0, 1.0) = 1.0 → riskUsdt = 1.0 * 0.004 = 0.004
+        $result = $sizer->calculate(new RiskCalculationRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            equity: null,
+            availableBalance: 1.0,
+            entryPrice: 100.0,
+            stopPrice: null,
+            stopPct: 0.02,
+            fixedRiskPct: null,
+            riskPctPercentLegacy: 0.004,
+            initialMarginUsdt: null,
+            fallbackAccountBalance: 1000.0,
+        ));
+
+        self::assertSame(0.004, $result->riskUsdt);
+        self::assertSame(0.2, $result->positionNotional);
+    }
+
     public function testSizesFallbackCapitalUsingLegacyDoubleRiskPctPattern(): void
     {
         $sizer = new PositionSizer();

--- a/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
+++ b/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
@@ -204,6 +204,36 @@ final class PositionSizerTest extends TestCase
         self::assertSame(0.008, $result->quantity);
     }
 
+    public function testRejectsWhenLegacyRiskPctIsZeroInsteadOfFallingBackToFixedRisk(): void
+    {
+        $interpreter = new RiskConfigInterpreter();
+        $sizer = new PositionSizer();
+
+        // risk_pct_percent=0.0 normalizes to 0.0 → source is RiskPctPercentLegacy with value 0.
+        // Must NOT fall through to fixedRiskPct — legacy runtime would have returned null (rejected).
+        $request = $interpreter->fromLegacyTradeEntryConfig(
+            symbol: 'BTCUSDT',
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            entryPrice: 100.0,
+            stopPct: 0.02,
+            defaults: [
+                'risk_pct_percent' => 0.0,
+                'initial_margin_usdt' => 50.0,
+            ],
+            risk: [
+                'fixed_risk_pct' => 5.0,
+            ],
+            availableBalance: 100.0,
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('effective risk pct must be positive');
+
+        $sizer->calculate($request);
+    }
+
     public function testPreservesLegacyRuntimeRiskSourceWhenRequestComesFromInterpreter(): void
     {
         $interpreter = new RiskConfigInterpreter();

--- a/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
+++ b/trading-app/tests/TradingCore/Risk/PositionSizerTest.php
@@ -95,6 +95,36 @@ final class PositionSizerTest extends TestCase
         self::assertContains('Both fixedRiskPct and legacy riskPctPercent are present; fixedRiskPct is the canonical module source.', $result->warnings);
     }
 
+    public function testSizesFallbackCapitalUsingLegacyDoubleRiskPctPattern(): void
+    {
+        $sizer = new PositionSizer();
+
+        // fallback_account_balance = 1000, riskPct = 0.004, initialMarginUsdt = null
+        // resolveCapitalBase returns 1000 * 0.004 = 4.0 (mirrors TradeEntryRequestBuilder)
+        // riskUsdt = 4.0 * 0.004 = 0.016 (riskPct applied twice — matches legacy behavior)
+        $result = $sizer->calculate(new RiskCalculationRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            equity: null,
+            availableBalance: null,
+            entryPrice: 100.0,
+            stopPrice: null,
+            stopPct: 0.02,
+            fixedRiskPct: null,
+            riskPctPercentLegacy: 0.004,
+            initialMarginUsdt: null,
+            fallbackAccountBalance: 1000.0,
+        ));
+
+        self::assertSame(RiskSource::RiskPctPercentLegacy, $result->riskSource);
+        self::assertSame(0.016, $result->riskUsdt);
+        self::assertSame(0.8, $result->positionNotional);
+        self::assertSame(0.008, $result->quantity);
+    }
+
     public function testPreservesLegacyRuntimeRiskSourceWhenRequestComesFromInterpreter(): void
     {
         $interpreter = new RiskConfigInterpreter();

--- a/trading-app/tests/TradingCore/Risk/RiskConfigInterpreterTest.php
+++ b/trading-app/tests/TradingCore/Risk/RiskConfigInterpreterTest.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Risk;
+
+use App\TradingCore\Risk\Dto\RiskCalculationRequest;
+use App\TradingCore\Risk\Enum\RiskSource;
+use App\TradingCore\Risk\Service\RiskConfigInterpreter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RiskConfigInterpreter::class)]
+#[CoversClass(RiskCalculationRequest::class)]
+#[CoversClass(RiskSource::class)]
+final class RiskConfigInterpreterTest extends TestCase
+{
+    public function testLegacyRiskPctPercentIsRuntimeSourceWhenPresent(): void
+    {
+        $interpreter = new RiskConfigInterpreter();
+
+        $request = $interpreter->fromLegacyTradeEntryConfig(
+            symbol: 'BTCUSDT',
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            entryPrice: 100.0,
+            stopPct: 0.01,
+            defaults: [
+                'risk_pct_percent' => 0.4,
+                'initial_margin_usdt' => 50.0,
+                'fallback_account_balance' => 0.0,
+            ],
+            risk: [
+                'fixed_risk_pct' => 5.0,
+            ],
+        );
+
+        self::assertSame(0.004, $request->riskPctPercentLegacy);
+        self::assertSame(0.05, $request->fixedRiskPct);
+        self::assertSame(RiskSource::RiskPctPercentLegacy, $request->metadata['legacy_runtime_risk_source']);
+        self::assertContains('risk.fixed_risk_pct is configured but legacy TradeEntry runtime derives TradeEntryRequest::riskPct from defaults.risk_pct_percent.', $request->metadata['warnings']);
+    }
+
+    public function testFixedRiskPctIsFallbackWhenLegacyRiskPctPercentIsMissing(): void
+    {
+        $interpreter = new RiskConfigInterpreter();
+
+        $request = $interpreter->fromLegacyTradeEntryConfig(
+            symbol: 'ETHUSDT',
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            entryPrice: 100.0,
+            stopPct: 0.02,
+            defaults: [
+                'initial_margin_usdt' => 40.0,
+            ],
+            risk: [
+                'fixed_risk_pct' => 2.5,
+            ],
+        );
+
+        self::assertSame(0.025, $request->fixedRiskPct);
+        self::assertNull($request->riskPctPercentLegacy);
+        self::assertSame(RiskSource::FixedRiskPct, $request->metadata['legacy_runtime_risk_source']);
+    }
+}


### PR DESCRIPTION
## Objectif

Introduire/formaliser le module Risk / Leverage du TradingCore.

Cette PR clarifie la source de vérité du risque, les champs legacy, le calcul cible du levier dérivé et les caps, sans changer le comportement runtime ni les valeurs de risque/levier.

## Scope

- Ajout de DTOs / services Risk / Leverage.
- Ajout de tests unitaires sur risk/leverage.
- Documentation du module Risk / Leverage.
- Aucun changement runtime sauf délégation mécanique sûre si nécessaire.

## Hors-scope

- Aucun changement `mtf:run`.
- Aucun changement `POST /api/mtf/run`.
- Aucun changement Temporal.
- Aucun changement règles MTF.
- Aucun changement READY / REJECTED.
- Aucun changement EntryZone.
- Aucun changement SL/TP.
- Aucun branchement `EffectiveTradingConfigResolver`.
- Aucun live OKX/Hyperliquid.
- Aucune suppression Bitmart.
- Aucun changement YAML stratégie.
- Aucun changement des valeurs risk/leverage.
- Aucun objectif d’augmentation du risque ou du levier.

## Tests

- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/TradingCore/Risk`
- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/TradingCore/Risk tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision tests/Application/Runner`
- `vendor/bin/phpstan analyse src/TradingCore/Risk tests/TradingCore/Risk --memory-limit=512M`
- `vendor/bin/phpstan analyse src/TradingCore/Risk src/TradingCore/Entry src/TradingCore/Mtf src/TradingCore/Decision tests/TradingCore/Risk tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision --memory-limit=512M`
- `DEFAULT_URI=http://localhost:8082 php bin/console lint:yaml config`
- `DEFAULT_URI=http://localhost:8082 php bin/console lint:container`
- `DEFAULT_URI=http://localhost:8082 php bin/console list mtf --raw | grep -E '^mtf:run\s'`
- `DEFAULT_URI=http://localhost:8082 php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Risques

Le risque principal est de modifier involontairement la taille de position ou le levier effectif. Cette PR reste une formalisation/préparation sans changement de comportement runtime.

Note locale: les commandes Symfony nécessitent `DEFAULT_URI=http://localhost:8082` dans cet environnement. `lint:container` passe mais affiche une dépréciation existante sur `EntryZoneStatsCommand::__construct()`.

## Critères d’acceptation

- Module Risk / Leverage ajouté.
- Tests risk/leverage ajoutés.
- Source de vérité du risque documentée.
- Aucun changement de valeur risk/leverage.
- Aucun levier arbitraire.
- Entrypoints préservés.
- Aucun comportement runtime changé.
