### PR TITLE
[codex] PR 10 — Fake/Paper gateway + OrderPlanBuilder

### DIFF
--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -1,0 +1,91 @@
+# Fake / Paper gateway
+
+## Objectif
+
+PR10 ajoute deux pièces préparatoires au-dessus du module `OrderPlan / ExecutionPort`
+livré en PR09 :
+
+1. `App\TradingCore\OrderPlan\Service\OrderPlanBuilder` — l'assembleur minimal qui
+   construit un `OrderPlan` à partir des DTOs TradingCore.
+2. `App\TradingCore\Execution\Fake\FakeExecutionPort` — la première implémentation de
+   `ExecutionPortInterface`, une gateway **Fake / Paper** qui simule une exécution
+   **sans aucun ordre réel ni side effect**.
+
+PR10 ne branche rien dans le runtime : ni `mtf:run`, ni `POST /api/mtf/run`, ni Temporal,
+ni `TradeEntry`, ni les YAML stratégie.
+
+## OrderPlanBuilder
+
+`OrderPlanBuilder::build(OrderPlanBuildRequest): OrderPlan` complète PR09 : la PR09 avait
+livré le DTO `OrderPlanBuildRequest` sans consommateur. Le builder :
+
+- assemble `TradeCandidate + EntryZone + RiskCalculationResult + LeverageCalculationResult + ProtectionPlan` ;
+- dérive `entry_price = entryZone.center`, `quantity = risk.quantity`, `leverage = leverage.finalLeverage`,
+  `side = candidate.direction`, exchange/market_type depuis le candidate ;
+- dérive `client_order_id` depuis l'`idempotency_key` via `ClientOrderIdFactory` (même contrat que `LegacyOrderPlanMapper`) ;
+- **réutilise `OrderPlanValidator`** : le plan est retourné avec sa validation fraîche ;
+- ne lève pas d'exception sur input manquant : il produit un `OrderPlan` invalide
+  (entry/quantity/leverage dérivés à 0, protection absente) pour permettre l'inspection,
+  et expose `metadata.build_missing_inputs` pour l'audit.
+
+Le builder est **pur** : aucune dépendance Symfony, Doctrine, Messenger, provider concret
+ou HTTP. Il ne passe aucun ordre.
+
+## FakeExecutionPort
+
+`FakeExecutionPort implements ExecutionPortInterface` est la gateway de test canonique.
+Elle respecte strictement l'interface existante : `execute(ExecutionRequest): ExecutionResult`.
+
+Comportement :
+
+| Cas | Résultat |
+| --- | --- |
+| `ExecutionMode::Live` | `ExecutionStatus::Rejected` (`live_not_supported_by_fake_gateway`), aucun side effect. |
+| `DryRun` + plan non exécutable (revalidé) | `ExecutionStatus::Rejected` + `invalid_reasons`. |
+| `DryRun` + plan exécutable | `ExecutionStatus::DryRun` (succès simulé), `exchange_order_id = FAKE-{client_order_id}`. |
+
+Propriétés :
+
+- aucun appel HTTP, aucun provider réel, aucun side effect exchange ;
+- `client_order_id` et `idempotency_key` conservés (dans le résultat et sa metadata) ;
+- mode (`dry_run`) conservé dans la metadata ;
+- fake order id **déterministe** : même plan ⇒ même `exchange_order_id` ;
+- gateway **sans état** : deux appels identiques donnent un résultat identique ;
+- au boundary, la validation portée par le DTO n'est pas crue : `FakeExecutionPort` revalide
+  via `OrderPlanValidator` avant de simuler.
+
+Elle est distincte du fake exchange legacy `App\Exchange\Fake\*` (simulation au niveau
+adapter / websocket du provider) : la gateway PR10 vit dans le Core et reste pure.
+
+## Pourquoi Fake / Paper avant OKX / Hyperliquid
+
+La gateway Fake / Paper permet d'exercer toute la chaîne
+`TradeCandidate → … → OrderPlan → ExecutionPort` sans risque, avant d'écrire le moindre
+adapter live. Elle sert de référence pour :
+
+- vérifier l'idempotence sans side effects réels ;
+- comparer les payloads legacy `TradeEntry` et TradingCore avant tout branchement ;
+- fournir une base déterministe au backtesting / paper-trading futur.
+
+Les gateways OKX et Hyperliquid restent en dry-run / runtime-check (PR11 / PR12). Bitmart
+reste legacy.
+
+## Hors-scope PR10
+
+- aucune **gate readiness live** OKX / Hyperliquid — reportée à PR11 / PR12 ;
+- aucun branchement runtime (`mtf:run`, `/api/mtf/run`, Temporal, `TradeEntry`, `EffectiveTradingConfigResolver`) ;
+- aucun changement EntryZone / Risk / Leverage / SL-TP / YAML ;
+- aucune suppression Bitmart, aucun ordre live.
+
+## Limites restantes
+
+- `OrderPlanBuildRequest` porte un `EntryZone`, pas un `EntryZoneDecision` : le statut
+  « zone acceptée » n'est pas re-vérifié au build (le builder suppose la décision déjà prise en amont).
+- `entry_price = entryZone.center` simplifie le pricing legacy (carnet, hint, quantization) ;
+  acceptable hors live, à rapprocher du legacy avant tout branchement.
+- Aucune persistance ni audit réel : la gateway est en mémoire.
+
+## Suite
+
+PR11 : OKX dry-run + gate readiness live. PR12 : Hyperliquid dry-run. Le `FakeExecutionPort`
+servira de référence de comparaison pour ces adapters.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - Risk / Leverage module: technical/risk-and-leverage-module.md
       - SLTP / LiquidationGuard module: technical/sltp-liquidation-guard-module.md
       - OrderPlan / ExecutionPort module: technical/order-plan-execution-port-module.md
+      - Fake / Paper gateway: technical/fake-paper-gateway.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
+++ b/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Fake;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Dto\ExecutionResult;
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+use App\TradingCore\Execution\Port\ExecutionPortInterface;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+
+/**
+ * In-memory Fake / Paper gateway: the canonical, test-only implementation of
+ * {@see ExecutionPortInterface}. It simulates an execution with no side effect:
+ * no HTTP, no provider, no Symfony / Doctrine / Messenger. It never places a real
+ * order and refuses live mode entirely.
+ *
+ * It is distinct from the legacy provider-level fake exchange (App\Exchange\Fake\*)
+ * which simulates an exchange at the adapter / websocket level.
+ *
+ * The gateway is a pure function of its input: the same plan always yields the
+ * same fake exchange order id, and the input ExecutionRequest is never mutated.
+ */
+final class FakeExecutionPort implements ExecutionPortInterface
+{
+    public function __construct(
+        private readonly OrderPlanValidator $validator = new OrderPlanValidator(),
+    ) {
+    }
+
+    public function execute(ExecutionRequest $request): ExecutionResult
+    {
+        $plan = $request->orderPlan;
+
+        $metadata = [
+            'gateway' => 'fake_paper',
+            'mode' => $request->mode->value,
+            'requested_at' => $request->requestedAt->format(\DateTimeInterface::ATOM),
+            'client_order_id' => $plan->clientOrderId,
+            'idempotency_key' => $plan->idempotencyKey,
+            'simulated' => true,
+        ];
+
+        // The fake gateway never executes live: it has no real venue to route to.
+        if ($request->mode === ExecutionMode::Live) {
+            return new ExecutionResult(
+                status: ExecutionStatus::Rejected,
+                clientOrderId: $plan->clientOrderId,
+                metadata: $metadata + ['reject_reason' => 'live_not_supported_by_fake_gateway'],
+            );
+        }
+
+        // Boundary does not trust the validation carried by the DTO: revalidate.
+        $validation = $this->validator->validate($plan);
+        if (!$validation->isExecutable) {
+            return new ExecutionResult(
+                status: ExecutionStatus::Rejected,
+                clientOrderId: $plan->clientOrderId,
+                metadata: $metadata + [
+                    'reject_reason' => 'order_plan_not_executable',
+                    'invalid_reasons' => $validation->invalidReasons,
+                ],
+            );
+        }
+
+        return new ExecutionResult(
+            status: ExecutionStatus::DryRun,
+            clientOrderId: $plan->clientOrderId,
+            exchangeOrderId: $this->fakeOrderId($plan->clientOrderId),
+            metadata: $metadata + ['dry_run' => true],
+        );
+    }
+
+    private function fakeOrderId(?string $clientOrderId): string
+    {
+        $seed = $clientOrderId !== null && trim($clientOrderId) !== '' ? $clientOrderId : 'UNKNOWN';
+
+        return 'FAKE-' . $seed;
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
+++ b/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
@@ -33,14 +33,20 @@ final class FakeExecutionPort implements ExecutionPortInterface
     {
         $plan = $request->orderPlan;
 
-        $metadata = [
-            'gateway' => 'fake_paper',
-            'mode' => $request->mode->value,
-            'requested_at' => $request->requestedAt->format(\DateTimeInterface::ATOM),
-            'client_order_id' => $plan->clientOrderId,
-            'idempotency_key' => $plan->idempotencyKey,
-            'simulated' => true,
-        ];
+        // Preserve incoming audit metadata (run_id, decision_key, correlation_id,
+        // schedule_id, profile, ...) while keeping the gateway's own fields authoritative:
+        // a caller must not be able to spoof gateway/simulated/client_order_id.
+        $metadata = array_merge(
+            $request->metadata,
+            [
+                'gateway' => 'fake_paper',
+                'mode' => $request->mode->value,
+                'requested_at' => $request->requestedAt->format(\DateTimeInterface::ATOM),
+                'client_order_id' => $plan->clientOrderId,
+                'idempotency_key' => $plan->idempotencyKey,
+                'simulated' => true,
+            ],
+        );
 
         // The fake gateway never executes live: it has no real venue to route to.
         if ($request->mode === ExecutionMode::Live) {

--- a/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
+++ b/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
@@ -53,7 +53,7 @@ final class FakeExecutionPort implements ExecutionPortInterface
             return new ExecutionResult(
                 status: ExecutionStatus::Rejected,
                 clientOrderId: $plan->clientOrderId,
-                metadata: $metadata + ['reject_reason' => 'live_not_supported_by_fake_gateway'],
+                metadata: array_merge($metadata, ['reject_reason' => 'live_not_supported_by_fake_gateway']),
             );
         }
 
@@ -63,10 +63,10 @@ final class FakeExecutionPort implements ExecutionPortInterface
             return new ExecutionResult(
                 status: ExecutionStatus::Rejected,
                 clientOrderId: $plan->clientOrderId,
-                metadata: $metadata + [
+                metadata: array_merge($metadata, [
                     'reject_reason' => 'order_plan_not_executable',
                     'invalid_reasons' => $validation->invalidReasons,
-                ],
+                ]),
             );
         }
 
@@ -74,7 +74,7 @@ final class FakeExecutionPort implements ExecutionPortInterface
             status: ExecutionStatus::DryRun,
             clientOrderId: $plan->clientOrderId,
             exchangeOrderId: $this->fakeOrderId($plan->clientOrderId),
-            metadata: $metadata + ['dry_run' => true],
+            metadata: array_merge($metadata, ['dry_run' => true]),
         );
     }
 

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanBuilder.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanBuilder.php
@@ -72,14 +72,16 @@ final readonly class OrderPlanBuilder
             entryZone: $request->entryZone,
             riskCalculation: $request->riskCalculation,
             leverageCalculation: $request->leverageCalculation,
-            metadata: $request->metadata + [
+            // Builder audit fields are authoritative: a caller must not be able to forge
+            // source/dry_run/build_missing_inputs while caller-only keys are still preserved.
+            metadata: array_merge($request->metadata, [
                 'source' => 'trading_core_order_plan_builder',
                 'candidate_direction' => $candidate->direction,
                 'execution_timeframe' => $candidate->executionTimeframe,
                 'signal_time' => $candidate->signalTime->format(\DateTimeInterface::ATOM),
                 'dry_run' => $candidate->dryRun,
                 'build_missing_inputs' => $missingInputs,
-            ],
+            ]),
             instrument: $candidate->instrument,
         );
 

--- a/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanBuilder.php
+++ b/trading-app/src/TradingCore/OrderPlan/Service/OrderPlanBuilder.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\OrderPlan\Service;
+
+use App\TradingCore\Execution\Service\ClientOrderIdFactory;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Dto\OrderPlanBuildRequest;
+
+/**
+ * Minimal, strictly preparatory builder: assembles the TradingCore DTOs
+ * (TradeCandidate + EntryZone + Risk + Leverage + ProtectionPlan) into an
+ * {@see OrderPlan} and validates it through {@see OrderPlanValidator}.
+ *
+ * It is pure: no Symfony, Doctrine, Messenger, concrete provider, HTTP, nor any
+ * side effect. It does not place orders and is not wired into the runtime.
+ *
+ * Missing inputs are not thrown on: the builder still produces an OrderPlan whose
+ * derived values (entry price, quantity, leverage, protection) make it invalid
+ * through the validator, so callers can inspect why the plan is not executable.
+ */
+final readonly class OrderPlanBuilder
+{
+    public function __construct(
+        private OrderPlanValidator $validator = new OrderPlanValidator(),
+        private ClientOrderIdFactory $clientOrderIdFactory = new ClientOrderIdFactory(),
+    ) {
+    }
+
+    public function build(OrderPlanBuildRequest $request): OrderPlan
+    {
+        $candidate = $request->candidate;
+
+        $idempotencyKey = $request->idempotencyKey !== null && trim($request->idempotencyKey) !== ''
+            ? $request->idempotencyKey
+            : null;
+
+        $clientOrderId = $request->clientOrderId !== null && trim($request->clientOrderId) !== ''
+            ? $request->clientOrderId
+            : ($idempotencyKey !== null ? $this->clientOrderIdFactory->fromIdempotencyKey($idempotencyKey) : null);
+
+        $missingInputs = [];
+        if ($request->entryZone === null) {
+            $missingInputs[] = 'entry_zone';
+        }
+        if ($request->riskCalculation === null) {
+            $missingInputs[] = 'risk_calculation';
+        }
+        if ($request->leverageCalculation === null) {
+            $missingInputs[] = 'leverage_calculation';
+        }
+        if ($request->protectionPlan === null) {
+            $missingInputs[] = 'protection_plan';
+        }
+
+        $plan = new OrderPlan(
+            symbol: $candidate->symbol,
+            profile: $candidate->profile,
+            exchange: $candidate->exchange?->value ?? '',
+            marketType: $candidate->marketType?->value ?? '',
+            side: strtolower($candidate->direction),
+            orderType: $request->orderType,
+            marginMode: $request->marginMode,
+            timeInForce: $request->timeInForce,
+            entryPrice: $request->entryZone?->center ?? 0.0,
+            quantity: $request->riskCalculation?->quantity ?? 0.0,
+            leverage: $request->leverageCalculation?->finalLeverage ?? 0,
+            protectionPlan: $request->protectionPlan,
+            clientOrderId: $clientOrderId,
+            idempotencyKey: $idempotencyKey,
+            decisionKey: $idempotencyKey,
+            entryZone: $request->entryZone,
+            riskCalculation: $request->riskCalculation,
+            leverageCalculation: $request->leverageCalculation,
+            metadata: $request->metadata + [
+                'source' => 'trading_core_order_plan_builder',
+                'candidate_direction' => $candidate->direction,
+                'execution_timeframe' => $candidate->executionTimeframe,
+                'signal_time' => $candidate->signalTime->format(\DateTimeInterface::ATOM),
+                'dry_run' => $candidate->dryRun,
+                'build_missing_inputs' => $missingInputs,
+            ],
+            instrument: $candidate->instrument,
+        );
+
+        return $plan->withValidation($this->validator->validate($plan));
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
+++ b/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
@@ -1,0 +1,159 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+use App\TradingCore\Execution\Fake\FakeExecutionPort;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FakeExecutionPort::class)]
+final class FakeExecutionPortTest extends TestCase
+{
+    public function testDryRunValidPlanReturnsSimulatedDryRunResult(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new FakeExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::DryRun, $result->status);
+        self::assertSame('CID-ABC', $result->clientOrderId);
+        self::assertSame('FAKE-CID-ABC', $result->exchangeOrderId);
+        self::assertTrue($result->metadata['simulated']);
+        self::assertSame('fake_paper', $result->metadata['gateway']);
+        self::assertSame('dry_run', $result->metadata['mode']);
+        self::assertTrue($result->metadata['dry_run']);
+    }
+
+    public function testDryRunInvalidPlanIsRejectedWithoutExecuting(): void
+    {
+        $request = ExecutionRequest::forPlan($this->invalidPlan(), ExecutionMode::DryRun);
+
+        $result = (new FakeExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('order_plan_not_executable', $result->metadata['reject_reason']);
+        self::assertContains('protection_plan_missing', $result->metadata['invalid_reasons']);
+    }
+
+    public function testLiveModeIsRefusedByFakeGateway(): void
+    {
+        // forPlan() allows a live request only for an executable plan; the fake
+        // gateway must still refuse to route it anywhere.
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::Live);
+
+        $result = (new FakeExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('live_not_supported_by_fake_gateway', $result->metadata['reject_reason']);
+    }
+
+    public function testFakeOrderIdIsDeterministicAndPortIsStateless(): void
+    {
+        $port = new FakeExecutionPort();
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $first = $port->execute($request);
+        $second = $port->execute($request);
+
+        // Same plan -> same fake exchange order id; no accumulated state -> equal results.
+        self::assertSame('FAKE-CID-ABC', $first->exchangeOrderId);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertEquals($first, $second);
+    }
+
+    public function testPreservesClientOrderIdAndIdempotencyKey(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new FakeExecutionPort())->execute($request);
+
+        self::assertSame('CID-ABC', $result->clientOrderId);
+        self::assertSame('CID-ABC', $result->metadata['client_order_id']);
+        self::assertSame('decision:BTCUSDT:long', $result->metadata['idempotency_key']);
+    }
+
+    // --- fixtures ---
+
+    private function executablePlan(): OrderPlan
+    {
+        $plan = new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: $this->protectionPlan(),
+            clientOrderId: 'CID-ABC',
+            idempotencyKey: 'decision:BTCUSDT:long',
+        );
+
+        return $plan->withValidation((new OrderPlanValidator())->validate($plan));
+    }
+
+    private function invalidPlan(): OrderPlan
+    {
+        return new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'bitmart',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: null,
+            clientOrderId: 'CID-ABC',
+            idempotencyKey: 'decision:BTCUSDT:long',
+        );
+    }
+
+    private function protectionPlan(): ProtectionPlan
+    {
+        return new ProtectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+            takeProfit: new TakeProfitResult(
+                tp1Price: 103.0,
+                tp2Price: null,
+                expectedR: 1.5,
+                expectedNetR: 1.4,
+                tpPolicyApplied: 'r_multiple',
+            ),
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: true,
+                liquidationPrice: 80.0,
+                liquidationDistancePct: 0.20,
+                stopToLiquidationRatio: 0.1,
+            ),
+            isValid: true,
+            status: ProtectionPlanStatus::Valid,
+        );
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
+++ b/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
@@ -85,6 +85,34 @@ final class FakeExecutionPortTest extends TestCase
         self::assertSame('decision:BTCUSDT:long', $result->metadata['idempotency_key']);
     }
 
+    public function testPreservesIncomingRequestMetadata(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::DryRun,
+            ['run_id' => 'run-123', 'correlation_id' => 'corr-9'],
+        );
+
+        $result = (new FakeExecutionPort())->execute($request);
+
+        self::assertSame('run-123', $result->metadata['run_id']);
+        self::assertSame('corr-9', $result->metadata['correlation_id']);
+    }
+
+    public function testCallerCannotOverrideGatewayAuthoritativeMetadata(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::DryRun,
+            ['gateway' => 'spoofed', 'simulated' => false],
+        );
+
+        $result = (new FakeExecutionPort())->execute($request);
+
+        self::assertSame('fake_paper', $result->metadata['gateway']);
+        self::assertTrue($result->metadata['simulated']);
+    }
+
     // --- fixtures ---
 
     private function executablePlan(): OrderPlan

--- a/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
+++ b/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
@@ -104,13 +104,31 @@ final class FakeExecutionPortTest extends TestCase
         $request = ExecutionRequest::forPlan(
             $this->executablePlan(),
             ExecutionMode::DryRun,
-            ['gateway' => 'spoofed', 'simulated' => false],
+            ['gateway' => 'spoofed', 'simulated' => false, 'dry_run' => false],
         );
 
         $result = (new FakeExecutionPort())->execute($request);
 
         self::assertSame('fake_paper', $result->metadata['gateway']);
         self::assertTrue($result->metadata['simulated']);
+        // dry_run is a result-path field: the gateway value must overwrite the caller's.
+        self::assertTrue($result->metadata['dry_run']);
+    }
+
+    public function testCallerCannotSpoofRejectReasonOnLivePath(): void
+    {
+        // reject_reason carried by the incoming metadata must not survive: the gateway's
+        // own result reason is authoritative.
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::Live,
+            ['reject_reason' => 'caller_spoofed'],
+        );
+
+        $result = (new FakeExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertSame('live_not_supported_by_fake_gateway', $result->metadata['reject_reason']);
     }
 
     // --- fixtures ---

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanBuilderTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanBuilderTest.php
@@ -157,6 +157,23 @@ final class OrderPlanBuilderTest extends TestCase
         self::assertSame('unit-test', $plan->metadata['caller']);
     }
 
+    public function testBuilderAuditMetadataIsAuthoritativeOverCallerMetadata(): void
+    {
+        // A caller cannot forge the builder's audit fields, but its own keys survive.
+        $plan = (new OrderPlanBuilder())->build($this->request([
+            'entryZone' => null,
+            'metadata' => [
+                'source' => 'caller',
+                'build_missing_inputs' => [],
+                'run_id' => 'run-123',
+            ],
+        ]));
+
+        self::assertSame('trading_core_order_plan_builder', $plan->metadata['source']);
+        self::assertContains('entry_zone', $plan->metadata['build_missing_inputs']);
+        self::assertSame('run-123', $plan->metadata['run_id']);
+    }
+
     // --- fixtures ---
 
     /**

--- a/trading-app/tests/TradingCore/OrderPlan/OrderPlanBuilderTest.php
+++ b/trading-app/tests/TradingCore/OrderPlan/OrderPlanBuilderTest.php
@@ -1,0 +1,266 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\OrderPlan;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\TradingCore\Decision\Dto\TradeCandidate;
+use App\TradingCore\Entry\Dto\EntryZone;
+use App\TradingCore\Mtf\Dto\MtfValidationResult;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Dto\OrderPlanBuildRequest;
+use App\TradingCore\OrderPlan\Enum\OrderPlanStatus;
+use App\TradingCore\OrderPlan\Service\OrderPlanBuilder;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+use App\TradingCore\Risk\Dto\LeverageCalculationResult;
+use App\TradingCore\Risk\Dto\RiskCalculationResult;
+use App\TradingCore\Risk\Enum\RiskSource;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OrderPlanBuilder::class)]
+#[CoversClass(OrderPlanBuildRequest::class)]
+final class OrderPlanBuilderTest extends TestCase
+{
+    public function testBuildsValidExecutableOrderPlanFromCompleteRequest(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request());
+
+        self::assertSame(OrderPlanStatus::Valid, $plan->validation->status);
+        self::assertTrue($plan->validation->isExecutable);
+        self::assertSame('BTCUSDT', $plan->symbol);
+        self::assertSame('long', $plan->side);
+        self::assertSame('bitmart', $plan->exchange);
+        self::assertSame('perpetual', $plan->marketType);
+        self::assertSame(100.0, $plan->entryPrice);   // entryZone.center
+        self::assertSame(12.0, $plan->quantity);       // riskCalculation.quantity
+        self::assertSame(5, $plan->leverage);          // leverageCalculation.finalLeverage
+        self::assertSame('trading_core_order_plan_builder', $plan->metadata['source']);
+    }
+
+    public function testUsesOrderPlanValidatorToProduceValidation(): void
+    {
+        // The validation carried by the built plan must match an independent
+        // OrderPlanValidator run — proving the builder delegates to it.
+        $plan = (new OrderPlanBuilder())->build($this->request());
+        $independent = (new OrderPlanValidator())->validate($plan);
+
+        self::assertSame($independent->status, $plan->validation->status);
+        self::assertSame($independent->isExecutable, $plan->validation->isExecutable);
+        self::assertSame($independent->invalidReasons, $plan->validation->invalidReasons);
+    }
+
+    public function testRejectsWhenEntryZoneMissing(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request(['entryZone' => null]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('entry_price_not_positive', $plan->validation->invalidReasons);
+        self::assertContains('entry_zone', $plan->metadata['build_missing_inputs']);
+    }
+
+    public function testRejectsWhenRiskCalculationMissing(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request(['risk' => null]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('quantity_not_positive', $plan->validation->invalidReasons);
+        self::assertContains('risk_calculation', $plan->metadata['build_missing_inputs']);
+    }
+
+    public function testRejectsWhenLeverageCalculationMissing(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request(['leverage' => null]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('leverage_not_positive', $plan->validation->invalidReasons);
+        self::assertContains('leverage_calculation', $plan->metadata['build_missing_inputs']);
+    }
+
+    public function testRejectsWhenProtectionPlanMissing(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request(['protectionPlan' => null]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('protection_plan_missing', $plan->validation->invalidReasons);
+        self::assertContains('protection_plan', $plan->metadata['build_missing_inputs']);
+    }
+
+    public function testRejectsWhenProtectionPlanInvalid(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request([
+            'protectionPlan' => $this->protectionPlan(isValid: false),
+        ]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('protection_plan_invalid', $plan->validation->invalidReasons);
+    }
+
+    public function testRejectsWhenStopLossMissing(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request([
+            'protectionPlan' => $this->protectionPlan(stopLoss: null),
+        ]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('stop_loss_missing', $plan->validation->invalidReasons);
+    }
+
+    public function testRejectsWhenStopLossNotFullSize(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request([
+            'protectionPlan' => $this->protectionPlan(stopLoss: new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: false,
+            )),
+        ]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('stop_loss_not_full_size', $plan->validation->invalidReasons);
+    }
+
+    public function testRejectsUnusableCandidate(): void
+    {
+        // TradeCandidate is type-guaranteed present in OrderPlanBuildRequest, so an
+        // unusable candidate (blank symbol / unknown direction) is the meaningful
+        // "missing candidate" path: the plan must still be invalid.
+        $plan = (new OrderPlanBuilder())->build($this->request([
+            'candidate' => $this->candidate(symbol: '', direction: 'sideways'),
+        ]));
+
+        self::assertFalse($plan->validation->isExecutable);
+        self::assertContains('symbol_missing', $plan->validation->invalidReasons);
+        self::assertContains('side_invalid', $plan->validation->invalidReasons);
+    }
+
+    public function testPreservesIdempotencyKeyClientOrderIdAndMetadata(): void
+    {
+        $plan = (new OrderPlanBuilder())->build($this->request([
+            'clientOrderId' => null,
+            'idempotencyKey' => 'decision:BTCUSDT:long:v1',
+            'metadata' => ['caller' => 'unit-test'],
+        ]));
+
+        self::assertSame('decision:BTCUSDT:long:v1', $plan->idempotencyKey);
+        self::assertSame('decision:BTCUSDT:long:v1', $plan->decisionKey);
+        self::assertNotNull($plan->clientOrderId);
+        self::assertStringStartsWith('CID', $plan->clientOrderId);
+        self::assertSame('unit-test', $plan->metadata['caller']);
+    }
+
+    // --- fixtures ---
+
+    /**
+     * @param array<string,mixed> $overrides
+     */
+    private function request(array $overrides = []): OrderPlanBuildRequest
+    {
+        return new OrderPlanBuildRequest(
+            candidate: $overrides['candidate'] ?? $this->candidate(),
+            entryZone: \array_key_exists('entryZone', $overrides) ? $overrides['entryZone'] : $this->entryZone(),
+            riskCalculation: \array_key_exists('risk', $overrides) ? $overrides['risk'] : $this->risk(),
+            leverageCalculation: \array_key_exists('leverage', $overrides) ? $overrides['leverage'] : $this->leverage(),
+            protectionPlan: \array_key_exists('protectionPlan', $overrides) ? $overrides['protectionPlan'] : $this->protectionPlan(),
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            clientOrderId: \array_key_exists('clientOrderId', $overrides) ? $overrides['clientOrderId'] : 'CID-PREBUILT',
+            idempotencyKey: \array_key_exists('idempotencyKey', $overrides) ? $overrides['idempotencyKey'] : 'decision:BTCUSDT:long',
+            metadata: $overrides['metadata'] ?? [],
+        );
+    }
+
+    private function candidate(string $symbol = 'BTCUSDT', string $direction = 'long'): TradeCandidate
+    {
+        return new TradeCandidate(
+            symbol: $symbol,
+            profile: 'scalper_micro',
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            direction: $direction,
+            executionTimeframe: '1m',
+            signalTime: new \DateTimeImmutable('2025-12-10T10:00:00+00:00'),
+            validationResult: new MtfValidationResult(symbol: $symbol, profile: 'scalper_micro', status: 'READY'),
+            dryRun: true,
+        );
+    }
+
+    private function entryZone(float $center = 100.0): EntryZone
+    {
+        return new EntryZone(
+            low: 99.5,
+            high: 100.5,
+            center: $center,
+            widthPct: 0.01,
+            ttlSec: 60,
+            expiresAt: null,
+            source: 'test',
+            atrUsed: null,
+            quantized: true,
+        );
+    }
+
+    private function risk(?float $quantity = 12.0): RiskCalculationResult
+    {
+        return new RiskCalculationResult(
+            effectiveRiskPct: 0.01,
+            riskSource: RiskSource::FixedRiskPct,
+            riskUsdt: 10.0,
+            stopPct: 0.02,
+            positionNotional: 1200.0,
+            quantity: $quantity,
+        );
+    }
+
+    private function leverage(int $final = 5): LeverageCalculationResult
+    {
+        return new LeverageCalculationResult(
+            rawLeverage: 5.0,
+            cappedLeverage: 5.0,
+            finalLeverage: $final,
+            capsApplied: [],
+        );
+    }
+
+    private function protectionPlan(StopLossResult|false|null $stopLoss = false, bool $isValid = true): ProtectionPlan
+    {
+        $sl = $stopLoss === false
+            ? new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            )
+            : $stopLoss;
+
+        return new ProtectionPlan(
+            stopLoss: $sl,
+            takeProfit: new TakeProfitResult(
+                tp1Price: 103.0,
+                tp2Price: null,
+                expectedR: 1.5,
+                expectedNetR: 1.4,
+                tpPolicyApplied: 'r_multiple',
+            ),
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: true,
+                liquidationPrice: 80.0,
+                liquidationDistancePct: 0.20,
+                stopToLiquidationRatio: 0.1,
+            ),
+            isValid: $isValid,
+            status: $isValid ? ProtectionPlanStatus::Valid : ProtectionPlanStatus::Invalid,
+            invalidReasons: $isValid ? [] : ['liquidation_guard_unsafe'],
+        );
+    }
+}


### PR DESCRIPTION
## Objectif

Première implémentation de l'`ExecutionPort` (gateway Fake/Paper) et `OrderPlanBuilder` minimal, **sans aucun ordre live ni side effect**. Complète PR09.

## Scope

- `App\TradingCore\OrderPlan\Service\OrderPlanBuilder` — assemble `TradeCandidate + EntryZone + Risk + Leverage + ProtectionPlan` → `OrderPlan`, consomme `OrderPlanBuildRequest` (jusqu'ici inutilisé), réutilise `OrderPlanValidator`.
- `App\TradingCore\Execution\Fake\FakeExecutionPort` — implémente `ExecutionPortInterface::execute(ExecutionRequest): ExecutionResult` ; pur (zéro HTTP / provider / Symfony / Doctrine / Messenger) ; refuse le mode live ; rejette les plans non exécutables (revalidés au boundary) ; conserve `client_order_id` / `idempotency_key` ; fake order id déterministe `FAKE-{coid}`.
- Doc `technical/fake-paper-gateway.md` + nav mkdocs.

## Hors-scope

- Aucun branchement runtime : `mtf:run`, `POST /api/mtf/run`, Temporal, schedules, `TradeEntry`, `EffectiveTradingConfigResolver`.
- Aucun changement EntryZone / Risk / Leverage / SL-TP / YAML stratégie.
- **Aucune gate readiness live** OKX/Hyperliquid → PR11/PR12.
- Aucune suppression Bitmart, aucun secret, aucun ordre live.

## Tests

- ✅ `php bin/phpunit tests/TradingCore/OrderPlan tests/TradingCore/Execution` → 49/49 (17 nouveaux).
- ✅ `phpstan analyse src/TradingCore/{OrderPlan,Execution} tests/TradingCore/{OrderPlan,Execution}` → no errors (level 6).
- ✅ `lint:yaml config`, `lint:container`.
- ✅ `mtf:run` enregistré, route `/api/mtf/run` présente.
- ✅ `mkdocs build --strict`, `git diff --check`.

Les tests prouvent : OrderPlanBuilder utilise OrderPlanValidator · FakeExecutionPort refuse le live · rejette un plan invalide · aucun side effect (déterministe + stateless) · idempotency_key / client_order_id conservés · même plan = même fake order id.

## Risques

Extraction purement additive et dormante. `entry_price = entryZone.center` simplifie le pricing legacy (documenté). `OrderPlanBuildRequest` porte `EntryZone` (pas `EntryZoneDecision`) → statut zone non re-vérifié au build (documenté).

## Critères d'acceptation

- Comportement runtime changé : Non.
- Ordre live possible : Non. Side effects Fake : Non.
- OrderPlanBuilder ajouté : Oui. Gate readiness live : Non (PR11/PR12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)