### PR TITLE
[codex] PR 09 - OrderPlan / ExecutionPort

### DIFF
--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -101,6 +101,7 @@ OrderPlan invalide si side inconnu
 OrderPlan invalide si type d'ordre inconnu
 OrderPlan invalide si margin_mode absent ou hors isolated/cross
 OrderPlan invalide si time_in_force absent ou hors gtc/fok/ioc/post_only
+OrderPlan invalide si type d'ordre market avec time_in_force post_only
 OrderPlan invalide si entry_price <= 0 ou non fini
 OrderPlan invalide si quantity <= 0 ou non finie
 OrderPlan invalide si leverage <= 0

--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -93,18 +93,29 @@ non valide explicitement est non executable.
 
 ```text
 OrderPlan invalide si symbole absent
+OrderPlan invalide si instrument absent
+OrderPlan invalide si profile absent
+OrderPlan invalide si exchange absent
+OrderPlan invalide si market_type absent
 OrderPlan invalide si side inconnu
 OrderPlan invalide si type d'ordre inconnu
-OrderPlan invalide si entry_price <= 0
-OrderPlan invalide si quantity <= 0
+OrderPlan invalide si margin_mode absent ou hors isolated/cross
+OrderPlan invalide si time_in_force absent ou hors gtc/fok/ioc/post_only
+OrderPlan invalide si entry_price <= 0 ou non fini
+OrderPlan invalide si quantity <= 0 ou non finie
 OrderPlan invalide si leverage <= 0
+OrderPlan invalide si contract_size fourni <= 0 ou non fini
 OrderPlan invalide si client_order_id absent
 OrderPlan invalide si idempotency_key absente
 OrderPlan invalide si ProtectionPlan absent
 OrderPlan invalide si ProtectionPlan invalide
 OrderPlan invalide si stop-loss absent
 OrderPlan invalide si stop-loss non full size
-OrderPlan invalide si stop_pct <= 0
+OrderPlan invalide si stop_price <= 0 ou non fini
+OrderPlan invalide si stop_pct <= 0 ou non fini
+OrderPlan invalide si stop_distance <= 0 ou non fini
+OrderPlan perpetual invalide si liquidation guard absent
+OrderPlan perpetual invalide si liquidation guard unsafe
 ```
 
 Cette validation cible ne change pas le runtime legacy. Elle prepare la regle :
@@ -129,6 +140,22 @@ ExecutionRequest -> ExecutionResult
 
 Le mode live exige un plan executable. Le mode dry-run reste autorise avec un
 plan invalide pour permettre inspection, audit et comparaison avec le legacy.
+
+Le boundary live ne fait pas confiance a la validation portee par le DTO. Avant
+de construire une requete live, `ExecutionRequest::forPlan()` revalide le plan
+avec `OrderPlanValidator` et remplace la validation stale par le resultat frais.
+Un appelant ne peut donc pas rendre un plan live executable en injectant un
+`OrderPlanValidationResult` forge.
+
+`ExecutionResult` transporte un `ExecutionStatus` enum, pas une string libre :
+
+```text
+dry_run
+accepted
+rejected
+failed
+skipped
+```
 
 PR09 n'ajoute aucune implementation live du port. Le placement cible du port
 est entre `ExecuteOrderPlan` et les gateways exchange, apres validation du plan

--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -1,0 +1,238 @@
+# OrderPlan / ExecutionPort module
+
+## Objectif
+
+PR09 introduit un module `App\TradingCore\OrderPlan` et un contrat
+`App\TradingCore\Execution` explicites, testables et preparatoires.
+
+Cette PR ne branche pas le module dans `TradeEntry`, ne modifie pas les YAML et
+ne change pas le comportement runtime. Elle formalise le contrat cible entre :
+
+- `TradeCandidate` ;
+- `EntryZone` ;
+- `Risk / Leverage` ;
+- `SLTP / ProtectionPlan` ;
+- `OrderPlan` ;
+- `ExecutionPort` ;
+- les gateways exchange.
+
+## Source runtime actuelle
+
+Le runtime legacy reste le suivant :
+
+```text
+TradingDecisionHandler
+  -> TradeEntryRequestBuilder
+  -> TradeEntryRequest
+  -> BuildOrderPlan
+  -> OrderPlanBuilder
+  -> ExecuteOrderPlan
+  -> ExecutionBox / ExchangeExecutionService
+  -> ProtectionEnforcer
+  -> exchange adapter
+```
+
+Le plan d'ordre executable est construit aujourd'hui dans
+`App\TradeEntry\OrderPlan\OrderPlanBuilder`. Le modele transporte par le runtime
+reste `App\TradeEntry\OrderPlan\OrderPlanModel`.
+
+PR09 ne remplace pas ces classes dans le flux d'execution.
+
+## Decisions legacy
+
+| Decision | Source actuelle |
+| --- | --- |
+| `side` | `SymbolResultDto` puis `TradeEntryRequestBuilder`. |
+| `order_type` | YAML `trade_entry.defaults.market_entry` et fallback maker/taker dans `OrderPlanBuilder`. |
+| `quantity` | `OrderPlanBuilder`, avec risk, stop, contract size et clamps exchange. |
+| `entry_price` | `OrderPlanBuilder`, carnet, hint, quantization et `EntryZone`. |
+| `leverage` | `OrderPlanBuilder`, `DynamicLeverageService`, caps preflight et ajustements execution. |
+| `stop_loss` | `OrderPlanBuilder` puis `ProtectionEnforcer` cote execution. |
+| `take_profit` | `OrderPlanBuilder`, en R et/ou pivot selon profil. |
+| `client_order_id` | `IdempotencyPolicy`. |
+| `idempotency_key` | `DecisionKeyFactory` et `OrderIntentManager`. |
+| `dry_run/live` | `TradingDecisionHandler`, puis `BuildOrderPlan` ou `ExecuteOrderPlan`. |
+| `exchange` | `ExchangeContext`, avec fallback Bitmart legacy. |
+| `market_type` | `ExchangeContext`, avec perpetual legacy. |
+
+Les side effects exchange restent concentres dans `PreTradeChecks`,
+`ExecutionBox`, `ExchangeExecutionService`, `ProtectionEnforcer`,
+`EmergencyCloseService` et les adapters provider.
+
+## Contrat cible
+
+`App\TradingCore\OrderPlan\Dto\OrderPlan` represente le plan cible apres
+composition des modules TradingCore :
+
+```text
+symbol / instrument
+profile
+exchange
+market_type
+side
+order_type
+margin_mode
+time_in_force
+entry_price
+quantity
+leverage
+protection_plan
+client_order_id
+idempotency_key
+decision_key
+entry_zone
+risk_calculation
+leverage_calculation
+metadata
+```
+
+Le plan porte aussi un `OrderPlanValidationResult`. Par defaut, un `OrderPlan`
+non valide explicitement est non executable.
+
+`OrderPlanValidator` formalise les contraintes minimales :
+
+```text
+OrderPlan invalide si symbole absent
+OrderPlan invalide si side inconnu
+OrderPlan invalide si type d'ordre inconnu
+OrderPlan invalide si entry_price <= 0
+OrderPlan invalide si quantity <= 0
+OrderPlan invalide si leverage <= 0
+OrderPlan invalide si client_order_id absent
+OrderPlan invalide si idempotency_key absente
+OrderPlan invalide si ProtectionPlan absent
+OrderPlan invalide si ProtectionPlan invalide
+OrderPlan invalide si stop-loss absent
+OrderPlan invalide si stop-loss non full size
+OrderPlan invalide si stop_pct <= 0
+```
+
+Cette validation cible ne change pas le runtime legacy. Elle prepare la regle :
+aucun plan live executable ne peut etre considere valide sans stop-loss
+automatique full size.
+
+## ExecutionPort
+
+`App\TradingCore\Execution\Port\ExecutionPortInterface` formalise le futur port
+d'execution :
+
+```text
+ExecutionRequest -> ExecutionResult
+```
+
+`ExecutionRequest` transporte :
+
+- le `OrderPlan` cible ;
+- le mode `dry_run` ou `live` ;
+- les metadata d'orchestration ;
+- l'horodatage de demande.
+
+Le mode live exige un plan executable. Le mode dry-run reste autorise avec un
+plan invalide pour permettre inspection, audit et comparaison avec le legacy.
+
+PR09 n'ajoute aucune implementation live du port. Le placement cible du port
+est entre `ExecuteOrderPlan` et les gateways exchange, apres validation du plan
+et avant tout side effect provider.
+
+## Client order id
+
+`ClientOrderIdFactory` formalise la generation cible du `client_order_id`
+depuis une cle d'idempotence :
+
+```text
+client_order_id = CID + sha256(idempotency_key)[0:29]
+```
+
+Le format reste alphanumerique et borne a 32 caracteres pour rester compatible
+avec les contraintes legacy Bitmart. La factory est deterministe et ne produit
+pas d'identifiant si la cle d'idempotence est vide.
+
+PR09 ne remplace pas `App\TradeEntry\Policy\IdempotencyPolicy` dans le runtime.
+Elle rend seulement le contrat cible explicite.
+
+## Mapper legacy
+
+`LegacyOrderPlanMapper` convertit un `App\TradeEntry\OrderPlan\OrderPlanModel`
+vers le DTO cible sans inventer de protection et sans modifier les valeurs
+d'execution.
+
+Il preserve les champs utiles dans `metadata` :
+
+- stop legacy ;
+- take-profit legacy ;
+- source finale du stop ;
+- entry zone min/max ;
+- taille de zone ;
+- mode d'ordre legacy ;
+- precision prix ;
+- contract size.
+
+Comme le modele legacy ne transporte pas encore un `ProtectionPlan`, le plan
+mappe reste invalide pour execution cible live. Ce comportement est volontaire :
+la future migration devra brancher explicitement `SLTP / ProtectionPlan`.
+
+Quand un `decisionKey` legacy est fourni au mapper preparatoire, il devient la
+`idempotency_key` cible et sert a deriver un `client_order_id` deterministe.
+Quand il est absent, le plan cible reste invalide pour execution live.
+
+## Idempotence
+
+PR09 ne deplace pas l'idempotence runtime.
+
+Les sources legacy restent :
+
+- `DecisionKeyFactory` pour la cle de decision ;
+- `OrderIntentManager` pour l'intent persiste ;
+- `IdempotencyPolicy` pour le `client_order_id`.
+
+Le DTO cible transporte `client_order_id`, `idempotency_key` et `decision_key`
+et `OrderPlanValidator` les rend obligatoires pour un plan executable. PR09 ne
+modifie pas les cles existantes dans le runtime.
+
+## Non branche dans PR09
+
+PR09 ne branche pas :
+
+- `OrderPlan` TradingCore dans `BuildOrderPlan` ;
+- `OrderPlanValidator` dans `ExecuteOrderPlan` ;
+- `ExecutionPortInterface` dans `ExecutionBox` ;
+- les gateways exchange dans un nouveau port ;
+- `EffectiveTradingConfigResolver` dans le runtime.
+
+PR09 ne modifie pas :
+
+- `mtf:run` ;
+- `POST /api/mtf/run` ;
+- Temporal ;
+- les schedules ;
+- les regles MTF ;
+- les decisions `READY` / `REJECTED` ;
+- EntryZone ;
+- Risk / Leverage ;
+- SLTP / LiquidationGuard ;
+- les valeurs SL/TP, risk ou leverage dans les YAML ;
+- Bitmart, OKX ou Hyperliquid live.
+
+## Contraintes avant branchement live
+
+Avant tout branchement runtime, il faudra :
+
+- comparer les plans TradingCore avec `OrderPlanBuilder` sur un echantillon de
+  decisions ;
+- brancher explicitement `ProtectionPlan` depuis PR08 ;
+- verifier que le SL attache est full size dans tous les payloads exchange ;
+- rendre l'idempotence obligatoire avant tout side effect ;
+- separer les side effects exchange derriere des gateways testables ;
+- conserver un chemin dry-run capable d'inspecter les plans invalides ;
+- prouver que les quantites, stops, TP, levier et prix d'entree ne changent pas.
+
+## Suite PR10
+
+PR10 devrait traiter un gateway `Fake / Paper` ou une premiere implementation
+adapter du `ExecutionPort`.
+
+Objectif recommande :
+
+- executer un `OrderPlan` cible valide sans toucher aux exchanges live ;
+- verifier l'idempotence sans side effects reels ;
+- comparer les payloads legacy et TradingCore avant tout branchement live.

--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -117,6 +117,8 @@ OrderPlan invalide si stop_distance <= 0 ou non fini
 OrderPlan invalide si le stop n'est pas protecteur pour le side
 OrderPlan perpetual invalide si liquidation guard absent
 OrderPlan perpetual invalide si liquidation guard unsafe
+OrderPlan perpetual invalide si les metriques liquidation sont absentes ou non finies
+OrderPlan perpetual invalide si le prix de liquidation n'est pas au-dela du stop
 ```
 
 Cette validation cible ne change pas le runtime legacy. Elle prepare la regle :

--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -119,6 +119,7 @@ OrderPlan perpetual invalide si liquidation guard absent
 OrderPlan perpetual invalide si liquidation guard unsafe
 OrderPlan perpetual invalide si les metriques liquidation sont absentes ou non finies
 OrderPlan perpetual invalide si le prix de liquidation n'est pas au-dela du stop
+OrderPlan perpetual invalide si le ratio liquidation est sous le min_distance_ratio enregistre
 ```
 
 Cette validation cible ne change pas le runtime legacy. Elle prepare la regle :

--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -96,7 +96,7 @@ OrderPlan invalide si symbole absent
 OrderPlan invalide si instrument absent
 OrderPlan invalide si profile absent
 OrderPlan invalide si exchange absent
-OrderPlan invalide si market_type absent
+OrderPlan invalide si market_type absent ou hors perpetual/spot
 OrderPlan invalide si side inconnu
 OrderPlan invalide si type d'ordre inconnu
 OrderPlan invalide si margin_mode absent ou hors isolated/cross

--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -119,7 +119,7 @@ OrderPlan perpetual invalide si liquidation guard absent
 OrderPlan perpetual invalide si liquidation guard unsafe
 OrderPlan perpetual invalide si les metriques liquidation sont absentes ou non finies
 OrderPlan perpetual invalide si le prix de liquidation n'est pas au-dela du stop
-OrderPlan perpetual invalide si le ratio liquidation est sous le min_distance_ratio enregistre
+OrderPlan perpetual invalide si le ratio liquidation recalcule est sous le min_distance_ratio enregistre
 ```
 
 Cette validation cible ne change pas le runtime legacy. Elle prepare la regle :

--- a/docs/handbook/technical/order-plan-execution-port-module.md
+++ b/docs/handbook/technical/order-plan-execution-port-module.md
@@ -114,6 +114,7 @@ OrderPlan invalide si stop-loss non full size
 OrderPlan invalide si stop_price <= 0 ou non fini
 OrderPlan invalide si stop_pct <= 0 ou non fini
 OrderPlan invalide si stop_distance <= 0 ou non fini
+OrderPlan invalide si le stop n'est pas protecteur pour le side
 OrderPlan perpetual invalide si liquidation guard absent
 OrderPlan perpetual invalide si liquidation guard unsafe
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - EntryZone module: technical/entry-zone-module.md
       - Risk / Leverage module: technical/risk-and-leverage-module.md
       - SLTP / LiquidationGuard module: technical/sltp-liquidation-guard-module.md
+      - OrderPlan / ExecutionPort module: technical/order-plan-execution-port-module.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/TradingCore/Execution/Dto/ExecutionRequest.php
+++ b/trading-app/src/TradingCore/Execution/Dto/ExecutionRequest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Dto;
+
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+
+final readonly class ExecutionRequest
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function __construct(
+        public OrderPlan $orderPlan,
+        public ExecutionMode $mode,
+        public \DateTimeImmutable $requestedAt,
+        public array $metadata = [],
+    ) {
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public static function forPlan(
+        OrderPlan $orderPlan,
+        ExecutionMode $mode,
+        array $metadata = [],
+        ?\DateTimeImmutable $requestedAt = null,
+    ): self {
+        if ($mode === ExecutionMode::Live && !$orderPlan->validation->isExecutable) {
+            throw new \InvalidArgumentException('Live execution requires an executable order plan.');
+        }
+
+        return new self(
+            orderPlan: $orderPlan,
+            mode: $mode,
+            requestedAt: $requestedAt ?? new \DateTimeImmutable('now', new \DateTimeZone('UTC')),
+            metadata: $metadata,
+        );
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Dto/ExecutionRequest.php
+++ b/trading-app/src/TradingCore/Execution/Dto/ExecutionRequest.php
@@ -5,6 +5,7 @@ namespace App\TradingCore\Execution\Dto;
 
 use App\TradingCore\Execution\Enum\ExecutionMode;
 use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
 
 final readonly class ExecutionRequest
 {
@@ -28,12 +29,17 @@ final readonly class ExecutionRequest
         array $metadata = [],
         ?\DateTimeImmutable $requestedAt = null,
     ): self {
-        if ($mode === ExecutionMode::Live && !$orderPlan->validation->isExecutable) {
+        $validatedPlan = $orderPlan;
+        if ($mode === ExecutionMode::Live) {
+            $validatedPlan = $orderPlan->withValidation((new OrderPlanValidator())->validate($orderPlan));
+        }
+
+        if ($mode === ExecutionMode::Live && !$validatedPlan->validation->isExecutable) {
             throw new \InvalidArgumentException('Live execution requires an executable order plan.');
         }
 
         return new self(
-            orderPlan: $orderPlan,
+            orderPlan: $validatedPlan,
             mode: $mode,
             requestedAt: $requestedAt ?? new \DateTimeImmutable('now', new \DateTimeZone('UTC')),
             metadata: $metadata,

--- a/trading-app/src/TradingCore/Execution/Dto/ExecutionResult.php
+++ b/trading-app/src/TradingCore/Execution/Dto/ExecutionResult.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace App\TradingCore\Execution\Dto;
 
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+
 final readonly class ExecutionResult
 {
     /**
@@ -10,7 +12,7 @@ final readonly class ExecutionResult
      * @param array<string,mixed> $metadata
      */
     public function __construct(
-        public string $status,
+        public ExecutionStatus $status,
         public ?string $clientOrderId = null,
         public ?string $exchangeOrderId = null,
         public array $raw = [],

--- a/trading-app/src/TradingCore/Execution/Dto/ExecutionResult.php
+++ b/trading-app/src/TradingCore/Execution/Dto/ExecutionResult.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Dto;
+
+final readonly class ExecutionResult
+{
+    /**
+     * @param array<string,mixed> $raw
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $status,
+        public ?string $clientOrderId = null,
+        public ?string $exchangeOrderId = null,
+        public array $raw = [],
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Enum/ExecutionMode.php
+++ b/trading-app/src/TradingCore/Execution/Enum/ExecutionMode.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Enum;
+
+enum ExecutionMode: string
+{
+    case DryRun = 'dry_run';
+    case Live = 'live';
+}

--- a/trading-app/src/TradingCore/Execution/Enum/ExecutionStatus.php
+++ b/trading-app/src/TradingCore/Execution/Enum/ExecutionStatus.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Enum;
+
+enum ExecutionStatus: string
+{
+    case DryRun = 'dry_run';
+    case Accepted = 'accepted';
+    case Rejected = 'rejected';
+    case Failed = 'failed';
+    case Skipped = 'skipped';
+}

--- a/trading-app/src/TradingCore/Execution/Port/ExecutionPortInterface.php
+++ b/trading-app/src/TradingCore/Execution/Port/ExecutionPortInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Port;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Dto\ExecutionResult;
+
+interface ExecutionPortInterface
+{
+    public function execute(ExecutionRequest $request): ExecutionResult;
+}

--- a/trading-app/src/TradingCore/Execution/Service/ClientOrderIdFactory.php
+++ b/trading-app/src/TradingCore/Execution/Service/ClientOrderIdFactory.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Service;
+
+final class ClientOrderIdFactory
+{
+    public function fromIdempotencyKey(string $idempotencyKey): string
+    {
+        $normalized = trim($idempotencyKey);
+        if ($normalized === '') {
+            throw new \InvalidArgumentException('Idempotency key is required to build a client order id.');
+        }
+
+        return 'CID' . substr(strtoupper(hash('sha256', $normalized)), 0, 29);
+    }
+}

--- a/trading-app/src/TradingCore/OrderPlan/Dto/OrderPlan.php
+++ b/trading-app/src/TradingCore/OrderPlan/Dto/OrderPlan.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\OrderPlan\Dto;
+
+use App\TradingCore\Entry\Dto\EntryZone;
+use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+use App\TradingCore\Risk\Dto\LeverageCalculationResult;
+use App\TradingCore\Risk\Dto\RiskCalculationResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+
+final readonly class OrderPlan
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public string $symbol,
+        public string $profile,
+        public string $exchange,
+        public string $marketType,
+        public string $side,
+        public string $orderType,
+        public string $marginMode,
+        public string $timeInForce,
+        public float $entryPrice,
+        public float $quantity,
+        public int $leverage,
+        public ?ProtectionPlan $protectionPlan = null,
+        public ?string $clientOrderId = null,
+        public ?string $idempotencyKey = null,
+        public ?string $decisionKey = null,
+        public ?EntryZone $entryZone = null,
+        public ?RiskCalculationResult $riskCalculation = null,
+        public ?LeverageCalculationResult $leverageCalculation = null,
+        public ?int $pricePrecision = null,
+        public ?float $contractSize = null,
+        ?OrderPlanValidationResult $validation = null,
+        public array $metadata = [],
+        ?string $instrument = null,
+    ) {
+        $this->instrument = $instrument ?? $symbol;
+        $this->validation = $validation ?? new OrderPlanValidationResult(
+            status: OrderPlanStatus::Invalid,
+            isExecutable: false,
+            invalidReasons: ['order_plan_not_validated'],
+        );
+    }
+
+    public string $instrument;
+
+    public OrderPlanValidationResult $validation;
+
+    public function withValidation(OrderPlanValidationResult $validation): self
+    {
+        return new self(
+            symbol: $this->symbol,
+            profile: $this->profile,
+            exchange: $this->exchange,
+            marketType: $this->marketType,
+            side: $this->side,
+            orderType: $this->orderType,
+            marginMode: $this->marginMode,
+            timeInForce: $this->timeInForce,
+            entryPrice: $this->entryPrice,
+            quantity: $this->quantity,
+            leverage: $this->leverage,
+            protectionPlan: $this->protectionPlan,
+            clientOrderId: $this->clientOrderId,
+            idempotencyKey: $this->idempotencyKey,
+            decisionKey: $this->decisionKey,
+            entryZone: $this->entryZone,
+            riskCalculation: $this->riskCalculation,
+            leverageCalculation: $this->leverageCalculation,
+            pricePrecision: $this->pricePrecision,
+            contractSize: $this->contractSize,
+            validation: $validation,
+            metadata: $this->metadata,
+            instrument: $this->instrument,
+        );
+    }
+}

--- a/trading-app/src/TradingCore/OrderPlan/Dto/OrderPlanBuildRequest.php
+++ b/trading-app/src/TradingCore/OrderPlan/Dto/OrderPlanBuildRequest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\OrderPlan\Dto;
+
+use App\TradingCore\Decision\Dto\TradeCandidate;
+use App\TradingCore\Entry\Dto\EntryZone;
+use App\TradingCore\Risk\Dto\LeverageCalculationResult;
+use App\TradingCore\Risk\Dto\RiskCalculationResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+
+final readonly class OrderPlanBuildRequest
+{
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public TradeCandidate $candidate,
+        public ?EntryZone $entryZone,
+        public ?RiskCalculationResult $riskCalculation,
+        public ?LeverageCalculationResult $leverageCalculation,
+        public ?ProtectionPlan $protectionPlan,
+        public string $orderType,
+        public string $marginMode,
+        public string $timeInForce,
+        public ?string $clientOrderId = null,
+        public ?string $idempotencyKey = null,
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/TradingCore/OrderPlan/Dto/OrderPlanValidationResult.php
+++ b/trading-app/src/TradingCore/OrderPlan/Dto/OrderPlanValidationResult.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\OrderPlan\Dto;
+
+use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+
+final readonly class OrderPlanValidationResult
+{
+    /**
+     * @param list<string> $invalidReasons
+     * @param list<string> $warnings
+     * @param array<string,mixed> $metadata
+     */
+    public function __construct(
+        public OrderPlanStatus $status,
+        public bool $isExecutable,
+        public array $invalidReasons = [],
+        public array $warnings = [],
+        public array $metadata = [],
+    ) {
+    }
+}

--- a/trading-app/src/TradingCore/OrderPlan/Enum/OrderPlanStatus.php
+++ b/trading-app/src/TradingCore/OrderPlan/Enum/OrderPlanStatus.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\OrderPlan\Enum;
+
+enum OrderPlanStatus: string
+{
+    case Valid = 'valid';
+    case Invalid = 'invalid';
+}

--- a/trading-app/src/TradingCore/OrderPlan/Mapper/LegacyOrderPlanMapper.php
+++ b/trading-app/src/TradingCore/OrderPlan/Mapper/LegacyOrderPlanMapper.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\OrderPlan\Mapper;
+
+use App\Provider\Context\ExchangeContext;
+use App\TradeEntry\OrderPlan\OrderPlanModel as LegacyOrderPlanModel;
+use App\TradeEntry\Types\Side;
+use App\TradingCore\Execution\Service\ClientOrderIdFactory;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+
+final readonly class LegacyOrderPlanMapper
+{
+    public function __construct(
+        private OrderPlanValidator $validator = new OrderPlanValidator(),
+        private ClientOrderIdFactory $clientOrderIdFactory = new ClientOrderIdFactory(),
+    ) {
+    }
+
+    public function fromLegacy(
+        LegacyOrderPlanModel $legacy,
+        string $profile,
+        ?string $decisionKey,
+        ?ProtectionPlan $protectionPlan,
+    ): OrderPlan {
+        $context = ExchangeContext::resolve($legacy->exchangeContext);
+        $idempotencyKey = $decisionKey !== null && trim($decisionKey) !== '' ? $decisionKey : null;
+
+        $plan = new OrderPlan(
+            symbol: $legacy->symbol,
+            profile: $profile,
+            exchange: $context->exchange->value,
+            marketType: $context->marketType->value,
+            side: $legacy->side === Side::Long ? 'long' : 'short',
+            orderType: $legacy->orderType,
+            marginMode: $legacy->openType,
+            timeInForce: $this->timeInForce($legacy),
+            entryPrice: $legacy->entry,
+            quantity: (float) $legacy->size,
+            leverage: $legacy->leverage,
+            protectionPlan: $protectionPlan,
+            clientOrderId: $idempotencyKey !== null ? $this->clientOrderIdFactory->fromIdempotencyKey($idempotencyKey) : null,
+            idempotencyKey: $idempotencyKey,
+            decisionKey: $idempotencyKey,
+            pricePrecision: $legacy->pricePrecision,
+            contractSize: $legacy->contractSize,
+            metadata: [
+                'source' => 'legacy_order_plan_model',
+                'legacy_order_mode' => $legacy->orderMode,
+                'legacy_stop' => $legacy->stop,
+                'legacy_take_profit' => $legacy->takeProfit,
+                'legacy_stop_atr' => $legacy->stopAtr,
+                'legacy_stop_risk' => $legacy->stopRisk,
+                'legacy_stop_pivot' => $legacy->stopPivot,
+                'legacy_stop_final_source' => $legacy->stopFinalSource,
+                'entry_zone_low' => $legacy->entryZoneLow,
+                'entry_zone_high' => $legacy->entryZoneHigh,
+                'zone_expires_at' => $legacy->zoneExpiresAt?->format(\DateTimeInterface::ATOM),
+                'entry_zone_meta' => $legacy->entryZoneMeta,
+            ],
+        );
+
+        return $plan->withValidation($this->validator->validate($plan));
+    }
+
+    private function timeInForce(LegacyOrderPlanModel $legacy): string
+    {
+        if ($legacy->orderType === 'market') {
+            return 'ioc';
+        }
+
+        return match ($legacy->orderMode) {
+            2 => 'fok',
+            3 => 'ioc',
+            4 => 'post_only',
+            default => 'gtc',
+        };
+    }
+}

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -29,10 +29,10 @@ final class OrderPlanValidator
         if (trim($plan->timeInForce) === '') {
             $invalidReasons[] = 'time_in_force_missing';
         }
-        if ($plan->entryPrice <= 0.0) {
+        if ($plan->entryPrice <= 0.0 || !\is_finite($plan->entryPrice)) {
             $invalidReasons[] = 'entry_price_not_positive';
         }
-        if ($plan->quantity <= 0.0) {
+        if ($plan->quantity <= 0.0 || !\is_finite($plan->quantity)) {
             $invalidReasons[] = 'quantity_not_positive';
         }
         if ($plan->leverage <= 0) {

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -38,6 +38,7 @@ final class OrderPlanValidator
         if (!\in_array(strtolower($plan->orderType), ['limit', 'market'], true)) {
             $invalidReasons[] = 'order_type_invalid';
         }
+        $orderType = strtolower(trim($plan->orderType));
         $marginMode = strtolower(trim($plan->marginMode));
         if ($marginMode === '') {
             $invalidReasons[] = 'margin_mode_missing';
@@ -49,6 +50,8 @@ final class OrderPlanValidator
             $invalidReasons[] = 'time_in_force_missing';
         } elseif (!\in_array($timeInForce, ['gtc', 'fok', 'ioc', 'post_only'], true)) {
             $invalidReasons[] = 'time_in_force_invalid';
+        } elseif ($orderType === 'market' && $timeInForce === 'post_only') {
+            $invalidReasons[] = 'post_only_requires_limit_order';
         }
         if ($plan->entryPrice <= 0.0 || !\is_finite($plan->entryPrice)) {
             $invalidReasons[] = 'entry_price_not_positive';

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -134,6 +134,23 @@ final class OrderPlanValidator
                             $invalidReasons[] = 'liquidation_price_not_beyond_stop';
                         }
                     }
+
+                    if (\array_key_exists('min_distance_ratio', $liquidationCheck->metadata)) {
+                        $minDistanceRatio = $liquidationCheck->metadata['min_distance_ratio'];
+                        if (!\is_int($minDistanceRatio) && !\is_float($minDistanceRatio)) {
+                            $invalidReasons[] = 'invalid_min_distance_ratio';
+                        } else {
+                            $minDistanceRatio = (float) $minDistanceRatio;
+                            if (!\is_finite($minDistanceRatio) || $minDistanceRatio < 0.0) {
+                                $invalidReasons[] = 'invalid_min_distance_ratio';
+                            } elseif (
+                                $liquidationCheck->stopToLiquidationRatio !== null
+                                && $liquidationCheck->stopToLiquidationRatio < $minDistanceRatio
+                            ) {
+                                $invalidReasons[] = 'liquidation_distance_below_min_ratio';
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -92,6 +92,13 @@ final class OrderPlanValidator
                 if ($stopLoss->stopDistance <= 0.0 || !\is_finite($stopLoss->stopDistance)) {
                     $invalidReasons[] = 'stop_distance_not_positive';
                 }
+                $side = strtolower(trim($plan->side));
+                if (
+                    ($side === 'long' && $stopLoss->stopPrice >= $plan->entryPrice)
+                    || ($side === 'short' && $stopLoss->stopPrice <= $plan->entryPrice)
+                ) {
+                    $invalidReasons[] = 'stop_loss_side_invalid';
+                }
             }
 
             if (strtolower(trim($plan->marketType)) === 'perpetual') {

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -143,11 +143,26 @@ final class OrderPlanValidator
                             $minDistanceRatio = (float) $minDistanceRatio;
                             if (!\is_finite($minDistanceRatio) || $minDistanceRatio < 0.0) {
                                 $invalidReasons[] = 'invalid_min_distance_ratio';
-                            } elseif (
-                                $liquidationCheck->stopToLiquidationRatio !== null
-                                && $liquidationCheck->stopToLiquidationRatio < $minDistanceRatio
-                            ) {
-                                $invalidReasons[] = 'liquidation_distance_below_min_ratio';
+                            } else {
+                                $ratio = $liquidationCheck->stopToLiquidationRatio;
+                                if (
+                                    $stopLoss !== null
+                                    && $liquidationCheck->liquidationPrice !== null
+                                    && $plan->entryPrice > 0.0
+                                    && \is_finite($plan->entryPrice)
+                                    && \is_finite($stopLoss->stopPrice)
+                                    && \is_finite($liquidationCheck->liquidationPrice)
+                                ) {
+                                    $stopDistance = abs($plan->entryPrice - $stopLoss->stopPrice);
+                                    $liquidationDistance = abs($plan->entryPrice - $liquidationCheck->liquidationPrice);
+                                    if ($stopDistance > 0.0 && \is_finite($stopDistance) && \is_finite($liquidationDistance)) {
+                                        $ratio = $liquidationDistance / $stopDistance;
+                                    }
+                                }
+
+                                if ($ratio !== null && $ratio < $minDistanceRatio) {
+                                    $invalidReasons[] = 'liquidation_distance_below_min_ratio';
+                                }
                             }
                         }
                     }

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -26,8 +26,11 @@ final class OrderPlanValidator
         if (trim($plan->exchange) === '') {
             $invalidReasons[] = 'exchange_missing';
         }
-        if (trim($plan->marketType) === '') {
+        $marketType = strtolower(trim($plan->marketType));
+        if ($marketType === '') {
             $invalidReasons[] = 'market_type_missing';
+        } elseif (!\in_array($marketType, ['perpetual', 'spot'], true)) {
+            $invalidReasons[] = 'market_type_invalid';
         }
         if (!\in_array(strtolower($plan->side), ['long', 'short'], true)) {
             $invalidReasons[] = 'side_invalid';
@@ -101,7 +104,7 @@ final class OrderPlanValidator
                 }
             }
 
-            if (strtolower(trim($plan->marketType)) === 'perpetual') {
+            if ($marketType === 'perpetual') {
                 if ($protection->liquidationCheck === null) {
                     $invalidReasons[] = 'liquidation_guard_missing';
                 } elseif (!$protection->liquidationCheck->isSafe) {

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\OrderPlan\Service;
+
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Dto\OrderPlanValidationResult;
+use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+
+final class OrderPlanValidator
+{
+    public function validate(OrderPlan $plan): OrderPlanValidationResult
+    {
+        $invalidReasons = [];
+        $warnings = [];
+
+        if (trim($plan->symbol) === '') {
+            $invalidReasons[] = 'symbol_missing';
+        }
+        if (!\in_array(strtolower($plan->side), ['long', 'short'], true)) {
+            $invalidReasons[] = 'side_invalid';
+        }
+        if (!\in_array(strtolower($plan->orderType), ['limit', 'market'], true)) {
+            $invalidReasons[] = 'order_type_invalid';
+        }
+        if (trim($plan->marginMode) === '') {
+            $invalidReasons[] = 'margin_mode_missing';
+        }
+        if (trim($plan->timeInForce) === '') {
+            $invalidReasons[] = 'time_in_force_missing';
+        }
+        if ($plan->entryPrice <= 0.0) {
+            $invalidReasons[] = 'entry_price_not_positive';
+        }
+        if ($plan->quantity <= 0.0) {
+            $invalidReasons[] = 'quantity_not_positive';
+        }
+        if ($plan->leverage <= 0) {
+            $invalidReasons[] = 'leverage_not_positive';
+        }
+        if ($plan->clientOrderId === null || trim($plan->clientOrderId) === '') {
+            $invalidReasons[] = 'client_order_id_missing';
+        }
+        if ($plan->idempotencyKey === null || trim($plan->idempotencyKey) === '') {
+            $invalidReasons[] = 'idempotency_key_missing';
+        }
+
+        $protection = $plan->protectionPlan;
+        if ($protection === null) {
+            $invalidReasons[] = 'protection_plan_missing';
+        } else {
+            $warnings = array_values(array_unique(array_merge($warnings, $protection->warnings)));
+            if (!$protection->isValid) {
+                $invalidReasons[] = 'protection_plan_invalid';
+                $invalidReasons = array_merge($invalidReasons, $protection->invalidReasons);
+            }
+
+            $stopLoss = $protection->stopLoss;
+            if ($stopLoss === null) {
+                $invalidReasons[] = 'stop_loss_missing';
+            } else {
+                if (!$stopLoss->isFullSize) {
+                    $invalidReasons[] = 'stop_loss_not_full_size';
+                }
+                if ($stopLoss->stopPct <= 0.0) {
+                    $invalidReasons[] = 'stop_pct_not_positive';
+                }
+            }
+        }
+
+        $invalidReasons = array_values(array_unique($invalidReasons));
+        $status = $invalidReasons === [] ? OrderPlanStatus::Valid : OrderPlanStatus::Invalid;
+
+        return new OrderPlanValidationResult(
+            status: $status,
+            isExecutable: $status === OrderPlanStatus::Valid,
+            invalidReasons: $invalidReasons,
+            warnings: $warnings,
+        );
+    }
+}

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -17,23 +17,44 @@ final class OrderPlanValidator
         if (trim($plan->symbol) === '') {
             $invalidReasons[] = 'symbol_missing';
         }
+        if (trim($plan->instrument) === '') {
+            $invalidReasons[] = 'instrument_missing';
+        }
+        if (trim($plan->profile) === '') {
+            $invalidReasons[] = 'profile_missing';
+        }
+        if (trim($plan->exchange) === '') {
+            $invalidReasons[] = 'exchange_missing';
+        }
+        if (trim($plan->marketType) === '') {
+            $invalidReasons[] = 'market_type_missing';
+        }
         if (!\in_array(strtolower($plan->side), ['long', 'short'], true)) {
             $invalidReasons[] = 'side_invalid';
         }
         if (!\in_array(strtolower($plan->orderType), ['limit', 'market'], true)) {
             $invalidReasons[] = 'order_type_invalid';
         }
-        if (trim($plan->marginMode) === '') {
+        $marginMode = strtolower(trim($plan->marginMode));
+        if ($marginMode === '') {
             $invalidReasons[] = 'margin_mode_missing';
+        } elseif (!\in_array($marginMode, ['isolated', 'cross'], true)) {
+            $invalidReasons[] = 'margin_mode_invalid';
         }
-        if (trim($plan->timeInForce) === '') {
+        $timeInForce = strtolower(trim($plan->timeInForce));
+        if ($timeInForce === '') {
             $invalidReasons[] = 'time_in_force_missing';
+        } elseif (!\in_array($timeInForce, ['gtc', 'fok', 'ioc', 'post_only'], true)) {
+            $invalidReasons[] = 'time_in_force_invalid';
         }
         if ($plan->entryPrice <= 0.0 || !\is_finite($plan->entryPrice)) {
             $invalidReasons[] = 'entry_price_not_positive';
         }
         if ($plan->quantity <= 0.0 || !\is_finite($plan->quantity)) {
             $invalidReasons[] = 'quantity_not_positive';
+        }
+        if ($plan->contractSize !== null && ($plan->contractSize <= 0.0 || !\is_finite($plan->contractSize))) {
+            $invalidReasons[] = 'contract_size_not_positive';
         }
         if ($plan->leverage <= 0) {
             $invalidReasons[] = 'leverage_not_positive';
@@ -62,8 +83,22 @@ final class OrderPlanValidator
                 if (!$stopLoss->isFullSize) {
                     $invalidReasons[] = 'stop_loss_not_full_size';
                 }
-                if ($stopLoss->stopPct <= 0.0) {
+                if ($stopLoss->stopPrice <= 0.0 || !\is_finite($stopLoss->stopPrice)) {
+                    $invalidReasons[] = 'stop_price_not_positive';
+                }
+                if ($stopLoss->stopPct <= 0.0 || !\is_finite($stopLoss->stopPct)) {
                     $invalidReasons[] = 'stop_pct_not_positive';
+                }
+                if ($stopLoss->stopDistance <= 0.0 || !\is_finite($stopLoss->stopDistance)) {
+                    $invalidReasons[] = 'stop_distance_not_positive';
+                }
+            }
+
+            if (strtolower(trim($plan->marketType)) === 'perpetual') {
+                if ($protection->liquidationCheck === null) {
+                    $invalidReasons[] = 'liquidation_guard_missing';
+                } elseif (!$protection->liquidationCheck->isSafe) {
+                    $invalidReasons[] = 'liquidation_guard_unsafe';
                 }
             }
         }

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanValidator.php
@@ -109,6 +109,31 @@ final class OrderPlanValidator
                     $invalidReasons[] = 'liquidation_guard_missing';
                 } elseif (!$protection->liquidationCheck->isSafe) {
                     $invalidReasons[] = 'liquidation_guard_unsafe';
+                } else {
+                    $liquidationCheck = $protection->liquidationCheck;
+                    if (
+                        $liquidationCheck->liquidationPrice === null
+                        || $liquidationCheck->liquidationDistancePct === null
+                        || $liquidationCheck->stopToLiquidationRatio === null
+                        || $liquidationCheck->liquidationPrice <= 0.0
+                        || $liquidationCheck->liquidationDistancePct <= 0.0
+                        || $liquidationCheck->stopToLiquidationRatio <= 0.0
+                        || !\is_finite($liquidationCheck->liquidationPrice)
+                        || !\is_finite($liquidationCheck->liquidationDistancePct)
+                        || !\is_finite($liquidationCheck->stopToLiquidationRatio)
+                    ) {
+                        $invalidReasons[] = 'liquidation_guard_data_invalid';
+                    }
+
+                    if ($stopLoss !== null) {
+                        $side = strtolower(trim($plan->side));
+                        if (
+                            ($side === 'long' && $liquidationCheck->liquidationPrice !== null && $liquidationCheck->liquidationPrice >= $stopLoss->stopPrice)
+                            || ($side === 'short' && $liquidationCheck->liquidationPrice !== null && $liquidationCheck->liquidationPrice <= $stopLoss->stopPrice)
+                        ) {
+                            $invalidReasons[] = 'liquidation_price_not_beyond_stop';
+                        }
+                    }
                 }
             }
         }

--- a/trading-app/tests/TradingCore/Execution/ClientOrderIdFactoryTest.php
+++ b/trading-app/tests/TradingCore/Execution/ClientOrderIdFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution;
+
+use App\TradingCore\Execution\Service\ClientOrderIdFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ClientOrderIdFactory::class)]
+final class ClientOrderIdFactoryTest extends TestCase
+{
+    public function testBuildsDeterministicClientOrderIdFromIdempotencyKey(): void
+    {
+        $factory = new ClientOrderIdFactory();
+
+        $first = $factory->fromIdempotencyKey('decision:BTCUSDT:long:2025-12-10T10:00:00Z');
+        $second = $factory->fromIdempotencyKey('decision:BTCUSDT:long:2025-12-10T10:00:00Z');
+
+        self::assertSame($first, $second);
+        self::assertStringStartsWith('CID', $first);
+        self::assertMatchesRegularExpression('/^[A-Z0-9]{32}$/', $first);
+    }
+
+    public function testRejectsBlankIdempotencyKey(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Idempotency key is required to build a client order id.');
+
+        (new ClientOrderIdFactory())->fromIdempotencyKey('  ');
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/ExecutionRequestTest.php
+++ b/trading-app/tests/TradingCore/Execution/ExecutionRequestTest.php
@@ -8,6 +8,10 @@ use App\TradingCore\Execution\Enum\ExecutionMode;
 use App\TradingCore\OrderPlan\Dto\OrderPlan;
 use App\TradingCore\OrderPlan\Dto\OrderPlanValidationResult;
 use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -30,6 +34,64 @@ final class ExecutionRequestTest extends TestCase
         self::assertFalse($request->orderPlan->validation->isExecutable);
     }
 
+    public function testLiveExecutionRejectsPlanWithForgedExecutableValidation(): void
+    {
+        $forgedPlan = new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 1.0,
+            leverage: 5,
+            clientOrderId: 'CID123',
+            idempotencyKey: 'decision:BTCUSDT:long',
+            validation: new OrderPlanValidationResult(
+                status: OrderPlanStatus::Valid,
+                isExecutable: true,
+            ),
+        );
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Live execution requires an executable order plan.');
+
+        ExecutionRequest::forPlan($forgedPlan, ExecutionMode::Live);
+    }
+
+    public function testLiveExecutionRequestUsesFreshValidationResult(): void
+    {
+        $stalePlan = new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 1.0,
+            leverage: 5,
+            protectionPlan: $this->protectionPlan(),
+            clientOrderId: 'CID123',
+            idempotencyKey: 'decision:BTCUSDT:long',
+            validation: new OrderPlanValidationResult(
+                status: OrderPlanStatus::Invalid,
+                isExecutable: false,
+                invalidReasons: ['stale_validation'],
+            ),
+        );
+
+        $request = ExecutionRequest::forPlan($stalePlan, ExecutionMode::Live);
+
+        self::assertTrue($request->orderPlan->validation->isExecutable);
+        self::assertSame([], $request->orderPlan->validation->invalidReasons);
+    }
+
     private function invalidPlan(): OrderPlan
     {
         return new OrderPlan(
@@ -49,6 +111,28 @@ final class ExecutionRequestTest extends TestCase
                 isExecutable: false,
                 invalidReasons: ['protection_plan_missing'],
             ),
+        );
+    }
+
+    private function protectionPlan(): ProtectionPlan
+    {
+        return new ProtectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+            takeProfit: null,
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: true,
+                liquidationPrice: 80.0,
+                liquidationDistancePct: 0.20,
+                stopToLiquidationRatio: 0.1,
+            ),
+            isValid: true,
+            status: ProtectionPlanStatus::Valid,
         );
     }
 }

--- a/trading-app/tests/TradingCore/Execution/ExecutionRequestTest.php
+++ b/trading-app/tests/TradingCore/Execution/ExecutionRequestTest.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Dto\OrderPlanValidationResult;
+use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExecutionRequest::class)]
+final class ExecutionRequestTest extends TestCase
+{
+    public function testLiveExecutionRequestRequiresExecutableOrderPlan(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Live execution requires an executable order plan.');
+
+        ExecutionRequest::forPlan($this->invalidPlan(), ExecutionMode::Live);
+    }
+
+    public function testDryRunExecutionRequestCanCarryInvalidPlanForInspection(): void
+    {
+        $request = ExecutionRequest::forPlan($this->invalidPlan(), ExecutionMode::DryRun);
+
+        self::assertSame(ExecutionMode::DryRun, $request->mode);
+        self::assertFalse($request->orderPlan->validation->isExecutable);
+    }
+
+    private function invalidPlan(): OrderPlan
+    {
+        return new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 1.0,
+            leverage: 5,
+            validation: new OrderPlanValidationResult(
+                status: OrderPlanStatus::Invalid,
+                isExecutable: false,
+                invalidReasons: ['protection_plan_missing'],
+            ),
+        );
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/ExecutionResultTest.php
+++ b/trading-app/tests/TradingCore/Execution/ExecutionResultTest.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution;
+
+use App\TradingCore\Execution\Dto\ExecutionResult;
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExecutionResult::class)]
+final class ExecutionResultTest extends TestCase
+{
+    public function testUsesExecutionStatusEnum(): void
+    {
+        $result = new ExecutionResult(
+            status: ExecutionStatus::DryRun,
+            clientOrderId: 'CID123',
+        );
+
+        self::assertSame(ExecutionStatus::DryRun, $result->status);
+        self::assertSame('CID123', $result->clientOrderId);
+    }
+}

--- a/trading-app/tests/TradingCore/OrderPlan/LegacyOrderPlanMapperTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/LegacyOrderPlanMapperTest.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\OrderPlan;
+
+use App\Provider\Context\ExchangeContext;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\TradeEntry\OrderPlan\OrderPlanModel as LegacyOrderPlanModel;
+use App\TradeEntry\Types\Side;
+use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+use App\TradingCore\OrderPlan\Mapper\LegacyOrderPlanMapper;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LegacyOrderPlanMapper::class)]
+final class LegacyOrderPlanMapperTest extends TestCase
+{
+    public function testMapsLegacyOrderPlanWithoutChangingExecutionValues(): void
+    {
+        $legacy = new LegacyOrderPlanModel(
+            symbol: 'BTCUSDT',
+            side: Side::Long,
+            orderType: 'limit',
+            openType: 'isolated',
+            orderMode: 4,
+            entry: 100.25,
+            stop: 98.0,
+            takeProfit: 104.0,
+            size: 17,
+            leverage: 6,
+            pricePrecision: 2,
+            contractSize: 0.001,
+            exchangeContext: new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+        );
+
+        $plan = (new LegacyOrderPlanMapper())->fromLegacy(
+            legacy: $legacy,
+            profile: 'scalper_micro',
+            decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764160440:long:scalper_micro:v1',
+            protectionPlan: $this->protectionPlan(),
+        );
+
+        self::assertSame('BTCUSDT', $plan->symbol);
+        self::assertSame('scalper_micro', $plan->profile);
+        self::assertSame('bitmart', $plan->exchange);
+        self::assertSame('perpetual', $plan->marketType);
+        self::assertSame('long', $plan->side);
+        self::assertSame('limit', $plan->orderType);
+        self::assertSame('post_only', $plan->timeInForce);
+        self::assertSame(100.25, $plan->entryPrice);
+        self::assertSame(17.0, $plan->quantity);
+        self::assertSame(6, $plan->leverage);
+        self::assertSame(2, $plan->pricePrecision);
+        self::assertSame(0.001, $plan->contractSize);
+        self::assertSame('bitmart:perpetual:BTCUSDT:1m:1764160440:long:scalper_micro:v1', $plan->decisionKey);
+        self::assertSame('bitmart:perpetual:BTCUSDT:1m:1764160440:long:scalper_micro:v1', $plan->idempotencyKey);
+        self::assertSame('CIDB6B3948EB6D29D505D7CCCA3FB9A9', $plan->clientOrderId);
+        self::assertSame(OrderPlanStatus::Valid, $plan->validation->status);
+        self::assertTrue($plan->validation->isExecutable);
+    }
+
+    public function testDoesNotInventProtectionWhenLegacyPlanHasOnlyScalarStops(): void
+    {
+        $legacy = new LegacyOrderPlanModel(
+            symbol: 'ETHUSDT',
+            side: Side::Short,
+            orderType: 'market',
+            openType: 'isolated',
+            orderMode: 1,
+            entry: 2000.0,
+            stop: 2040.0,
+            takeProfit: 1940.0,
+            size: 3,
+            leverage: 4,
+            pricePrecision: 2,
+            contractSize: 0.01,
+        );
+
+        $plan = (new LegacyOrderPlanMapper())->fromLegacy(
+            legacy: $legacy,
+            profile: 'regular',
+            decisionKey: null,
+            protectionPlan: null,
+        );
+
+        self::assertNull($plan->protectionPlan);
+        self::assertSame(OrderPlanStatus::Invalid, $plan->validation->status);
+        self::assertContains('protection_plan_missing', $plan->validation->invalidReasons);
+        self::assertContains('client_order_id_missing', $plan->validation->invalidReasons);
+        self::assertContains('idempotency_key_missing', $plan->validation->invalidReasons);
+        self::assertSame(2040.0, $plan->metadata['legacy_stop']);
+        self::assertSame(1940.0, $plan->metadata['legacy_take_profit']);
+    }
+
+    private function protectionPlan(): ProtectionPlan
+    {
+        return new ProtectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'legacy_mapped',
+                isFullSize: true,
+            ),
+            takeProfit: null,
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: true,
+                liquidationPrice: 80.0,
+                liquidationDistancePct: 0.20,
+                stopToLiquidationRatio: 0.1,
+            ),
+            isValid: true,
+            status: ProtectionPlanStatus::Valid,
+        );
+    }
+}

--- a/trading-app/tests/TradingCore/OrderPlan/LegacyOrderPlanMapperTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/LegacyOrderPlanMapperTest.php
@@ -89,6 +89,7 @@ final class LegacyOrderPlanMapperTest extends TestCase
         );
 
         self::assertNull($plan->protectionPlan);
+        self::assertSame('short', $plan->side);
         self::assertSame(OrderPlanStatus::Invalid, $plan->validation->status);
         self::assertContains('protection_plan_missing', $plan->validation->invalidReasons);
         self::assertContains('client_order_id_missing', $plan->validation->invalidReasons);

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -117,6 +117,17 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('time_in_force_invalid', $result->invalidReasons);
     }
 
+    public function testRejectsPostOnlyMarketOrder(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            orderType: 'market',
+            timeInForce: 'post_only',
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('post_only_requires_limit_order', $result->invalidReasons);
+    }
+
     public function testRejectsNonFiniteExecutionFields(): void
     {
         $result = (new OrderPlanValidator())->validate($this->plan(
@@ -410,6 +421,7 @@ final class OrderPlanValidatorTest extends TestCase
         string $marketType = 'perpetual',
         string $instrument = 'BTCUSDT',
         string $side = 'long',
+        string $orderType = 'limit',
         string $marginMode = 'isolated',
         string $timeInForce = 'gtc',
         ?ProtectionPlan $protectionPlan = null,
@@ -426,7 +438,7 @@ final class OrderPlanValidatorTest extends TestCase
             exchange: $exchange,
             marketType: $marketType,
             side: $side,
-            orderType: 'limit',
+            orderType: $orderType,
             marginMode: $marginMode,
             timeInForce: $timeInForce,
             entryPrice: $entryPrice,

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -143,6 +143,45 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('stop_distance_not_positive', $result->invalidReasons);
     }
 
+    public function testRejectsLongStopLossAtOrAboveEntry(): void
+    {
+        $protection = $this->protectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 100.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+        );
+
+        $result = (new OrderPlanValidator())->validate($this->plan(protectionPlan: $protection));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('stop_loss_side_invalid', $result->invalidReasons);
+    }
+
+    public function testRejectsShortStopLossAtOrBelowEntry(): void
+    {
+        $protection = $this->protectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 100.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+        );
+
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            side: 'short',
+            protectionPlan: $protection,
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('stop_loss_side_invalid', $result->invalidReasons);
+    }
+
     public function testRejectsPerpetualPlanWithoutLiquidationGuard(): void
     {
         $result = (new OrderPlanValidator())->validate($this->plan(
@@ -236,6 +275,7 @@ final class OrderPlanValidatorTest extends TestCase
         string $exchange = 'bitmart',
         string $marketType = 'perpetual',
         string $instrument = 'BTCUSDT',
+        string $side = 'long',
         string $marginMode = 'isolated',
         string $timeInForce = 'gtc',
         ?ProtectionPlan $protectionPlan = null,
@@ -251,7 +291,7 @@ final class OrderPlanValidatorTest extends TestCase
             profile: $profile,
             exchange: $exchange,
             marketType: $marketType,
-            side: 'long',
+            side: $side,
             orderType: 'limit',
             marginMode: $marginMode,
             timeInForce: $timeInForce,

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -97,6 +97,14 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('instrument_missing', $result->invalidReasons);
     }
 
+    public function testRejectsUnsupportedMarketType(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(marketType: 'futures'));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('market_type_invalid', $result->invalidReasons);
+    }
+
     public function testRejectsInvalidMarginModeAndTimeInForce(): void
     {
         $result = (new OrderPlanValidator())->validate($this->plan(

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -218,6 +218,82 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('liquidation_guard_unsafe', $result->invalidReasons);
     }
 
+    public function testRejectsPerpetualPlanWithMissingLiquidationMetrics(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            protectionPlan: $this->protectionPlan(
+                liquidationCheck: new LiquidationCheckResult(
+                    isSafe: true,
+                    liquidationPrice: null,
+                    liquidationDistancePct: null,
+                    stopToLiquidationRatio: null,
+                ),
+            ),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_guard_data_invalid', $result->invalidReasons);
+    }
+
+    public function testRejectsPerpetualPlanWithNonFiniteLiquidationMetrics(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            protectionPlan: $this->protectionPlan(
+                liquidationCheck: new LiquidationCheckResult(
+                    isSafe: true,
+                    liquidationPrice: INF,
+                    liquidationDistancePct: NAN,
+                    stopToLiquidationRatio: -INF,
+                ),
+            ),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_guard_data_invalid', $result->invalidReasons);
+    }
+
+    public function testRejectsLongLiquidationPriceAtOrAboveStop(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            protectionPlan: $this->protectionPlan(
+                liquidationCheck: new LiquidationCheckResult(
+                    isSafe: true,
+                    liquidationPrice: 98.0,
+                    liquidationDistancePct: 0.02,
+                    stopToLiquidationRatio: 1.0,
+                ),
+            ),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_price_not_beyond_stop', $result->invalidReasons);
+    }
+
+    public function testRejectsShortLiquidationPriceAtOrBelowStop(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            side: 'short',
+            protectionPlan: $this->protectionPlan(
+                stopLoss: new StopLossResult(
+                    stopPrice: 102.0,
+                    stopPct: 0.02,
+                    stopDistance: 2.0,
+                    stopSource: 'pivot',
+                    isFullSize: true,
+                ),
+                liquidationCheck: new LiquidationCheckResult(
+                    isSafe: true,
+                    liquidationPrice: 102.0,
+                    liquidationDistancePct: 0.02,
+                    stopToLiquidationRatio: 1.0,
+                ),
+            ),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_price_not_beyond_stop', $result->invalidReasons);
+    }
+
     public function testWithValidationPreservesAllFields(): void
     {
         $plan = new OrderPlan(

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -79,6 +79,52 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('leverage_not_positive', $result->invalidReasons);
     }
 
+    public function testRejectsNonFiniteExecutionFields(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            entryPrice: INF,
+            quantity: NAN,
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('entry_price_not_positive', $result->invalidReasons);
+        self::assertContains('quantity_not_positive', $result->invalidReasons);
+    }
+
+    public function testWithValidationPreservesAllFields(): void
+    {
+        $plan = new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: $this->protectionPlan(),
+            clientOrderId: 'CID123',
+            idempotencyKey: 'key:BTCUSDT',
+            metadata: ['foo' => 'bar'],
+        );
+
+        $validation = new \App\TradingCore\OrderPlan\Dto\OrderPlanValidationResult(
+            status: OrderPlanStatus::Valid,
+            isExecutable: true,
+        );
+        $updated = $plan->withValidation($validation);
+
+        self::assertSame($plan->symbol, $updated->symbol);
+        self::assertSame($plan->entryPrice, $updated->entryPrice);
+        self::assertSame($plan->quantity, $updated->quantity);
+        self::assertSame($plan->metadata, $updated->metadata);
+        self::assertSame($plan->clientOrderId, $updated->clientOrderId);
+        self::assertSame(OrderPlanStatus::Valid, $updated->validation->status);
+    }
+
     public function testRejectsPlanWithoutClientOrderId(): void
     {
         $result = (new OrderPlanValidator())->validate($this->plan(clientOrderId: ''));

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -319,6 +319,31 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('liquidation_distance_below_min_ratio', $result->invalidReasons);
     }
 
+    public function testRejectsForgedLiquidationRatioBelowRecomputedMinimum(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            protectionPlan: $this->protectionPlan(
+                stopLoss: new StopLossResult(
+                    stopPrice: 95.0,
+                    stopPct: 0.05,
+                    stopDistance: 5.0,
+                    stopSource: 'pivot',
+                    isFullSize: true,
+                ),
+                liquidationCheck: new LiquidationCheckResult(
+                    isSafe: true,
+                    liquidationPrice: 94.9,
+                    liquidationDistancePct: 0.051,
+                    stopToLiquidationRatio: 3.0,
+                    metadata: ['min_distance_ratio' => 3.0],
+                ),
+            ),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_distance_below_min_ratio', $result->invalidReasons);
+    }
+
     public function testWithValidationPreservesAllFields(): void
     {
         $plan = new OrderPlan(

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -294,6 +294,31 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('liquidation_price_not_beyond_stop', $result->invalidReasons);
     }
 
+    public function testRejectsLiquidationRatioBelowRecordedMinimum(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            protectionPlan: $this->protectionPlan(
+                stopLoss: new StopLossResult(
+                    stopPrice: 95.0,
+                    stopPct: 0.05,
+                    stopDistance: 5.0,
+                    stopSource: 'pivot',
+                    isFullSize: true,
+                ),
+                liquidationCheck: new LiquidationCheckResult(
+                    isSafe: true,
+                    liquidationPrice: 90.0,
+                    liquidationDistancePct: 0.10,
+                    stopToLiquidationRatio: 2.0,
+                    metadata: ['min_distance_ratio' => 3.0],
+                ),
+            ),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_distance_below_min_ratio', $result->invalidReasons);
+    }
+
     public function testWithValidationPreservesAllFields(): void
     {
         $plan = new OrderPlan(

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -79,16 +79,96 @@ final class OrderPlanValidatorTest extends TestCase
         self::assertContains('leverage_not_positive', $result->invalidReasons);
     }
 
+    public function testRejectsMissingRoutingFields(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            symbol: '',
+            profile: '',
+            exchange: '',
+            marketType: '',
+            instrument: '',
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('symbol_missing', $result->invalidReasons);
+        self::assertContains('profile_missing', $result->invalidReasons);
+        self::assertContains('exchange_missing', $result->invalidReasons);
+        self::assertContains('market_type_missing', $result->invalidReasons);
+        self::assertContains('instrument_missing', $result->invalidReasons);
+    }
+
+    public function testRejectsInvalidMarginModeAndTimeInForce(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            marginMode: 'portfolio',
+            timeInForce: 'maker_only',
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('margin_mode_invalid', $result->invalidReasons);
+        self::assertContains('time_in_force_invalid', $result->invalidReasons);
+    }
+
     public function testRejectsNonFiniteExecutionFields(): void
     {
         $result = (new OrderPlanValidator())->validate($this->plan(
             entryPrice: INF,
             quantity: NAN,
+            contractSize: -INF,
         ));
 
         self::assertSame(OrderPlanStatus::Invalid, $result->status);
         self::assertContains('entry_price_not_positive', $result->invalidReasons);
         self::assertContains('quantity_not_positive', $result->invalidReasons);
+        self::assertContains('contract_size_not_positive', $result->invalidReasons);
+    }
+
+    public function testRejectsNonFiniteStopLossFields(): void
+    {
+        $protection = $this->protectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: INF,
+                stopPct: NAN,
+                stopDistance: -INF,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+        );
+
+        $result = (new OrderPlanValidator())->validate($this->plan(protectionPlan: $protection));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('stop_price_not_positive', $result->invalidReasons);
+        self::assertContains('stop_pct_not_positive', $result->invalidReasons);
+        self::assertContains('stop_distance_not_positive', $result->invalidReasons);
+    }
+
+    public function testRejectsPerpetualPlanWithoutLiquidationGuard(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            protectionPlan: $this->protectionPlan(liquidationCheck: null),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_guard_missing', $result->invalidReasons);
+    }
+
+    public function testRejectsPerpetualPlanWithUnsafeLiquidationGuard(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            protectionPlan: $this->protectionPlan(
+                liquidationCheck: new LiquidationCheckResult(
+                    isSafe: false,
+                    liquidationPrice: 99.0,
+                    liquidationDistancePct: 0.01,
+                    stopToLiquidationRatio: 0.5,
+                    reasonIfUnsafe: 'stop_too_close_to_liquidation',
+                ),
+            ),
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('liquidation_guard_unsafe', $result->invalidReasons);
     }
 
     public function testWithValidationPreservesAllFields(): void
@@ -151,28 +231,38 @@ final class OrderPlanValidatorTest extends TestCase
     }
 
     private function plan(
+        string $symbol = 'BTCUSDT',
+        string $profile = 'scalper_micro',
+        string $exchange = 'bitmart',
+        string $marketType = 'perpetual',
+        string $instrument = 'BTCUSDT',
+        string $marginMode = 'isolated',
+        string $timeInForce = 'gtc',
         ?ProtectionPlan $protectionPlan = null,
         float $entryPrice = 100.0,
         float $quantity = 12.0,
         int $leverage = 5,
+        ?float $contractSize = null,
         ?string $clientOrderId = 'CID123',
         ?string $idempotencyKey = 'decision:BTCUSDT:long',
     ): OrderPlan {
         return new OrderPlan(
-            symbol: 'BTCUSDT',
-            profile: 'scalper_micro',
-            exchange: 'bitmart',
-            marketType: 'perpetual',
+            symbol: $symbol,
+            profile: $profile,
+            exchange: $exchange,
+            marketType: $marketType,
             side: 'long',
             orderType: 'limit',
-            marginMode: 'isolated',
-            timeInForce: 'gtc',
+            marginMode: $marginMode,
+            timeInForce: $timeInForce,
             entryPrice: $entryPrice,
             quantity: $quantity,
             leverage: $leverage,
             protectionPlan: $protectionPlan ?? $this->protectionPlan(),
             clientOrderId: $clientOrderId,
             idempotencyKey: $idempotencyKey,
+            contractSize: $contractSize,
+            instrument: $instrument,
         );
     }
 
@@ -196,6 +286,12 @@ final class OrderPlanValidatorTest extends TestCase
 
     private function protectionPlan(
         ?StopLossResult $stopLoss = null,
+        ?LiquidationCheckResult $liquidationCheck = new LiquidationCheckResult(
+            isSafe: true,
+            liquidationPrice: 80.0,
+            liquidationDistancePct: 0.20,
+            stopToLiquidationRatio: 0.1,
+        ),
         bool $isValid = true,
     ): ProtectionPlan {
         return new ProtectionPlan(
@@ -213,12 +309,7 @@ final class OrderPlanValidatorTest extends TestCase
                 expectedNetR: 1.4,
                 tpPolicyApplied: 'r_multiple',
             ),
-            liquidationCheck: new LiquidationCheckResult(
-                isSafe: true,
-                liquidationPrice: 80.0,
-                liquidationDistancePct: 0.20,
-                stopToLiquidationRatio: 0.1,
-            ),
+            liquidationCheck: $liquidationCheck,
             isValid: $isValid,
             status: $isValid ? ProtectionPlanStatus::Valid : ProtectionPlanStatus::Invalid,
             invalidReasons: $isValid ? [] : ['liquidation_guard_unsafe'],

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanValidatorTest.php
@@ -1,0 +1,181 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\OrderPlan;
+
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OrderPlan::class)]
+#[CoversClass(OrderPlanValidator::class)]
+final class OrderPlanValidatorTest extends TestCase
+{
+    public function testRejectsPlanWithoutProtectionPlan(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->planWithoutProtection());
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertFalse($result->isExecutable);
+        self::assertContains('protection_plan_missing', $result->invalidReasons);
+    }
+
+    public function testRejectsPlanWhenStopLossDoesNotCoverFullSize(): void
+    {
+        $protection = $this->protectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: false,
+            ),
+            isValid: true,
+        );
+
+        $result = (new OrderPlanValidator())->validate($this->plan(protectionPlan: $protection));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('stop_loss_not_full_size', $result->invalidReasons);
+    }
+
+    public function testRejectsPlanWhenStopPctIsNotPositive(): void
+    {
+        $protection = $this->protectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 100.0,
+                stopPct: 0.0,
+                stopDistance: 0.0,
+                stopSource: 'risk',
+                isFullSize: true,
+            ),
+            isValid: true,
+        );
+
+        $result = (new OrderPlanValidator())->validate($this->plan(protectionPlan: $protection));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('stop_pct_not_positive', $result->invalidReasons);
+    }
+
+    public function testRejectsNonPositiveExecutionFields(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(
+            entryPrice: 0.0,
+            quantity: 0.0,
+            leverage: 0,
+        ));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('entry_price_not_positive', $result->invalidReasons);
+        self::assertContains('quantity_not_positive', $result->invalidReasons);
+        self::assertContains('leverage_not_positive', $result->invalidReasons);
+    }
+
+    public function testRejectsPlanWithoutClientOrderId(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(clientOrderId: ''));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('client_order_id_missing', $result->invalidReasons);
+    }
+
+    public function testRejectsPlanWithoutIdempotencyKey(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan(idempotencyKey: ''));
+
+        self::assertSame(OrderPlanStatus::Invalid, $result->status);
+        self::assertContains('idempotency_key_missing', $result->invalidReasons);
+    }
+
+    public function testValidPlanRequiresFullSizeStopPositiveQuantityAndSafeProtection(): void
+    {
+        $result = (new OrderPlanValidator())->validate($this->plan());
+
+        self::assertSame(OrderPlanStatus::Valid, $result->status);
+        self::assertTrue($result->isExecutable);
+        self::assertSame([], $result->invalidReasons);
+    }
+
+    private function plan(
+        ?ProtectionPlan $protectionPlan = null,
+        float $entryPrice = 100.0,
+        float $quantity = 12.0,
+        int $leverage = 5,
+        ?string $clientOrderId = 'CID123',
+        ?string $idempotencyKey = 'decision:BTCUSDT:long',
+    ): OrderPlan {
+        return new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: $entryPrice,
+            quantity: $quantity,
+            leverage: $leverage,
+            protectionPlan: $protectionPlan ?? $this->protectionPlan(),
+            clientOrderId: $clientOrderId,
+            idempotencyKey: $idempotencyKey,
+        );
+    }
+
+    private function planWithoutProtection(): OrderPlan
+    {
+        return new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: null,
+        );
+    }
+
+    private function protectionPlan(
+        ?StopLossResult $stopLoss = null,
+        bool $isValid = true,
+    ): ProtectionPlan {
+        return new ProtectionPlan(
+            stopLoss: $stopLoss ?? new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+            takeProfit: new TakeProfitResult(
+                tp1Price: 103.0,
+                tp2Price: null,
+                expectedR: 1.5,
+                expectedNetR: 1.4,
+                tpPolicyApplied: 'r_multiple',
+            ),
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: true,
+                liquidationPrice: 80.0,
+                liquidationDistancePct: 0.20,
+                stopToLiquidationRatio: 0.1,
+            ),
+            isValid: $isValid,
+            status: $isValid ? ProtectionPlanStatus::Valid : ProtectionPlanStatus::Invalid,
+            invalidReasons: $isValid ? [] : ['liquidation_guard_unsafe'],
+        );
+    }
+}


### PR DESCRIPTION
## Objectif

Introduire/formaliser le module OrderPlan / ExecutionPort du TradingCore.

Cette PR rend explicite le contrat entre la décision trading protégée et l'exécution exchange, sans changer le comportement runtime ni activer d'exchange live.

## Scope

- Ajout de DTOs / services `TradingCore\Execution`.
- Ajout de `OrderPlan`.
- Ajout de `ExecutionPort`.
- Ajout de `OrderPlanValidator`.
- Ajout de `ClientOrderIdFactory`.
- Tests unitaires sur validation OrderPlan / idempotence / dry-run.
- Documentation du module OrderPlan / ExecutionPort.

## Hors-scope

- Aucun changement `mtf:run`.
- Aucun changement `POST /api/mtf/run`.
- Aucun changement Temporal.
- Aucun changement schedules.
- Aucun changement règles MTF.
- Aucun changement READY / REJECTED.
- Aucun changement EntryZone.
- Aucun changement Risk/Leverage.
- Aucun changement SL/TP.
- Aucun branchement `EffectiveTradingConfigResolver`.
- Aucun live OKX/Hyperliquid.
- Aucune suppression Bitmart.
- Aucun changement YAML stratégie.
- Aucun branchement runtime risqué dans TradeEntry.

## Tests

- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/TradingCore/OrderPlan tests/TradingCore/Execution tests/TradingCore/SlTp tests/TradingCore/Risk tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision tests/Application/Runner`
- `vendor/bin/phpstan analyse src/TradingCore/OrderPlan src/TradingCore/Execution src/TradingCore/SlTp src/TradingCore/Risk src/TradingCore/Entry src/TradingCore/Mtf src/TradingCore/Decision tests/TradingCore/OrderPlan tests/TradingCore/Execution tests/TradingCore/SlTp tests/TradingCore/Risk tests/TradingCore/Entry tests/TradingCore/Mtf tests/TradingCore/Decision --memory-limit=512M`
- `DEFAULT_URI=http://localhost:8082 php bin/console lint:yaml config`
- `DEFAULT_URI=http://localhost:8082 php bin/console lint:container`
- `DEFAULT_URI=http://localhost:8082 php bin/console list mtf --raw | grep -E '^mtf:run\s'`
- `DEFAULT_URI=http://localhost:8082 php bin/console debug:router --show-controllers | grep -E '/api/mtf/run|mtf_run'`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Risques

Le risque principal est d'introduire un contrat d'exécution trop proche d'un exchange concret. Cette PR reste centrée TradingCore et prépare PR10 Fake/Paper gateway.

## Critères d'acceptation

- OrderPlan ajouté.
- ExecutionPort ajouté.
- OrderPlan invalide sans ProtectionPlan.
- OrderPlan invalide avec ProtectionPlan invalide.
- Idempotency key obligatoire.
- Client order id obligatoire.
- Dry-run/live explicite.
- Aucun changement runtime.
- Aucun live OKX/Hyperliquid.
