### PR TITLE
[codex] PR 08 — SLTP / LiquidationGuard module

### DIFF
--- a/docs/handbook/technical/sltp-liquidation-guard-module.md
+++ b/docs/handbook/technical/sltp-liquidation-guard-module.md
@@ -1,0 +1,249 @@
+# SLTP / LiquidationGuard module
+
+## Objectif
+
+PR08 introduit un module `App\TradingCore\SlTp` explicite, testable et
+preparatoire.
+
+Cette PR ne branche pas le module dans `TradeEntry`, ne modifie pas les YAML et
+ne change pas le comportement runtime. Elle formalise le contrat cible pour le
+stop-loss, le take-profit, la validation du plan de protection et le
+`LiquidationGuard`.
+
+## Regle de protection
+
+Aucun plan executable ne doit etre considere valide sans stop-loss automatique.
+Le stop-loss doit couvrir la taille complete de la position.
+
+Cette regle est representee par `ProtectionPlanValidator` :
+
+```text
+ProtectionPlan invalide si stop_loss absent
+ProtectionPlan invalide si stop_loss non full size
+ProtectionPlan invalide si stop_pct <= 0
+ProtectionPlan invalide si liquidation guard unsafe
+ProtectionPlan warning si TP net incoherent
+```
+
+Le module produit aussi des warnings quand le TP net devient incoherent apres
+frais, spread ou slippage. Ces warnings ne changent pas le runtime dans PR08.
+
+## Source runtime actuelle
+
+Le runtime legacy reste le suivant :
+
+```text
+TradingDecisionHandler
+  -> TradeEntryRequestBuilder
+  -> TradeEntryRequest
+  -> BuildOrderPlan
+  -> OrderPlanBuilder
+  -> ExecutionBox / ExchangeExecutionService
+  -> ProtectionEnforcer
+```
+
+Les classes effectives restent :
+
+- `App\TradeEntry\RiskSizer\StopLossCalculator` ;
+- `App\TradeEntry\RiskSizer\TakeProfitCalculator` ;
+- `App\TradeEntry\Policy\LiquidationGuard` ;
+- `App\TradeEntry\OrderPlan\OrderPlanBuilder` ;
+- `App\TradeEntry\Execution\ExchangeExecutionService` ;
+- `App\TradeEntry\Execution\ProtectionEnforcer`.
+
+PR08 ne remplace pas ces classes dans le flux d'execution.
+
+## Stop-loss legacy
+
+Le stop runtime est calcule dans `OrderPlanBuilder`.
+
+Champs legacy principaux :
+
+| Champ | Statut PR08 | Interpretation |
+| --- | --- | --- |
+| `defaults.stop_from` | Runtime actuel | Source du stop : `pivot`, `atr` ou `risk`. |
+| `defaults.stop_fallback` | Runtime actuel | Fallback pivot vers `atr`, `risk` ou `none` selon profil. |
+| `defaults.atr_k` | Runtime actuel | Multiplicateur ATR pour distance SL. |
+| `defaults.pivot_sl_policy` | Runtime actuel | Selection pivot, avec normalisation legacy `nearest_below`/`nearest_above`. |
+| `defaults.pivot_sl_buffer_pct` | Runtime actuel | Buffer autour du pivot SL. |
+| `defaults.pivot_sl_min_keep_ratio` | Runtime partiel | Ratio de preservation documente par la config legacy. |
+| `defaults.sl_full_size` | Runtime protection / cible | Le SL doit couvrir toute la position. |
+
+Le runtime actuel applique aussi une garde minimale de distance stop a 0.5 %
+dans `OrderPlanBuilder`. PR08 documente ce comportement mais ne le deplace pas.
+
+## Take-profit legacy
+
+Le TP runtime est calcule en R puis peut etre aligne sur pivot.
+
+Champs legacy principaux :
+
+| Champ | Statut PR08 | Interpretation |
+| --- | --- | --- |
+| `defaults.r_multiple` | Runtime actuel | R cible principal pour le TP. |
+| `defaults.tp1_r` | Runtime partiel / deux targets | R de TP1 lorsque le flux deux targets est utilise. |
+| `defaults.tp_policy` | Runtime actuel | Politique TP, par exemple `pivot_conservative`. |
+| `defaults.tp_buffer_pct` | Runtime actuel avec pivot | Buffer TP applique lors de l'alignement pivot. |
+| `defaults.tp_min_keep_ratio` | Runtime actuel | Garde pour ne pas reduire trop fortement le R theorique. |
+| `defaults.tp_max_extra_r` | Runtime actuel | Cap du surplus de R accepte par rapport au TP theorique. |
+
+`TakeProfitCalculator` du module cible represente :
+
+```text
+tp1_price = entry +/- tp1_r * risk_distance
+tp2_price = entry +/- r_multiple * risk_distance si disponible
+expected_r = R effectif du TP1
+expected_net_r = expected_r - couts(fees, spread, slippage) si calculable
+```
+
+PR08 ne deplace pas les TP live.
+
+## Frais, spread et slippage
+
+Le module transporte explicitement :
+
+- `fees_bps` ;
+- `spread_bps` ;
+- `slippage_bps`.
+
+Ces champs permettent d'estimer un `expected_net_r`. Si le R net devient
+inferieur ou egal a zero, le resultat genere un warning.
+
+PR08 ne change pas les seuils de spread, les frais exchange ou les conditions
+MTF.
+
+## LiquidationGuard
+
+Le guard live actuel `App\TradeEntry\Policy\LiquidationGuard` verifie surtout
+que la distance entre entry et stop n'est pas nulle. La formule exacte de
+liquidation reste dependante des specs exchange et des donnees disponibles.
+
+Le nouveau `App\TradingCore\SlTp\Service\LiquidationGuard` formalise le contrat
+cible :
+
+```text
+entry_price
+stop_price
+leverage
+maintenance_margin_rate si disponible
+liquidation_price si fourni par l'exchange
+min_distance_ratio
+```
+
+Le resultat expose :
+
+```text
+is_safe
+liquidation_price
+liquidation_distance_pct
+stop_to_liquidation_ratio
+reason_if_unsafe
+warnings
+```
+
+Si aucun prix de liquidation n'est fourni et que le levier est absent, le
+module ne pretend pas que le plan est safe. Il retourne `is_safe=false` avec
+`insufficient_liquidation_data`.
+
+## Ajouts PR08
+
+Namespace ajoute :
+
+```text
+App\TradingCore\SlTp
+```
+
+DTOs et enum :
+
+- `Dto\StopLossRequest` ;
+- `Dto\StopLossResult` ;
+- `Dto\TakeProfitRequest` ;
+- `Dto\TakeProfitResult` ;
+- `Dto\ProtectionPlan` ;
+- `Dto\LiquidationCheckRequest` ;
+- `Dto\LiquidationCheckResult` ;
+- `Enum\ProtectionPlanStatus`.
+
+Services :
+
+- `Service\StopLossCalculator` ;
+- `Service\TakeProfitCalculator` ;
+- `Service\LiquidationGuard` ;
+- `Service\ProtectionPlanValidator`.
+
+## Non branche dans PR08
+
+PR08 ne branche pas :
+
+- `StopLossCalculator` TradingCore dans `OrderPlanBuilder` ;
+- `TakeProfitCalculator` TradingCore dans `OrderPlanBuilder` ;
+- `LiquidationGuard` TradingCore dans `BuildOrderPlan` ;
+- `ProtectionPlanValidator` dans `ExecutionBox` ou `ExecutionPort` ;
+- `EffectiveTradingConfigResolver` dans le runtime.
+
+PR08 ne modifie pas :
+
+- `mtf:run` ;
+- `POST /api/mtf/run` ;
+- Temporal ;
+- les schedules ;
+- les regles MTF ;
+- les decisions `READY` / `REJECTED` ;
+- EntryZone ;
+- Risk / Leverage ;
+- ExecutionPort ;
+- les valeurs SL/TP dans les YAML ;
+- Bitmart, OKX ou Hyperliquid live.
+
+## Contraintes avant branchement live
+
+Avant tout branchement runtime, il faudra :
+
+- comparer les resultats SL/TP TradingCore avec `OrderPlanBuilder` sur un
+  echantillon de decisions ;
+- verifier que le SL reste full size dans les payloads exchange ;
+- verifier les cas ou l'exchange refuse l'attachement de protection ;
+- aligner le calcul de liquidation sur les specs OKX, Hyperliquid et Bitmart
+  legacy ;
+- integrer `ProtectionPlan` au futur `OrderPlan` cible ;
+- conserver les checks `mtf:run`, `/api/mtf/run`, container lint et mkdocs.
+
+## Suite PR09
+
+PR09 doit traiter `OrderPlan / ExecutionPort`.
+
+Objectif recommande :
+
+- faire recevoir a l'execution un plan deja valide ;
+- rendre impossible un `OrderPlan` cible executable sans `ProtectionPlan`
+  valide ;
+- isoler les mappings exchange dans les gateways ;
+- garder Bitmart legacy tant que son retrait n'est pas planifie dans une PR
+  dediee.
+
+## Tests
+
+Tests ajoutes :
+
+- `tests/TradingCore/SlTp/StopLossCalculatorTest.php` ;
+- `tests/TradingCore/SlTp/TakeProfitCalculatorTest.php` ;
+- `tests/TradingCore/SlTp/LiquidationGuardTest.php` ;
+- `tests/TradingCore/SlTp/ProtectionPlanValidatorTest.php`.
+
+Ils couvrent :
+
+- SL long sous entry ;
+- SL short au-dessus entry ;
+- buffer pivot SL ;
+- rejet d'un SL du mauvais cote de l'entry ;
+- TP en R long et short ;
+- preservation de `tp1_r` et `r_multiple` ;
+- representation du buffer TP ;
+- warning de TP net incoherent apres couts ;
+- liquidation safe ;
+- liquidation unsafe ;
+- liquidation indeterminee sans donnees suffisantes ;
+- plan invalide sans SL ;
+- plan invalide si SL non full size ;
+- plan invalide si `stop_pct <= 0` ;
+- plan valide avec SL full size, TP coherent et liquidation safe.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - DTOs MTF et TradeCandidate: technical/mtf-dtos-and-trade-candidate.md
       - EntryZone module: technical/entry-zone-module.md
       - Risk / Leverage module: technical/risk-and-leverage-module.md
+      - SLTP / LiquidationGuard module: technical/sltp-liquidation-guard-module.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/TradingCore/SlTp/Dto/LiquidationCheckRequest.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/LiquidationCheckRequest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Dto;
+
+final readonly class LiquidationCheckRequest
+{
+    public string $instrument;
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $symbol,
+        ?string $instrument,
+        public string $exchange,
+        public string $marketType,
+        public string $direction,
+        public float $entryPrice,
+        public float $stopPrice,
+        public ?int $leverage,
+        public ?float $maintenanceMarginRate,
+        public ?float $liquidationPrice,
+        public float $minDistanceRatio,
+        public array $metadata = [],
+    ) {
+        $this->instrument = $instrument ?? $symbol;
+    }
+}

--- a/trading-app/src/TradingCore/SlTp/Dto/LiquidationCheckResult.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/LiquidationCheckResult.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Dto;
+
+final readonly class LiquidationCheckResult
+{
+    /**
+     * @param list<string> $warnings
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public bool $isSafe,
+        public ?float $liquidationPrice,
+        public ?float $liquidationDistancePct,
+        public ?float $stopToLiquidationRatio,
+        public array $warnings = [],
+        public ?string $reasonIfUnsafe = null,
+        public array $metadata = [],
+    ) {}
+}

--- a/trading-app/src/TradingCore/SlTp/Dto/ProtectionPlan.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/ProtectionPlan.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Dto;
+
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+
+final readonly class ProtectionPlan
+{
+    /**
+     * @param list<string> $invalidReasons
+     * @param list<string> $warnings
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public ?StopLossResult $stopLoss,
+        public ?TakeProfitResult $takeProfit,
+        public ?LiquidationCheckResult $liquidationCheck,
+        public bool $isValid,
+        public ProtectionPlanStatus $status,
+        public array $invalidReasons = [],
+        public array $warnings = [],
+        public array $metadata = [],
+    ) {}
+}

--- a/trading-app/src/TradingCore/SlTp/Dto/StopLossRequest.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/StopLossRequest.php
@@ -26,8 +26,8 @@ final readonly class StopLossRequest
         public string $pivotSlPolicy,
         public ?float $pivotSlBufferPct,
         public ?float $pivotSlMinKeepRatio,
-        public ?bool $slFullSize,
-        public ?float $positionSize,
+        public bool $slFullSize = true,
+        public ?float $positionSize = null,
         public ?float $providedStopPrice = null,
         public array $metadata = [],
     ) {

--- a/trading-app/src/TradingCore/SlTp/Dto/StopLossRequest.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/StopLossRequest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Dto;
+
+final readonly class StopLossRequest
+{
+    public string $instrument;
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $symbol,
+        ?string $instrument,
+        public string $profile,
+        public string $exchange,
+        public string $marketType,
+        public string $direction,
+        public float $entryPrice,
+        public string $stopFrom,
+        public ?string $stopFallback,
+        public ?float $atr,
+        public ?float $atrK,
+        public ?float $pivotPrice,
+        public string $pivotSlPolicy,
+        public ?float $pivotSlBufferPct,
+        public ?float $pivotSlMinKeepRatio,
+        public ?bool $slFullSize,
+        public ?float $positionSize,
+        public ?float $providedStopPrice = null,
+        public array $metadata = [],
+    ) {
+        $this->instrument = $instrument ?? $symbol;
+    }
+}

--- a/trading-app/src/TradingCore/SlTp/Dto/StopLossRequest.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/StopLossRequest.php
@@ -28,6 +28,7 @@ final readonly class StopLossRequest
         public ?float $pivotSlMinKeepRatio,
         public bool $slFullSize = true,
         public ?float $positionSize = null,
+        public ?float $pivotSlMaxDistancePct = null,
         public ?float $providedStopPrice = null,
         public array $metadata = [],
     ) {

--- a/trading-app/src/TradingCore/SlTp/Dto/StopLossResult.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/StopLossResult.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Dto;
+
+final readonly class StopLossResult
+{
+    /**
+     * @param list<string> $warnings
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public float $stopPrice,
+        public float $stopPct,
+        public float $stopDistance,
+        public string $stopSource,
+        public bool $isFullSize,
+        public array $warnings = [],
+        public array $metadata = [],
+    ) {}
+}

--- a/trading-app/src/TradingCore/SlTp/Dto/TakeProfitRequest.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/TakeProfitRequest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Dto;
+
+final readonly class TakeProfitRequest
+{
+    public string $instrument;
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $symbol,
+        ?string $instrument,
+        public string $profile,
+        public string $exchange,
+        public string $marketType,
+        public string $direction,
+        public float $entryPrice,
+        public float $stopPrice,
+        public ?float $riskDistance,
+        public float $rMultiple,
+        public ?float $tp1R,
+        public string $tpPolicy,
+        public ?float $tpBufferPct,
+        public float $tpMinKeepRatio,
+        public ?float $tpMaxExtraR,
+        public ?float $feesBps,
+        public ?float $spreadBps,
+        public ?float $slippageBps,
+        public array $metadata = [],
+    ) {
+        $this->instrument = $instrument ?? $symbol;
+    }
+}

--- a/trading-app/src/TradingCore/SlTp/Dto/TakeProfitRequest.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/TakeProfitRequest.php
@@ -29,6 +29,7 @@ final readonly class TakeProfitRequest
         public ?float $feesBps,
         public ?float $spreadBps,
         public ?float $slippageBps,
+        public bool $pivotAligned = false,
         public array $metadata = [],
     ) {
         $this->instrument = $instrument ?? $symbol;

--- a/trading-app/src/TradingCore/SlTp/Dto/TakeProfitResult.php
+++ b/trading-app/src/TradingCore/SlTp/Dto/TakeProfitResult.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Dto;
+
+final readonly class TakeProfitResult
+{
+    /**
+     * @param list<string> $warnings
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public float $tp1Price,
+        public ?float $tp2Price,
+        public float $expectedR,
+        public ?float $expectedNetR,
+        public string $tpPolicyApplied,
+        public array $warnings = [],
+        public array $metadata = [],
+    ) {}
+}

--- a/trading-app/src/TradingCore/SlTp/Enum/ProtectionPlanStatus.php
+++ b/trading-app/src/TradingCore/SlTp/Enum/ProtectionPlanStatus.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Enum;
+
+enum ProtectionPlanStatus: string
+{
+    case Valid = 'valid';
+    case Invalid = 'invalid';
+}

--- a/trading-app/src/TradingCore/SlTp/Service/LiquidationGuard.php
+++ b/trading-app/src/TradingCore/SlTp/Service/LiquidationGuard.php
@@ -51,6 +51,11 @@ final class LiquidationGuard
             return $this->unsafe($request, $liquidationPrice, $liquidationDistancePct, $ratio, 'liquidation_not_beyond_stop');
         }
 
+        // Fail closed: NAN or negative threshold makes any comparison unreliable.
+        if (!\is_finite($request->minDistanceRatio) || $request->minDistanceRatio < 0.0) {
+            return $this->unsafe($request, $liquidationPrice, $liquidationDistancePct, $ratio, 'invalid_min_distance_ratio');
+        }
+
         if ($ratio < $request->minDistanceRatio) {
             return $this->unsafe($request, $liquidationPrice, $liquidationDistancePct, $ratio, 'liquidation_distance_below_min_ratio');
         }

--- a/trading-app/src/TradingCore/SlTp/Service/LiquidationGuard.php
+++ b/trading-app/src/TradingCore/SlTp/Service/LiquidationGuard.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Service;
+
+use App\TradingCore\SlTp\Dto\LiquidationCheckRequest;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+
+final class LiquidationGuard
+{
+    public function check(LiquidationCheckRequest $request): LiquidationCheckResult
+    {
+        if ($request->entryPrice <= 0.0 || !\is_finite($request->entryPrice)) {
+            throw new \InvalidArgumentException('entryPrice must be positive');
+        }
+
+        $direction = $this->direction($request->direction);
+        $stopDistance = abs($request->entryPrice - $request->stopPrice);
+        if ($stopDistance <= 0.0 || !\is_finite($stopDistance)) {
+            return $this->unsafe($request, null, null, null, 'stop_distance_not_positive');
+        }
+
+        $liquidationPrice = $this->resolveLiquidationPrice($request, $direction);
+        if ($liquidationPrice === null) {
+            return $this->unsafe(
+                request: $request,
+                liquidationPrice: null,
+                liquidationDistancePct: null,
+                ratio: null,
+                reason: 'insufficient_liquidation_data',
+                warnings: ['Liquidation price cannot be derived without leverage or an exchange-provided liquidation price.'],
+            );
+        }
+
+        $liquidationDistance = abs($request->entryPrice - $liquidationPrice);
+        $liquidationDistancePct = $liquidationDistance / $request->entryPrice;
+        $ratio = $liquidationDistance / $stopDistance;
+
+        $isBeyondStop = $direction === 'long'
+            ? $liquidationPrice < $request->stopPrice
+            : $liquidationPrice > $request->stopPrice;
+        if (!$isBeyondStop) {
+            return $this->unsafe($request, $liquidationPrice, $liquidationDistancePct, $ratio, 'liquidation_not_beyond_stop');
+        }
+
+        if ($ratio < $request->minDistanceRatio) {
+            return $this->unsafe($request, $liquidationPrice, $liquidationDistancePct, $ratio, 'liquidation_distance_below_min_ratio');
+        }
+
+        return new LiquidationCheckResult(
+            isSafe: true,
+            liquidationPrice: $this->normalize($liquidationPrice),
+            liquidationDistancePct: $this->normalize($liquidationDistancePct),
+            stopToLiquidationRatio: $this->normalize($ratio),
+            warnings: [],
+            reasonIfUnsafe: null,
+            metadata: $this->metadata($request, $direction),
+        );
+    }
+
+    private function resolveLiquidationPrice(LiquidationCheckRequest $request, string $direction): ?float
+    {
+        if ($request->liquidationPrice !== null && $request->liquidationPrice > 0.0 && \is_finite($request->liquidationPrice)) {
+            return $request->liquidationPrice;
+        }
+
+        if ($request->leverage === null || $request->leverage <= 0) {
+            return null;
+        }
+
+        $maintenance = $request->maintenanceMarginRate !== null && \is_finite($request->maintenanceMarginRate)
+            ? max(0.0, $request->maintenanceMarginRate)
+            : 0.0;
+
+        if ($direction === 'long') {
+            return $request->entryPrice * max(0.0, 1.0 - (1.0 / $request->leverage) + $maintenance);
+        }
+
+        return $request->entryPrice * (1.0 + (1.0 / $request->leverage) - $maintenance);
+    }
+
+    /**
+     * @param list<string> $warnings
+     */
+    private function unsafe(
+        LiquidationCheckRequest $request,
+        ?float $liquidationPrice,
+        ?float $liquidationDistancePct,
+        ?float $ratio,
+        string $reason,
+        array $warnings = [],
+    ): LiquidationCheckResult {
+        return new LiquidationCheckResult(
+            isSafe: false,
+            liquidationPrice: $liquidationPrice !== null ? $this->normalize($liquidationPrice) : null,
+            liquidationDistancePct: $liquidationDistancePct !== null ? $this->normalize($liquidationDistancePct) : null,
+            stopToLiquidationRatio: $ratio !== null ? $this->normalize($ratio) : null,
+            warnings: $warnings,
+            reasonIfUnsafe: $reason,
+            metadata: $this->metadata($request, strtolower($request->direction)),
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function metadata(LiquidationCheckRequest $request, string $direction): array
+    {
+        return $request->metadata + [
+            'symbol' => $request->symbol,
+            'instrument' => $request->instrument,
+            'exchange' => $request->exchange,
+            'market_type' => $request->marketType,
+            'direction' => $direction,
+            'entry_price' => $request->entryPrice,
+            'stop_price' => $request->stopPrice,
+            'leverage' => $request->leverage,
+            'maintenance_margin_rate' => $request->maintenanceMarginRate,
+            'min_distance_ratio' => $request->minDistanceRatio,
+        ];
+    }
+
+    private function direction(string $direction): string
+    {
+        $normalized = strtolower($direction);
+        if (!\in_array($normalized, ['long', 'short'], true)) {
+            throw new \InvalidArgumentException('direction must be long or short');
+        }
+
+        return $normalized;
+    }
+
+    private function normalize(float $value): float
+    {
+        return round($value, 12);
+    }
+}

--- a/trading-app/src/TradingCore/SlTp/Service/LiquidationGuard.php
+++ b/trading-app/src/TradingCore/SlTp/Service/LiquidationGuard.php
@@ -15,6 +15,14 @@ final class LiquidationGuard
         }
 
         $direction = $this->direction($request->direction);
+
+        $isStopOnCorrectSide = $direction === 'long'
+            ? $request->stopPrice < $request->entryPrice
+            : $request->stopPrice > $request->entryPrice;
+        if (!$isStopOnCorrectSide) {
+            return $this->unsafe($request, null, null, null, 'stop_on_wrong_side_of_entry');
+        }
+
         $stopDistance = abs($request->entryPrice - $request->stopPrice);
         if ($stopDistance <= 0.0 || !\is_finite($stopDistance)) {
             return $this->unsafe($request, null, null, null, 'stop_distance_not_positive');

--- a/trading-app/src/TradingCore/SlTp/Service/ProtectionPlanValidator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/ProtectionPlanValidator.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Service;
+
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+
+final class ProtectionPlanValidator
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function validate(
+        ?StopLossResult $stopLoss,
+        ?TakeProfitResult $takeProfit,
+        ?LiquidationCheckResult $liquidationCheck,
+        array $metadata = [],
+    ): ProtectionPlan {
+        $invalidReasons = [];
+        $warnings = [];
+
+        if (!$stopLoss instanceof StopLossResult) {
+            $invalidReasons[] = 'stop_loss_missing';
+        } else {
+            if (!$stopLoss->isFullSize) {
+                $invalidReasons[] = 'stop_loss_not_full_size';
+            }
+            if ($stopLoss->stopPct <= 0.0 || !\is_finite($stopLoss->stopPct)) {
+                $invalidReasons[] = 'stop_pct_not_positive';
+            }
+        }
+
+        if ($liquidationCheck instanceof LiquidationCheckResult && !$liquidationCheck->isSafe) {
+            $invalidReasons[] = 'liquidation_guard_unsafe';
+        }
+
+        if ($takeProfit instanceof TakeProfitResult && $takeProfit->expectedNetR !== null && $takeProfit->expectedNetR <= 0.0) {
+            $warnings[] = 'take_profit_net_r_not_positive';
+        }
+
+        $isValid = $invalidReasons === [];
+
+        return new ProtectionPlan(
+            stopLoss: $stopLoss,
+            takeProfit: $takeProfit,
+            liquidationCheck: $liquidationCheck,
+            isValid: $isValid,
+            status: $isValid ? ProtectionPlanStatus::Valid : ProtectionPlanStatus::Invalid,
+            invalidReasons: $invalidReasons,
+            warnings: $warnings,
+            metadata: $metadata,
+        );
+    }
+}

--- a/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Service;
+
+use App\TradingCore\SlTp\Dto\StopLossRequest;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+
+final class StopLossCalculator
+{
+    public function calculate(StopLossRequest $request): StopLossResult
+    {
+        if ($request->entryPrice <= 0.0 || !\is_finite($request->entryPrice)) {
+            throw new \InvalidArgumentException('entryPrice must be positive');
+        }
+
+        $direction = $this->direction($request->direction);
+        [$stopPrice, $source, $warnings] = $this->resolveStop($request, $direction);
+        $this->assertStopSide($direction, $request->entryPrice, $stopPrice);
+
+        $stopDistance = abs($request->entryPrice - $stopPrice);
+        $stopPct = $stopDistance / $request->entryPrice;
+        if ($stopPct <= 0.0 || !\is_finite($stopPct)) {
+            throw new \InvalidArgumentException('stopPct must be positive');
+        }
+
+        return new StopLossResult(
+            stopPrice: $this->normalize($stopPrice),
+            stopPct: $this->normalize($stopPct),
+            stopDistance: $this->normalize($stopDistance),
+            stopSource: $source,
+            isFullSize: $request->slFullSize ?? true,
+            warnings: $warnings,
+            metadata: $request->metadata + [
+                'symbol' => $request->symbol,
+                'instrument' => $request->instrument,
+                'profile' => $request->profile,
+                'exchange' => $request->exchange,
+                'market_type' => $request->marketType,
+                'direction' => $direction,
+                'stop_from' => $request->stopFrom,
+                'stop_fallback' => $request->stopFallback,
+                'atr' => $request->atr,
+                'atr_k' => $request->atrK,
+                'pivot_price' => $request->pivotPrice,
+                'pivot_sl_policy' => $request->pivotSlPolicy,
+                'pivot_sl_buffer_pct' => $request->pivotSlBufferPct,
+                'pivot_sl_min_keep_ratio' => $request->pivotSlMinKeepRatio,
+                'sl_full_size' => $request->slFullSize,
+                'position_size' => $request->positionSize,
+            ],
+        );
+    }
+
+    /**
+     * @return array{0:float,1:string,2:list<string>}
+     */
+    private function resolveStop(StopLossRequest $request, string $direction): array
+    {
+        $stopFrom = strtolower($request->stopFrom);
+        $warnings = [];
+
+        if ($stopFrom === 'provided') {
+            if ($request->providedStopPrice === null || $request->providedStopPrice <= 0.0 || !\is_finite($request->providedStopPrice)) {
+                throw new \InvalidArgumentException('providedStopPrice must be positive when stopFrom=provided');
+            }
+
+            return [$request->providedStopPrice, 'provided', $warnings];
+        }
+
+        if ($stopFrom === 'pivot') {
+            if ($request->pivotPrice !== null && $request->pivotPrice > 0.0 && \is_finite($request->pivotPrice)) {
+                $buffer = abs($request->pivotSlBufferPct ?? 0.0);
+                $stop = $direction === 'long'
+                    ? $request->pivotPrice * (1.0 - $buffer)
+                    : $request->pivotPrice * (1.0 + $buffer);
+
+                return [$stop, 'pivot', $warnings];
+            }
+
+            if (strtolower((string)$request->stopFallback) === 'atr') {
+                $warnings[] = 'Pivot stop unavailable; falling back to ATR stop.';
+
+                return [$this->atrStop($request, $direction), 'atr_fallback', $warnings];
+            }
+
+            throw new \InvalidArgumentException('pivotPrice must be positive when stopFrom=pivot');
+        }
+
+        if ($stopFrom === 'atr') {
+            return [$this->atrStop($request, $direction), 'atr', $warnings];
+        }
+
+        if ($request->providedStopPrice !== null && $request->providedStopPrice > 0.0 && \is_finite($request->providedStopPrice)) {
+            $warnings[] = 'Using providedStopPrice for legacy risk stop representation.';
+
+            return [$request->providedStopPrice, 'risk', $warnings];
+        }
+
+        throw new \InvalidArgumentException('stop loss source cannot be resolved');
+    }
+
+    private function atrStop(StopLossRequest $request, string $direction): float
+    {
+        if ($request->atr === null || $request->atr <= 0.0 || !\is_finite($request->atr)) {
+            throw new \InvalidArgumentException('atr must be positive for ATR stop');
+        }
+        if ($request->atrK === null || $request->atrK <= 0.0 || !\is_finite($request->atrK)) {
+            throw new \InvalidArgumentException('atrK must be positive for ATR stop');
+        }
+
+        $distance = $request->atr * $request->atrK;
+
+        return $direction === 'long'
+            ? $request->entryPrice - $distance
+            : $request->entryPrice + $distance;
+    }
+
+    private function assertStopSide(string $direction, float $entryPrice, float $stopPrice): void
+    {
+        if ($direction === 'long' && $stopPrice >= $entryPrice) {
+            throw new \InvalidArgumentException('stop loss must be below entry for long positions');
+        }
+        if ($direction === 'short' && $stopPrice <= $entryPrice) {
+            throw new \InvalidArgumentException('stop loss must be above entry for short positions');
+        }
+    }
+
+    private function direction(string $direction): string
+    {
+        $normalized = strtolower($direction);
+        if (!\in_array($normalized, ['long', 'short'], true)) {
+            throw new \InvalidArgumentException('direction must be long or short');
+        }
+
+        return $normalized;
+    }
+
+    private function normalize(float $value): float
+    {
+        return round($value, 12);
+    }
+}

--- a/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
@@ -29,7 +29,7 @@ final class StopLossCalculator
             stopPct: $this->normalize($stopPct),
             stopDistance: $this->normalize($stopDistance),
             stopSource: $source,
-            isFullSize: $request->slFullSize ?? true,
+            isFullSize: $request->slFullSize,
             warnings: $warnings,
             metadata: $request->metadata + [
                 'symbol' => $request->symbol,

--- a/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
@@ -83,7 +83,9 @@ final class StopLossCalculator
                 if ($maxDistancePct !== null && \is_finite($maxDistancePct) && $maxDistancePct > 0.0) {
                     $distancePct = abs($request->entryPrice - $stop) / $request->entryPrice;
                     if ($distancePct > $maxDistancePct) {
-                        if (strtolower((string)$request->stopFallback) === 'atr') {
+                        $hasAtrInputs = $request->atr !== null && $request->atr > 0.0 && \is_finite($request->atr)
+                            && $request->atrK !== null && $request->atrK > 0.0 && \is_finite($request->atrK);
+                        if (strtolower((string)$request->stopFallback) === 'atr' && $hasAtrInputs) {
                             $warnings[] = 'Pivot stop exceeds max distance; falling back to ATR stop.';
                             return [$this->atrStop($request, $direction), 'atr_fallback', $warnings];
                         }

--- a/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
@@ -84,6 +84,14 @@ final class StopLossCalculator
                 return [$this->atrStop($request, $direction), 'atr_fallback', $warnings];
             }
 
+            if (strtolower((string)$request->stopFallback) === 'risk') {
+                if ($request->providedStopPrice !== null && $request->providedStopPrice > 0.0 && \is_finite($request->providedStopPrice)) {
+                    $warnings[] = 'Pivot stop unavailable; falling back to risk stop.';
+
+                    return [$request->providedStopPrice, 'risk_fallback', $warnings];
+                }
+            }
+
             throw new \InvalidArgumentException('pivotPrice must be positive when stopFrom=pivot');
         }
 

--- a/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
@@ -79,6 +79,30 @@ final class StopLossCalculator
                     throw new \InvalidArgumentException('pivot stop price must be positive; pivotSlBufferPct is too large');
                 }
 
+                $maxDistancePct = $request->pivotSlMaxDistancePct;
+                if ($maxDistancePct !== null && \is_finite($maxDistancePct) && $maxDistancePct > 0.0) {
+                    $distancePct = abs($request->entryPrice - $stop) / $request->entryPrice;
+                    if ($distancePct > $maxDistancePct) {
+                        if (strtolower((string)$request->stopFallback) === 'atr') {
+                            $warnings[] = 'Pivot stop exceeds max distance; falling back to ATR stop.';
+                            return [$this->atrStop($request, $direction), 'atr_fallback', $warnings];
+                        }
+                        if (strtolower((string)$request->stopFallback) === 'risk'
+                            && $request->providedStopPrice !== null
+                            && $request->providedStopPrice > 0.0
+                            && \is_finite($request->providedStopPrice)
+                        ) {
+                            $warnings[] = 'Pivot stop exceeds max distance; falling back to risk stop.';
+                            return [$request->providedStopPrice, 'risk_fallback', $warnings];
+                        }
+                        $warnings[] = sprintf(
+                            'Pivot stop distance %.4f exceeds max %.4f but no fallback is available.',
+                            $distancePct,
+                            $maxDistancePct,
+                        );
+                    }
+                }
+
                 return [$stop, 'pivot', $warnings];
             }
 

--- a/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
@@ -111,9 +111,15 @@ final class StopLossCalculator
 
         $distance = $request->atr * $request->atrK;
 
-        return $direction === 'long'
+        $stopPrice = $direction === 'long'
             ? $request->entryPrice - $distance
             : $request->entryPrice + $distance;
+
+        if ($stopPrice <= 0.0 || !\is_finite($stopPrice)) {
+            throw new \InvalidArgumentException('atr stop price must be positive; atr * atrK exceeds entry price');
+        }
+
+        return $stopPrice;
     }
 
     private function assertStopSide(string $direction, float $entryPrice, float $stopPrice): void

--- a/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/StopLossCalculator.php
@@ -75,6 +75,10 @@ final class StopLossCalculator
                     ? $request->pivotPrice * (1.0 - $buffer)
                     : $request->pivotPrice * (1.0 + $buffer);
 
+                if ($stop <= 0.0 || !\is_finite($stop)) {
+                    throw new \InvalidArgumentException('pivot stop price must be positive; pivotSlBufferPct is too large');
+                }
+
                 return [$stop, 'pivot', $warnings];
             }
 

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\SlTp\Service;
+
+use App\TradingCore\SlTp\Dto\TakeProfitRequest;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+
+final class TakeProfitCalculator
+{
+    public function calculate(TakeProfitRequest $request): TakeProfitResult
+    {
+        if ($request->entryPrice <= 0.0 || !\is_finite($request->entryPrice)) {
+            throw new \InvalidArgumentException('entryPrice must be positive');
+        }
+
+        $direction = $this->direction($request->direction);
+        $riskDistance = $request->riskDistance ?? abs($request->entryPrice - $request->stopPrice);
+        if ($riskDistance <= 0.0 || !\is_finite($riskDistance)) {
+            throw new \InvalidArgumentException('riskDistance must be positive');
+        }
+
+        $tp1R = $request->tp1R !== null && $request->tp1R > 0.0 ? $request->tp1R : $request->rMultiple;
+        $tp2R = $request->rMultiple > 0.0 ? $request->rMultiple : null;
+
+        $tp1Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp1R);
+        $tp2Price = $tp2R !== null ? $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp2R) : null;
+
+        $bufferPct = $request->tpBufferPct !== null ? max(0.0, $request->tpBufferPct) : 0.0;
+        if ($bufferPct > 0.0) {
+            $buffer = $request->entryPrice * $bufferPct;
+            $tp1Price = $direction === 'long' ? $tp1Price - $buffer : $tp1Price + $buffer;
+            if ($tp2Price !== null) {
+                $tp2Price = $direction === 'long' ? $tp2Price - $buffer : $tp2Price + $buffer;
+            }
+
+            $effectiveR = $this->effectiveR($request->entryPrice, $tp1Price, $riskDistance, $direction);
+            if ($effectiveR < $tp1R * max(0.0, $request->tpMinKeepRatio)) {
+                $tp1Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp1R);
+            }
+        }
+
+        if ($tp2Price !== null && $request->tpMaxExtraR !== null && $request->tpMaxExtraR >= 0.0) {
+            $capR = $request->rMultiple + $request->tpMaxExtraR;
+            $tp2EffectiveR = $this->effectiveR($request->entryPrice, $tp2Price, $riskDistance, $direction);
+            if ($tp2EffectiveR > $capR) {
+                $tp2Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $capR);
+            }
+        }
+
+        $expectedR = $this->effectiveR($request->entryPrice, $tp1Price, $riskDistance, $direction);
+        $costR = $this->costR($request, $riskDistance);
+        $expectedNetR = $costR !== null ? $expectedR - $costR : null;
+        $warnings = [];
+        if ($expectedNetR !== null && $expectedNetR <= 0.0) {
+            $warnings[] = 'expectedNetR is not positive after fees/spread/slippage.';
+        }
+
+        return new TakeProfitResult(
+            tp1Price: $this->normalize($tp1Price),
+            tp2Price: $tp2Price !== null ? $this->normalize($tp2Price) : null,
+            expectedR: $this->normalize($expectedR),
+            expectedNetR: $expectedNetR !== null ? $this->normalize($expectedNetR) : null,
+            tpPolicyApplied: $request->tpPolicy,
+            warnings: $warnings,
+            metadata: $request->metadata + [
+                'symbol' => $request->symbol,
+                'instrument' => $request->instrument,
+                'profile' => $request->profile,
+                'exchange' => $request->exchange,
+                'market_type' => $request->marketType,
+                'direction' => $direction,
+                'risk_distance' => $riskDistance,
+                'r_multiple' => $request->rMultiple,
+                'tp1_r' => $tp1R,
+                'tp_buffer_pct' => $request->tpBufferPct,
+                'tp_min_keep_ratio' => $request->tpMinKeepRatio,
+                'tp_max_extra_r' => $request->tpMaxExtraR,
+                'fees_bps' => $request->feesBps,
+                'spread_bps' => $request->spreadBps,
+                'slippage_bps' => $request->slippageBps,
+            ],
+        );
+    }
+
+    private function priceForR(float $entry, float $riskDistance, string $direction, float $r): float
+    {
+        return $direction === 'long'
+            ? $entry + $riskDistance * $r
+            : $entry - $riskDistance * $r;
+    }
+
+    private function effectiveR(float $entry, float $target, float $riskDistance, string $direction): float
+    {
+        return $direction === 'long'
+            ? ($target - $entry) / $riskDistance
+            : ($entry - $target) / $riskDistance;
+    }
+
+    private function costR(TakeProfitRequest $request, float $riskDistance): ?float
+    {
+        $costBps = 0.0;
+        $hasCost = false;
+        foreach ([$request->feesBps, $request->spreadBps, $request->slippageBps] as $cost) {
+            if ($cost !== null && \is_finite($cost) && $cost > 0.0) {
+                $costBps += $cost;
+                $hasCost = true;
+            }
+        }
+
+        if (!$hasCost) {
+            return null;
+        }
+
+        return ($request->entryPrice * ($costBps / 10000.0)) / $riskDistance;
+    }
+
+    private function direction(string $direction): string
+    {
+        $normalized = strtolower($direction);
+        if (!\in_array($normalized, ['long', 'short'], true)) {
+            throw new \InvalidArgumentException('direction must be long or short');
+        }
+
+        return $normalized;
+    }
+
+    private function normalize(float $value): float
+    {
+        return round($value, 12);
+    }
+}

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -13,6 +13,9 @@ final class TakeProfitCalculator
         if ($request->entryPrice <= 0.0 || !\is_finite($request->entryPrice)) {
             throw new \InvalidArgumentException('entryPrice must be positive');
         }
+        if ($request->rMultiple <= 0.0 || !\is_finite($request->rMultiple)) {
+            throw new \InvalidArgumentException('rMultiple must be positive');
+        }
 
         $direction = $this->direction($request->direction);
         $riskDistance = $request->riskDistance ?? abs($request->entryPrice - $request->stopPrice);
@@ -20,8 +23,9 @@ final class TakeProfitCalculator
             throw new \InvalidArgumentException('riskDistance must be positive');
         }
 
+        // tp1R defaults to rMultiple when absent; tp2 is only emitted when a distinct tp1R is set.
         $tp1R = $request->tp1R !== null && $request->tp1R > 0.0 ? $request->tp1R : $request->rMultiple;
-        $tp2R = $request->rMultiple > 0.0 ? $request->rMultiple : null;
+        $tp2R = $request->tp1R !== null && $request->tp1R > 0.0 ? $request->rMultiple : null;
 
         $tp1Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp1R);
         $tp2Price = $tp2R !== null ? $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp2R) : null;

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -41,12 +41,19 @@ final class TakeProfitCalculator
 
         // Buffer only applies when a pivot was actually selected — matching legacy OrderPlanBuilder
         // which skips the buffer when pivotLevels is empty even for pivot policies.
+        // Legacy clamps buffered price with max/min against the base R target so the buffer never
+        // moves TP inside the theoretical target (TakeProfitCalculator::alignWithPivot:107-133).
         $bufferPct = $request->tpBufferPct !== null ? max(0.0, $request->tpBufferPct) : 0.0;
         if ($bufferPct > 0.0 && $request->pivotAligned) {
             $buffer = $request->entryPrice * $bufferPct;
-            $tp1Price = $direction === 'long' ? $tp1Price - $buffer : $tp1Price + $buffer;
+            $baseTp1 = $tp1Price;
+            $baseTp2 = $tp2Price;
+            $buffered1 = $direction === 'long' ? $tp1Price - $buffer : $tp1Price + $buffer;
+            // Clamp: buffer must not push TP inside the base R target.
+            $tp1Price = $direction === 'long' ? max($baseTp1, $buffered1) : min($baseTp1, $buffered1);
             if ($tp2Price !== null) {
-                $tp2Price = $direction === 'long' ? $tp2Price - $buffer : $tp2Price + $buffer;
+                $buffered2 = $direction === 'long' ? $tp2Price - $buffer : $tp2Price + $buffer;
+                $tp2Price = $direction === 'long' ? max($baseTp2, $buffered2) : min($baseTp2, $buffered2);
             }
 
             $effectiveR = $this->effectiveR($request->entryPrice, $tp1Price, $riskDistance, $direction);

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -31,12 +31,18 @@ final class TakeProfitCalculator
             : null;
 
         $tp1Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp1R);
+        if ($tp1Price <= 0.0 || !\is_finite($tp1Price)) {
+            throw new \InvalidArgumentException('take-profit price must be positive; riskDistance * R exceeds entry price');
+        }
         $tp2Price = $tp2R !== null ? $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp2R) : null;
+        if ($tp2Price !== null && ($tp2Price <= 0.0 || !\is_finite($tp2Price))) {
+            $tp2Price = null;
+        }
 
-        // Buffer only applies during pivot alignment — not for pure R-multiple policies.
+        // Buffer only applies when a pivot was actually selected — matching legacy OrderPlanBuilder
+        // which skips the buffer when pivotLevels is empty even for pivot policies.
         $bufferPct = $request->tpBufferPct !== null ? max(0.0, $request->tpBufferPct) : 0.0;
-        $isPivotPolicy = str_contains(strtolower($request->tpPolicy), 'pivot');
-        if ($bufferPct > 0.0 && $isPivotPolicy) {
+        if ($bufferPct > 0.0 && $request->pivotAligned) {
             $buffer = $request->entryPrice * $bufferPct;
             $tp1Price = $direction === 'long' ? $tp1Price - $buffer : $tp1Price + $buffer;
             if ($tp2Price !== null) {

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -46,6 +46,13 @@ final class TakeProfitCalculator
             $effectiveR = $this->effectiveR($request->entryPrice, $tp1Price, $riskDistance, $direction);
             if ($effectiveR < $tp1R * max(0.0, $request->tpMinKeepRatio)) {
                 $tp1Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp1R);
+                // Suppress TP2 if the buffer left it closer to entry than the restored TP1.
+                if ($tp2Price !== null) {
+                    $tp2StillFarther = $direction === 'long' ? $tp2Price > $tp1Price : $tp2Price < $tp1Price;
+                    if (!$tp2StillFarther) {
+                        $tp2Price = null;
+                    }
+                }
             }
         }
 

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -23,9 +23,12 @@ final class TakeProfitCalculator
             throw new \InvalidArgumentException('riskDistance must be positive');
         }
 
-        // tp1R defaults to rMultiple when absent; tp2 is only emitted when a distinct tp1R is set.
+        // tp1R defaults to rMultiple when absent; tp2 is emitted only when tp1R is explicitly set
+        // to a value different from rMultiple — otherwise both legs would land at the same price.
         $tp1R = $request->tp1R !== null && $request->tp1R > 0.0 ? $request->tp1R : $request->rMultiple;
-        $tp2R = $request->tp1R !== null && $request->tp1R > 0.0 ? $request->rMultiple : null;
+        $tp2R = $request->tp1R !== null && $request->tp1R > 0.0 && $request->tp1R !== $request->rMultiple
+            ? $request->rMultiple
+            : null;
 
         $tp1Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp1R);
         $tp2Price = $tp2R !== null ? $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp2R) : null;

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -23,10 +23,10 @@ final class TakeProfitCalculator
             throw new \InvalidArgumentException('riskDistance must be positive');
         }
 
-        // tp1R defaults to rMultiple when absent; tp2 is emitted only when tp1R is explicitly set
-        // to a value different from rMultiple — otherwise both legs would land at the same price.
+        // tp1R defaults to rMultiple when absent; tp2 is emitted only when rMultiple is strictly
+        // farther than tp1R — same direction, larger R = farther price for both long and short.
         $tp1R = $request->tp1R !== null && $request->tp1R > 0.0 ? $request->tp1R : $request->rMultiple;
-        $tp2R = $request->tp1R !== null && $request->tp1R > 0.0 && $request->tp1R !== $request->rMultiple
+        $tp2R = $request->tp1R !== null && $request->tp1R > 0.0 && $request->rMultiple > $tp1R
             ? $request->rMultiple
             : null;
 

--- a/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
+++ b/trading-app/src/TradingCore/SlTp/Service/TakeProfitCalculator.php
@@ -33,8 +33,10 @@ final class TakeProfitCalculator
         $tp1Price = $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp1R);
         $tp2Price = $tp2R !== null ? $this->priceForR($request->entryPrice, $riskDistance, $direction, $tp2R) : null;
 
+        // Buffer only applies during pivot alignment — not for pure R-multiple policies.
         $bufferPct = $request->tpBufferPct !== null ? max(0.0, $request->tpBufferPct) : 0.0;
-        if ($bufferPct > 0.0) {
+        $isPivotPolicy = str_contains(strtolower($request->tpPolicy), 'pivot');
+        if ($bufferPct > 0.0 && $isPivotPolicy) {
             $buffer = $request->entryPrice * $bufferPct;
             $tp1Price = $direction === 'long' ? $tp1Price - $buffer : $tp1Price + $buffer;
             if ($tp2Price !== null) {

--- a/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
+++ b/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
@@ -62,6 +62,29 @@ final class LiquidationGuardTest extends TestCase
         self::assertSame('liquidation_distance_below_min_ratio', $result->reasonIfUnsafe);
     }
 
+    public function testMarksPlanUnsafeWhenLiquidationIsNotBeyondStop(): void
+    {
+        $guard = new LiquidationGuard();
+
+        // Long: liquidationPrice must be below stopPrice — here it sits between stop and entry.
+        $result = $guard->check(new LiquidationCheckRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            leverage: 5,
+            maintenanceMarginRate: null,
+            liquidationPrice: 96.0,
+            minDistanceRatio: 3.0,
+        ));
+
+        self::assertFalse($result->isSafe);
+        self::assertSame('liquidation_not_beyond_stop', $result->reasonIfUnsafe);
+    }
+
     public function testMarksPlanUnsafeWhenLiquidationDataIsUnavailable(): void
     {
         $guard = new LiquidationGuard();

--- a/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
+++ b/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\SlTp;
+
+use App\TradingCore\SlTp\Dto\LiquidationCheckRequest;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Service\LiquidationGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LiquidationGuard::class)]
+#[CoversClass(LiquidationCheckRequest::class)]
+#[CoversClass(LiquidationCheckResult::class)]
+final class LiquidationGuardTest extends TestCase
+{
+    public function testMarksPlanSafeWhenLiquidationIsFarEnoughBeyondStop(): void
+    {
+        $guard = new LiquidationGuard();
+
+        $result = $guard->check(new LiquidationCheckRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            leverage: 5,
+            maintenanceMarginRate: null,
+            liquidationPrice: 80.0,
+            minDistanceRatio: 3.0,
+        ));
+
+        self::assertTrue($result->isSafe);
+        self::assertSame(80.0, $result->liquidationPrice);
+        self::assertSame(0.2, $result->liquidationDistancePct);
+        self::assertSame(4.0, $result->stopToLiquidationRatio);
+        self::assertNull($result->reasonIfUnsafe);
+    }
+
+    public function testMarksPlanUnsafeWhenLiquidationIsTooCloseToStop(): void
+    {
+        $guard = new LiquidationGuard();
+
+        $result = $guard->check(new LiquidationCheckRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            leverage: 5,
+            maintenanceMarginRate: null,
+            liquidationPrice: 90.0,
+            minDistanceRatio: 3.0,
+        ));
+
+        self::assertFalse($result->isSafe);
+        self::assertSame(2.0, $result->stopToLiquidationRatio);
+        self::assertSame('liquidation_distance_below_min_ratio', $result->reasonIfUnsafe);
+    }
+
+    public function testMarksPlanUnsafeWhenLiquidationDataIsUnavailable(): void
+    {
+        $guard = new LiquidationGuard();
+
+        $result = $guard->check(new LiquidationCheckRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'short',
+            entryPrice: 100.0,
+            stopPrice: 105.0,
+            leverage: null,
+            maintenanceMarginRate: null,
+            liquidationPrice: null,
+            minDistanceRatio: 3.0,
+        ));
+
+        self::assertFalse($result->isSafe);
+        self::assertSame('insufficient_liquidation_data', $result->reasonIfUnsafe);
+        self::assertContains('Liquidation price cannot be derived without leverage or an exchange-provided liquidation price.', $result->warnings);
+    }
+}

--- a/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
+++ b/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
@@ -108,6 +108,47 @@ final class LiquidationGuardTest extends TestCase
         self::assertSame('liquidation_not_beyond_stop', $result->reasonIfUnsafe);
     }
 
+    public function testMarksPlanUnsafeWhenMinDistanceRatioIsInvalid(): void
+    {
+        $guard = new LiquidationGuard();
+
+        // NAN threshold: ratio < NAN evaluates false in PHP → would pass as safe without guard.
+        $result = $guard->check(new LiquidationCheckRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            leverage: 5,
+            maintenanceMarginRate: null,
+            liquidationPrice: 80.0,
+            minDistanceRatio: NAN,
+        ));
+
+        self::assertFalse($result->isSafe);
+        self::assertSame('invalid_min_distance_ratio', $result->reasonIfUnsafe);
+
+        // Negative threshold: any ratio passes → same fail-closed behaviour.
+        $result2 = $guard->check(new LiquidationCheckRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            leverage: 5,
+            maintenanceMarginRate: null,
+            liquidationPrice: 80.0,
+            minDistanceRatio: -1.0,
+        ));
+
+        self::assertFalse($result2->isSafe);
+        self::assertSame('invalid_min_distance_ratio', $result2->reasonIfUnsafe);
+    }
+
     public function testMarksPlanUnsafeWhenLiquidationDataIsUnavailable(): void
     {
         $guard = new LiquidationGuard();

--- a/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
+++ b/trading-app/tests/TradingCore/SlTp/LiquidationGuardTest.php
@@ -62,6 +62,29 @@ final class LiquidationGuardTest extends TestCase
         self::assertSame('liquidation_distance_below_min_ratio', $result->reasonIfUnsafe);
     }
 
+    public function testMarksPlanUnsafeWhenStopIsOnWrongSideOfEntry(): void
+    {
+        $guard = new LiquidationGuard();
+
+        // Long: stop above entry — invalid regardless of liquidation price.
+        $result = $guard->check(new LiquidationCheckRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 105.0,
+            leverage: 5,
+            maintenanceMarginRate: null,
+            liquidationPrice: 80.0,
+            minDistanceRatio: 3.0,
+        ));
+
+        self::assertFalse($result->isSafe);
+        self::assertSame('stop_on_wrong_side_of_entry', $result->reasonIfUnsafe);
+    }
+
     public function testMarksPlanUnsafeWhenLiquidationIsNotBeyondStop(): void
     {
         $guard = new LiquidationGuard();

--- a/trading-app/tests/TradingCore/SlTp/ProtectionPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/ProtectionPlanValidatorTest.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\SlTp;
+
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+use App\TradingCore\SlTp\Service\ProtectionPlanValidator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ProtectionPlanValidator::class)]
+#[CoversClass(ProtectionPlan::class)]
+#[CoversClass(ProtectionPlanStatus::class)]
+final class ProtectionPlanValidatorTest extends TestCase
+{
+    public function testInvalidatesPlanWithoutStopLoss(): void
+    {
+        $validator = new ProtectionPlanValidator();
+
+        $plan = $validator->validate(
+            stopLoss: null,
+            takeProfit: $this->takeProfit(),
+            liquidationCheck: $this->safeLiquidation(),
+        );
+
+        self::assertFalse($plan->isValid);
+        self::assertSame(ProtectionPlanStatus::Invalid, $plan->status);
+        self::assertContains('stop_loss_missing', $plan->invalidReasons);
+    }
+
+    public function testInvalidatesPlanWhenStopLossIsNotFullSize(): void
+    {
+        $validator = new ProtectionPlanValidator();
+
+        $plan = $validator->validate(
+            stopLoss: $this->stopLoss(isFullSize: false),
+            takeProfit: $this->takeProfit(),
+            liquidationCheck: $this->safeLiquidation(),
+        );
+
+        self::assertFalse($plan->isValid);
+        self::assertContains('stop_loss_not_full_size', $plan->invalidReasons);
+    }
+
+    public function testInvalidatesPlanWhenStopPctIsNotPositive(): void
+    {
+        $validator = new ProtectionPlanValidator();
+
+        $plan = $validator->validate(
+            stopLoss: $this->stopLoss(stopPct: 0.0),
+            takeProfit: $this->takeProfit(),
+            liquidationCheck: $this->safeLiquidation(),
+        );
+
+        self::assertFalse($plan->isValid);
+        self::assertContains('stop_pct_not_positive', $plan->invalidReasons);
+    }
+
+    public function testInvalidatesPlanWhenLiquidationGuardIsUnsafe(): void
+    {
+        $validator = new ProtectionPlanValidator();
+
+        $plan = $validator->validate(
+            stopLoss: $this->stopLoss(),
+            takeProfit: $this->takeProfit(),
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: false,
+                liquidationPrice: 90.0,
+                liquidationDistancePct: 0.1,
+                stopToLiquidationRatio: 2.0,
+                warnings: [],
+                reasonIfUnsafe: 'liquidation_distance_below_min_ratio',
+                metadata: [],
+            ),
+        );
+
+        self::assertFalse($plan->isValid);
+        self::assertContains('liquidation_guard_unsafe', $plan->invalidReasons);
+    }
+
+    public function testValidatesPlanWithFullSizeStopCoherentTpAndSafeLiquidation(): void
+    {
+        $validator = new ProtectionPlanValidator();
+
+        $plan = $validator->validate(
+            stopLoss: $this->stopLoss(),
+            takeProfit: $this->takeProfit(),
+            liquidationCheck: $this->safeLiquidation(),
+        );
+
+        self::assertTrue($plan->isValid);
+        self::assertSame(ProtectionPlanStatus::Valid, $plan->status);
+        self::assertSame([], $plan->invalidReasons);
+    }
+
+    public function testWarnsWhenTakeProfitNetRIsNotPositive(): void
+    {
+        $validator = new ProtectionPlanValidator();
+
+        $plan = $validator->validate(
+            stopLoss: $this->stopLoss(),
+            takeProfit: new TakeProfitResult(
+                tp1Price: 100.2,
+                tp2Price: null,
+                expectedR: 0.2,
+                expectedNetR: -0.4,
+                tpPolicyApplied: 'r_multiple',
+                warnings: ['expectedNetR is not positive after fees/spread/slippage.'],
+                metadata: [],
+            ),
+            liquidationCheck: $this->safeLiquidation(),
+        );
+
+        self::assertTrue($plan->isValid);
+        self::assertContains('take_profit_net_r_not_positive', $plan->warnings);
+    }
+
+    private function stopLoss(bool $isFullSize = true, float $stopPct = 0.05): StopLossResult
+    {
+        return new StopLossResult(
+            stopPrice: 95.0,
+            stopPct: $stopPct,
+            stopDistance: 5.0,
+            stopSource: 'atr',
+            isFullSize: $isFullSize,
+            warnings: [],
+            metadata: [],
+        );
+    }
+
+    private function takeProfit(): TakeProfitResult
+    {
+        return new TakeProfitResult(
+            tp1Price: 107.0,
+            tp2Price: 109.0,
+            expectedR: 1.4,
+            expectedNetR: 1.2,
+            tpPolicyApplied: 'r_multiple',
+            warnings: [],
+            metadata: [],
+        );
+    }
+
+    private function safeLiquidation(): LiquidationCheckResult
+    {
+        return new LiquidationCheckResult(
+            isSafe: true,
+            liquidationPrice: 80.0,
+            liquidationDistancePct: 0.2,
+            stopToLiquidationRatio: 4.0,
+            warnings: [],
+            reasonIfUnsafe: null,
+            metadata: [],
+        );
+    }
+}

--- a/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
@@ -106,6 +106,33 @@ final class StopLossCalculatorTest extends TestCase
         self::assertSame('pivot', $result->stopSource);
     }
 
+    public function testRejectsAtrStopWhenDistanceExceedsEntryPrice(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        // atr=80, atrK=2 → distance=160 > entryPrice=100 → stopPrice=-60 (invalid).
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('atr stop price must be positive');
+
+        $calculator->calculate(new StopLossRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'atr',
+            stopFallback: null,
+            atr: 80.0,
+            atrK: 2.0,
+            pivotPrice: null,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: null,
+            pivotSlMinKeepRatio: null,
+        ));
+    }
+
     public function testFallsBackToAtrWhenPivotIsUnavailable(): void
     {
         $calculator = new StopLossCalculator();

--- a/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\SlTp;
+
+use App\TradingCore\SlTp\Dto\StopLossRequest;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Service\StopLossCalculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StopLossCalculator::class)]
+#[CoversClass(StopLossRequest::class)]
+#[CoversClass(StopLossResult::class)]
+final class StopLossCalculatorTest extends TestCase
+{
+    public function testCalculatesAtrStopBelowEntryForLong(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        $result = $calculator->calculate(new StopLossRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'atr',
+            stopFallback: 'risk',
+            atr: 2.0,
+            atrK: 1.5,
+            pivotPrice: null,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: 0.003,
+            pivotSlMinKeepRatio: 0.8,
+            slFullSize: true,
+            positionSize: 12.0,
+        ));
+
+        self::assertSame(97.0, $result->stopPrice);
+        self::assertSame(0.03, $result->stopPct);
+        self::assertSame(3.0, $result->stopDistance);
+        self::assertSame('atr', $result->stopSource);
+        self::assertTrue($result->isFullSize);
+    }
+
+    public function testCalculatesAtrStopAboveEntryForShort(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        $result = $calculator->calculate(new StopLossRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'short',
+            entryPrice: 100.0,
+            stopFrom: 'atr',
+            stopFallback: 'risk',
+            atr: 2.0,
+            atrK: 1.5,
+            pivotPrice: null,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: 0.003,
+            pivotSlMinKeepRatio: 0.8,
+            slFullSize: true,
+            positionSize: 12.0,
+        ));
+
+        self::assertSame(103.0, $result->stopPrice);
+        self::assertSame(0.03, $result->stopPct);
+        self::assertSame(3.0, $result->stopDistance);
+        self::assertSame('atr', $result->stopSource);
+        self::assertTrue($result->isFullSize);
+    }
+
+    public function testAppliesPivotBufferWithoutChangingConfigValues(): void
+    {
+        $calculator = new StopLossCalculator();
+        $buffer = 0.003;
+
+        $result = $calculator->calculate(new StopLossRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'pivot',
+            stopFallback: 'atr',
+            atr: 2.0,
+            atrK: 1.5,
+            pivotPrice: 95.0,
+            pivotSlPolicy: 'nearest_below',
+            pivotSlBufferPct: $buffer,
+            pivotSlMinKeepRatio: 0.8,
+            slFullSize: true,
+            positionSize: 12.0,
+        ));
+
+        self::assertSame(94.715, $result->stopPrice);
+        self::assertSame($buffer, $result->metadata['pivot_sl_buffer_pct']);
+        self::assertSame('pivot', $result->stopSource);
+    }
+
+    public function testRejectsStopOnWrongSideOfEntry(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('stop loss must be below entry for long positions');
+
+        $calculator->calculate(new StopLossRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'provided',
+            stopFallback: null,
+            atr: null,
+            atrK: null,
+            pivotPrice: null,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: null,
+            pivotSlMinKeepRatio: null,
+            slFullSize: true,
+            positionSize: 12.0,
+            providedStopPrice: 101.0,
+        ));
+    }
+}

--- a/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
@@ -106,6 +106,33 @@ final class StopLossCalculatorTest extends TestCase
         self::assertSame('pivot', $result->stopSource);
     }
 
+    public function testRejectsPivotStopWhenBufferMakesItNonPositive(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        // pivotPrice=95, pivotSlBufferPct=1.0 → stop = 95*(1-1.0) = 0 → invalid.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('pivot stop price must be positive');
+
+        $calculator->calculate(new StopLossRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'pivot',
+            stopFallback: null,
+            atr: null,
+            atrK: null,
+            pivotPrice: 95.0,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: 1.0,
+            pivotSlMinKeepRatio: null,
+        ));
+    }
+
     public function testRejectsAtrStopWhenDistanceExceedsEntryPrice(): void
     {
         $calculator = new StopLossCalculator();

--- a/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
@@ -106,6 +106,35 @@ final class StopLossCalculatorTest extends TestCase
         self::assertSame('pivot', $result->stopSource);
     }
 
+    public function testFallsBackToAtrWhenPivotExceedsMaxDistance(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        // entry=100, pivot=50 → distancePct=50%, maxDistancePct=0.02 → exceeds → ATR fallback.
+        $result = $calculator->calculate(new StopLossRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'pivot',
+            stopFallback: 'atr',
+            atr: 2.0,
+            atrK: 1.5,
+            pivotPrice: 50.0,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: 0.003,
+            pivotSlMinKeepRatio: 0.8,
+            pivotSlMaxDistancePct: 0.02,
+        ));
+
+        self::assertSame('atr_fallback', $result->stopSource);
+        self::assertSame(97.0, $result->stopPrice);
+        self::assertContains('Pivot stop exceeds max distance; falling back to ATR stop.', $result->warnings);
+    }
+
     public function testRejectsPivotStopWhenBufferMakesItNonPositive(): void
     {
         $calculator = new StopLossCalculator();

--- a/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
@@ -106,6 +106,34 @@ final class StopLossCalculatorTest extends TestCase
         self::assertSame('pivot', $result->stopSource);
     }
 
+    public function testKeepsPivotWhenMaxDistanceExceededButAtrUnavailable(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        // Pivot too far (50% > 2%) but no ATR inputs → must use pivot with warning, not throw.
+        $result = $calculator->calculate(new StopLossRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'pivot',
+            stopFallback: 'atr',
+            atr: null,
+            atrK: null,
+            pivotPrice: 50.0,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: 0.0,
+            pivotSlMinKeepRatio: null,
+            pivotSlMaxDistancePct: 0.02,
+        ));
+
+        self::assertSame('pivot', $result->stopSource);
+        self::assertNotEmpty(array_filter($result->warnings, fn(string $w): bool => str_contains($w, 'Pivot stop distance')));
+    }
+
     public function testFallsBackToAtrWhenPivotExceedsMaxDistance(): void
     {
         $calculator = new StopLossCalculator();

--- a/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
@@ -133,6 +133,35 @@ final class StopLossCalculatorTest extends TestCase
         ));
     }
 
+    public function testFallsBackToRiskStopWhenPivotIsUnavailableAndFallbackIsRisk(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        // stopFrom=pivot, no pivot, stopFallback=risk → use providedStopPrice.
+        $result = $calculator->calculate(new StopLossRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'pivot',
+            stopFallback: 'risk',
+            atr: null,
+            atrK: null,
+            pivotPrice: null,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: null,
+            pivotSlMinKeepRatio: null,
+            providedStopPrice: 94.0,
+        ));
+
+        self::assertSame(94.0, $result->stopPrice);
+        self::assertSame('risk_fallback', $result->stopSource);
+        self::assertContains('Pivot stop unavailable; falling back to risk stop.', $result->warnings);
+    }
+
     public function testFallsBackToAtrWhenPivotIsUnavailable(): void
     {
         $calculator = new StopLossCalculator();

--- a/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/StopLossCalculatorTest.php
@@ -106,6 +106,34 @@ final class StopLossCalculatorTest extends TestCase
         self::assertSame('pivot', $result->stopSource);
     }
 
+    public function testFallsBackToAtrWhenPivotIsUnavailable(): void
+    {
+        $calculator = new StopLossCalculator();
+
+        // stopFrom=pivot but no pivotPrice → fallback to ATR stop.
+        $result = $calculator->calculate(new StopLossRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopFrom: 'pivot',
+            stopFallback: 'atr',
+            atr: 2.0,
+            atrK: 1.5,
+            pivotPrice: null,
+            pivotSlPolicy: 'nearest',
+            pivotSlBufferPct: 0.003,
+            pivotSlMinKeepRatio: 0.8,
+        ));
+
+        self::assertSame(97.0, $result->stopPrice);
+        self::assertSame('atr_fallback', $result->stopSource);
+        self::assertContains('Pivot stop unavailable; falling back to ATR stop.', $result->warnings);
+    }
+
     public function testRejectsStopOnWrongSideOfEntry(): void
     {
         $calculator = new StopLossCalculator();

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -160,6 +160,40 @@ final class TakeProfitCalculatorTest extends TestCase
         ));
     }
 
+    public function testSuppressesTp2WhenBufferLeavesItCloserThanRestoredTp1(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        // entry=100, stop=99.95 → riskDistance=0.05
+        // tp1R=1 → tp1=100.05; tp2R=1.8 → tp2=100.09
+        // buffer=0.001 → bufferAbs=0.1 (entry*buffer)
+        // tp1=100.05-0.1=99.95, effectiveR=(99.95-100)/0.05=-1 < minKeep=0.95 → reset tp1=100.05
+        // tp2=100.09-0.1=99.99 < tp1=100.05 → tp2 suppressed (not a farther target)
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 99.95,
+            riskDistance: null,
+            rMultiple: 1.8,
+            tp1R: 1.0,
+            tpPolicy: 'pivot_conservative',
+            tpBufferPct: 0.001,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(100.05, $result->tp1Price);
+        self::assertNull($result->tp2Price);
+    }
+
     public function testSuppressesTp2WhenTp1RAliasesRMultiple(): void
     {
         $calculator = new TakeProfitCalculator();

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -135,6 +135,36 @@ final class TakeProfitCalculatorTest extends TestCase
         ));
     }
 
+    public function testSuppressesTp2WhenTp1RAliasesRMultiple(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        // tp1R == rMultiple (regular.yaml alias pattern): must not emit a duplicate tp2 leg.
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 2.0,
+            tp1R: 2.0,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(110.0, $result->tp1Price);
+        self::assertNull($result->tp2Price);
+    }
+
     public function testEmitsSingleTpWhenTp1RIsAbsent(): void
     {
         $calculator = new TakeProfitCalculator();

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -81,7 +81,7 @@ final class TakeProfitCalculatorTest extends TestCase
         $calculator = new TakeProfitCalculator();
         $buffer = 0.001;
 
-        // Pivot policy: buffer is applied → tp1Price = 105 - 0.1 = 104.9.
+        // Pivot policy with an actual pivot selected: buffer is applied → tp1Price = 105 - 0.1 = 104.9.
         $pivotResult = $calculator->calculate(new TakeProfitRequest(
             symbol: 'SOLUSDT',
             instrument: null,
@@ -101,6 +101,7 @@ final class TakeProfitCalculatorTest extends TestCase
             feesBps: null,
             spreadBps: null,
             slippageBps: null,
+            pivotAligned: true,
         ));
 
         self::assertSame(104.9, $pivotResult->tp1Price);
@@ -129,6 +130,66 @@ final class TakeProfitCalculatorTest extends TestCase
         ));
 
         self::assertSame(105.0, $rResult->tp1Price);
+    }
+
+    public function testDoesNotApplyBufferWhenNoPivotWasSelected(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        // pivot_conservative policy but pivotAligned=false (no pivot available) → buffer must not shift TP.
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 2.0,
+            tp1R: null,
+            tpPolicy: 'pivot_conservative',
+            tpBufferPct: 0.001,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+            pivotAligned: false,
+        ));
+
+        self::assertSame(110.0, $result->tp1Price);
+    }
+
+    public function testRejectsWhenShortTakeProfitPriceIsNotPositive(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        // short, entry=100, stop=180 → riskDistance=80, r=1.5 → tp=100-80*1.5=-20 → must throw.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('take-profit price must be positive');
+
+        $calculator->calculate(new TakeProfitRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'short',
+            entryPrice: 100.0,
+            stopPrice: 180.0,
+            riskDistance: null,
+            rMultiple: 1.5,
+            tp1R: null,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
     }
 
     public function testRejectsWhenRMultipleIsNotPositive(): void
@@ -188,6 +249,7 @@ final class TakeProfitCalculatorTest extends TestCase
             feesBps: null,
             spreadBps: null,
             slippageBps: null,
+            pivotAligned: true,
         ));
 
         self::assertSame(100.05, $result->tp1Price);

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -106,6 +106,66 @@ final class TakeProfitCalculatorTest extends TestCase
         self::assertSame($buffer, $result->metadata['tp_buffer_pct']);
     }
 
+    public function testRejectsWhenRMultipleIsNotPositive(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('rMultiple must be positive');
+
+        $calculator->calculate(new TakeProfitRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 0.0,
+            tp1R: null,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+    }
+
+    public function testEmitsSingleTpWhenTp1RIsAbsent(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        // No explicit tp1R → tp1 lands at rMultiple, no tp2 emitted.
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 1.8,
+            tp1R: null,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(109.0, $result->tp1Price);
+        self::assertNull($result->tp2Price);
+        self::assertSame(1.8, $result->expectedR);
+    }
+
     public function testWarnsWhenNetRIsIncoherentAfterCosts(): void
     {
         $calculator = new TakeProfitCalculator();

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -1,0 +1,137 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\SlTp;
+
+use App\TradingCore\SlTp\Dto\TakeProfitRequest;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Service\TakeProfitCalculator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TakeProfitCalculator::class)]
+#[CoversClass(TakeProfitRequest::class)]
+#[CoversClass(TakeProfitResult::class)]
+final class TakeProfitCalculatorTest extends TestCase
+{
+    public function testCalculatesTakeProfitInRForLong(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 1.8,
+            tp1R: 1.4,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: 0.5,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(107.0, $result->tp1Price);
+        self::assertSame(109.0, $result->tp2Price);
+        self::assertSame(1.4, $result->expectedR);
+        self::assertSame(1.4, $result->metadata['tp1_r']);
+        self::assertSame(1.8, $result->metadata['r_multiple']);
+    }
+
+    public function testCalculatesTakeProfitInRForShort(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'ETHUSDT',
+            instrument: null,
+            profile: 'regular',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'short',
+            entryPrice: 100.0,
+            stopPrice: 105.0,
+            riskDistance: null,
+            rMultiple: 1.8,
+            tp1R: 1.4,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: 0.5,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(93.0, $result->tp1Price);
+        self::assertSame(91.0, $result->tp2Price);
+        self::assertSame(1.4, $result->expectedR);
+    }
+
+    public function testCarriesTpBufferWithoutMutatingConfiguredValue(): void
+    {
+        $calculator = new TakeProfitCalculator();
+        $buffer = 0.001;
+
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 1.0,
+            tp1R: 1.0,
+            tpPolicy: 'pivot_conservative',
+            tpBufferPct: $buffer,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: 0.5,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(104.9, $result->tp1Price);
+        self::assertSame($buffer, $result->metadata['tp_buffer_pct']);
+    }
+
+    public function testWarnsWhenNetRIsIncoherentAfterCosts(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'DOGEUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 99.0,
+            riskDistance: null,
+            rMultiple: 0.2,
+            tp1R: 0.2,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: 20.0,
+            spreadBps: 20.0,
+            slippageBps: 20.0,
+        ));
+
+        self::assertSame(-0.4, $result->expectedNetR);
+        self::assertContains('expectedNetR is not positive after fees/spread/slippage.', $result->warnings);
+    }
+}

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -194,6 +194,36 @@ final class TakeProfitCalculatorTest extends TestCase
         self::assertNull($result->tp2Price);
     }
 
+    public function testSuppressesTp2WhenTp1RIsGreaterThanRMultiple(): void
+    {
+        $calculator = new TakeProfitCalculator();
+
+        // tp1R=2.0 > rMultiple=1.5 → tp2 at 1.5R would be closer than tp1 at 2.0R — must be null.
+        $result = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'BTCUSDT',
+            instrument: null,
+            profile: 'scalper',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 1.5,
+            tp1R: 2.0,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: null,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(110.0, $result->tp1Price);
+        self::assertNull($result->tp2Price);
+    }
+
     public function testSuppressesTp2WhenTp1RAliasesRMultiple(): void
     {
         $calculator = new TakeProfitCalculator();

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -76,12 +76,13 @@ final class TakeProfitCalculatorTest extends TestCase
         self::assertSame(1.4, $result->expectedR);
     }
 
-    public function testCarriesTpBufferWithoutMutatingConfiguredValue(): void
+    public function testAppliesTpBufferOnlyForPivotPolicy(): void
     {
         $calculator = new TakeProfitCalculator();
         $buffer = 0.001;
 
-        $result = $calculator->calculate(new TakeProfitRequest(
+        // Pivot policy: buffer is applied → tp1Price = 105 - 0.1 = 104.9.
+        $pivotResult = $calculator->calculate(new TakeProfitRequest(
             symbol: 'SOLUSDT',
             instrument: null,
             profile: 'scalper_micro',
@@ -102,8 +103,32 @@ final class TakeProfitCalculatorTest extends TestCase
             slippageBps: null,
         ));
 
-        self::assertSame(104.9, $result->tp1Price);
-        self::assertSame($buffer, $result->metadata['tp_buffer_pct']);
+        self::assertSame(104.9, $pivotResult->tp1Price);
+        self::assertSame($buffer, $pivotResult->metadata['tp_buffer_pct']);
+
+        // R-multiple policy: buffer must NOT be applied → tp1Price stays at 105.0.
+        $rResult = $calculator->calculate(new TakeProfitRequest(
+            symbol: 'SOLUSDT',
+            instrument: null,
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'futures',
+            direction: 'long',
+            entryPrice: 100.0,
+            stopPrice: 95.0,
+            riskDistance: null,
+            rMultiple: 1.0,
+            tp1R: 1.0,
+            tpPolicy: 'r_multiple',
+            tpBufferPct: $buffer,
+            tpMinKeepRatio: 0.95,
+            tpMaxExtraR: null,
+            feesBps: null,
+            spreadBps: null,
+            slippageBps: null,
+        ));
+
+        self::assertSame(105.0, $rResult->tp1Price);
     }
 
     public function testRejectsWhenRMultipleIsNotPositive(): void

--- a/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
+++ b/trading-app/tests/TradingCore/SlTp/TakeProfitCalculatorTest.php
@@ -104,7 +104,8 @@ final class TakeProfitCalculatorTest extends TestCase
             pivotAligned: true,
         ));
 
-        self::assertSame(104.9, $pivotResult->tp1Price);
+        // Clamp: buffer cannot push TP inside the base R target → stays at 105.0.
+        self::assertSame(105.0, $pivotResult->tp1Price);
         self::assertSame($buffer, $pivotResult->metadata['tp_buffer_pct']);
 
         // R-multiple policy: buffer must NOT be applied → tp1Price stays at 105.0.
@@ -221,15 +222,14 @@ final class TakeProfitCalculatorTest extends TestCase
         ));
     }
 
-    public function testSuppressesTp2WhenBufferLeavesItCloserThanRestoredTp1(): void
+    public function testBufferClampsToBaseRTargetAndPreservesBothLegs(): void
     {
         $calculator = new TakeProfitCalculator();
 
-        // entry=100, stop=99.95 → riskDistance=0.05
-        // tp1R=1 → tp1=100.05; tp2R=1.8 → tp2=100.09
-        // buffer=0.001 → bufferAbs=0.1 (entry*buffer)
-        // tp1=100.05-0.1=99.95, effectiveR=(99.95-100)/0.05=-1 < minKeep=0.95 → reset tp1=100.05
-        // tp2=100.09-0.1=99.99 < tp1=100.05 → tp2 suppressed (not a farther target)
+        // With the clamp, buffer can never push TP below the base R target.
+        // baseTp1 = 100 + 5*1.0 = 105.0; buffered = 105 - 0.1 = 104.9 → clamped to 105.0.
+        // baseTp2 = 100 + 5*1.8 = 109.0; buffered = 109 - 0.1 = 108.9 → clamped to 109.0.
+        // Both legs stay at their theoretical R values; TP2 is still farther → not suppressed.
         $result = $calculator->calculate(new TakeProfitRequest(
             symbol: 'BTCUSDT',
             instrument: null,
@@ -238,7 +238,7 @@ final class TakeProfitCalculatorTest extends TestCase
             marketType: 'futures',
             direction: 'long',
             entryPrice: 100.0,
-            stopPrice: 99.95,
+            stopPrice: 95.0,
             riskDistance: null,
             rMultiple: 1.8,
             tp1R: 1.0,
@@ -252,8 +252,8 @@ final class TakeProfitCalculatorTest extends TestCase
             pivotAligned: true,
         ));
 
-        self::assertSame(100.05, $result->tp1Price);
-        self::assertNull($result->tp2Price);
+        self::assertSame(105.0, $result->tp1Price);
+        self::assertSame(109.0, $result->tp2Price);
     }
 
     public function testSuppressesTp2WhenTp1RIsGreaterThanRMultiple(): void


### PR DESCRIPTION
## Objectif

Introduire/formaliser le module SLTP / LiquidationGuard du TradingCore.

Cette PR clarifie les contrats de stop-loss, take-profit, validation de plan de protection et liquidation guard, sans changer le comportement runtime ni les valeurs SL/TP.

## Scope

- Ajout de DTOs / services `App\TradingCore\SlTp`.
- Ajout de tests unitaires SLTP / LiquidationGuard.
- Documentation du module SLTP / LiquidationGuard.
- Aucun branchement runtime dans `TradeEntry`.

## Hors-scope

- Aucun changement `mtf:run`.
- Aucun changement `POST /api/mtf/run`.
- Aucun changement Temporal.
- Aucun changement schedules.
- Aucun changement règles MTF.
- Aucun changement READY / REJECTED.
- Aucun changement EntryZone.
- Aucun changement Risk/Leverage.
- Aucun changement SL/TP dans les YAML.
- Aucun changement ExecutionPort.
- Aucun branchement `EffectiveTradingConfigResolver`.
- Aucun changement live.
- Aucun desserrage de stop.
- Aucun déplacement de TP.
- Aucun changement levier/risque.
- Aucun live OKX/Hyperliquid.
- Aucune suppression Bitmart.
- Aucun secret.

## Tests

- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/TradingCore/SlTp tests/TradingCore/Risk tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision tests/Application/Runner`
- `vendor/bin/phpstan analyse src/TradingCore/SlTp src/TradingCore/Risk src/TradingCore/Entry src/TradingCore/Mtf src/TradingCore/Decision tests/TradingCore/SlTp tests/TradingCore/Risk tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision --memory-limit=512M`
- `DEFAULT_URI=http://localhost:8082 php bin/console lint:yaml config`
- `DEFAULT_URI=http://localhost:8082 php bin/console lint:container`
- `DEFAULT_URI=http://localhost:8082 php bin/console list mtf --raw | grep -E '^mtf:run\s'`
- `DEFAULT_URI=http://localhost:8082 php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Risques

Le risque principal est de modifier involontairement le stop-loss, le take-profit ou la validation de liquidation effective. Cette PR reste préparatoire : aucun service TradingCore SLTP n'est branché dans le runtime legacy.

## Critères d’acceptation

- Module SLTP / LiquidationGuard ajouté.
- Tests SLTP / LiquidationGuard ajoutés.
- ProtectionPlan invalide sans SL.
- ProtectionPlan invalide si SL non full size.
- ProtectionPlan invalide si `stop_pct <= 0`.
- LiquidationGuard explicite ajouté.
- Entrypoints préservés.
- Aucun changement de valeur SL/TP.
- Aucun comportement runtime changé.