### PR TITLE
PR12 — Hyperliquid dry-run ExecutionPort + dry-run-only gates

### DIFF
--- a/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py
@@ -22,23 +22,32 @@ SUPPORTED_EXCHANGES = {"bitmart", "binance", "fake", "hyperliquid", "okx"}
 SUPPORTED_MARKET_TYPES = {"perpetual", "spot"}
 SUPPORTED_PROFILES = {"regular", "scalper", "scalper_micro"}
 
-# PR11: OKX stays dry-run only until a dedicated live-readiness PR. A live (dry_run=false)
-# OKX schedule must never be created, regardless of --skip-runtime-check.
-DRY_RUN_ONLY_EXCHANGES = {"okx"}
-OKX_DRY_RUN_ONLY_MESSAGE = (
-    "OKX schedules must stay dry_run=true until a dedicated live-readiness PR."
-)
+# PR11/PR12: OKX and Hyperliquid stay dry-run only until a dedicated live-readiness PR.
+# A live (dry_run=false) schedule for these exchanges must never be created, regardless
+# of --skip-runtime-check.
+DRY_RUN_ONLY_EXCHANGES = {"okx", "hyperliquid"}
+
+
+def dry_run_only_message(exchange: Optional[str]) -> str:
+    """Build the dry-run-only guardrail message for a given exchange."""
+    label = (exchange or "").strip().lower().upper()
+    return f"{label} schedules must stay dry_run=true until a dedicated live-readiness PR."
+
+
+# Backward-compatible aliases: the exact message raised per dry-run-only exchange.
+OKX_DRY_RUN_ONLY_MESSAGE = dry_run_only_message("okx")
+HYPERLIQUID_DRY_RUN_ONLY_MESSAGE = dry_run_only_message("hyperliquid")
 
 
 def assert_exchange_schedule_policy(exchange: Optional[str], dry_run: bool) -> None:
-    """Block live schedules for exchanges that are still dry-run only (PR11: OKX).
+    """Block live schedules for exchanges that are still dry-run only (PR11: OKX, PR12: Hyperliquid).
 
     The exchange is normalized so the gate cannot be bypassed by casing/whitespace
-    (e.g. a ScheduleConfig built in code with exchange="OKX").
+    (e.g. a ScheduleConfig built in code with exchange="OKX" or " Hyperliquid ").
     """
     normalized_exchange = (exchange or "").strip().lower()
     if normalized_exchange in DRY_RUN_ONLY_EXCHANGES and not dry_run:
-        raise RuntimeError(OKX_DRY_RUN_ONLY_MESSAGE)
+        raise RuntimeError(dry_run_only_message(normalized_exchange))
 
 
 @dataclass(frozen=True)
@@ -268,7 +277,7 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
         raise RuntimeError("create requires --exchange and --profile")
 
     # Dry-run-only policy is independent of the runtime-check and cannot be bypassed
-    # with --skip-runtime-check: OKX live schedules are forbidden in PR11.
+    # with --skip-runtime-check: OKX (PR11) and Hyperliquid (PR12) live schedules are forbidden.
     assert_exchange_schedule_policy(config.exchange, config.dry_run)
 
     job = build_job(

--- a/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_exchange_profile_schedule.py
@@ -6,6 +6,7 @@ import pytest
 
 import scripts.manage_exchange_profile_schedule as schedule_manager
 from scripts.manage_exchange_profile_schedule import (
+    HYPERLIQUID_DRY_RUN_ONLY_MESSAGE,
     OKX_DRY_RUN_ONLY_MESSAGE,
     ScheduleConfig,
     assert_exchange_schedule_policy,
@@ -13,6 +14,7 @@ from scripts.manage_exchange_profile_schedule import (
     build_job,
     build_parser,
     create_schedule,
+    dry_run_only_message,
     generate_schedule_id,
     generate_workflow_id,
     parse_runtime_check_output,
@@ -293,9 +295,10 @@ def test_resolve_schedule_config_allows_dry_run_okx_create():
 
 
 def test_assert_exchange_schedule_policy_allows_live_for_non_dry_run_only_exchanges():
-    # Bitmart legacy can still go live; only dry-run-only exchanges (OKX) are blocked.
+    # Bitmart legacy can still go live; only dry-run-only exchanges (OKX, Hyperliquid) are blocked.
     assert_exchange_schedule_policy("bitmart", dry_run=False) is None
     assert_exchange_schedule_policy("okx", dry_run=True) is None
+    assert_exchange_schedule_policy("hyperliquid", dry_run=True) is None
 
 
 def test_assert_exchange_schedule_policy_blocks_uppercase_okx_live():
@@ -305,3 +308,65 @@ def test_assert_exchange_schedule_policy_blocks_uppercase_okx_live():
 
     with pytest.raises(RuntimeError, match=OKX_DRY_RUN_ONLY_MESSAGE):
         assert_exchange_schedule_policy("  Okx ", dry_run=False)
+
+
+def test_create_live_hyperliquid_schedule_is_blocked_even_with_runtime_check_bypass():
+    class FailingClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise AssertionError("Hyperliquid live schedule must never reach Temporal creation")
+
+    config = ScheduleConfig(
+        command="create",
+        exchange="hyperliquid",
+        market_type="perpetual",
+        profile="scalper",
+        workers=4,
+        dry_run=False,
+        cron="*/1 * * * *",
+        schedule_id="cron-mtf-hyperliquid-scalper-1m",
+        workflow_id="mtf-hyperliquid-scalper-runner",
+        dry_run_schedule=False,
+        skip_runtime_check=True,
+    )
+
+    with pytest.raises(RuntimeError, match=HYPERLIQUID_DRY_RUN_ONLY_MESSAGE):
+        asyncio.run(create_schedule(FailingClient(), config))
+
+
+def test_resolve_schedule_config_blocks_live_hyperliquid_create():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["create", "--exchange", "hyperliquid", "--profile", "scalper", "--dry-run=false"]
+    )
+
+    with pytest.raises(RuntimeError, match=HYPERLIQUID_DRY_RUN_ONLY_MESSAGE):
+        resolve_schedule_config(args)
+
+
+def test_resolve_schedule_config_allows_dry_run_hyperliquid_create():
+    parser = build_parser()
+    args = parser.parse_args(
+        ["create", "--exchange", "hyperliquid", "--profile", "scalper", "--dry-run=true"]
+    )
+
+    config = resolve_schedule_config(args)
+
+    assert config.exchange == "hyperliquid"
+    assert config.dry_run is True
+
+
+def test_assert_exchange_schedule_policy_blocks_uppercase_hyperliquid_live():
+    # The gate normalizes casing/whitespace: a hand-built "HYPERLIQUID" must not bypass it.
+    with pytest.raises(RuntimeError, match=HYPERLIQUID_DRY_RUN_ONLY_MESSAGE):
+        assert_exchange_schedule_policy("HYPERLIQUID", dry_run=False)
+
+    with pytest.raises(RuntimeError, match=HYPERLIQUID_DRY_RUN_ONLY_MESSAGE):
+        assert_exchange_schedule_policy("  Hyperliquid ", dry_run=False)
+
+
+def test_dry_run_only_message_is_exchange_specific():
+    # The generalized message names the offending exchange (uppercased), so OKX and
+    # Hyperliquid get distinct, actionable guardrail messages.
+    assert dry_run_only_message("okx") == OKX_DRY_RUN_ONLY_MESSAGE
+    assert dry_run_only_message("  Hyperliquid ") == HYPERLIQUID_DRY_RUN_ONLY_MESSAGE
+    assert OKX_DRY_RUN_ONLY_MESSAGE != HYPERLIQUID_DRY_RUN_ONLY_MESSAGE

--- a/docs/handbook/technical/hyperliquid-dry-run.md
+++ b/docs/handbook/technical/hyperliquid-dry-run.md
@@ -1,0 +1,118 @@
+# Hyperliquid dry-run
+
+## Statut
+
+Hyperliquid est `target_dry_run_only`. PR12 prépare Hyperliquid en **dry-run / runtime-check
+uniquement**, au même niveau de prudence qu'OKX (PR11) : aucune exécution live, aucun branchement
+runtime, aucun ordre réel, aucune activation mainnet. La bascule live de Hyperliquid reste
+interdite et exigera une **PR de readiness live dédiée**, séparément relue.
+
+Cette page complète :
+
+- `technical/exchange-runtime-gates.md` (gates obligatoires avant tout live) ;
+- `technical/exchange-readiness-matrix.md` (statut par exchange) ;
+- `technical/okx-dry-run.md` (le même patron appliqué à OKX) ;
+- `technical/fake-paper-gateway.md` (le filet de sécurité Fake / Paper).
+
+## HyperliquidDryRunExecutionPort
+
+`App\TradingCore\Execution\Hyperliquid\HyperliquidDryRunExecutionPort` est la troisième
+implémentation de `ExecutionPortInterface` (après `FakeExecutionPort` et
+`OkxDryRunExecutionPort`). Elle respecte strictement l'interface existante :
+`execute(ExecutionRequest): ExecutionResult`.
+
+C'est une **preview / simulation TradingCore**, pas une exécution exchange réelle :
+
+- **aucun appel HTTP**, jamais ;
+- **aucun appel `/exchange`**, **aucun signing**, **aucune private key** : le port ne touche ni
+  `HyperliquidExchangeAdapter`, ni `HyperliquidRestClient`, ni `HyperliquidActionFactory`, ni
+  aucune classe `App\Exchange\Hyperliquid\*` ;
+- aucune dépendance Symfony, Doctrine, Messenger, Temporal ni provider runtime concret ;
+- le port est **pur** : même plan ⇒ même `exchange_order_id`, requête jamais mutée.
+
+Comportement :
+
+| Cas | Résultat |
+| --- | --- |
+| `ExecutionMode::Live` | `ExecutionStatus::Rejected` (`live_not_supported_by_hyperliquid_dry_run`). |
+| Plan d'un autre exchange (`exchange != hyperliquid`) | `Rejected` (`wrong_exchange_for_hyperliquid_dry_run`). |
+| Market type non supporté (≠ `perpetual`) | `Rejected` (`market_type_not_supported_by_hyperliquid_dry_run`). |
+| Plan non exécutable (revalidé via `OrderPlanValidator`) | `Rejected` (`order_plan_not_executable` + `invalid_reasons`). |
+| Plan Hyperliquid perpetual valide en dry-run | `ExecutionStatus::DryRun`, `exchange_order_id = HYPERLIQUID-DRYRUN-{client_order_id}`. |
+
+Metadata produite (success) : `gateway=hyperliquid`, `mode=dry_run`, `simulated=true`,
+`no_http=true`, `no_exchange_call=true`, `client_order_id`, `idempotency_key`, `requested_at`,
+`order_type`, `side`, `symbol`, `entry_price`, `quantity`, `leverage`, `protection_present`. Les
+descripteurs gateway (`gateway`, `simulated`, `no_http`, `no_exchange_call`) et le `reject_reason`
+sont autoritaires : un appelant ne peut pas les usurper via la metadata entrante.
+
+`client_order_id` et `idempotency_key` sont conservés sur tous les chemins.
+
+## Runtime-check : Hyperliquid reste dry-run only
+
+`app:exchange:runtime-check hyperliquid perpetual` durcit la gate Hyperliquid :
+
+- `Live trading: disabled` — Hyperliquid ne peut pas passer live en PR12, même si
+  `HYPERLIQUID_ENV=testnet`, `HYPERLIQUID_MAINNET_ENABLED=1` et les credentials sont présents ;
+- `Dry-run only: yes` ;
+- `Live allowed: no` ;
+- `Network: testnet/mainnet` — réseau configuré, **distinct** de l'autorisation live ;
+- `Mainnet enabled: yes/no` — capacité réseau (`HYPERLIQUID_MAINNET_ENABLED`), **distincte** de
+  l'autorisation live ;
+- `Recommended dry_run: true` (toujours, pour Hyperliquid).
+
+Le choix testnet/mainnet et le flag `HYPERLIQUID_MAINNET_ENABLED` ne sont donc jamais assimilés à
+« live allowed ». OKX et Bitmart legacy ne sont pas affectés : ces lignes sont spécifiques à
+Hyperliquid.
+
+## Schedules Temporal : Hyperliquid dry_run=false interdit
+
+`cron_symfony_mtf_workers/scripts/manage_exchange_profile_schedule.py` refuse explicitement la
+création d'un schedule Hyperliquid live :
+
+- `create --exchange hyperliquid --dry-run=false` lève
+  `RuntimeError: HYPERLIQUID schedules must stay dry_run=true until a dedicated live-readiness PR.` ;
+- la règle est **indépendante du runtime-check** : `--skip-runtime-check` ne la contourne pas ;
+- le blocage résiste à la casse et aux espaces (`HYPERLIQUID`, `" Hyperliquid "`) ;
+- `--dry-run=true` (défaut) pour Hyperliquid reste autorisé ;
+- Bitmart legacy peut toujours créer un schedule live ; OKX et Hyperliquid sont bloqués.
+
+La politique dry-run-only est désormais généralisée (`DRY_RUN_ONLY_EXCHANGES = {"okx",
+"hyperliquid"}`) avec un message d'erreur spécifique à l'exchange.
+
+## Adapter existant ≠ live-ready
+
+`HyperliquidExchangeAdapter` / `HyperliquidRestClient` existent déjà dans `App\Exchange\*`, mais leur
+présence **ne rend pas Hyperliquid prêt au live** dans TradingCore. Le port dry-run est volontairement
+découplé de ces classes. Toute activation live future est une PR dédiée qui devra prouver :
+
+- credentials présents et valides ;
+- runtime-check OK ;
+- WebSocket privé / équivalent validé ;
+- SL/TP attach et liquidation guard adaptés au modèle Hyperliquid ;
+- reconciliation testée ;
+- audit minimal complet ;
+- schedule Temporal explicitement autorisé.
+
+## Hors-scope PR12
+
+- aucune activation live Hyperliquid, aucun mainnet trading (PR de readiness live dédiée requise) ;
+- aucun signing, aucun appel HTTP, aucun appel `/exchange` ;
+- **aucun bundle provider Hyperliquid runtime MTF activé** : `mtf:run`, `POST /api/mtf/run` et le
+  Temporal scheduler ne sont pas branchés sur Hyperliquid par cette PR ;
+- aucun branchement `TradeEntry` runtime ;
+- aucun changement de stratégie (`regular` / `scalper` / `scalper_micro`), EntryZone,
+  Risk / Leverage / SL-TP ni YAML ;
+- aucune suppression Bitmart ; OKX inchangé (sauf factorisation neutre testée) ;
+- aucun secret ajouté dans Git (`config_file/*.env` restent des templates de noms de clés).
+
+## Filet de sécurité
+
+`FakeExecutionPort` (Fake / Paper) reste le filet de sécurité : il permet d'exercer toute la
+chaîne `OrderPlan → ExecutionPort` sans aucun risque. `HyperliquidDryRunExecutionPort` sert de
+référence de preview pour comparer les futurs payloads Hyperliquid avant toute PR d'activation live.
+
+## Suite
+
+La bascule live Hyperliquid (et OKX) restera une PR dédiée, testée et réversible, conditionnée par
+toutes les gates de `technical/exchange-runtime-gates.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - OrderPlan / ExecutionPort module: technical/order-plan-execution-port-module.md
       - Fake / Paper gateway: technical/fake-paper-gateway.md
       - OKX dry-run: technical/okx-dry-run.md
+      - Hyperliquid dry-run: technical/hyperliquid-dry-run.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -81,6 +81,15 @@ final class ExchangeRuntimeCheckCommand extends Command
             $output->writeln('Live allowed: no');
             $output->writeln(sprintf('Demo trading enabled: %s', $this->okxConfig->demoTradingEnabled ? 'yes' : 'no'));
         }
+        if ($exchange === Exchange::HYPERLIQUID) {
+            // PR12: Hyperliquid is dry-run only. Surface the gate explicitly so that the
+            // configured network (testnet/mainnet) and the mainnet capability flag are never
+            // mistaken for live-trading authorization.
+            $output->writeln('Dry-run only: yes');
+            $output->writeln('Live allowed: no');
+            $output->writeln(sprintf('Network: %s', $this->hyperliquidConfig->normalizedEnvironment()));
+            $output->writeln(sprintf('Mainnet enabled: %s', $this->hyperliquidConfig->mainnetEnabled ? 'yes' : 'no'));
+        }
         $output->writeln(sprintf('Recommended dry_run: %s', $recommendedDryRun ? 'true' : 'false'));
         $output->writeln(sprintf('Schedule ready: %s', $scheduleReady ? 'yes' : 'no'));
 
@@ -153,9 +162,10 @@ final class ExchangeRuntimeCheckCommand extends Command
             // is NOT live trading, and OKX_LIVE_ENABLED is intentionally ignored here: live
             // remains disabled until a dedicated OKX live-readiness PR flips this gate.
             Exchange::OKX => 'disabled',
-            Exchange::HYPERLIQUID => $this->hyperliquidConfig->isTestnet()
-                ? 'enabled'
-                : ($this->hyperliquidConfig->mainnetEnabled ? 'enabled' : 'disabled'),
+            // PR12: Hyperliquid stays dry-run only. Testnet/mainnet network selection and
+            // HYPERLIQUID_MAINNET_ENABLED are NOT live-trading authorization: live remains
+            // disabled until a dedicated Hyperliquid live-readiness PR flips this gate.
+            Exchange::HYPERLIQUID => 'disabled',
             default => 'enabled',
         };
     }

--- a/trading-app/src/TradingCore/Execution/Hyperliquid/HyperliquidDryRunExecutionPort.php
+++ b/trading-app/src/TradingCore/Execution/Hyperliquid/HyperliquidDryRunExecutionPort.php
@@ -1,0 +1,133 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Hyperliquid;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Dto\ExecutionResult;
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+use App\TradingCore\Execution\Port\ExecutionPortInterface;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+
+/**
+ * Hyperliquid dry-run / preview implementation of {@see ExecutionPortInterface}.
+ *
+ * PR12 keeps Hyperliquid strictly `dry-run only`: this port simulates what a
+ * Hyperliquid order submission would look like, but it NEVER routes anything to
+ * the exchange and NEVER signs anything.
+ *
+ * It is a pure TradingCore preview, NOT an exchange execution:
+ * - no HTTP call, ever; no `/exchange` action; no signing; no private key;
+ * - it never touches {@see \App\Exchange\Adapter\HyperliquidExchangeAdapter},
+ *   {@see \App\Exchange\Hyperliquid\HyperliquidRestClient} nor
+ *   {@see \App\Exchange\Hyperliquid\HyperliquidActionFactory};
+ * - no Symfony, Doctrine, Messenger, Temporal nor any concrete runtime provider.
+ *
+ * Live mode (and mainnet trading) is always refused. A real Hyperliquid live
+ * activation requires a dedicated, separately reviewed readiness PR.
+ *
+ * Like {@see \App\TradingCore\Execution\Okx\OkxDryRunExecutionPort} and
+ * {@see \App\TradingCore\Execution\Fake\FakeExecutionPort}, it is a pure function
+ * of its input: the same plan always yields the same dry-run order id, and the
+ * input ExecutionRequest is never mutated.
+ */
+final class HyperliquidDryRunExecutionPort implements ExecutionPortInterface
+{
+    private const EXCHANGE = 'hyperliquid';
+    private const MARKET_TYPE = 'perpetual';
+
+    public function __construct(
+        private readonly OrderPlanValidator $validator = new OrderPlanValidator(),
+    ) {
+    }
+
+    public function execute(ExecutionRequest $request): ExecutionResult
+    {
+        $plan = $request->orderPlan;
+
+        // Preserve incoming audit metadata (run_id, correlation_id, schedule_id, ...)
+        // while keeping the gateway's own descriptors authoritative: a caller must not
+        // be able to spoof gateway/simulated/no_http/no_exchange_call.
+        $metadata = array_merge(
+            $request->metadata,
+            [
+                'gateway' => self::EXCHANGE,
+                'mode' => $request->mode->value,
+                'simulated' => true,
+                'no_http' => true,
+                'no_exchange_call' => true,
+                'requested_at' => $request->requestedAt->format(\DateTimeInterface::ATOM),
+                'client_order_id' => $plan->clientOrderId,
+                'idempotency_key' => $plan->idempotencyKey,
+                'order_type' => $plan->orderType,
+                'side' => $plan->side,
+                'symbol' => $plan->symbol,
+                'entry_price' => $plan->entryPrice,
+                'quantity' => $plan->quantity,
+                'leverage' => $plan->leverage,
+                'protection_present' => $plan->protectionPlan !== null,
+            ],
+        );
+
+        // PR12 hard gate: Hyperliquid live is forbidden. This port has no live venue to route to.
+        if ($request->mode === ExecutionMode::Live) {
+            return $this->reject($plan->clientOrderId, $metadata, 'live_not_supported_by_hyperliquid_dry_run');
+        }
+
+        // Routing gate: this port only previews Hyperliquid plans.
+        if (strtolower(trim($plan->exchange)) !== self::EXCHANGE) {
+            return $this->reject(
+                $plan->clientOrderId,
+                array_merge($metadata, ['plan_exchange' => $plan->exchange]),
+                'wrong_exchange_for_hyperliquid_dry_run',
+            );
+        }
+
+        // Routing gate: Hyperliquid preview is scoped to perpetual futures in PR12.
+        if (strtolower(trim($plan->marketType)) !== self::MARKET_TYPE) {
+            return $this->reject(
+                $plan->clientOrderId,
+                array_merge($metadata, ['plan_market_type' => $plan->marketType]),
+                'market_type_not_supported_by_hyperliquid_dry_run',
+            );
+        }
+
+        // Boundary does not trust the validation carried by the DTO: revalidate.
+        $validation = $this->validator->validate($plan);
+        if (!$validation->isExecutable) {
+            return $this->reject(
+                $plan->clientOrderId,
+                array_merge($metadata, ['invalid_reasons' => $validation->invalidReasons]),
+                'order_plan_not_executable',
+            );
+        }
+
+        return new ExecutionResult(
+            status: ExecutionStatus::DryRun,
+            clientOrderId: $plan->clientOrderId,
+            exchangeOrderId: $this->dryRunOrderId($plan->clientOrderId),
+            metadata: $metadata,
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function reject(?string $clientOrderId, array $metadata, string $reason): ExecutionResult
+    {
+        return new ExecutionResult(
+            status: ExecutionStatus::Rejected,
+            clientOrderId: $clientOrderId,
+            // Result reason is authoritative: a caller cannot spoof reject_reason via metadata.
+            metadata: array_merge($metadata, ['reject_reason' => $reason]),
+        );
+    }
+
+    private function dryRunOrderId(?string $clientOrderId): string
+    {
+        $seed = $clientOrderId !== null && trim($clientOrderId) !== '' ? $clientOrderId : 'UNKNOWN';
+
+        return 'HYPERLIQUID-DRYRUN-' . $seed;
+    }
+}

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -99,6 +99,113 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('Demo trading enabled: yes', $output);
         self::assertStringContainsString('Recommended dry_run: true', $output);
         self::assertStringContainsString('Schedule ready: yes', $output);
+        // The Hyperliquid-specific lines must never leak into OKX output.
+        self::assertStringNotContainsString('Network:', $output);
+        self::assertStringNotContainsString('Mainnet enabled:', $output);
+    }
+
+    public function testReportsUnreadyHyperliquidRuntimeWithoutProviderOrCredentials(): void
+    {
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(Exchange::HYPERLIQUID, MarketType::PERPETUAL)),
+            $this->missingProviderRegistry(),
+            new OkxConfig(environment: 'demo'),
+            new HyperliquidConfig(environment: 'testnet'),
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'exchange' => 'hyperliquid',
+            'market_type' => 'perpetual',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Exchange: hyperliquid', $output);
+        self::assertStringContainsString('Adapter: found', $output);
+        self::assertStringContainsString('Provider bundle: missing', $output);
+        self::assertStringContainsString('Credentials: missing', $output);
+        self::assertStringContainsString('Live trading: disabled', $output);
+        self::assertStringContainsString('Dry-run only: yes', $output);
+        self::assertStringContainsString('Live allowed: no', $output);
+        self::assertStringContainsString('Network: testnet', $output);
+        self::assertStringContainsString('Mainnet enabled: no', $output);
+        self::assertStringContainsString('Recommended dry_run: true', $output);
+        self::assertStringContainsString('Schedule ready: no', $output);
+        // The OKX-specific demo line must never leak into Hyperliquid output.
+        self::assertStringNotContainsString('Demo trading enabled:', $output);
+    }
+
+    public function testHyperliquidStaysDryRunOnlyEvenWithCredentialsProviderAndTestnet(): void
+    {
+        // PR12 hardening: a fully "ready" Hyperliquid runtime on testnet with credentials must
+        // still report live as forbidden and recommend dry-run. Testnet capability != live trading.
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(Exchange::HYPERLIQUID, MarketType::PERPETUAL, supportsPrivateWs: true)),
+            $this->providerRegistry($this->providerBundle(Exchange::HYPERLIQUID, MarketType::PERPETUAL)),
+            new OkxConfig(environment: 'demo'),
+            new HyperliquidConfig(
+                environment: 'testnet',
+                accountAddress: '0xabc',
+                privateKey: '0xkey',
+            ),
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'exchange' => 'hyperliquid',
+            'market_type' => 'perpetual',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Exchange: hyperliquid', $output);
+        self::assertStringContainsString('Adapter: found', $output);
+        self::assertStringContainsString('Provider bundle: found', $output);
+        self::assertStringContainsString('Credentials: ok', $output);
+        self::assertStringContainsString('Live trading: disabled', $output);
+        self::assertStringContainsString('Dry-run only: yes', $output);
+        self::assertStringContainsString('Live allowed: no', $output);
+        self::assertStringContainsString('Network: testnet', $output);
+        self::assertStringContainsString('Mainnet enabled: no', $output);
+        self::assertStringContainsString('Recommended dry_run: true', $output);
+        self::assertStringContainsString('Schedule ready: yes', $output);
+    }
+
+    public function testHyperliquidMainnetEnabledStillForbidsLive(): void
+    {
+        // HYPERLIQUID_MAINNET_ENABLED=1 on mainnet is a network capability, NOT a live-trading
+        // authorization: live stays disabled and dry-run stays recommended in PR12.
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(Exchange::HYPERLIQUID, MarketType::PERPETUAL, supportsPrivateWs: true)),
+            $this->providerRegistry($this->providerBundle(Exchange::HYPERLIQUID, MarketType::PERPETUAL)),
+            new OkxConfig(environment: 'demo'),
+            new HyperliquidConfig(
+                environment: 'mainnet',
+                accountAddress: '0xabc',
+                privateKey: '0xkey',
+                mainnetEnabled: true,
+            ),
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'exchange' => 'hyperliquid',
+            'market_type' => 'perpetual',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Credentials: ok', $output);
+        self::assertStringContainsString('Live trading: disabled', $output);
+        self::assertStringContainsString('Dry-run only: yes', $output);
+        self::assertStringContainsString('Live allowed: no', $output);
+        self::assertStringContainsString('Network: mainnet', $output);
+        self::assertStringContainsString('Mainnet enabled: yes', $output);
+        self::assertStringContainsString('Recommended dry_run: true', $output);
     }
 
     public function testReportsReadyBitmartRuntimeWhenAdapterAndProviderExist(): void
@@ -128,9 +235,11 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('REST: unknown', $output);
         self::assertStringContainsString('Recommended dry_run: false', $output);
         self::assertStringContainsString('Schedule ready: yes', $output);
-        // The OKX-specific dry-run-only gate must not leak into Bitmart legacy output.
+        // The OKX/Hyperliquid dry-run-only gates must not leak into Bitmart legacy output.
         self::assertStringNotContainsString('Dry-run only:', $output);
         self::assertStringNotContainsString('Live allowed:', $output);
+        self::assertStringNotContainsString('Network:', $output);
+        self::assertStringNotContainsString('Mainnet enabled:', $output);
     }
 
     public function testReportsUnreadyBitmartRuntimeWhenCredentialsAreMissing(): void

--- a/trading-app/tests/TradingCore/Execution/HyperliquidDryRunExecutionPortTest.php
+++ b/trading-app/tests/TradingCore/Execution/HyperliquidDryRunExecutionPortTest.php
@@ -1,0 +1,243 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution;
+
+use App\TradingCore\Execution\Dto\ExecutionRequest;
+use App\TradingCore\Execution\Enum\ExecutionMode;
+use App\TradingCore\Execution\Enum\ExecutionStatus;
+use App\TradingCore\Execution\Hyperliquid\HyperliquidDryRunExecutionPort;
+use App\TradingCore\OrderPlan\Dto\OrderPlan;
+use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
+use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
+use App\TradingCore\SlTp\Dto\ProtectionPlan;
+use App\TradingCore\SlTp\Dto\StopLossResult;
+use App\TradingCore\SlTp\Dto\TakeProfitResult;
+use App\TradingCore\SlTp\Enum\ProtectionPlanStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HyperliquidDryRunExecutionPort::class)]
+final class HyperliquidDryRunExecutionPortTest extends TestCase
+{
+    public function testDryRunValidHyperliquidPlanReturnsSimulatedDryRunResult(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::DryRun, $result->status);
+        self::assertSame('CID-HL-1', $result->clientOrderId);
+        self::assertSame('HYPERLIQUID-DRYRUN-CID-HL-1', $result->exchangeOrderId);
+        self::assertSame('hyperliquid', $result->metadata['gateway']);
+        self::assertSame('dry_run', $result->metadata['mode']);
+        self::assertTrue($result->metadata['simulated']);
+        self::assertTrue($result->metadata['protection_present']);
+    }
+
+    public function testDryRunResultAdvertisesNoHttpAndNoExchangeCall(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertTrue($result->metadata['no_http']);
+        self::assertTrue($result->metadata['no_exchange_call']);
+        // The plan fields are echoed for audit/preview comparison against future live payloads.
+        self::assertSame('BTCUSDT', $result->metadata['symbol']);
+        self::assertSame('long', $result->metadata['side']);
+        self::assertSame('limit', $result->metadata['order_type']);
+        self::assertSame(100.0, $result->metadata['entry_price']);
+        self::assertSame(12.0, $result->metadata['quantity']);
+        self::assertSame(5, $result->metadata['leverage']);
+    }
+
+    public function testLiveModeIsRefused(): void
+    {
+        // forPlan() allows a live request only for an executable plan; the Hyperliquid dry-run
+        // port must still refuse to route it anywhere (and never sign).
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::Live);
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('live_not_supported_by_hyperliquid_dry_run', $result->metadata['reject_reason']);
+    }
+
+    public function testRejectsPlanForAnotherExchange(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(exchange: 'okx'), ExecutionMode::DryRun);
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('wrong_exchange_for_hyperliquid_dry_run', $result->metadata['reject_reason']);
+        self::assertSame('okx', $result->metadata['plan_exchange']);
+    }
+
+    public function testRejectsUnsupportedMarketType(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(marketType: 'spot'), ExecutionMode::DryRun);
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('market_type_not_supported_by_hyperliquid_dry_run', $result->metadata['reject_reason']);
+        self::assertSame('spot', $result->metadata['plan_market_type']);
+    }
+
+    public function testRejectsNonExecutablePlanWithoutExecuting(): void
+    {
+        $request = ExecutionRequest::forPlan($this->invalidPlan(), ExecutionMode::DryRun);
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertNull($result->exchangeOrderId);
+        self::assertSame('order_plan_not_executable', $result->metadata['reject_reason']);
+        self::assertContains('protection_plan_missing', $result->metadata['invalid_reasons']);
+    }
+
+    public function testDryRunOrderIdIsDeterministicAndPortIsStateless(): void
+    {
+        $port = new HyperliquidDryRunExecutionPort();
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $first = $port->execute($request);
+        $second = $port->execute($request);
+
+        self::assertSame('HYPERLIQUID-DRYRUN-CID-HL-1', $first->exchangeOrderId);
+        self::assertSame($first->exchangeOrderId, $second->exchangeOrderId);
+        self::assertEquals($first, $second);
+    }
+
+    public function testPreservesClientOrderIdAndIdempotencyKey(): void
+    {
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame('CID-HL-1', $result->clientOrderId);
+        self::assertSame('CID-HL-1', $result->metadata['client_order_id']);
+        self::assertSame('decision:BTCUSDT:long', $result->metadata['idempotency_key']);
+    }
+
+    public function testPreservesIncomingRequestMetadata(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::DryRun,
+            ['run_id' => 'run-77', 'correlation_id' => 'corr-9'],
+        );
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame('run-77', $result->metadata['run_id']);
+        self::assertSame('corr-9', $result->metadata['correlation_id']);
+    }
+
+    public function testCallerCannotOverrideGatewayAuthoritativeMetadata(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::DryRun,
+            ['gateway' => 'spoofed', 'simulated' => false, 'no_http' => false, 'no_exchange_call' => false],
+        );
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame('hyperliquid', $result->metadata['gateway']);
+        self::assertTrue($result->metadata['simulated']);
+        self::assertTrue($result->metadata['no_http']);
+        self::assertTrue($result->metadata['no_exchange_call']);
+    }
+
+    public function testCallerCannotSpoofRejectReasonOnLivePath(): void
+    {
+        $request = ExecutionRequest::forPlan(
+            $this->executablePlan(),
+            ExecutionMode::Live,
+            ['reject_reason' => 'caller_spoofed'],
+        );
+
+        $result = (new HyperliquidDryRunExecutionPort())->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertSame('live_not_supported_by_hyperliquid_dry_run', $result->metadata['reject_reason']);
+    }
+
+    // --- fixtures ---
+
+    private function executablePlan(string $exchange = 'hyperliquid', string $marketType = 'perpetual'): OrderPlan
+    {
+        $plan = new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: $exchange,
+            marketType: $marketType,
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: $this->protectionPlan(),
+            clientOrderId: 'CID-HL-1',
+            idempotencyKey: 'decision:BTCUSDT:long',
+        );
+
+        return $plan->withValidation((new OrderPlanValidator())->validate($plan));
+    }
+
+    private function invalidPlan(): OrderPlan
+    {
+        return new OrderPlan(
+            symbol: 'BTCUSDT',
+            profile: 'scalper_micro',
+            exchange: 'hyperliquid',
+            marketType: 'perpetual',
+            side: 'long',
+            orderType: 'limit',
+            marginMode: 'isolated',
+            timeInForce: 'gtc',
+            entryPrice: 100.0,
+            quantity: 12.0,
+            leverage: 5,
+            protectionPlan: null,
+            clientOrderId: 'CID-HL-1',
+            idempotencyKey: 'decision:BTCUSDT:long',
+        );
+    }
+
+    private function protectionPlan(): ProtectionPlan
+    {
+        return new ProtectionPlan(
+            stopLoss: new StopLossResult(
+                stopPrice: 98.0,
+                stopPct: 0.02,
+                stopDistance: 2.0,
+                stopSource: 'pivot',
+                isFullSize: true,
+            ),
+            takeProfit: new TakeProfitResult(
+                tp1Price: 103.0,
+                tp2Price: null,
+                expectedR: 1.5,
+                expectedNetR: 1.4,
+                tpPolicyApplied: 'r_multiple',
+            ),
+            liquidationCheck: new LiquidationCheckResult(
+                isSafe: true,
+                liquidationPrice: 80.0,
+                liquidationDistancePct: 0.20,
+                stopToLiquidationRatio: 0.1,
+            ),
+            isValid: true,
+            status: ProtectionPlanStatus::Valid,
+        );
+    }
+}


### PR DESCRIPTION
## Objectif

Préparer **Hyperliquid en dry-run / runtime-check uniquement**, au même niveau de prudence que PR11 (OKX, #152). Aucune activation live, aucun mainnet trading, aucun signing, aucun HTTP, aucun provider runtime MTF, aucun branchement TradeEntry, aucun changement stratégie/EntryZone/Risk/Leverage/SLTP.

## Trois couches anti-live (indépendantes)

1. **`App\TradingCore\Execution\Hyperliquid\HyperliquidDryRunExecutionPort`** — 3ᵉ implémentation de `ExecutionPortInterface`, **pure** (aucune dépendance Symfony/Doctrine/Messenger/Temporal/provider). Refuse `Live`, rejette les plans wrong-exchange / non-perpetual / non-exécutables (revalidés via `OrderPlanValidator`), retourne `DryRun` avec `HYPERLIQUID-DRYRUN-{client_order_id}` déterministe. Ne touche **jamais** `HyperliquidExchangeAdapter`, `HyperliquidRestClient` ni `HyperliquidActionFactory`.
2. **`ExchangeRuntimeCheckCommand`** — Hyperliquid `Live trading: disabled` même avec credentials + testnet/mainnet + `HYPERLIQUID_MAINNET_ENABLED=1` ; expose `Dry-run only: yes` / `Live allowed: no` / `Network` / `Mainnet enabled`. OKX & Bitmart inchangés.
3. **`manage_exchange_profile_schedule.py`** — politique dry-run-only généralisée `{okx, hyperliquid}` avec message par exchange ; `dry_run=false` Hyperliquid lève `RuntimeError` dans `resolve_schedule_config` **et** `create_schedule`, non contournable par `--skip-runtime-check` ni casse/espaces.

## Comportement du port

| Cas | Résultat |
|---|---|
| `ExecutionMode::Live` | `Rejected` · `live_not_supported_by_hyperliquid_dry_run` |
| exchange ≠ hyperliquid | `Rejected` · `wrong_exchange_for_hyperliquid_dry_run` (+`plan_exchange`) |
| marketType ≠ perpetual | `Rejected` · `market_type_not_supported_by_hyperliquid_dry_run` (+`plan_market_type`) |
| plan non exécutable | `Rejected` · `order_plan_not_executable` (+`invalid_reasons`) |
| HL perpetual valide | `DryRun` · `HYPERLIQUID-DRYRUN-{client_order_id}` |

Metadata `gateway/simulated/no_http/no_exchange_call` + `reject_reason` autoritaires (non spoofables) ; `client_order_id`/`idempotency_key` conservés.

## Tests

- `phpunit tests/TradingCore/Execution tests/Command/ExchangeRuntimeCheckCommandTest.php` → **44 / 230 OK** (+14)
- `phpstan analyse src/TradingCore/Execution/Hyperliquid` → **No errors**
- `phpstan analyse src/Command/ExchangeRuntimeCheckCommand.php` → 1 erreur `$bitmartEnv` **préexistante (identique sur main)**, 0 nouvelle
- `pytest test_manage_exchange_profile_schedule.py` → **24 passed** (+5)
- `lint:yaml config` · `lint:container` · `py_compile` · `mkdocs build --strict` → OK
- route `/api/mtf/run` intacte

## Critères

- **Comportement runtime changé : Non** · **Live Hyperliquid possible : Non**
- HTTP / `/exchange` / signing dans le port : **Non** · provider bundle HL runtime : **Non**
- Bitmart non supprimé · OKX inchangé (refacto neutre testée du message scheduler) · **aucun secret ajouté**

🤖 Generated with [Claude Code](https://claude.com/claude-code)