### PR TITLE
docs: define Python orchestrator and simplified Temporal cron

### DIFF
--- a/docs/handbook/functional/orchestration-dashboard.md
+++ b/docs/handbook/functional/orchestration-dashboard.md
@@ -1,0 +1,186 @@
+# Cockpit d'orchestration
+
+## Objectif
+
+Le cockpit d'orchestration permet de paramétrer les sets d'appels que l'API Python exécutera.
+
+Il ne remplace pas Symfony. Il prépare et pilote les appels vers Symfony.
+
+## Principe fonctionnel
+
+```text
+Front cockpit
+→ configure les sets
+→ force une mise à jour des contrats si nécessaire
+→ déclenche un run
+→ visualise le dernier résultat JSON
+```
+
+Les sets sont déjà prêts au moment du run. L'API Python ne recalcule pas les contrats à chaque déclenchement.
+
+## Écrans attendus
+
+### 1. Liste des dashboards
+
+Affiche les configurations disponibles :
+
+| Champ | Description |
+| --- | --- |
+| Nom | Nom fonctionnel du dashboard. |
+| Statut | Actif ou inactif. |
+| Nombre de sets | Nombre de sets configurés. |
+| Dernier run | Date et statut du dernier run. |
+| Dernier résultat | OK, non OK, partiel. |
+
+### 2. Détail d'un dashboard
+
+Affiche les sets configurés.
+
+| Champ | Description |
+| --- | --- |
+| Enabled | Set actif ou non. |
+| Set ID | Identifiant stable. |
+| Action | `mtf_run`, `sync_contracts`, reporting ou autre action future. |
+| Exchange | Bitmart, OKX, Hyperliquid, Fake. |
+| Market type | `perpetual`, `spot`. |
+| Profil | `regular`, `scalper`, `scalper_micro`. |
+| Environment | `demo`, `testnet`, `mainnet`. |
+| Dry-run | Simulation ou exécution réelle. |
+| Workers Symfony | Gardé à `1` au début. |
+| Contrats | Liste ou nombre de contrats. |
+| Priorité | Ordre ou priorité fonctionnelle. |
+
+### 3. Preview du plan d'exécution
+
+Avant un lancement manuel, le front doit afficher ce qui va être exécuté :
+
+```text
+Run preview
+- 6 sets actifs
+- 6 appels Symfony prévus
+- workers Symfony = 1
+- concurrence globale = 2
+- OKX = dry-run uniquement
+- Hyperliquid = dry-run uniquement
+- Bitmart live = attention / confirmation
+```
+
+Le but est d'éviter un lancement opaque.
+
+### 4. Dernier run
+
+Affiche le dernier résultat global retourné par l'API Python.
+
+| Champ | Description |
+| --- | --- |
+| Run ID | Identifiant du run. |
+| Statut | `success`, `partial_failure`, `failed`. |
+| Started at | Date de début. |
+| Finished at | Date de fin. |
+| Total calls | Nombre d'appels Symfony lancés. |
+| Success | Appels réussis. |
+| Failed | Appels échoués. |
+| Last JSON | Réponse complète du dernier run. |
+
+### 5. Détail par set
+
+Pour chaque set :
+
+| Champ | Description |
+| --- | --- |
+| Set ID | Identifiant du set. |
+| Payload envoyé | JSON envoyé à Symfony. |
+| Réponse Symfony | JSON retourné par Symfony. |
+| Statut | OK ou non OK. |
+| Erreur | Message d'erreur si échec. |
+| Durée | Durée de l'appel. |
+
+## Mise à jour des contrats
+
+La mise à jour des contrats est une action explicite.
+
+```plantuml
+@startuml
+title Recalcul des contrats depuis le cockpit
+
+actor "Utilisateur" as User
+participant "Front cockpit" as Front
+participant "API Python" as Python
+participant "Symfony" as Symfony
+participant "Base orchestration" as Db
+
+User -> Front : modifier config / demander recalcul
+Front -> Python : POST /contracts/refresh
+Python -> Symfony : demander contrats sollicités
+Symfony --> Python : contrats filtrés selon mtf_contracts
+Python -> Python : reconstruire les sets prêts
+Python -> Db : sauvegarder sets et payloads
+Python --> Front : preview des sets mis à jour
+@enduml
+```
+
+Cette action est distincte du run.
+
+## Déclenchement d'un run
+
+```plantuml
+@startuml
+title Lancement manuel ou planifié
+
+actor "Utilisateur ou Temporal" as Trigger
+participant "API Python" as Python
+participant "Base orchestration" as Db
+participant "Symfony" as Symfony
+
+Trigger -> Python : POST /orchestrator/run
+Python -> Db : lire les sets actifs
+loop appels parallèles bornés
+    Python -> Symfony : POST payload prêt
+    Symfony --> Python : réponse JSON
+end
+Python -> Db : sauvegarder dernier JSON
+Python --> Trigger : ok / non ok + résumé
+@enduml
+```
+
+## Règles de sécurité fonctionnelle
+
+Le front aide l'utilisateur, mais l'API Python doit revérifier toutes les règles.
+
+Règles minimales :
+
+- OKX live interdit ;
+- Hyperliquid live interdit ;
+- confirmation obligatoire pour Bitmart live ;
+- pas de même symbole live exécuté deux fois en parallèle ;
+- `workers` Symfony à `1` au début ;
+- concurrence globale bornée ;
+- nombre de contrats borné par set ;
+- dry-run visible clairement ;
+- dernier JSON conservé.
+
+## Ce que le cockpit ne doit pas faire
+
+Le cockpit ne doit pas :
+
+- modifier directement les stratégies YAML ;
+- desserrer les EntryZones ;
+- augmenter le levier ;
+- activer OKX live ;
+- activer Hyperliquid live ;
+- masquer les erreurs ;
+- transformer la parallélisation en objectif de fréquence de trades.
+
+## Mesure fonctionnelle
+
+Les runs doivent ensuite pouvoir être rapprochés de :
+
+- `position_trade_analysis` ;
+- PnL net ;
+- MFE / MAE ;
+- durée de trade ;
+- frais / spread / slippage ;
+- erreurs d'exécution ;
+- trades évités ou bloqués.
+
+L'objectif reste la qualité des setups et l'expectancy nette, pas le nombre brut d'appels ou de trades.

--- a/docs/handbook/functional/orchestration-dashboard.md
+++ b/docs/handbook/functional/orchestration-dashboard.md
@@ -99,48 +99,42 @@ Pour chaque set :
 
 La mise à jour des contrats est une action explicite.
 
-```plantuml
-@startuml
-title Recalcul des contrats depuis le cockpit
+```mermaid
+sequenceDiagram
+    participant User as Utilisateur
+    participant Front as Front cockpit
+    participant Python as API Python
+    participant Symfony as Symfony
+    participant Db as Base orchestration
 
-actor "Utilisateur" as User
-participant "Front cockpit" as Front
-participant "API Python" as Python
-participant "Symfony" as Symfony
-participant "Base orchestration" as Db
-
-User -> Front : modifier config / demander recalcul
-Front -> Python : POST /contracts/refresh
-Python -> Symfony : demander contrats sollicités
-Symfony --> Python : contrats filtrés selon mtf_contracts
-Python -> Python : reconstruire les sets prêts
-Python -> Db : sauvegarder sets et payloads
-Python --> Front : preview des sets mis à jour
-@enduml
+    User->>Front: modifier config / demander recalcul
+    Front->>Python: POST /contracts/refresh
+    Python->>Symfony: demander contrats sollicités
+    Symfony-->>Python: contrats filtrés selon mtf_contracts
+    Python->>Python: reconstruire les sets prêts
+    Python->>Db: sauvegarder sets et payloads
+    Python-->>Front: preview des sets mis à jour
 ```
 
 Cette action est distincte du run.
 
 ## Déclenchement d'un run
 
-```plantuml
-@startuml
-title Lancement manuel ou planifié
+```mermaid
+sequenceDiagram
+    participant Trigger as Utilisateur ou Temporal
+    participant Python as API Python
+    participant Db as Base orchestration
+    participant Symfony as Symfony
 
-actor "Utilisateur ou Temporal" as Trigger
-participant "API Python" as Python
-participant "Base orchestration" as Db
-participant "Symfony" as Symfony
-
-Trigger -> Python : POST /orchestrator/run
-Python -> Db : lire les sets actifs
-loop appels parallèles bornés
-    Python -> Symfony : POST payload prêt
-    Symfony --> Python : réponse JSON
-end
-Python -> Db : sauvegarder dernier JSON
-Python --> Trigger : ok / non ok + résumé
-@enduml
+    Trigger->>Python: POST /orchestrator/run
+    Python->>Db: lire les sets actifs
+    loop appels parallèles bornés
+        Python->>Symfony: POST payload prêt
+        Symfony-->>Python: réponse JSON
+    end
+    Python->>Db: sauvegarder dernier JSON
+    Python-->>Trigger: ok / non ok + résumé
 ```
 
 ## Règles de sécurité fonctionnelle

--- a/docs/handbook/technical/exchange-schedule-policy.md
+++ b/docs/handbook/technical/exchange-schedule-policy.md
@@ -2,47 +2,80 @@
 
 ## Objectif
 
-Cette page définit la politique des schedules Temporal par exchange, market type et profil.
+Cette page définit la politique des déclenchements par exchange, market type et profil.
 
-Elle évite qu’un nouveau schedule rende OKX ou Hyperliquid live avant validation complète.
+Historiquement, la politique portait surtout sur les schedules Temporal. La cible retenue déplace l'orchestration vers une API Python : Temporal reste un cron basique qui appelle `/orchestrator/run`, tandis que les sets et les appels parallèles sont pilotés par l'API Python.
+
+Cette page évite qu'un nouveau déclenchement rende OKX ou Hyperliquid live avant validation complète.
 
 ## Règle générale
 
-Un schedule doit déclarer explicitement :
+Un déclenchement doit déclarer explicitement :
 
 - exchange ;
 - market type ;
 - profil ;
+- environnement ;
 - mode dry-run ou live ;
-- cadence ;
+- quota de contrats ;
 - garde-fous rate limits ;
 - audit attendu ;
 - statut readiness.
 
-## Statuts schedule
+## Statuts
 
 | Statut | Sens |
 |---|---|
 | `simulation_allowed` | Autorisé seulement avec Fake/Paper. |
-| `dry_run_allowed` | Autorisé sans ordre live, après runtime-check. |
+| `dry_run_allowed` | Autorisé sans ordre live, après validation des garde-fous. |
 | `legacy_allowed` | Autorisé uniquement parce que le runtime historique en dépend. |
 | `live_forbidden` | Interdit en live. |
 | `live_candidate` | Potentiellement live plus tard, après PR dédiée. |
 
 ## Politique par exchange
 
-| Exchange | Schedule simulation | Schedule dry-run | Schedule live | Commentaire |
+| Exchange | Simulation | Dry-run | Live | Commentaire |
 |---|---:|---:|---:|---|
 | Fake / Paper | Oui | Oui | Non | Filet de sécurité et gateway de test. |
 | OKX | Oui via Fake/Paper | Oui après runtime-check | Non | Live interdit dans les PRs de préparation. |
 | Hyperliquid | Oui via Fake/Paper | Oui après runtime-check | Non | Live interdit dans les PRs de préparation. |
-| Bitmart legacy | Non cible | Legacy seulement | Legacy seulement | À retirer plus tard, sans casser l’existant. |
+| Bitmart legacy | Non cible | Legacy seulement | Legacy seulement | À retirer plus tard, sans casser l'existant. |
+
+## Cible avec API Python
+
+Le déclenchement cible n'est plus "un schedule Temporal par exchange/profil". La cible devient :
+
+```text
+Temporal schedule unique
+→ activity minimale
+→ POST /orchestrator/run
+→ API Python lit les sets actifs
+→ API Python lance les appels Symfony en parallèle
+```
+
+Les sets Python deviennent la déclaration opérationnelle. Chaque set doit porter au minimum :
+
+```yaml
+set_id: bitmart_regular_live_top_30
+enabled: true
+action: mtf_run
+exchange: bitmart
+market_type: perpetual
+mtf_profile: regular
+environment: mainnet
+dry_run: false
+workers: 1
+contracts_limit: 30
+priority: 10
+```
+
+Ce format est indicatif pour la documentation. Il décrit la cible fonctionnelle, pas une implémentation déjà livrée.
 
 ## Cadence
 
 La cadence 1 minute est sensible.
 
-Avant d’autoriser une cadence 1m pour un exchange/profil, il faut valider :
+Avant d'autoriser une cadence 1m pour un dashboard ou un set, il faut valider :
 
 - rate limits exchange ;
 - coûts de requêtes REST ;
@@ -53,25 +86,20 @@ Avant d’autoriser une cadence 1m pour un exchange/profil, il faut valider :
 - dry-run stable ;
 - absence de double soumission ;
 - SL attaché immédiatement ;
-- logs exploitables.
+- logs exploitables ;
+- dernier JSON conservé.
 
-## Format cible de déclaration
+## Concurrence
 
-Un schedule devrait pouvoir être décrit ainsi :
+La concurrence est pilotée par l'API Python, pas par les workers Symfony.
 
-```yaml
-exchange: okx
-market_type: perpetual
-profile: scalper
-mode: dry_run
-cadence: "*/1 * * * *"
-runtime_check_required: true
-live_enabled: false
-audit_required: true
-fallback_gateway: fake
-```
+Règles cibles :
 
-Ce format est indicatif pour la documentation. Il ne branche aucun runtime dans cette PR.
+- `workers=1` côté Symfony au début ;
+- concurrence globale bornée côté API Python ;
+- pas deux appels live incompatibles sur le même symbole ;
+- pas de parallélisation illimitée ;
+- pas de live orchestré sans idempotence et locks.
 
 ## Fake / Paper
 
@@ -79,17 +107,17 @@ Fake/Paper est autorisé pour :
 
 - simulation ;
 - dry-run ;
-- validation d’OrderPlan ;
-- validation d’ExecutionPort ;
+- validation d'OrderPlan ;
+- validation d'ExecutionPort ;
 - replay ;
 - backtesting ;
 - contrôle des invariants.
 
-Fake/Paper ne doit jamais envoyer d’ordre live.
+Fake/Paper ne doit jamais envoyer d'ordre live.
 
 ## OKX
 
-OKX peut avoir des schedules dry-run seulement si :
+OKX peut avoir des sets dry-run seulement si :
 
 - runtime-check OK ;
 - credentials disponibles hors Git ;
@@ -98,11 +126,11 @@ OKX peut avoir des schedules dry-run seulement si :
 - audit actif ;
 - Fake/Paper disponible comme fallback.
 
-OKX live est interdit tant qu’une PR dédiée de readiness live n’a pas été validée.
+OKX live est interdit tant qu'une PR dédiée de readiness live n'a pas été validée.
 
 ## Hyperliquid
 
-Hyperliquid peut avoir des schedules dry-run seulement si :
+Hyperliquid peut avoir des sets dry-run seulement si :
 
 - runtime-check OK ;
 - credentials disponibles hors Git ;
@@ -112,30 +140,30 @@ Hyperliquid peut avoir des schedules dry-run seulement si :
 - audit actif ;
 - Fake/Paper disponible comme fallback.
 
-Hyperliquid live est interdit tant qu’une PR dédiée de readiness live n’a pas été validée.
+Hyperliquid live est interdit tant qu'une PR dédiée de readiness live n'a pas été validée.
 
 ## Bitmart legacy
 
-Bitmart peut rester schedulé uniquement si le runtime historique en dépend encore.
+Bitmart peut rester schedulé ou orchestré uniquement si le runtime historique en dépend encore.
 
 Règles :
 
-- ne pas créer de nouveaux schedules Bitmart comme cible future ;
-- documenter les schedules legacy existants ;
+- ne pas créer de nouveaux chemins Bitmart live sans idempotence et locks ;
+- documenter les déclenchements legacy existants ;
 - retirer Bitmart après inventaire ;
-- ne pas casser `mtf:run`, `POST /api/mtf/run` ou Temporal pendant la transition.
+- ne pas casser `mtf:run`, `POST /api/mtf/run` ou le déclenchement Temporal pendant la transition.
 
-## Gates avant ajout d’un nouveau schedule
+## Gates avant ajout d'un nouveau set
 
-Avant tout nouveau schedule, vérifier :
+Avant tout nouveau set, vérifier :
 
 1. la gateway est listée dans la readiness matrix ;
 2. le runtime-check est disponible ;
-3. l’exchange n’est pas live par défaut ;
+3. l'exchange n'est pas live par défaut ;
 4. le profil est explicitement autorisé ;
 5. la cadence est justifiée ;
 6. les rate limits sont connus ;
-7. l’audit minimal est actif ;
+7. l'audit minimal est actif ;
 8. Fake/Paper fallback existe ;
 9. la PR reste atomique ;
 10. les invariants trading ne sont pas cassés.
@@ -144,11 +172,11 @@ Avant tout nouveau schedule, vérifier :
 
 Les PRs de préparation ne doivent pas :
 
-- créer de schedule live OKX ;
-- créer de schedule live Hyperliquid ;
+- créer de chemin live OKX ;
+- créer de chemin live Hyperliquid ;
 - augmenter la cadence pour chercher plus de trades ;
 - contourner le runtime-check ;
-- désactiver le dry-run ;
+- désactiver le dry-run sans validation ;
 - modifier les stratégies pour forcer des trades ;
 - desserrer les EntryZones ;
 - modifier le levier.

--- a/docs/handbook/technical/exchange-schedule-policy.md
+++ b/docs/handbook/technical/exchange-schedule-policy.md
@@ -65,9 +65,12 @@ mtf_profile: regular
 environment: mainnet
 dry_run: false
 workers: 1
+sync_tables: false
 contracts_limit: 30
 priority: 10
 ```
+
+`sync_tables: false` est obligatoire pour les sets préparés `mtf_run` lorsque les contrats ont déjà été rafraîchis via le flux explicite front/API Python. Tant que Symfony ne sait pas honorer ce champ, ces sets ne doivent pas être considérés comme prêts pour l'orchestration parallèle.
 
 Ce format est indicatif pour la documentation. Il décrit la cible fonctionnelle, pas une implémentation déjà livrée.
 
@@ -96,6 +99,7 @@ La concurrence est pilotée par l'API Python, pas par les workers Symfony.
 Règles cibles :
 
 - `workers=1` côté Symfony au début ;
+- `sync_tables=false` pour les sets préparés ;
 - concurrence globale bornée côté API Python ;
 - pas deux appels live incompatibles sur le même symbole ;
 - pas de parallélisation illimitée ;

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -1,0 +1,213 @@
+# Python orchestrator
+
+## Statut
+
+Cette page décrit la cible fonctionnelle retenue pour l'orchestration des appels TradingV3.
+
+L'API Python devient l'orchestrateur principal. Temporal reste un déclencheur planifié basique et Symfony reste le moteur métier MTF.
+
+## Objectif
+
+Remplacer le modèle "un worker lance un gros traitement" par un modèle où l'API Python :
+
+1. lit des sets de payloads déjà préparés ;
+2. lance plusieurs appels Symfony en parallèle ;
+3. garde `workers=1` côté Symfony au début ;
+4. agrège les résultats ;
+5. sauvegarde le dernier JSON retourné ;
+6. expose une visualisation fonctionnelle au front.
+
+Le but n'est pas d'augmenter le nombre de trades. Le but est de mieux contrôler les appels, isoler les erreurs, comparer les modes et réduire les mauvais trades.
+
+## Responsabilités
+
+| Composant | Rôle |
+| --- | --- |
+| Front cockpit | Configure les sets, force une mise à jour des contrats, déclenche un run, visualise le dernier JSON. |
+| API Python | Orchestre, parallélise, agrège, persiste les sets et les résultats. |
+| Symfony | Fournit la liste des contrats sollicités, exécute `/api/mtf/run`, conserve la logique métier trading. |
+| Temporal | Déclenche périodiquement `/orchestrator/run` et reçoit OK / non OK. |
+| PostgreSQL | Stocke la configuration d'orchestration, les sets prêts, les runs et le dernier JSON. |
+
+## Flux fonctionnel principal
+
+```plantuml
+@startuml
+title Orchestration Python fonctionnelle
+
+actor "Front / Cron / Temporal" as Trigger
+participant "API Python" as Python
+participant "Base orchestration" as Db
+participant "Symfony" as Symfony
+
+Trigger -> Python : POST /orchestrator/run
+Python -> Db : lire les sets actifs déjà prêts
+loop appels parallèles bornés
+    Python -> Symfony : POST /api/mtf/run
+    Symfony --> Python : JSON existant
+end
+Python -> Db : sauvegarder dernier JSON global et par set
+Python --> Trigger : { ok, run_id, summary }
+@enduml
+```
+
+## Mise à jour des contrats
+
+La récupération des contrats depuis Symfony ne se fait pas à chaque run.
+
+Elle se fait uniquement lors d'un changement de configuration ou via une action explicite du front.
+
+```plantuml
+@startuml
+title Mise à jour des contrats sollicités
+
+actor "Front cockpit" as Front
+participant "API Python" as Python
+participant "Symfony" as Symfony
+participant "Base orchestration" as Db
+
+Front -> Python : demande de recalcul des contrats
+Python -> Symfony : appel explicite liste contrats sollicités
+Symfony -> Symfony : applique mtf_contracts
+Symfony --> Python : contrats filtrés
+Python -> Python : prépare / met à jour les sets
+Python -> Db : persiste sets et payloads prêts
+Python --> Front : preview des sets disponibles
+@enduml
+```
+
+## Lien avec `mtf_contracts`
+
+Symfony reste la source de vérité pour la sélection initiale des contrats. La configuration `mtf_contracts` filtre déjà les contrats selon :
+
+- activation de la sélection ;
+- devise de cotation ;
+- statut du contrat ;
+- turnover 24h minimal ;
+- séparation TOP / MID ;
+- limite `top_n` ;
+- limite `mid_n`.
+
+L'évolution fonctionnelle attendue est d'ajouter une notion de quotas ou de répartition par exchange, profil, environnement ou set.
+
+Exemples fonctionnels :
+
+```text
+Bitmart regular live        -> 30 contrats
+Bitmart scalper live        -> 20 contrats
+OKX regular dry-run         -> 20 contrats
+Hyperliquid regular dry-run -> 20 contrats
+Scalper micro               -> 10 contrats
+```
+
+## Sets de payloads
+
+Un set est une unité fonctionnelle prête à être exécutée.
+
+Un set peut représenter :
+
+- un exchange ;
+- un profil MTF ;
+- un environnement ;
+- une liste de contrats ;
+- une action ;
+- un niveau de priorité ;
+- un statut `enabled` / `disabled` ;
+- un mode `dry_run` / live.
+
+Exemple fonctionnel :
+
+```json
+{
+  "set_id": "bitmart_regular_live_top_30",
+  "enabled": true,
+  "action": "mtf_run",
+  "exchange": "bitmart",
+  "market_type": "perpetual",
+  "mtf_profile": "regular",
+  "environment": "mainnet",
+  "dry_run": false,
+  "workers": 1,
+  "symbols": ["BTCUSDT", "ETHUSDT"],
+  "priority": 10
+}
+```
+
+Au moment du run, l'API Python ne recalcule pas ce set. Elle le lit, l'exécute, puis sauvegarde le résultat.
+
+## Déclenchement
+
+L'endpoint cible est :
+
+```text
+POST /orchestrator/run
+```
+
+Il doit :
+
+1. créer un `run_id` ;
+2. lire les sets actifs ;
+3. appliquer les garde-fous fonctionnels ;
+4. lancer les appels en parallèle avec concurrence bornée ;
+5. attendre tous les résultats ;
+6. agréger ;
+7. sauvegarder le dernier JSON ;
+8. retourner un statut court.
+
+## Réponse minimale
+
+```json
+{
+  "ok": false,
+  "run_id": "run_20260616_001",
+  "status": "partial_failure",
+  "summary": {
+    "total_calls": 6,
+    "success": 5,
+    "failed": 1
+  }
+}
+```
+
+Le front peut ensuite récupérer le détail complet depuis l'API Python.
+
+## Dernier JSON retourné
+
+L'API Python garde toujours :
+
+- le dernier JSON global du run ;
+- le dernier JSON par set ;
+- les payloads envoyés ;
+- les réponses Symfony brutes ;
+- le résumé affichable ;
+- les erreurs.
+
+Le front peut donc afficher le même type de retour que le retour existant de Symfony, avec une vue supplémentaire par set.
+
+## Garde-fous fonctionnels
+
+Avant tout run :
+
+- ne jamais lancer deux sets live incompatibles sur le même symbole ;
+- ne pas autoriser OKX live ;
+- ne pas autoriser Hyperliquid live ;
+- garder `workers=1` côté Symfony au début ;
+- borner la concurrence globale ;
+- refuser les valeurs dangereuses de workers, concurrence ou nombre de contrats ;
+- conserver une trace du dernier payload et de la dernière réponse ;
+- ne pas déclencher des trades simplement pour augmenter la fréquence.
+
+## Hors-scope de la première PR code
+
+La première PR technique de l'API Python ne doit pas encore gérer tout le trading live.
+
+Elle peut se limiter à :
+
+- squelette API ;
+- endpoint `/orchestrator/run` ;
+- lecture de sets persistés ou simulés ;
+- appels parallèles dry-run ;
+- stockage du dernier JSON ;
+- visualisation minimale.
+
+Le live orchestré nécessite une étape dédiée avec idempotence, locks et validation côté Symfony.

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -222,6 +222,20 @@ Avant tout run :
 - conserver une trace du dernier payload et de la dernière réponse ;
 - ne pas déclencher des trades simplement pour augmenter la fréquence.
 
+## Plan court de PR atomiques
+
+| PR | Objectif | Résultat attendu |
+| --- | --- | --- |
+| DOC-001 | Figer la cible fonctionnelle | Documentation actuelle validée. |
+| PY-001 | Créer le squelette API Python | Service API lancé, endpoint healthcheck, structure projet. |
+| DB-001 | Persister dashboards, sets et derniers runs | Tables orchestration + dernier JSON global/par set. |
+| SF-001 | Supporter `sync_tables=false` côté Symfony | `/api/mtf/run` peut exécuter un set préparé sans sync par run. |
+| PY-002 | Implémenter `/orchestrator/run` | Lecture des sets actifs, appels parallèles bornés, agrégation. |
+| UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
+| TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
+
+Ce plan reste volontairement court. Les issues et prompts détaillés seront créés au moment de chaque PR.
+
 ## Hors-scope de la première PR code
 
 La première PR technique de l'API Python ne doit pas encore gérer tout le trading live.

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -218,6 +218,7 @@ Avant tout run :
 - garder `workers=1` côté Symfony au début ;
 - borner la concurrence globale ;
 - refuser les valeurs dangereuses de workers, concurrence ou nombre de contrats ;
+- exiger une API Symfony exposant les contrats filtrés par `mtf_contracts` avant de persister des sets réels ;
 - exiger le support Symfony de `sync_tables=false` avant d'utiliser des sets préparés en parallèle ;
 - conserver une trace du dernier payload et de la dernière réponse ;
 - ne pas déclencher des trades simplement pour augmenter la fréquence.
@@ -227,9 +228,10 @@ Avant tout run :
 | PR | Objectif | Résultat attendu |
 | --- | --- | --- |
 | DOC-001 | Figer la cible fonctionnelle | Documentation actuelle validée. |
+| SF-001 | Exposer les contrats filtrés par `mtf_contracts` | Endpoint Symfony retournant les symboles réellement sélectionnés. |
 | PY-001 | Créer le squelette API Python | Service API lancé, endpoint healthcheck, structure projet. |
 | DB-001 | Persister dashboards, sets et derniers runs | Tables orchestration + dernier JSON global/par set. |
-| SF-001 | Supporter `sync_tables=false` côté Symfony | `/api/mtf/run` peut exécuter un set préparé sans sync par run. |
+| SF-002 | Supporter `sync_tables=false` côté Symfony | `/api/mtf/run` peut exécuter un set préparé sans sync par run. |
 | PY-002 | Implémenter `/orchestrator/run` | Lecture des sets actifs, appels parallèles bornés, agrégation. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -109,7 +109,7 @@ Un set peut représenter :
 - un statut `enabled` / `disabled` ;
 - un mode `dry_run` / live.
 
-Exemple fonctionnel :
+Exemple fonctionnel cible :
 
 ```json
 {
@@ -122,12 +122,42 @@ Exemple fonctionnel :
   "environment": "mainnet",
   "dry_run": false,
   "workers": 1,
+  "sync_tables": false,
   "symbols": ["BTCUSDT", "ETHUSDT"],
   "priority": 10
 }
 ```
 
 Au moment du run, l'API Python ne recalcule pas ce set. Elle le lit, l'exécute, puis sauvegarde le résultat.
+
+## Dépendance Symfony : `sync_tables=false`
+
+Pour que le modèle "sets déjà prêts" fonctionne, Symfony doit pouvoir exécuter `/api/mtf/run` sans relancer une synchronisation des tables exchange/open-state à chaque appel.
+
+La cible fonctionnelle est :
+
+```text
+refresh explicite des contrats
+→ sets préparés
+→ runs parallèles avec sync_tables=false
+```
+
+Donc une PR technique devra faire accepter et respecter un champ équivalent à :
+
+```json
+{
+  "sync_tables": false
+}
+```
+
+Règles attendues :
+
+- `sync_tables=true` reste le comportement legacy par défaut ;
+- `sync_tables=false` est utilisé uniquement par l'orchestrateur Python sur des sets déjà préparés ;
+- si Symfony ne sait pas encore honorer `sync_tables=false`, les runs parallèles ne doivent pas être considérés comme prêts pour la cible ;
+- le front doit distinguer "refresh contrats" et "run des sets".
+
+Sans ce contrat, chaque set pourrait encore déclencher une sync Symfony, ce qui annulerait le bénéfice du flux de refresh explicite.
 
 ## Déclenchement
 
@@ -188,6 +218,7 @@ Avant tout run :
 - garder `workers=1` côté Symfony au début ;
 - borner la concurrence globale ;
 - refuser les valeurs dangereuses de workers, concurrence ou nombre de contrats ;
+- exiger le support Symfony de `sync_tables=false` avant d'utiliser des sets préparés en parallèle ;
 - conserver une trace du dernier payload et de la dernière réponse ;
 - ne pas déclencher des trades simplement pour augmenter la fréquence.
 
@@ -204,4 +235,4 @@ Elle peut se limiter à :
 - stockage du dernier JSON ;
 - visualisation minimale.
 
-Le live orchestré nécessite une étape dédiée avec idempotence, locks et validation côté Symfony.
+Le live orchestré nécessite une étape dédiée avec idempotence, locks, support `sync_tables=false` et validation côté Symfony.

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -31,24 +31,21 @@ Le but n'est pas d'augmenter le nombre de trades. Le but est de mieux contrôler
 
 ## Flux fonctionnel principal
 
-```plantuml
-@startuml
-title Orchestration Python fonctionnelle
+```mermaid
+sequenceDiagram
+    participant Trigger as Front / Cron / Temporal
+    participant Python as API Python
+    participant Db as Base orchestration
+    participant Symfony as Symfony
 
-actor "Front / Cron / Temporal" as Trigger
-participant "API Python" as Python
-participant "Base orchestration" as Db
-participant "Symfony" as Symfony
-
-Trigger -> Python : POST /orchestrator/run
-Python -> Db : lire les sets actifs déjà prêts
-loop appels parallèles bornés
-    Python -> Symfony : POST /api/mtf/run
-    Symfony --> Python : JSON existant
-end
-Python -> Db : sauvegarder dernier JSON global et par set
-Python --> Trigger : { ok, run_id, summary }
-@enduml
+    Trigger->>Python: POST /orchestrator/run
+    Python->>Db: lire les sets actifs déjà prêts
+    loop appels parallèles bornés
+        Python->>Symfony: POST /api/mtf/run
+        Symfony-->>Python: JSON existant
+    end
+    Python->>Db: sauvegarder dernier JSON global et par set
+    Python-->>Trigger: { ok, run_id, summary }
 ```
 
 ## Mise à jour des contrats
@@ -57,23 +54,20 @@ La récupération des contrats depuis Symfony ne se fait pas à chaque run.
 
 Elle se fait uniquement lors d'un changement de configuration ou via une action explicite du front.
 
-```plantuml
-@startuml
-title Mise à jour des contrats sollicités
+```mermaid
+sequenceDiagram
+    participant Front as Front cockpit
+    participant Python as API Python
+    participant Symfony as Symfony
+    participant Db as Base orchestration
 
-actor "Front cockpit" as Front
-participant "API Python" as Python
-participant "Symfony" as Symfony
-participant "Base orchestration" as Db
-
-Front -> Python : demande de recalcul des contrats
-Python -> Symfony : appel explicite liste contrats sollicités
-Symfony -> Symfony : applique mtf_contracts
-Symfony --> Python : contrats filtrés
-Python -> Python : prépare / met à jour les sets
-Python -> Db : persiste sets et payloads prêts
-Python --> Front : preview des sets disponibles
-@enduml
+    Front->>Python: demande de recalcul des contrats
+    Python->>Symfony: appel explicite liste contrats sollicités
+    Symfony->>Symfony: applique mtf_contracts
+    Symfony-->>Python: contrats filtrés
+    Python->>Python: prépare / met à jour les sets
+    Python->>Db: persiste sets et payloads prêts
+    Python-->>Front: preview des sets disponibles
 ```
 
 ## Lien avec `mtf_contracts`

--- a/docs/handbook/technical/temporal.md
+++ b/docs/handbook/technical/temporal.md
@@ -1,63 +1,103 @@
 # Temporal Workers
 
-Le sous-projet `cron_symfony_mtf_workers/` orchestre les appels planifies vers Symfony. Il ne valide pas les signaux lui-meme: il construit des jobs, demarre un workflow Temporal, appelle l'API Symfony, compacte la reponse et conserve la reponse complete dans le resultat workflow.
+Le sous-projet `cron_symfony_mtf_workers/` orchestre historiquement des appels planifiés vers Symfony. Il ne valide pas les signaux lui-même : il construit des jobs, démarre un workflow Temporal, appelle l'API Symfony, compacte la réponse et conserve la réponse complète dans le résultat workflow.
 
-## Responsabilites
+La cible fonctionnelle retenue pour la suite est plus simple : Temporal redevient un déclencheur planifié basique. L'orchestration parallèle, les sets de payloads, la conservation du dernier JSON et la visualisation sont portés par une API Python dédiée.
 
-| Composant | Fichier | Role |
+## Décision cible
+
+| Composant | Responsabilité cible |
+| --- | --- |
+| Temporal schedule | Déclencher périodiquement un run. |
+| Temporal workflow / activity | Appeler une URL unique de l'orchestrateur Python et retourner OK / non OK. |
+| API Python orchestratrice | Lire les sets prêts, lancer les appels Symfony en parallèle, agréger, persister le dernier JSON. |
+| Symfony / TradingV3 | Rester le moteur métier : `/api/mtf/run`, `/api/mtf/sync-contracts`, configuration `mtf_contracts`. |
+| Front cockpit | Paramétrer les sets, lancer un run manuel, visualiser le dernier retour JSON. |
+
+Cette décision évite de faire porter à Temporal la logique de sélection, de découpage, de concurrence et d'audit des appels. Temporal reste utile comme cron supervisé, mais ne devient pas le moteur d'orchestration trading.
+
+## Flux cible simplifié
+
+```plantuml
+@startuml
+title Temporal comme cron basique
+
+participant "Temporal Schedule" as Schedule
+participant "Workflow/Activity\nminimal" as Activity
+participant "API Python\n/orchestrator/run" as Python
+participant "Symfony\n/api/mtf/run" as Symfony
+participant "Base orchestration" as Db
+
+Schedule -> Activity : tick planifié
+Activity -> Python : POST /orchestrator/run
+Python -> Db : lire les sets actifs déjà prêts
+Python -> Symfony : appels parallèles bornés
+Symfony --> Python : réponses JSON existantes
+Python -> Db : sauvegarder dernier JSON et statut
+Python --> Activity : { ok: true|false, run_id, summary }
+Activity --> Schedule : succès ou échec
+@enduml
+```
+
+## Responsabilités legacy
+
+| Composant | Fichier | Rôle |
 | --- | --- | --- |
-| Worker process | `cron_symfony_mtf_workers/worker.py` | Se connecte a Temporal, enregistre workflow et activity sur la task queue. |
-| Workflow | `workflows/mtf_workers.py` | Normalise les jobs, execute `mtf_api_call`, logge le resume. |
-| Activity HTTP | `activities/mtf_http.py` | POST JSON vers Symfony, parse la reponse, appelle le formatteur. |
+| Worker process | `cron_symfony_mtf_workers/worker.py` | Se connecte à Temporal, enregistre workflow et activity sur la task queue. |
+| Workflow legacy | `workflows/mtf_workers.py` | Normalise les jobs, exécute `mtf_api_call`, logge le résumé. |
+| Activity HTTP legacy | `activities/mtf_http.py` | POST JSON vers Symfony, parse la réponse, appelle le formatter. |
 | Model job | `models/mtf_job.py` | Normalise URL, workers, dry-run, profile, exchange, market type, timeout et symboles. |
-| Formatter | `utils/response_formatter.py` | Reduit une reponse MTF longue en resume exploitable dans Temporal UI. |
-| Schedules | `scripts/manage_*.py` | Cree, lit, pause, reprend ou supprime les schedules. |
-| Tests | `tests/*.py` | Valide le formatteur et les helpers de schedules. |
+| Formatter | `utils/response_formatter.py` | Réduit une réponse MTF longue en résumé exploitable. |
+| Schedules | `scripts/manage_*.py` | Crée, lit, pause, reprend ou supprime les schedules. |
+| Tests | `tests/*.py` | Valide le formatter et les helpers de schedules. |
 
-## Flux d'execution
+## Flux legacy actuel
 
-```mermaid
-sequenceDiagram
-    participant Ops as Operateur / Script
-    participant Temporal as Temporal Server
-    participant Worker as worker.py
-    participant Workflow as CronSymfonyMtfWorkersWorkflow
-    participant Activity as mtf_api_call
-    participant Symfony as trading-app-nginx /api/mtf/run
-    participant Formatter as response_formatter.py
+```plantuml
+@startuml
+title Workflow Temporal legacy
 
-    Ops->>Temporal: create schedule
-    Worker->>Temporal: poll task queue cron_symfony_mtf_workers
-    Temporal->>Workflow: cron tick avec jobs
-    Workflow->>Workflow: MtfJob.from_dict + payload()
-    Workflow->>Activity: execute_activity(url, payload)
-    Activity->>Symfony: POST JSON
-    Symfony-->>Activity: full MTF response
-    Activity->>Formatter: format_mtf_response(raw_response)
-    Formatter-->>Activity: summary + metrics + full_response
-    Activity-->>Workflow: formatted result
-    Workflow-->>Temporal: logs concis + result
+participant "Opérateur / Script" as Ops
+participant "Temporal Server" as Temporal
+participant "worker.py" as Worker
+participant "CronSymfonyMtfWorkersWorkflow" as Workflow
+participant "mtf_api_call" as Activity
+participant "Symfony\n/api/mtf/run" as Symfony
+participant "response_formatter.py" as Formatter
+
+Ops -> Temporal : create schedule
+Worker -> Temporal : poll task queue cron_symfony_mtf_workers
+Temporal -> Workflow : cron tick avec jobs
+Workflow -> Workflow : MtfJob.from_dict + payload()
+Workflow -> Activity : execute_activity(url, payload)
+Activity -> Symfony : POST JSON
+Symfony --> Activity : full MTF response
+Activity -> Formatter : format_mtf_response(raw_response)
+Formatter --> Activity : summary + metrics + full_response
+Activity --> Workflow : formatted result
+Workflow --> Temporal : logs concis + result
+@enduml
 ```
 
 ## Payload `MtfJob`
 
-Le model `MtfJob` accepte:
+Le modèle `MtfJob` accepte :
 
-| Champ | Defaut | Description |
+| Champ | Défaut | Description |
 | --- | --- | --- |
-| `url` | requis | Endpoint appele, souvent `http://trading-app-nginx:80/api/mtf/run`. |
-| `workers` | `4` | Nombre de workers cote runner Symfony. |
-| `dry_run` | `true` | Simule ou execute reellement. |
+| `url` | requis | Endpoint appelé, souvent `http://trading-app-nginx:80/api/mtf/run`. |
+| `workers` | `4` | Nombre de workers côté runner Symfony. |
+| `dry_run` | `true` | Simule ou exécute réellement. |
 | `force_run` | `false` | Ignore certains garde-fous de cadence. |
-| `force_timeframe_check` | `false` | Force les controles timeframe. |
-| `current_tf` | `null` | Timeframe courant impose si fourni. |
+| `force_timeframe_check` | `false` | Force les contrôles timeframe. |
+| `current_tf` | `null` | Timeframe courant imposé si fourni. |
 | `symbols` | `[]` | Liste optionnelle de symboles. |
-| `exchange` | `null` | Exchange explicite: `bitmart`, `okx`, `hyperliquid`, `fake`, etc. |
-| `market_type` | `null` | Type de marche, par exemple `perpetual` ou `spot`. |
-| `mtf_profile` | `null` | Profil MTF: `regular`, `scalper`, `scalper_micro`. |
+| `exchange` | `null` | Exchange explicite : `bitmart`, `okx`, `hyperliquid`, `fake`, etc. |
+| `market_type` | `null` | Type de marché, par exemple `perpetual` ou `spot`. |
+| `mtf_profile` | `null` | Profil MTF : `regular`, `scalper`, `scalper_micro`. |
 | `timeout_minutes` | `15` | Timeout workflow/activity par job. |
 
-Le payload envoye a Symfony garde uniquement les champs utiles:
+Le payload envoyé à Symfony garde uniquement les champs utiles :
 
 ```json
 {
@@ -71,118 +111,71 @@ Le payload envoye a Symfony garde uniquement les champs utiles:
 }
 ```
 
-## Scripts de schedules
+`url` sert à choisir l'endpoint HTTP. `timeout_minutes` sert au timeout Temporal. Ces deux champs ne font pas partie du JSON métier envoyé à Symfony.
+
+## Rôle cible de l'activity Temporal
+
+Dans la cible, l'activity Temporal ne construit plus plusieurs jobs Symfony. Elle appelle une seule URL :
+
+```text
+POST /orchestrator/run
+```
+
+Retour minimal attendu :
+
+```json
+{
+  "ok": true,
+  "run_id": "run_20260616_001",
+  "status": "success",
+  "summary": {
+    "total_calls": 6,
+    "success": 6,
+    "failed": 0
+  }
+}
+```
+
+Si `ok=false`, Temporal marque le tick en échec. Le JSON complet et les détails par set restent dans l'API Python et dans la base d'orchestration.
+
+## Scripts de schedules legacy
 
 | Script | Statut | Usage |
 | --- | --- | --- |
-| `scripts/manage_exchange_profile_schedule.py` | recommande | Schedule explicite par `exchange`, `market_type`, `profile`, cadence et dry-run. |
-| `scripts/manage_mtf_workers_schedule.py` | legacy | Ancien schedule generique vers `/api/mtf/run`. |
-| `scripts/manage_scalper_micro_schedule.py` | legacy | Ancien schedule dedie `scalper_micro`. |
+| `scripts/manage_exchange_profile_schedule.py` | legacy / transition | Schedule explicite par `exchange`, `market_type`, `profile`, cadence et dry-run. |
+| `scripts/manage_mtf_workers_schedule.py` | legacy | Ancien schedule générique vers `/api/mtf/run`. |
+| `scripts/manage_scalper_micro_schedule.py` | legacy | Ancien schedule dédié `scalper_micro`. |
 | `scripts/manage_contract_sync_schedule.py` | actif | Sync quotidienne des contrats via `/api/mtf/sync-contracts`. |
 | `scripts/manage_cleanup_schedule.py` | actif | Jobs de cleanup. |
 
-Actions communes:
-
-```bash
-python scripts/manage_exchange_profile_schedule.py create --exchange=bitmart --profile=scalper_micro --dry-run=true
-python scripts/manage_exchange_profile_schedule.py status --schedule-id=cron-mtf-bitmart-scalper-micro-1m
-python scripts/manage_exchange_profile_schedule.py pause --schedule-id=cron-mtf-bitmart-scalper-micro-1m
-python scripts/manage_exchange_profile_schedule.py resume --schedule-id=cron-mtf-bitmart-scalper-micro-1m
-python scripts/manage_exchange_profile_schedule.py delete --schedule-id=cron-mtf-bitmart-scalper-micro-1m
-```
-
-## IDs generes
-
-`manage_exchange_profile_schedule.py` genere les IDs avec:
-
-- `generate_schedule_id(exchange, profile, cron, market_type)`;
-- `generate_workflow_id(exchange, profile, market_type)`.
-
-Exemples:
-
-| Entree | Schedule ID | Workflow ID |
-| --- | --- | --- |
-| Bitmart + scalper micro + `*/1 * * * *` | `cron-mtf-bitmart-scalper-micro-1m` | `mtf-bitmart-scalper-micro-runner` |
-| OKX + scalper + `*/1 * * * *` | `cron-mtf-okx-scalper-1m` | `mtf-okx-scalper-runner` |
-| Hyperliquid + regular + `*/5 * * * *` | `cron-mtf-hyperliquid-regular-5m` | `mtf-hyperliquid-regular-runner` |
-| OKX spot + scalper + `*/1 * * * *` | `cron-mtf-okx-spot-scalper-1m` | `mtf-okx-spot-scalper-runner` |
-
-Le `market_type=perpetual` est omis dans l'ID pour garder les noms historiques. Les autres types sont inclus pour eviter les collisions.
+Le prochain chemin cible documenté est un schedule unique vers l'orchestrateur Python. Les scripts legacy restent disponibles tant que la transition n'est pas terminée.
 
 ## Garde-fous live
 
-Avant un schedule `dry_run=false`, le script recommande ou impose le diagnostic:
+Avant tout `dry_run=false`, conserver les règles :
 
-```bash
-docker compose exec -T trading-app-php php bin/console app:exchange:runtime-check bitmart perpetual
-```
+- pas de live OKX ;
+- pas de live Hyperliquid ;
+- Bitmart live uniquement tant que le runtime legacy le justifie ;
+- aucune position sans stop-loss automatique immédiatement attaché ;
+- pas de double soumission pour un même symbole ;
+- idempotence et lock par symbole obligatoires avant tout live orchestré.
 
-Pour `dry_run=false`, les champs attendus sont:
+## Observabilité cible
 
-| Check | Valeur attendue |
-| --- | --- |
-| `schedule_ready` | `yes` |
-| `credentials` | `ok` |
-| `live_trading` | `enabled` |
+Temporal garde un résultat court : `ok`, `run_id`, statut et résumé. L'API Python garde :
 
-Si `dry_run=true`, un `schedule_ready: no` est tolere avec warning.
-
-## Lancement Docker
-
-Lancer Temporal, son UI et le worker:
-
-```bash
-docker compose up -d postgresql temporal temporal-ui cron-symfony-mtf-workers
-```
-
-L'application cible doit aussi etre disponible:
-
-```bash
-docker compose up -d trading-app-db redis trading-app-php trading-app-nginx
-```
-
-UI:
-
-```text
-http://localhost:8233
-```
-
-Logs:
-
-```bash
-docker compose logs -f cron-symfony-mtf-workers
-```
-
-## Lancement local
-
-```bash
-cd cron_symfony_mtf_workers
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-export TEMPORAL_ADDRESS=localhost:7233
-export TEMPORAL_NAMESPACE=default
-export TASK_QUEUE_NAME=cron_symfony_mtf_workers
-python worker.py
-```
-
-En Docker compose, `TEMPORAL_ADDRESS` vaut plutot `temporal:7233`.
-
-## Observabilite
-
-Le workflow logge volontairement un resume court:
-
-- duree du run;
-- nombre de symboles traites;
-- success rate;
-- symboles `SUCCESS` par timeframe;
-- `INVALID` par timeframe.
-
-La reponse complete reste disponible dans `full_response` pour investigation Temporal UI.
+- le dernier JSON global retourné ;
+- le dernier JSON par set ;
+- le payload envoyé à Symfony ;
+- la réponse brute Symfony ;
+- l'erreur si l'appel a échoué ;
+- le statut agrégé ;
+- l'historique minimal des runs.
 
 ## Tests
 
-Depuis `cron_symfony_mtf_workers/`:
+Depuis `cron_symfony_mtf_workers/` :
 
 ```bash
 pytest
@@ -190,4 +183,9 @@ pytest tests/test_response_formatter.py
 pytest tests/test_manage_exchange_profile_schedule.py
 ```
 
-Ces tests doivent etre relances apres modification de formatter, generation d'IDs, garde-fous live ou structure de payload.
+Après création de l'orchestrateur Python, les tests attendus devront aussi couvrir :
+
+- appel unique Temporal vers `/orchestrator/run` ;
+- retour `ok=true` / `ok=false` ;
+- stockage du dernier JSON côté API Python ;
+- absence de logique de sélection des contrats dans Temporal.

--- a/docs/handbook/technical/temporal.md
+++ b/docs/handbook/technical/temporal.md
@@ -9,7 +9,7 @@ La cible fonctionnelle retenue pour la suite est plus simple : Temporal redevien
 | Composant | Responsabilité cible |
 | --- | --- |
 | Temporal schedule | Déclencher périodiquement un run. |
-| Temporal workflow / activity | Appeler une URL unique de l'orchestrateur Python et retourner OK / non OK. |
+| Temporal workflow / activity | Appeler une URL unique de l'orchestrateur Python, retourner OK / non OK et échouer explicitement si `ok=false`. |
 | API Python orchestratrice | Lire les sets prêts, lancer les appels Symfony en parallèle, agréger, persister le dernier JSON. |
 | Symfony / TradingV3 | Rester le moteur métier : `/api/mtf/run`, `/api/mtf/sync-contracts`, configuration `mtf_contracts`. |
 | Front cockpit | Paramétrer les sets, lancer un run manuel, visualiser le dernier retour JSON. |
@@ -33,7 +33,11 @@ sequenceDiagram
     Symfony-->>Python: réponses JSON existantes
     Python->>Db: sauvegarder dernier JSON et statut
     Python-->>Activity: { ok: true|false, run_id, summary }
-    Activity-->>Schedule: succès ou échec
+    alt ok=true
+        Activity-->>Schedule: succès
+    else ok=false
+        Activity--xSchedule: échec explicite du workflow/activity
+    end
 ```
 
 ## Responsabilités legacy
@@ -130,7 +134,11 @@ Retour minimal attendu :
 }
 ```
 
-Si `ok=false`, Temporal marque le tick en échec. Le JSON complet et les détails par set restent dans l'API Python et dans la base d'orchestration.
+Contrat important : `ok=false` n'est pas un succès Temporal.
+
+L'activity ou le workflow minimal doit explicitement échouer lorsque l'orchestrateur retourne `ok=false`, par exemple en levant une erreur après avoir journalisé le `run_id` et le résumé. Il ne faut pas seulement retourner un JSON contenant `ok=false`, sinon Temporal affichera le tick comme réussi.
+
+Le JSON complet et les détails par set restent dans l'API Python et dans la base d'orchestration.
 
 ## Scripts de schedules legacy
 
@@ -181,5 +189,6 @@ Après création de l'orchestrateur Python, les tests attendus devront aussi cou
 
 - appel unique Temporal vers `/orchestrator/run` ;
 - retour `ok=true` / `ok=false` ;
+- échec explicite du workflow/activity lorsque `ok=false` ;
 - stockage du dernier JSON côté API Python ;
 - absence de logique de sélection des contrats dans Temporal.

--- a/docs/handbook/technical/temporal.md
+++ b/docs/handbook/technical/temporal.md
@@ -18,25 +18,22 @@ Cette décision évite de faire porter à Temporal la logique de sélection, de 
 
 ## Flux cible simplifié
 
-```plantuml
-@startuml
-title Temporal comme cron basique
+```mermaid
+sequenceDiagram
+    participant Schedule as Temporal Schedule
+    participant Activity as Workflow/Activity minimal
+    participant Python as API Python /orchestrator/run
+    participant Symfony as Symfony /api/mtf/run
+    participant Db as Base orchestration
 
-participant "Temporal Schedule" as Schedule
-participant "Workflow/Activity\nminimal" as Activity
-participant "API Python\n/orchestrator/run" as Python
-participant "Symfony\n/api/mtf/run" as Symfony
-participant "Base orchestration" as Db
-
-Schedule -> Activity : tick planifié
-Activity -> Python : POST /orchestrator/run
-Python -> Db : lire les sets actifs déjà prêts
-Python -> Symfony : appels parallèles bornés
-Symfony --> Python : réponses JSON existantes
-Python -> Db : sauvegarder dernier JSON et statut
-Python --> Activity : { ok: true|false, run_id, summary }
-Activity --> Schedule : succès ou échec
-@enduml
+    Schedule->>Activity: tick planifié
+    Activity->>Python: POST /orchestrator/run
+    Python->>Db: lire les sets actifs déjà prêts
+    Python->>Symfony: appels parallèles bornés
+    Symfony-->>Python: réponses JSON existantes
+    Python->>Db: sauvegarder dernier JSON et statut
+    Python-->>Activity: { ok: true|false, run_id, summary }
+    Activity-->>Schedule: succès ou échec
 ```
 
 ## Responsabilités legacy
@@ -53,30 +50,27 @@ Activity --> Schedule : succès ou échec
 
 ## Flux legacy actuel
 
-```plantuml
-@startuml
-title Workflow Temporal legacy
+```mermaid
+sequenceDiagram
+    participant Ops as Opérateur / Script
+    participant Temporal as Temporal Server
+    participant Worker as worker.py
+    participant Workflow as CronSymfonyMtfWorkersWorkflow
+    participant Activity as mtf_api_call
+    participant Symfony as Symfony /api/mtf/run
+    participant Formatter as response_formatter.py
 
-participant "Opérateur / Script" as Ops
-participant "Temporal Server" as Temporal
-participant "worker.py" as Worker
-participant "CronSymfonyMtfWorkersWorkflow" as Workflow
-participant "mtf_api_call" as Activity
-participant "Symfony\n/api/mtf/run" as Symfony
-participant "response_formatter.py" as Formatter
-
-Ops -> Temporal : create schedule
-Worker -> Temporal : poll task queue cron_symfony_mtf_workers
-Temporal -> Workflow : cron tick avec jobs
-Workflow -> Workflow : MtfJob.from_dict + payload()
-Workflow -> Activity : execute_activity(url, payload)
-Activity -> Symfony : POST JSON
-Symfony --> Activity : full MTF response
-Activity -> Formatter : format_mtf_response(raw_response)
-Formatter --> Activity : summary + metrics + full_response
-Activity --> Workflow : formatted result
-Workflow --> Temporal : logs concis + result
-@enduml
+    Ops->>Temporal: create schedule
+    Worker->>Temporal: poll task queue cron_symfony_mtf_workers
+    Temporal->>Workflow: cron tick avec jobs
+    Workflow->>Workflow: MtfJob.from_dict + payload()
+    Workflow->>Activity: execute_activity(url, payload)
+    Activity->>Symfony: POST JSON
+    Symfony-->>Activity: full MTF response
+    Activity->>Formatter: format_mtf_response(raw_response)
+    Formatter-->>Activity: summary + metrics + full_response
+    Activity-->>Workflow: formatted result
+    Workflow-->>Temporal: logs concis + result
 ```
 
 ## Payload `MtfJob`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - Flux MTF: functional/mtf-run.md
       - Validation MTF: functional/mtf-validation.md
       - TradeEntry et risque: functional/trade-entry.md
+      - Cockpit d'orchestration: functional/orchestration-dashboard.md
   - Technique:
       - Modules backend: technical/backend-modules.md
       - Interfaces et commandes: technical/interfaces.md
@@ -39,6 +40,7 @@ nav:
       - Exchange schedule policy: technical/exchange-schedule-policy.md
       - Templates clés environnement: technical/environment-key-templates.md
       - Temporal workers: technical/temporal.md
+      - Python orchestrator: technical/python-orchestrator.md
       - Frontend et Ops: technical/frontend.md
       - Architecture cible trading platform: technical/trading-platform-target-architecture.md
       - Architecture Trading Core modulaire: technical/trading-core-modular-architecture.md


### PR DESCRIPTION
## Objectif

Documenter la nouvelle cible fonctionnelle après abandon de la PR d'orchestration Temporal avancée :

- Temporal reste un déclencheur basique, équivalent à un cron supervisé ;
- une activity Temporal appelle uniquement `POST /orchestrator/run` ;
- l'activity/workflow Temporal doit échouer explicitement si l'orchestrateur retourne `ok=false` ;
- l'API Python devient l'orchestrateur : lecture des sets prêts, appels Symfony parallèles, agrégation, persistance du dernier JSON ;
- Symfony reste le moteur métier : `/api/mtf/run`, `/api/mtf/sync-contracts`, sélection `mtf_contracts` ;
- Symfony devra exposer la liste des contrats filtrés par `mtf_contracts` pour préparer les sets ;
- Symfony devra honorer `sync_tables=false` pour éviter une sync par set préparé ;
- le front cockpit paramètre les sets, déclenche les runs et visualise le dernier retour JSON.

## Contenu

- Ajout `docs/handbook/technical/python-orchestrator.md`
  - responsabilités API Python / Temporal / Symfony / front ;
  - flux cible avec Mermaid ;
  - mise à jour des contrats seulement quand la config change ;
  - prérequis Symfony d'API liste contrats filtrés ;
  - sets de payloads prêts ;
  - dépendance Symfony `sync_tables=false` ;
  - endpoint cible `/orchestrator/run` ;
  - conservation du dernier JSON ;
  - plan court des PR atomiques.

- Ajout `docs/handbook/functional/orchestration-dashboard.md`
  - écrans fonctionnels du cockpit ;
  - dashboard, sets, preview, dernier run, détail par set ;
  - règles de sécurité fonctionnelle.

- Mise à jour `docs/handbook/technical/temporal.md`
  - distinction flux legacy / cible simplifiée ;
  - Temporal = cron basique ;
  - API Python = orchestration ;
  - échec explicite Temporal si `ok=false`.

- Mise à jour `docs/handbook/technical/exchange-schedule-policy.md`
  - politique adaptée aux sets Python ;
  - concurrence côté Python ;
  - workers Symfony à 1 au début ;
  - `sync_tables=false` dans le schéma minimum des sets `mtf_run` ;
  - live OKX/Hyperliquid toujours interdit.

- Mise à jour `mkdocs.yml`
  - ajout des nouvelles pages dans la navigation.

## TODO futures PR

- [x] DOC-001 — Documenter la cible Python Orchestrator + Temporal cron
- [x] SF-001 — Exposer les contrats filtrés par `mtf_contracts`
- [x] PY-001 — Créer le squelette de l'API Python Orchestrator
- [x] DB-001 — Ajouter le schéma orchestration pour dashboards, sets et runs
- [x] PY-002 — Ajouter la gestion des dashboards et sets côté API Python
- [x] SF-002a — Honorer `sync_tables=false` sur `/api/mtf/run` (skip de l'upsert DB uniquement)
- [x] SF-002b — Vrai mode « no exchange per set » : snapshot d'état orchestrateur consommé par `OpenActivityFilter`, fail-closed en live, sans détourner `skip_open_state_filter`
- [x] PY-003 — Ajouter le refresh explicite des contrats depuis Symfony
- [x] PY-004 — Générer et persister les sets de payloads prêts
- [x] PY-005 — Implémenter `/orchestrator/run` avec exécution parallèle bornée
- [x] PY-006 — Ajouter le stockage du dernier JSON global et par set
- [x] UI-001 — Ajouter le cockpit minimal d'orchestration
- [x] UI-002 — Ajouter la preview d'exécution des sets
- [x] PY-007 — Exposer le payload `/api/mtf/run` effectif via l'API et supprimer la duplication front (#170)
- [x] UI-003 — Ajouter le détail du dernier run et des erreurs par set
- [x] TM-001 — Brancher Temporal comme cron basique vers `/orchestrator/run`
- [x] TM-002 — Faire échouer le workflow Temporal quand `ok=false`
- [x] SAFE-001 — Ajouter les locks d'orchestration par symbole et profil
- [x] SAFE-002 — Ajouter l'idempotence des runs et des sets
- [x] SAFE-003 — Ajouter les garde-fous live OKX/Hyperliquid/Bitmart (#178)
- [x] OBS-001 — Ajouter l'audit des runs d'orchestration (#179)
- [x] OBS-002 — Ajouter les métriques d'exécution par set (#180)
- [x] OBS-003 — Relier les runs d'orchestration à `position_trade_analysis` (#181)
- [x] QA-001 — Ajouter les tests unitaires API Python Orchestrator (#182)
- [x] QA-002 — Ajouter les tests d'intégration Symfony ↔ Python (#183)
- [x] QA-003 — Ajouter les tests Temporal cron minimal (#184)
- [x] CLEAN-001 — Déprécier progressivement les anciens scripts Temporal multi-jobs (#185)
- [x] CLEAN-002 — Documenter la migration depuis le runner legacy (#186)

## Hors-scope

Aucun code applicatif.
Aucune API Python.
Aucune migration DB.
Aucun front.
Aucun changement Symfony.
Aucune modification de stratégie YAML.
Aucune activation live OKX/Hyperliquid.
Aucune suppression Bitmart.

## Vérifications attendues

- `mkdocs build --strict`
- revue documentaire uniquement

## Décision produit

Cette PR fige uniquement la cible documentaire :

```text
Temporal = cron basique
API Python = orchestrateur parallèle
Symfony = moteur métier MTF
Front = cockpit de configuration et visualisation
```

Les issues et prompts détaillés seront créés au moment de chaque PR.