### PR TITLE
PR11 — OKX dry-run ExecutionPort + dry-run-only gates

### DIFF
--- a/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
@@ -22,6 +22,19 @@ SUPPORTED_EXCHANGES = {"bitmart", "binance", "fake", "hyperliquid", "okx"}
 SUPPORTED_MARKET_TYPES = {"perpetual", "spot"}
 SUPPORTED_PROFILES = {"regular", "scalper", "scalper_micro"}
 
+# PR11: OKX stays dry-run only until a dedicated live-readiness PR. A live (dry_run=false)
+# OKX schedule must never be created, regardless of --skip-runtime-check.
+DRY_RUN_ONLY_EXCHANGES = {"okx"}
+OKX_DRY_RUN_ONLY_MESSAGE = (
+    "OKX schedules must stay dry_run=true until a dedicated live-readiness PR."
+)
+
+
+def assert_exchange_schedule_policy(exchange: Optional[str], dry_run: bool) -> None:
+    """Block live schedules for exchanges that are still dry-run only (PR11: OKX)."""
+    if exchange in DRY_RUN_ONLY_EXCHANGES and not dry_run:
+        raise RuntimeError(OKX_DRY_RUN_ONLY_MESSAGE)
+
 
 @dataclass(frozen=True)
 class ScheduleConfig:
@@ -180,6 +193,10 @@ def resolve_schedule_config(args: argparse.Namespace) -> ScheduleConfig:
     market_type = getattr(args, "market_type", "perpetual")
     profile = getattr(args, "profile", None)
 
+    if getattr(args, "command", None) == "create":
+        # Fail fast on the CLI path before contacting Temporal or running a runtime-check.
+        assert_exchange_schedule_policy(exchange, dry_run)
+
     if getattr(args, "schedule_id", None):
         schedule_id = args.schedule_id
     elif exchange and profile:
@@ -244,6 +261,10 @@ def temporal_schedule_classes():
 async def create_schedule(client: Any, config: ScheduleConfig) -> None:
     if config.exchange is None or config.profile is None:
         raise RuntimeError("create requires --exchange and --profile")
+
+    # Dry-run-only policy is independent of the runtime-check and cannot be bypassed
+    # with --skip-runtime-check: OKX live schedules are forbidden in PR11.
+    assert_exchange_schedule_policy(config.exchange, config.dry_run)
 
     job = build_job(
         exchange=config.exchange,

--- a/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
@@ -31,8 +31,13 @@ OKX_DRY_RUN_ONLY_MESSAGE = (
 
 
 def assert_exchange_schedule_policy(exchange: Optional[str], dry_run: bool) -> None:
-    """Block live schedules for exchanges that are still dry-run only (PR11: OKX)."""
-    if exchange in DRY_RUN_ONLY_EXCHANGES and not dry_run:
+    """Block live schedules for exchanges that are still dry-run only (PR11: OKX).
+
+    The exchange is normalized so the gate cannot be bypassed by casing/whitespace
+    (e.g. a ScheduleConfig built in code with exchange="OKX").
+    """
+    normalized_exchange = (exchange or "").strip().lower()
+    if normalized_exchange in DRY_RUN_ONLY_EXCHANGES and not dry_run:
         raise RuntimeError(OKX_DRY_RUN_ONLY_MESSAGE)
 
 

--- a/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
@@ -6,7 +6,9 @@ import pytest
 
 import scripts.manage_exchange_profile_schedule as schedule_manager
 from scripts.manage_exchange_profile_schedule import (
+    OKX_DRY_RUN_ONLY_MESSAGE,
     ScheduleConfig,
+    assert_exchange_schedule_policy,
     async_main,
     build_job,
     build_parser,
@@ -224,6 +226,32 @@ def test_create_live_schedule_with_runtime_check_bypass_skips_guardrail_validati
         ),
     )
 
+    # Bitmart is not dry-run-only, so the bypass still creates a live schedule.
+    config = ScheduleConfig(
+        command="create",
+        exchange="bitmart",
+        market_type="perpetual",
+        profile="scalper",
+        workers=4,
+        dry_run=False,
+        cron="*/1 * * * *",
+        schedule_id="cron-mtf-bitmart-scalper-1m",
+        workflow_id="mtf-bitmart-scalper-runner",
+        dry_run_schedule=False,
+        skip_runtime_check=True,
+    )
+    client = CapturingClient()
+
+    asyncio.run(create_schedule(client, config))
+
+    assert client.created[0][0] == "cron-mtf-bitmart-scalper-1m"
+
+
+def test_create_live_okx_schedule_is_blocked_even_with_runtime_check_bypass():
+    class FailingClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise AssertionError("OKX live schedule must never reach Temporal creation")
+
     config = ScheduleConfig(
         command="create",
         exchange="okx",
@@ -237,8 +265,34 @@ def test_create_live_schedule_with_runtime_check_bypass_skips_guardrail_validati
         dry_run_schedule=False,
         skip_runtime_check=True,
     )
-    client = CapturingClient()
 
-    asyncio.run(create_schedule(client, config))
+    with pytest.raises(RuntimeError, match=OKX_DRY_RUN_ONLY_MESSAGE):
+        asyncio.run(create_schedule(FailingClient(), config))
 
-    assert client.created[0][0] == "cron-mtf-okx-scalper-1m"
+
+def test_resolve_schedule_config_blocks_live_okx_create():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["create", "--exchange", "okx", "--profile", "scalper", "--dry-run=false"]
+    )
+
+    with pytest.raises(RuntimeError, match=OKX_DRY_RUN_ONLY_MESSAGE):
+        resolve_schedule_config(args)
+
+
+def test_resolve_schedule_config_allows_dry_run_okx_create():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["create", "--exchange", "okx", "--profile", "scalper", "--dry-run=true"]
+    )
+
+    config = resolve_schedule_config(args)
+
+    assert config.exchange == "okx"
+    assert config.dry_run is True
+
+
+def test_assert_exchange_schedule_policy_allows_live_for_non_dry_run_only_exchanges():
+    # Bitmart legacy can still go live; only dry-run-only exchanges (OKX) are blocked.
+    assert_exchange_schedule_policy("bitmart", dry_run=False) is None
+    assert_exchange_schedule_policy("okx", dry_run=True) is None

--- a/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
@@ -296,3 +296,12 @@ def test_assert_exchange_schedule_policy_allows_live_for_non_dry_run_only_exchan
     # Bitmart legacy can still go live; only dry-run-only exchanges (OKX) are blocked.
     assert_exchange_schedule_policy("bitmart", dry_run=False) is None
     assert_exchange_schedule_policy("okx", dry_run=True) is None
+
+
+def test_assert_exchange_schedule_policy_blocks_uppercase_okx_live():
+    # The gate normalizes casing/whitespace: a hand-built "OKX" must not bypass it.
+    with pytest.raises(RuntimeError, match=OKX_DRY_RUN_ONLY_MESSAGE):
+        assert_exchange_schedule_policy("OKX", dry_run=False)
+
+    with pytest.raises(RuntimeError, match=OKX_DRY_RUN_ONLY_MESSAGE):
+        assert_exchange_schedule_policy("  Okx ", dry_run=False)

--- a/docs/handbook/technical/okx-dry-run.md
+++ b/docs/handbook/technical/okx-dry-run.md
@@ -1,0 +1,91 @@
+# OKX dry-run
+
+## Statut
+
+OKX est `target_dry_run_only`. PR11 prépare OKX en **dry-run / runtime-check uniquement** :
+aucune exécution live, aucun branchement runtime, aucun ordre réel. La bascule live d'OKX
+reste interdite et exigera une **PR de readiness live dédiée**, séparément relue.
+
+Cette page complète :
+
+- `technical/exchange-runtime-gates.md` (gates obligatoires avant tout live) ;
+- `technical/exchange-readiness-matrix.md` (statut par exchange) ;
+- `technical/fake-paper-gateway.md` (le filet de sécurité Fake / Paper).
+
+## OkxDryRunExecutionPort
+
+`App\TradingCore\Execution\Okx\OkxDryRunExecutionPort` est la deuxième implémentation de
+`ExecutionPortInterface` (après `FakeExecutionPort`). Elle respecte strictement l'interface
+existante : `execute(ExecutionRequest): ExecutionResult`.
+
+C'est une **preview / simulation TradingCore**, pas une exécution exchange réelle :
+
+- **aucun appel HTTP**, jamais ;
+- **aucun `privatePost` OKX** : le port ne touche ni `OkxExchangeAdapter::placeOrder()`,
+  ni `OkxRestClient::privatePost()`, ni aucune classe `App\Exchange\Okx\*` ;
+- aucune dépendance Symfony, Doctrine, Messenger, Temporal ni provider runtime concret ;
+- le port est **pur** : même plan ⇒ même `exchange_order_id`, requête jamais mutée.
+
+Comportement :
+
+| Cas | Résultat |
+| --- | --- |
+| `ExecutionMode::Live` | `ExecutionStatus::Rejected` (`live_not_supported_by_okx_dry_run`). |
+| Plan d'un autre exchange (`exchange != okx`) | `Rejected` (`wrong_exchange_for_okx_dry_run`). |
+| Market type non supporté (≠ `perpetual`) | `Rejected` (`market_type_not_supported_by_okx_dry_run`). |
+| Plan non exécutable (revalidé via `OrderPlanValidator`) | `Rejected` (`order_plan_not_executable` + `invalid_reasons`). |
+| Plan OKX perpetual valide en dry-run | `ExecutionStatus::DryRun`, `exchange_order_id = OKX-DRYRUN-{client_order_id}`. |
+
+Metadata produite (success) : `gateway=okx`, `mode=dry_run`, `simulated=true`, `no_http=true`,
+`no_private_post=true`, `client_order_id`, `idempotency_key`, `requested_at`, `order_type`,
+`side`, `symbol`, `entry_price`, `quantity`, `leverage`, `protection_present`. Les descripteurs
+gateway (`gateway`, `simulated`, `no_http`, `no_private_post`) et le `reject_reason` sont
+autoritaires : un appelant ne peut pas les usurper via la metadata entrante.
+
+`client_order_id` et `idempotency_key` sont conservés sur tous les chemins.
+
+## Runtime-check : OKX reste dry-run only
+
+`app:exchange:runtime-check okx perpetual` durcit la gate OKX :
+
+- `Live trading: disabled` — OKX ne peut pas passer live en PR11, même si
+  `OKX_DEMO_TRADING_ENABLED=1` ou `OKX_LIVE_ENABLED=1` ;
+- `Dry-run only: yes` ;
+- `Live allowed: no` ;
+- `Demo trading enabled: yes/no` — capacité demo OKX, **distincte** de l'autorisation live ;
+- `Recommended dry_run: true` (toujours, pour OKX).
+
+La capacité « demo order » d'OKX n'est donc jamais assimilée à « live allowed ». Bitmart legacy
+n'est pas affecté : ces lignes sont spécifiques à OKX.
+
+## Schedules Temporal : OKX dry_run=false interdit
+
+`cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py` refuse explicitement la
+création d'un schedule OKX live :
+
+- `create --exchange okx --dry-run=false` lève
+  `RuntimeError: OKX schedules must stay dry_run=true until a dedicated live-readiness PR.` ;
+- la règle est **indépendante du runtime-check** : `--skip-runtime-check` ne la contourne pas ;
+- `--dry-run=true` (défaut) pour OKX reste autorisé ;
+- Bitmart legacy peut toujours créer un schedule live ; seule OKX est bloquée.
+
+## Hors-scope PR11
+
+- aucune activation live OKX (PR de readiness live dédiée requise) ;
+- **aucun bundle provider OKX runtime MTF activé** : `mtf:run`, `POST /api/mtf/run` et le
+  Temporal scheduler ne sont pas branchés sur OKX par cette PR ;
+- aucun branchement `TradeEntry` runtime ;
+- aucun changement de stratégie (`regular` / `scalper` / `scalper_micro`), EntryZone,
+  Risk / Leverage / SL-TP ni YAML ;
+- aucune suppression Bitmart ; Hyperliquid hors-scope ;
+- aucun secret ajouté dans Git (`config_file/*.env` restent des templates de noms de clés).
+
+## Filet de sécurité
+
+`FakeExecutionPort` (Fake / Paper) reste le filet de sécurité : il permet d'exercer toute la
+chaîne `OrderPlan → ExecutionPort` sans aucun risque. `OkxDryRunExecutionPort` sert de référence
+de preview pour comparer les futurs payloads OKX avant toute PR d'activation live.
+
+## Suite
+
+PR12 : Hyperliquid dry-run. La bascule live OKX restera une PR dédiée, testée et réversible.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
       - SLTP / LiquidationGuard module: technical/sltp-liquidation-guard-module.md
       - OrderPlan / ExecutionPort module: technical/order-plan-execution-port-module.md
       - Fake / Paper gateway: technical/fake-paper-gateway.md
+      - OKX dry-run: technical/okx-dry-run.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -74,6 +74,13 @@ final class ExchangeRuntimeCheckCommand extends Command
         $output->writeln('REST: unknown');
         $output->writeln(sprintf('Private WS: %s', $privateWs));
         $output->writeln(sprintf('Live trading: %s', $liveTrading));
+        if ($exchange === Exchange::OKX) {
+            // PR11: OKX is dry-run only. Surface the gate explicitly so that demo-trading
+            // capability is never mistaken for live-trading authorization.
+            $output->writeln('Dry-run only: yes');
+            $output->writeln('Live allowed: no');
+            $output->writeln(sprintf('Demo trading enabled: %s', $this->okxConfig->demoTradingEnabled ? 'yes' : 'no'));
+        }
         $output->writeln(sprintf('Recommended dry_run: %s', $recommendedDryRun ? 'true' : 'false'));
         $output->writeln(sprintf('Schedule ready: %s', $scheduleReady ? 'yes' : 'no'));
 
@@ -142,9 +149,10 @@ final class ExchangeRuntimeCheckCommand extends Command
         }
 
         return match ($exchange) {
-            Exchange::OKX => $this->okxConfig->isDemo()
-                ? ($this->okxConfig->demoTradingEnabled ? 'enabled' : 'disabled')
-                : ($this->okxConfig->liveEnabled ? 'enabled' : 'disabled'),
+            // PR11: OKX stays dry-run only. Demo-trading capability (OKX_DEMO_TRADING_ENABLED)
+            // is NOT live trading, and OKX_LIVE_ENABLED is intentionally ignored here: live
+            // remains disabled until a dedicated OKX live-readiness PR flips this gate.
+            Exchange::OKX => 'disabled',
             Exchange::HYPERLIQUID => $this->hyperliquidConfig->isTestnet()
                 ? 'enabled'
                 : ($this->hyperliquidConfig->mainnetEnabled ? 'enabled' : 'disabled'),

--- a/trading-app/src/TradingCore/Execution/Okx/OkxDryRunExecutionPort.php
+++ b/trading-app/src/TradingCore/Execution/Okx/OkxDryRunExecutionPort.php
@@ -18,7 +18,7 @@ use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
  *
  * It is a pure TradingCore preview, NOT an exchange execution:
  * - no HTTP call, ever;
- * - it never touches {@see \App\Exchange\Okx\OkxExchangeAdapter} or
+ * - it never touches {@see \App\Exchange\Adapter\OkxExchangeAdapter} or
  *   {@see \App\Exchange\Okx\OkxRestClient} (so no `privatePost`, no order placement);
  * - no Symfony, Doctrine, Messenger, Temporal nor any concrete runtime provider.
  *

--- a/trading-app/src/TradingCore/Execution/Okx/OkxDryRunExecutionPort.php
+++ b/trading-app/src/TradingCore/Execution/Okx/OkxDryRunExecutionPort.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Okx;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Dto\ExecutionResult;
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+use App\TradingCore\Execution\Port\ExecutionPortInterface;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+
+/**
+ * OKX dry-run / preview implementation of {@see ExecutionPortInterface}.
+ *
+ * PR11 keeps OKX strictly `dry-run only`: this port simulates what an OKX order
+ * submission would look like, but it NEVER routes anything to the exchange.
+ *
+ * It is a pure TradingCore preview, NOT an exchange execution:
+ * - no HTTP call, ever;
+ * - it never touches {@see \App\Exchange\Okx\OkxExchangeAdapter} or
+ *   {@see \App\Exchange\Okx\OkxRestClient} (so no `privatePost`, no order placement);
+ * - no Symfony, Doctrine, Messenger, Temporal nor any concrete runtime provider.
+ *
+ * Live mode is always refused. A real OKX live activation requires a dedicated,
+ * separately reviewed readiness PR.
+ *
+ * Like {@see \App\TradingCore\Execution\Fake\FakeExecutionPort}, it is a pure
+ * function of its input: the same plan always yields the same dry-run order id,
+ * and the input ExecutionRequest is never mutated.
+ */
+final class OkxDryRunExecutionPort implements ExecutionPortInterface
+{
+    private const EXCHANGE = 'okx';
+    private const MARKET_TYPE = 'perpetual';
+
+    public function __construct(
+        private readonly OrderPlanValidator $validator = new OrderPlanValidator(),
+    ) {
+    }
+
+    public function execute(ExecutionRequest $request): ExecutionResult
+    {
+        $plan = $request->orderPlan;
+
+        // Preserve incoming audit metadata (run_id, correlation_id, schedule_id, ...)
+        // while keeping the gateway's own descriptors authoritative: a caller must not
+        // be able to spoof gateway/simulated/no_http/no_private_post.
+        $metadata = array_merge(
+            $request->metadata,
+            [
+                'gateway' => self::EXCHANGE,
+                'mode' => $request->mode->value,
+                'simulated' => true,
+                'no_http' => true,
+                'no_private_post' => true,
+                'requested_at' => $request->requestedAt->format(\DateTimeInterface::ATOM),
+                'client_order_id' => $plan->clientOrderId,
+                'idempotency_key' => $plan->idempotencyKey,
+                'order_type' => $plan->orderType,
+                'side' => $plan->side,
+                'symbol' => $plan->symbol,
+                'entry_price' => $plan->entryPrice,
+                'quantity' => $plan->quantity,
+                'leverage' => $plan->leverage,
+                'protection_present' => $plan->protectionPlan !== null,
+            ],
+        );
+
+        // PR11 hard gate: OKX live is forbidden. This port has no live venue to route to.
+        if ($request->mode === ExecutionMode::Live) {
+            return $this->reject($plan->clientOrderId, $metadata, 'live_not_supported_by_okx_dry_run');
+        }
+
+        // Routing gate: this port only previews OKX plans.
+        if (strtolower(trim($plan->exchange)) !== self::EXCHANGE) {
+            return $this->reject(
+                $plan->clientOrderId,
+                array_merge($metadata, ['plan_exchange' => $plan->exchange]),
+                'wrong_exchange_for_okx_dry_run',
+            );
+        }
+
+        // Routing gate: OKX preview is scoped to perpetual futures in PR11.
+        if (strtolower(trim($plan->marketType)) !== self::MARKET_TYPE) {
+            return $this->reject(
+                $plan->clientOrderId,
+                array_merge($metadata, ['plan_market_type' => $plan->marketType]),
+                'market_type_not_supported_by_okx_dry_run',
+            );
+        }
+
+        // Boundary does not trust the validation carried by the DTO: revalidate.
+        $validation = $this->validator->validate($plan);
+        if (!$validation->isExecutable) {
+            return $this->reject(
+                $plan->clientOrderId,
+                array_merge($metadata, ['invalid_reasons' => $validation->invalidReasons]),
+                'order_plan_not_executable',
+            );
+        }
+
+        return new ExecutionResult(
+            status: ExecutionStatus::DryRun,
+            clientOrderId: $plan->clientOrderId,
+            exchangeOrderId: $this->dryRunOrderId($plan->clientOrderId),
+            metadata: $metadata,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function reject(?string $clientOrderId, array $metadata, string $reason): ExecutionResult
+    {
+        return new ExecutionResult(
+            status: ExecutionStatus::Rejected,
+            clientOrderId: $clientOrderId,
+            // Result reason is authoritative: a caller cannot spoof reject_reason via metadata.
+            metadata: array_merge($metadata, ['reject_reason' => $reason]),
+        );
+    }
+
+    private function dryRunOrderId(?string $clientOrderId): string
+    {
+        $seed = $clientOrderId !== null && trim($clientOrderId) !== '' ? $clientOrderId : 'UNKNOWN';
+
+        return 'OKX-DRYRUN-' . $seed;
+    }
+}

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -54,8 +54,51 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('REST: unknown', $output);
         self::assertStringContainsString('Private WS: unsupported', $output);
         self::assertStringContainsString('Live trading: disabled', $output);
+        self::assertStringContainsString('Dry-run only: yes', $output);
+        self::assertStringContainsString('Live allowed: no', $output);
+        self::assertStringContainsString('Demo trading enabled: no', $output);
         self::assertStringContainsString('Recommended dry_run: true', $output);
         self::assertStringContainsString('Schedule ready: no', $output);
+    }
+
+    public function testOkxStaysDryRunOnlyEvenWithCredentialsProviderAndDemoFlag(): void
+    {
+        // PR11 hardening: a fully "ready" OKX runtime with demo trading enabled must still
+        // report live as forbidden and recommend dry-run. Demo capability != live trading.
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(Exchange::OKX, MarketType::PERPETUAL, supportsPrivateWs: true)),
+            $this->providerRegistry($this->providerBundle(Exchange::OKX, MarketType::PERPETUAL)),
+            new OkxConfig(
+                environment: 'demo',
+                apiKey: 'key',
+                apiSecret: 'secret',
+                apiPassphrase: 'pass',
+                demoTradingEnabled: true,
+                liveEnabled: true,
+            ),
+            new HyperliquidConfig(),
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'exchange' => 'okx',
+            'market_type' => 'perpetual',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Exchange: okx', $output);
+        self::assertStringContainsString('Adapter: found', $output);
+        self::assertStringContainsString('Provider bundle: found', $output);
+        self::assertStringContainsString('Credentials: ok', $output);
+        // Even with OKX_LIVE_ENABLED=1 and demo trading on, live stays forbidden in PR11.
+        self::assertStringContainsString('Live trading: disabled', $output);
+        self::assertStringContainsString('Dry-run only: yes', $output);
+        self::assertStringContainsString('Live allowed: no', $output);
+        self::assertStringContainsString('Demo trading enabled: yes', $output);
+        self::assertStringContainsString('Recommended dry_run: true', $output);
+        self::assertStringContainsString('Schedule ready: yes', $output);
     }
 
     public function testReportsReadyBitmartRuntimeWhenAdapterAndProviderExist(): void
@@ -85,6 +128,9 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('REST: unknown', $output);
         self::assertStringContainsString('Recommended dry_run: false', $output);
         self::assertStringContainsString('Schedule ready: yes', $output);
+        // The OKX-specific dry-run-only gate must not leak into Bitmart legacy output.
+        self::assertStringNotContainsString('Dry-run only:', $output);
+        self::assertStringNotContainsString('Live allowed:', $output);
     }
 
     public function testReportsUnreadyBitmartRuntimeWhenCredentialsAreMissing(): void

--- a/trading-app/tests/TradingCore/Execution/OkxDryRunExecutionPortTest.php
+++ b/trading-app/tests/TradingCore/Execution/OkxDryRunExecutionPortTest.php
@@ -1,0 +1,243 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+use App\TradingCore\Execution\Okx\OkxDryRunExecutionPort;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OkxDryRunExecutionPort::class)]
+final class OkxDryRunExecutionPortTest extends TestCase
+{
+    public function testDryRunValidOkxPlanReturnsSimulatedDryRunResult(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::DryRun, $result->status);
+        self::assertSame('CID-OKX-1', $result->clientOrderId);
+        self::assertSame('OKX-DRYRUN-CID-OKX-1', $result->exchangeOrderId);
+        self::assertSame('okx', $result->metadata['gateway']);
+        self::assertSame('dry_run', $result->metadata['mode']);
+        self::assertTrue($result->metadata['simulated']);
+        self::assertTrue($result->metadata['protection_present']);
+    }
+
+    public function testDryRunResultAdvertisesNoHttpAndNoPrivatePost(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertTrue($result->metadata['no_http']);
+        self::assertTrue($result->metadata['no_private_post']);
+        // The plan fields are echoed for audit/preview comparison against future live payloads.
+        self::assertSame('BTCUSDT', $result->metadata['symbol']);
+        self::assertSame('long', $result->metadata['side']);
+        self::assertSame('limit', $result->metadata['order_type']);
+        self::assertSame(100.0, $result->metadata['entry_price']);
+        self::assertSame(12.0, $result->metadata['quantity']);
+        self::assertSame(5, $result->metadata['leverage']);
+    }
+
+    public function testLiveModeIsRefused(): void
+    {
+        // forPlan() allows a live request only for an executable plan; the OKX dry-run
+        // port must still refuse to route it anywhere.
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::Live);
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('live_not_supported_by_okx_dry_run', $result->metadata['reject_reason']);
+    }
+
+    public function testRejectsPlanForAnotherExchange(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(exchange: 'bitmart'), ExecutionMode::DryRun);
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('wrong_exchange_for_okx_dry_run', $result->metadata['reject_reason']);
+        self::assertSame('bitmart', $result->metadata['plan_exchange']);
+    }
+
+    public function testRejectsUnsupportedMarketType(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(marketType: 'spot'), ExecutionMode::DryRun);
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('market_type_not_supported_by_okx_dry_run', $result->metadata['reject_reason']);
+        self::assertSame('spot', $result->metadata['plan_market_type']);
+    }
+
+    public function testRejectsNonExecutablePlanWithoutExecuting(): void
+    {
+        $request = ExecutionRequest::forPlan($this->invalidPlan(), ExecutionMode::DryRun);
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('order_plan_not_executable', $result->metadata['reject_reason']);
+        self::assertContains('protection_plan_missing', $result->metadata['invalid_reasons']);
+    }
+
+    public function testDryRunOrderIdIsDeterministicAndPortIsStateless(): void
+    {
+        $port = new OkxDryRunExecutionPort();
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $first = $port->execute($request);
+        $second = $port->execute($request);
+
+        self::assertSame('OKX-DRYRUN-CID-OKX-1', $first->exchangeOrderId);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertEquals($first, $second);
+    }
+
+    public function testPreservesClientOrderIdAndIdempotencyKey(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame('CID-OKX-1', $result->clientOrderId);
+        self::assertSame('CID-OKX-1', $result->metadata['client_order_id']);
+        self::assertSame('decision:BTCUSDT:long', $result->metadata['idempotency_key']);
+    }
+
+    public function testPreservesIncomingRequestMetadata(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::DryRun,
+            ['run_id' => 'run-77', 'correlation_id' => 'corr-9'],
+        );
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame('run-77', $result->metadata['run_id']);
+        self::assertSame('corr-9', $result->metadata['correlation_id']);
+    }
+
+    public function testCallerCannotOverrideGatewayAuthoritativeMetadata(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::DryRun,
+            ['gateway' => 'spoofed', 'simulated' => false, 'no_http' => false, 'no_private_post' => false],
+        );
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame('okx', $result->metadata['gateway']);
+        self::assertTrue($result->metadata['simulated']);
+        self::assertTrue($result->metadata['no_http']);
+        self::assertTrue($result->metadata['no_private_post']);
+    }
+
+    public function testCallerCannotSpoofRejectReasonOnLivePath(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::Live,
+            ['reject_reason' => 'caller_spoofed'],
+        );
+
+        $result = (new OkxDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertSame('live_not_supported_by_okx_dry_run', $result->metadata['reject_reason']);
+    }
+
+    // --- fixtures ---
+
+    private function executablePlan(string $exchange = 'okx', string $marketType = 'perpetual'): OrderPlan
+    {
+        $plan = new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: $exchange,
+            marketType: $marketType,
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: $this->protectionPlan(),
+            clientOrderId: 'CID-OKX-1',
+            idempotencyKey: 'decision:BTCUSDT:long',
+        );
+
+        return $plan->withValidation((new OrderPlanValidator())->validate($plan));
+    }
+
+    private function invalidPlan(): OrderPlan
+    {
+        return new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'okx',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: null,
+            clientOrderId: 'CID-OKX-1',
+            idempotencyKey: 'decision:BTCUSDT:long',
+        );
+    }
+
+    private function protectionPlan(): ProtectionPlan
+    {
+        return new ProtectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+            takeProfit: new TakeProfitResult(
+                tp1Price: 103.0,
+                tp2Price: null,
+                expectedR: 1.5,
+                expectedNetR: 1.4,
+                tpPolicyApplied: 'r_multiple',
+            ),
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: true,
+                liquidationPrice: 80.0,
+                liquidationDistancePct: 0.20,
+                stopToLiquidationRatio: 0.1,
+            ),
+            isValid: true,
+            status: ProtectionPlanStatus::Valid,
+        );
+    }
+}


### PR DESCRIPTION
## Objectif

Préparer OKX en **dry-run / runtime-check uniquement**, sans aucun ordre live ni branchement runtime.

## Scope

- **`App\TradingCore\Execution\Okx\OkxDryRunExecutionPort`** : 2ᵉ implémentation **pure** de `ExecutionPortInterface::execute(ExecutionRequest): ExecutionResult`. Aucun HTTP, aucun `privatePost`, ne touche jamais `OkxExchangeAdapter`/`OkxRestClient`. Aucune dépendance Symfony/Doctrine/Messenger/Temporal/provider runtime.
  - `ExecutionMode::Live` → `Rejected` (`live_not_supported_by_okx_dry_run`) ;
  - `exchange != okx` → `Rejected` (`wrong_exchange_for_okx_dry_run`) ;
  - market type ≠ `perpetual` → `Rejected` (`market_type_not_supported_by_okx_dry_run`) ;
  - plan non exécutable (revalidé via `OrderPlanValidator`) → `Rejected` (`order_plan_not_executable` + `invalid_reasons`) ;
  - plan OKX perpetual valide → `DryRun`, `exchange_order_id = OKX-DRYRUN-{client_order_id}` (déterministe, stateless) ;
  - `client_order_id` / `idempotency_key` conservés ; descripteurs gateway + `reject_reason` autoritaires.
- **`app:exchange:runtime-check` (OKX)** durci : `Live trading: disabled` même avec `OKX_DEMO_TRADING_ENABLED=1` / `OKX_LIVE_ENABLED=1` ; lignes explicites `Dry-run only: yes` / `Live allowed: no` / `Demo trading enabled: yes|no`. Bitmart legacy inchangé (lignes OKX-only).
- **`manage_exchange_profile_schedule.py`** durci : `create --exchange okx --dry-run=false` → `RuntimeError`, y compris avec `--skip-runtime-check`. `dry_run=true` OKX reste autorisé ; Bitmart peut toujours créer un schedule live.
- Docs : `technical/okx-dry-run.md` + entrée mkdocs.

## Hors-scope

- aucune activation live OKX (PR readiness live dédiée requise) ;
- aucun bundle provider OKX runtime MTF, aucun branchement `TradeEntry` ;
- aucun changement stratégie (`regular`/`scalper`/`scalper_micro`), EntryZone, Risk/Leverage/SL-TP, ni YAML ;
- Hyperliquid inchangé (PR12) ; Bitmart non supprimé ; aucun secret ajouté.

## Tests

- `phpunit tests/TradingCore/Execution tests/Command/ExchangeRuntimeCheckCommandTest.php` → **30 / 141 assertions** ✅
- `phpstan src/TradingCore/Execution/Okx` → **No errors** ✅ (scope `src/Command` : 53 erreurs **toutes préexistantes**, 0 nouvelle)
- `lint:yaml config` ✅ · `lint:container` ✅ · `mkdocs build --strict` ✅
- `pytest cron_symfony_mtf_workers` → **23 passed** ✅ · `py_compile` ✅
- `mtf:run` / `POST /api/mtf/run` / `app:exchange:runtime-check` enregistrés ✅

_Préexistant hors-scope : `SymbolLockCommandTest` échoue aussi sur `main` (DB `findActive()`)._

## Risques

Durcissement de sécurité only. Comportement runtime inchangé. Ordre live OKX impossible (refusé sur 3 couches : port, runtime-check, scheduler).

## Critères d'acceptation

- [x] OKX dry-run ExecutionPort ajouté et testé
- [x] `ExecutionMode::Live` refusé · aucun HTTP · aucun `privatePost` · aucun ordre réel
- [x] OKX `dry_run=false` schedule explicitement interdit
- [x] demo trading ≠ live trading
- [x] Bitmart legacy & Fake/Paper non cassés
- [x] `mtf:run` / `POST /api/mtf/run` inchangés · aucun YAML stratégie · aucun secret
- [x] Documentation mise à jour · PR atomique

🤖 Generated with [Claude Code](https://claude.com/claude-code)