### PR TITLE
SF-001: expose mtf_contracts-selected contracts endpoint

### DIFF
--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -82,8 +82,22 @@ GET|POST /api/mtf/selected-contracts
 Paramètres (query string en GET, JSON en POST) :
 
 - `profile` / `mtf_profile` : profil de configuration (défaut = mode TradeEntry actif) ;
-- `exchange` / `market_type` : contexte exchange (défaut `bitmart` / `perpetual`) ;
-- `ignore_limits` : `true` pour obtenir tous les symboles éligibles sans `top_n` / `mid_n`.
+- `exchange` / `market_type` : contexte exchange (même jeu accepté que `/api/mtf/run` :
+  `bitmart`, `okx`, `hyperliquid`, ... ; défaut `bitmart` / `perpetual`) ;
+- `ignore_limits` : `true` pour obtenir tous les symboles éligibles sans `top_n` / `mid_n`
+  (filtres strictement identiques à la sélection limitée).
+
+Comportements explicites :
+
+- un corps POST JSON invalide renvoie `400` (pas de bascule silencieuse sur les défauts) ;
+- un `exchange` / `market_type` non supporté renvoie `400` ;
+- si le fichier de config dédié au profil n'existe pas, le provider retombe sur la config
+  par défaut : la réponse distingue alors `requested_profile`, `effective_profile`
+  (`default`) et `profile_config_found` ;
+- si `selection.enabled` vaut `false`, aucune sélection curée n'est exposée :
+  `symbols` est vide et `selection_enabled` vaut `false` ;
+- le `timestamp` est au format RFC3339 UTC ;
+- en cas d'erreur interne, le message reste générique (les détails vont dans les logs).
 
 Réponse type :
 
@@ -91,7 +105,9 @@ Réponse type :
 {
   "status": "success",
   "data": {
-    "profile": "scalper_micro",
+    "requested_profile": "scalper_micro",
+    "effective_profile": "scalper_micro",
+    "profile_config_found": true,
     "exchange": "bitmart",
     "market_type": "perpetual",
     "selection_enabled": true,
@@ -100,7 +116,7 @@ Réponse type :
     "symbols": ["BTCUSDT", "ETHUSDT"],
     "filters": { "quote_currency": "USDT", "status": "Trading", "min_turnover": 1500000 },
     "limits": { "top_n": 140, "mid_n": 0 },
-    "timestamp": "2026-06-16 19:30:00"
+    "timestamp": "2026-06-16T19:30:00+00:00"
   }
 }
 ```

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -70,6 +70,44 @@ sequenceDiagram
     Python-->>Front: preview des sets disponibles
 ```
 
+## API Symfony : contrats sélectionnés (SF-001)
+
+Symfony expose la liste des contrats réellement retenus par `mtf_contracts`, sans
+déclencher de run, via :
+
+```text
+GET|POST /api/mtf/selected-contracts
+```
+
+Paramètres (query string en GET, JSON en POST) :
+
+- `profile` / `mtf_profile` : profil de configuration (défaut = mode TradeEntry actif) ;
+- `exchange` / `market_type` : contexte exchange (défaut `bitmart` / `perpetual`) ;
+- `ignore_limits` : `true` pour obtenir tous les symboles éligibles sans `top_n` / `mid_n`.
+
+Réponse type :
+
+```json
+{
+  "status": "success",
+  "data": {
+    "profile": "scalper_micro",
+    "exchange": "bitmart",
+    "market_type": "perpetual",
+    "selection_enabled": true,
+    "ignore_limits": false,
+    "count": 2,
+    "symbols": ["BTCUSDT", "ETHUSDT"],
+    "filters": { "quote_currency": "USDT", "status": "Trading", "min_turnover": 1500000 },
+    "limits": { "top_n": 140, "mid_n": 0 },
+    "timestamp": "2026-06-16 19:30:00"
+  }
+}
+```
+
+C'est cet endpoint que l'API Python appelle lors du refresh explicite des contrats
+pour préparer ses sets de payloads.
+
 ## Lien avec `mtf_contracts`
 
 Symfony reste la source de vérité pour la sélection initiale des contrats. La configuration `mtf_contracts` filtre déjà les contrats selon :

--- a/trading-app/src/Config/MtfContractsConfigProvider.php
+++ b/trading-app/src/Config/MtfContractsConfigProvider.php
@@ -76,6 +76,21 @@ final class MtfContractsConfigProvider
     }
 
     /**
+     * Indique si un fichier de configuration spécifique existe pour ce profil.
+     * Si false, {@see getConfigForProfile()} retombe sur le fichier par défaut
+     * `mtf_contracts.yaml`. Utile pour distinguer le profil demandé du profil
+     * réellement appliqué.
+     */
+    public function hasProfileConfig(?string $profile): bool
+    {
+        if ($profile === null || $profile === '') {
+            return false;
+        }
+
+        return is_file($this->configDir . '/mtf_contracts.' . $profile . '.yaml');
+    }
+
+    /**
      * Résout le chemin du fichier de config avec fallback
      * 
      * @param string|null $profile Nom du profil

--- a/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
@@ -6,6 +6,7 @@ namespace App\MtfRunner\Dto;
 
 use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
+use App\Provider\Context\ExchangeContextResolver;
 
 /**
  * DTO pour les requêtes d'exécution du Runner MTF
@@ -109,19 +110,13 @@ final class MtfRunnerRequestDto
 
     private static function normalizeExchange(string $value): Exchange
     {
-        $normalized = strtolower(trim($value));
-
-        return Exchange::tryFrom($normalized)
-            ?? throw new \InvalidArgumentException(sprintf('Unsupported exchange "%s"', $value));
+        // Source de vérité partagée avec les endpoints HTTP (cf. SF-001).
+        return ExchangeContextResolver::normalizeExchange($value);
     }
 
     private static function normalizeMarketType(string $value): MarketType
     {
-        return match (strtolower(trim($value))) {
-            'perpetual', 'perp', 'future', 'futures' => MarketType::PERPETUAL,
-            'spot' => MarketType::SPOT,
-            default => throw new \InvalidArgumentException(sprintf('Unsupported market type "%s"', $value)),
-        };
+        return ExchangeContextResolver::normalizeMarketType($value);
     }
 
     private static function extractProfileAndMode(array $data): array

--- a/trading-app/src/MtfValidator/Controller/MtfController.php
+++ b/trading-app/src/MtfValidator/Controller/MtfController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\MtfValidator\Controller;
 
+use App\Config\MtfContractsConfigProvider;
+use App\Config\TradeEntryModeContext;
 use App\Contract\MtfValidator\MtfValidatorInterface;
 use App\Contract\Provider\MainProviderInterface;
 use App\Provider\Repository\ContractRepository;
@@ -35,6 +37,8 @@ class MtfController extends AbstractController
         private readonly ClockInterface $clock,
         private readonly ContractRepository $contractRepository,
         private readonly MainProviderInterface $mainProvider,
+        private readonly MtfContractsConfigProvider $contractsConfigProvider,
+        private readonly TradeEntryModeContext $modeContext,
     ) {
     }
 
@@ -354,6 +358,91 @@ class MtfController extends AbstractController
             return $this->json([
                 'status' => 'error',
                 'message' => $e->getMessage()
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Expose la liste des contrats réellement sélectionnés par la configuration
+     * `mtf_contracts` (filtres + limites top_n/mid_n), sans déclencher de run.
+     *
+     * Cible : permettre à l'orchestrateur Python (cf. SF-001) de préparer ses sets
+     * de payloads à partir des symboles effectivement retenus côté Symfony.
+     *
+     * Paramètres (query string en GET, JSON en POST) :
+     * - profile / mtf_profile : profil de config (défaut = mode actif TradeEntry) ;
+     * - exchange / market_type : contexte exchange (défaut bitmart / perpetual) ;
+     * - ignore_limits : true pour retourner tous les symboles éligibles sans top_n/mid_n.
+     */
+    #[Route('/selected-contracts', name: 'selected_contracts', methods: ['GET', 'POST'])]
+    public function selectedContracts(Request $request): JsonResponse
+    {
+        try {
+            $data = $request->getMethod() === 'POST'
+                ? (json_decode($request->getContent(), true) ?? [])
+                : $request->query->all();
+
+            try {
+                $context = $this->resolveExchangeContext($data);
+            } catch (\InvalidArgumentException $e) {
+                return $this->json([
+                    'status' => 'error',
+                    'message' => $e->getMessage(),
+                ], Response::HTTP_BAD_REQUEST);
+            }
+
+            // Profil : explicite sinon mode TradeEntry actif (même logique que /api/mtf/run).
+            $profileInput = $data['profile'] ?? $data['mtf_profile'] ?? null;
+            $profile = is_string($profileInput) && trim($profileInput) !== ''
+                ? trim($profileInput)
+                : $this->modeContext->resolve(null);
+
+            $ignoreLimits = filter_var($data['ignore_limits'] ?? false, FILTER_VALIDATE_BOOLEAN);
+
+            $config = $this->contractsConfigProvider->getConfigForProfile($profile);
+            $symbols = $this->contractRepository->allActiveSymbolNames([], $ignoreLimits, $profile, $context);
+
+            $this->mtfLogger->info('[MTF Controller] Selected contracts resolved', [
+                'profile' => $profile,
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+                'ignore_limits' => $ignoreLimits,
+                'count' => count($symbols),
+            ]);
+
+            return $this->json([
+                'status' => 'success',
+                'data' => [
+                    'profile' => $profile,
+                    'exchange' => $context->exchange->value,
+                    'market_type' => $context->marketType->value,
+                    'selection_enabled' => (bool) $config->get('enabled', true),
+                    'ignore_limits' => $ignoreLimits,
+                    'count' => count($symbols),
+                    'symbols' => $symbols,
+                    'filters' => [
+                        'quote_currency' => $config->getFilter('quote_currency'),
+                        'status' => $config->getFilter('status'),
+                        'min_turnover' => $config->getFilter('min_turnover'),
+                        'mid_max_turnover' => $config->getFilter('mid_max_turnover'),
+                        'max_age_hours' => $config->getFilter('max_age_hours'),
+                        'require_not_expired' => $config->getFilter('require_not_expired'),
+                    ],
+                    'limits' => [
+                        'top_n' => $config->getLimit('top_n'),
+                        'mid_n' => $config->getLimit('mid_n'),
+                    ],
+                    'timestamp' => $this->clock->now()->format('Y-m-d H:i:s'),
+                ],
+            ]);
+        } catch (\Throwable $e) {
+            $this->mtfLogger->error('[MTF Controller] Failed to resolve selected contracts', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
     }

--- a/trading-app/src/MtfValidator/Controller/MtfController.php
+++ b/trading-app/src/MtfValidator/Controller/MtfController.php
@@ -13,9 +13,8 @@ use App\MtfValidator\Repository\MtfAuditRepository;
 use App\MtfValidator\Repository\MtfLockRepository;
 use App\Repository\MtfStateRepository;
 use App\MtfValidator\Repository\MtfSwitchRepository;
-use App\Common\Enum\Exchange;
-use App\Common\Enum\MarketType;
 use App\Provider\Context\ExchangeContext;
+use App\Provider\Context\ExchangeContextResolver;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -39,6 +38,7 @@ class MtfController extends AbstractController
         private readonly MainProviderInterface $mainProvider,
         private readonly MtfContractsConfigProvider $contractsConfigProvider,
         private readonly TradeEntryModeContext $modeContext,
+        private readonly ExchangeContextResolver $exchangeContextResolver,
     ) {
     }
 
@@ -378,12 +378,17 @@ class MtfController extends AbstractController
     public function selectedContracts(Request $request): JsonResponse
     {
         try {
-            $data = $request->getMethod() === 'POST'
-                ? (json_decode($request->getContent(), true) ?? [])
-                : $request->query->all();
+            try {
+                $data = $this->parseRequestPayload($request);
+            } catch (\JsonException $e) {
+                return $this->json([
+                    'status' => 'error',
+                    'message' => 'Invalid JSON payload.',
+                ], Response::HTTP_BAD_REQUEST);
+            }
 
             try {
-                $context = $this->resolveExchangeContext($data);
+                $context = $this->exchangeContextResolver->resolve($data);
             } catch (\InvalidArgumentException $e) {
                 return $this->json([
                     'status' => 'error',
@@ -393,30 +398,45 @@ class MtfController extends AbstractController
 
             // Profil : explicite sinon mode TradeEntry actif (même logique que /api/mtf/run).
             $profileInput = $data['profile'] ?? $data['mtf_profile'] ?? null;
-            $profile = is_string($profileInput) && trim($profileInput) !== ''
+            $requestedProfile = is_string($profileInput) && trim($profileInput) !== ''
                 ? trim($profileInput)
                 : $this->modeContext->resolve(null);
 
+            // Profil demandé vs profil réellement appliqué : le provider retombe
+            // silencieusement sur la config par défaut si le fichier dédié manque.
+            $profileConfigFound = $this->contractsConfigProvider->hasProfileConfig($requestedProfile);
+            $effectiveProfile = $profileConfigFound ? $requestedProfile : 'default';
+
             $ignoreLimits = filter_var($data['ignore_limits'] ?? false, FILTER_VALIDATE_BOOLEAN);
 
-            $config = $this->contractsConfigProvider->getConfigForProfile($profile);
-            $symbols = $this->contractRepository->allActiveSymbolNames([], $ignoreLimits, $profile, $context);
+            $config = $this->contractsConfigProvider->getConfigForProfile($requestedProfile);
+            $selectionEnabled = (bool) $config->get('enabled', true);
+
+            // selection.enabled=false : aucune sélection curée n'est exposée.
+            // Comportement explicite et documenté → liste vide, pas de requête DB.
+            $symbols = $selectionEnabled
+                ? $this->contractRepository->allActiveSymbolNames([], $ignoreLimits, $requestedProfile, $context)
+                : [];
 
             $this->mtfLogger->info('[MTF Controller] Selected contracts resolved', [
-                'profile' => $profile,
+                'requested_profile' => $requestedProfile,
+                'effective_profile' => $effectiveProfile,
                 'exchange' => $context->exchange->value,
                 'market_type' => $context->marketType->value,
                 'ignore_limits' => $ignoreLimits,
+                'selection_enabled' => $selectionEnabled,
                 'count' => count($symbols),
             ]);
 
             return $this->json([
                 'status' => 'success',
                 'data' => [
-                    'profile' => $profile,
+                    'requested_profile' => $requestedProfile,
+                    'effective_profile' => $effectiveProfile,
+                    'profile_config_found' => $profileConfigFound,
                     'exchange' => $context->exchange->value,
                     'market_type' => $context->marketType->value,
-                    'selection_enabled' => (bool) $config->get('enabled', true),
+                    'selection_enabled' => $selectionEnabled,
                     'ignore_limits' => $ignoreLimits,
                     'count' => count($symbols),
                     'symbols' => $symbols,
@@ -432,7 +452,9 @@ class MtfController extends AbstractController
                         'top_n' => $config->getLimit('top_n'),
                         'mid_n' => $config->getLimit('mid_n'),
                     ],
-                    'timestamp' => $this->clock->now()->format('Y-m-d H:i:s'),
+                    'timestamp' => $this->clock->now()
+                        ->setTimezone(new \DateTimeZone('UTC'))
+                        ->format(\DateTimeInterface::RFC3339),
                 ],
             ]);
         } catch (\Throwable $e) {
@@ -442,9 +464,32 @@ class MtfController extends AbstractController
 
             return $this->json([
                 'status' => 'error',
-                'message' => $e->getMessage(),
+                'message' => 'Internal error while resolving selected contracts.',
             ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
+    }
+
+    /**
+     * Décode le payload de la requête : JSON pour POST (erreur explicite si
+     * invalide), query string pour GET.
+     *
+     * @return array<string,mixed>
+     * @throws \JsonException si le corps POST n'est pas un JSON valide.
+     */
+    private function parseRequestPayload(Request $request): array
+    {
+        if ($request->getMethod() !== 'POST') {
+            return $request->query->all();
+        }
+
+        $content = trim($request->getContent());
+        if ($content === '') {
+            return [];
+        }
+
+        $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : [];
     }
 
     #[Route('/sync-contracts', name: 'sync_contracts', methods: ['POST', 'GET'])]
@@ -517,36 +562,12 @@ class MtfController extends AbstractController
         }
     }
 
+    /**
+     * Délègue au resolver partagé pour garantir le même jeu d'exchanges/markets
+     * accepté que `/api/mtf/run` (cf. ExchangeContextResolver / MtfRunnerRequestDto).
+     */
     private function resolveExchangeContext(array $data): ExchangeContext
     {
-        $exchangeInput = $data['exchange'] ?? $data['cex'] ?? null;
-        $marketInput = $data['market_type'] ?? $data['type_contract'] ?? null;
-
-        $exchange = Exchange::BITMART;
-        if ($exchangeInput !== null) {
-            if (!is_string($exchangeInput) || $exchangeInput === '') {
-                throw new \InvalidArgumentException('Invalid exchange parameter.');
-            }
-
-            $exchange = match (strtolower(trim($exchangeInput))) {
-                'bitmart' => Exchange::BITMART,
-                default => throw new \InvalidArgumentException(sprintf('Unsupported exchange "%s".', $exchangeInput)),
-            };
-        }
-
-        $marketType = MarketType::PERPETUAL;
-        if ($marketInput !== null) {
-            if (!is_string($marketInput) || $marketInput === '') {
-                throw new \InvalidArgumentException('Invalid market_type parameter.');
-            }
-
-            $marketType = match (strtolower(trim($marketInput))) {
-                'perpetual', 'perp', 'future', 'futures' => MarketType::PERPETUAL,
-                'spot' => MarketType::SPOT,
-                default => throw new \InvalidArgumentException(sprintf('Unsupported market type "%s".', $marketInput)),
-            };
-        }
-
-        return new ExchangeContext($exchange, $marketType);
+        return $this->exchangeContextResolver->resolve($data);
     }
 }

--- a/trading-app/src/Provider/Context/ExchangeContextResolver.php
+++ b/trading-app/src/Provider/Context/ExchangeContextResolver.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Context;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+/**
+ * Résout un {@see ExchangeContext} à partir d'un payload (query string ou JSON).
+ *
+ * Source de vérité partagée pour le jeu d'exchanges/markets accepté par les
+ * endpoints HTTP (`/api/mtf/run`, `/api/mtf/selected-contracts`, ...). Garantit
+ * que la sélection exposée et ce que le runner accepte restent strictement
+ * alignés. Une entrée fournie mais invalide lève une {@see \InvalidArgumentException}
+ * (à traduire en HTTP 400 côté contrôleur) plutôt que de retomber silencieusement
+ * sur une valeur par défaut.
+ */
+final class ExchangeContextResolver
+{
+    /**
+     * @param array<string,mixed> $data
+     */
+    public function resolve(
+        array $data,
+        Exchange $defaultExchange = Exchange::BITMART,
+        MarketType $defaultMarket = MarketType::PERPETUAL,
+    ): ExchangeContext {
+        $exchangeInput = $data['exchange'] ?? $data['cex'] ?? null;
+        $marketInput = $data['market_type'] ?? $data['type_contract'] ?? null;
+
+        $exchange = $defaultExchange;
+        if ($exchangeInput !== null) {
+            if (!is_string($exchangeInput) || trim($exchangeInput) === '') {
+                throw new \InvalidArgumentException('Invalid exchange parameter.');
+            }
+            $exchange = self::normalizeExchange($exchangeInput);
+        }
+
+        $marketType = $defaultMarket;
+        if ($marketInput !== null) {
+            if (!is_string($marketInput) || trim($marketInput) === '') {
+                throw new \InvalidArgumentException('Invalid market_type parameter.');
+            }
+            $marketType = self::normalizeMarketType($marketInput);
+        }
+
+        return new ExchangeContext($exchange, $marketType);
+    }
+
+    public static function normalizeExchange(string $value): Exchange
+    {
+        return Exchange::tryFrom(strtolower(trim($value)))
+            ?? throw new \InvalidArgumentException(sprintf('Unsupported exchange "%s".', $value));
+    }
+
+    public static function normalizeMarketType(string $value): MarketType
+    {
+        return match (strtolower(trim($value))) {
+            'perpetual', 'perp', 'future', 'futures' => MarketType::PERPETUAL,
+            'spot' => MarketType::SPOT,
+            default => throw new \InvalidArgumentException(sprintf('Unsupported market type "%s".', $value)),
+        };
+    }
+}

--- a/trading-app/src/Provider/Repository/ContractRepository.php
+++ b/trading-app/src/Provider/Repository/ContractRepository.php
@@ -390,78 +390,107 @@ class ContractRepository extends ServiceEntityRepository
     public function findAllActiveSymbolsWithoutLimits(?string $profile = null, ?ExchangeContext $context = null): array
     {
         $config = $this->configProvider->getConfigForProfile($profile);
-        
-        // --- Config YAML ---
+
+        // Filtres strictement identiques à findSymbolsMixedLiquidity : seule la
+        // restriction top_n/mid_n est retirée ici (ignore_limits = true).
+        [$baseSql, $params] = $this->buildBaseFilter($config, $context);
+
+        $sql = "WITH base AS (\n{$baseSql}\n)\nSELECT symbol FROM base ORDER BY t24 DESC";
+
+        $stmt = $this->conn->prepare($sql);
+        $this->bindBaseFilterParams($stmt, $params);
+
+        $symbols = $stmt->executeQuery()->fetchFirstColumn();
+
+        return array_values(array_unique($symbols));
+    }
+
+    /**
+     * Construit le filtre de base commun (statut, exchange, quote, turnover,
+     * expiration, âge, blacklist, mtf_switch) partagé par la sélection limitée
+     * (TOP/MID) et la sélection sans limites. Garantit que `ignore_limits=true`
+     * applique exactement les mêmes filtres, seules les limites changeant.
+     *
+     * @return array{0: string, 1: array<string, array{0: mixed, 1: int|string|null}>}
+     *   SQL du corps de la CTE `base` (colonnes `symbol`, `t24`) et paramètres à binder.
+     */
+    private function buildBaseFilter(MtfContractsConfig $config, ?ExchangeContext $context): array
+    {
         $status            = (string) $config->getFilter('status', 'Trading');
         $quoteCurrency     = (string) $config->getFilter('quote_currency', 'USDT');
         $minTurnover       = (float)  $config->getFilter('min_turnover', 500000);
         $requireNotExpired = (bool)   $config->getFilter('require_not_expired', true);
-        $expireUnit        = (string) $config->getFilter('expire_unit', false); // 's' | 'ms'
+        $expireUnit        = (string) $config->getFilter('expire_unit', 's');   // 's' | 'ms'
         $maxAgeHours       = (int)    $config->getFilter('max_age_hours', 880);
+        $openUnit          = (string) $config->getFilter('open_unit', 's');     // 's' | 'ms'
 
-        // --- Horloge & unités ---
         $now    = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'));
         $nowSec = (int) $now->format('U');             // epoch seconds
         $nowMs  = (int) round(microtime(true) * 1000); // epoch millis
         $nowForExpire = ($expireUnit === 'ms') ? $nowMs : $nowSec;
 
-        $openTsMinSec = $maxAgeHours > 0
-            ? $now->sub(new \DateInterval('PT'.$maxAgeHours.'H'))->getTimestamp()
-            : null;
-        $openTsMin = $openTsMinSec;
-        $openTsMinSet = !is_null($openTsMin);
+        $openTsMin = null;
+        if ($maxAgeHours > 0) {
+            $boundarySec = $now->sub(new \DateInterval('PT'.$maxAgeHours.'H'))->getTimestamp();
+            $openTsMin   = ($openUnit === 'ms') ? $boundarySec * 1000 : $boundarySec;
+        }
+        $openTsMinSet = ($openTsMin !== null);
 
-        // --- Expression turnover ---
-        $turnoverExpr = 'turnover_24h';
-
-        // --- SQL sans LIMIT ---
         $sql = "
-SELECT c.symbol
-FROM contracts c
-WHERE c.status = :status
-  AND c.exchange = :exchange
-  AND c.market_type = :marketType
-  AND c.quote_currency = :quoteCurrency
-  AND {$turnoverExpr} >= :minTurnover
-  AND (
-        :requireNotExpired = FALSE
-     OR c.expire_timestamp IS NULL
-     OR c.expire_timestamp = 0
-     OR c.expire_timestamp > :nowForExpire
-  )
-  AND ( :openTsMinSet = FALSE OR c.open_timestamp > :openTsMin )
-  AND NOT EXISTS (
-      SELECT 1 FROM blacklisted_contract b
-      WHERE b.symbol = c.symbol
-        AND (b.expires_at IS NULL OR b.expires_at > :dtnow)
-  )
-  AND NOT EXISTS (
-      SELECT 1 FROM mtf_switch m
-      WHERE m.switch_key LIKE :symbolPattern
-        AND SUBSTRING(m.switch_key FROM 8) = c.symbol
-        AND m.is_on = :isOff
-        AND (m.expires_at IS NULL OR m.expires_at > :dtnow)
-  )
-ORDER BY {$turnoverExpr} DESC
+  SELECT c.symbol, turnover_24h AS t24
+  FROM contracts c
+  WHERE c.status = :status
+    AND c.exchange = :exchange
+    AND c.market_type = :marketType
+    AND c.quote_currency = :quoteCurrency
+    AND turnover_24h >= :minTurnover
+    AND (
+          :requireNotExpired = FALSE
+       OR c.expire_timestamp IS NULL
+       OR c.expire_timestamp = 0
+       OR c.expire_timestamp > :nowForExpire
+    )
+    AND ( :openTsMinSet = FALSE OR c.open_timestamp < :openTsMin )
+    AND NOT EXISTS (
+        SELECT 1 FROM blacklisted_contract b
+        WHERE b.symbol = c.symbol
+          AND (b.expires_at IS NULL OR b.expires_at > :dtnow)
+    )
+    AND NOT EXISTS (
+        SELECT 1 FROM mtf_switch m
+        WHERE m.switch_key LIKE :symbolPattern
+          AND SUBSTRING(m.switch_key FROM 8) = c.symbol
+          AND m.is_on = :isOff
+          AND (m.expires_at IS NULL OR m.expires_at > :dtnow)
+    )
 ";
 
-        $stmt = $this->conn->prepare($sql);
-        $stmt->bindValue('status', $status);
-        $stmt->bindValue('exchange', ExchangeContext::exchangeValue($context));
-        $stmt->bindValue('marketType', ExchangeContext::marketTypeValue($context));
-        $stmt->bindValue('quoteCurrency', $quoteCurrency);
-        $stmt->bindValue('minTurnover', $minTurnover);
-        $stmt->bindValue('requireNotExpired', $requireNotExpired, ParameterType::BOOLEAN);
-        $stmt->bindValue('nowForExpire', $nowForExpire, ParameterType::INTEGER);
-        $stmt->bindValue('openTsMin', $openTsMin, $openTsMin === null ? ParameterType::NULL : ParameterType::INTEGER);
-        $stmt->bindValue('dtnow', $now, Types::DATETIME_IMMUTABLE);
-        $stmt->bindValue('symbolPattern', 'SYMBOL:%');
-        $stmt->bindValue('isOff', false, ParameterType::BOOLEAN);
-        $stmt->bindValue('openTsMinSet', $openTsMinSet, ParameterType::BOOLEAN);
+        $params = [
+            'status'            => [$status, ParameterType::STRING],
+            'exchange'          => [ExchangeContext::exchangeValue($context), ParameterType::STRING],
+            'marketType'        => [ExchangeContext::marketTypeValue($context), ParameterType::STRING],
+            'quoteCurrency'     => [$quoteCurrency, ParameterType::STRING],
+            'minTurnover'       => [$minTurnover, ParameterType::STRING],
+            'requireNotExpired' => [$requireNotExpired, ParameterType::BOOLEAN],
+            'nowForExpire'      => [$nowForExpire, ParameterType::INTEGER],
+            'openTsMinSet'      => [$openTsMinSet, ParameterType::BOOLEAN],
+            'openTsMin'         => [$openTsMin, $openTsMin === null ? ParameterType::NULL : ParameterType::INTEGER],
+            'dtnow'             => [$now, Types::DATETIME_IMMUTABLE],
+            'symbolPattern'     => ['SYMBOL:%', ParameterType::STRING],
+            'isOff'             => [false, ParameterType::BOOLEAN],
+        ];
 
-        $symbols = $stmt->executeQuery()->fetchFirstColumn();
+        return [$sql, $params];
+    }
 
-        return array_values(array_unique($symbols));
+    /**
+     * @param array<string, array{0: mixed, 1: int|string|null}> $params
+     */
+    private function bindBaseFilterParams(\Doctrine\DBAL\Statement $stmt, array $params): void
+    {
+        foreach ($params as $name => [$value, $type]) {
+            $stmt->bindValue($name, $value, $type);
+        }
     }
     public function findWithFilters(?string $status = null, ?string $symbol = null, ?ExchangeContext $context = null): array
     {
@@ -494,16 +523,9 @@ ORDER BY {$turnoverExpr} DESC
     public function findSymbolsMixedLiquidity(?string $profile = null, ?ExchangeContext $context = null): array
     {
         $config = $this->configProvider->getConfigForProfile($profile);
-        
-        // --- Config YAML ---
-        $status            = (string) $config->getFilter('status', 'Trading');
-        $quoteCurrency     = (string) $config->getFilter('quote_currency', 'USDT');
-        $minTurnover       = (float)  $config->getFilter('min_turnover', 500000);
+
+        // --- Config YAML (limites + buckets, les filtres viennent de buildBaseFilter) ---
         $midMaxTurnover    = (float)  $config->getFilter('mid_max_turnover', 2000000);
-        $requireNotExpired = (bool)   $config->getFilter('require_not_expired', true);
-        $expireUnit        = (string) $config->getFilter('expire_unit', 's');   // 's' | 'ms'
-        $maxAgeHours       = (int)    $config->getFilter('max_age_hours', 880);
-        $openUnit          = (string) $config->getFilter('open_unit', 's');     // 's' | 'ms'
 
         $topN   = (int) $config->getLimit('top_n', 0);
         $midN   = (int) $config->getLimit('mid_n', 0);
@@ -518,59 +540,18 @@ ORDER BY {$turnoverExpr} DESC
             $orderMid = 'ASC';
         }
 
-        // --- Horloge & unités ---
-        $now = $this->clock->now()->setTimezone(new \DateTimeZone('UTC'));
-
-        $nowSec = (int) $now->format('U');             // epoch seconds
-        $nowMs  = (int) round(microtime(true) * 1000); // epoch millis
-
-        $nowForExpire = ($expireUnit === 'ms') ? $nowMs : $nowSec;
-
-        // borne min pour open_timestamp
-        $openTsMin = null;
-        if ($maxAgeHours > 0) {
-            $boundarySec = $now->sub(new \DateInterval('PT'.$maxAgeHours.'H'))->getTimestamp();
-            $openTsMin   = ($openUnit === 'ms') ? $boundarySec * 1000 : $boundarySec;
-        }
-        $openTsMinSet = ($openTsMin !== null);
-
-        // --- Expression turnover (caster si stocké en texte) ---
-        $turnoverExpr = 'turnover_24h'; // ou CAST(...) si besoin
-
         // --- Pas de requête si aucun bucket demandé ---
         if ($topN <= 0 && $midN <= 0) {
             return [];
         }
 
+        // Filtres de base partagés avec findAllActiveSymbolsWithoutLimits.
+        [$baseSql, $params] = $this->buildBaseFilter($config, $context);
+
         // --- SQL principal (table: contracts) ---
         $sql = "
 WITH base AS (
-  SELECT c.symbol, {$turnoverExpr} AS t24
-  FROM contracts c
-  WHERE c.status = :status
-    AND c.exchange = :exchange
-    AND c.market_type = :marketType
-    AND c.quote_currency = :quoteCurrency
-    AND {$turnoverExpr} >= :minTurnover
-    AND (
-          :requireNotExpired = FALSE
-       OR c.expire_timestamp IS NULL
-       OR c.expire_timestamp = 0
-       OR c.expire_timestamp > :nowForExpire
-    )
-    AND ( :openTsMinSet = FALSE OR c.open_timestamp < :openTsMin )
-    AND NOT EXISTS (
-        SELECT 1 FROM blacklisted_contract b
-        WHERE b.symbol = c.symbol
-          AND (b.expires_at IS NULL OR b.expires_at > :dtnow)
-    )
-    AND NOT EXISTS (
-        SELECT 1 FROM mtf_switch m
-        WHERE m.switch_key LIKE :symbolPattern
-          AND SUBSTRING(m.switch_key FROM 8) = c.symbol
-          AND m.is_on = :isOff
-          AND (m.expires_at IS NULL OR m.expires_at > :dtnow)
-    )
+{$baseSql}
 )
 ";
 
@@ -607,24 +588,8 @@ SELECT symbol FROM (
 
         $stmt = $this->conn->prepare($sql);
 
-        // --- Bind communs ---
-        $stmt->bindValue('status',         $status);
-        $stmt->bindValue('exchange',       ExchangeContext::exchangeValue($context));
-        $stmt->bindValue('marketType',     ExchangeContext::marketTypeValue($context));
-        $stmt->bindValue('quoteCurrency',  $quoteCurrency);
-        $stmt->bindValue('minTurnover',    $minTurnover);
-        $stmt->bindValue('requireNotExpired', $requireNotExpired, ParameterType::BOOLEAN);
-        $stmt->bindValue('nowForExpire',   $nowForExpire, ParameterType::INTEGER);
-        $stmt->bindValue('dtnow',          $now, Types::DATETIME_IMMUTABLE);
-        $stmt->bindValue('symbolPattern',  'SYMBOL:%');
-        $stmt->bindValue('isOff',          false, ParameterType::BOOLEAN);
-        $stmt->bindValue('openTsMinSet',   $openTsMinSet, ParameterType::BOOLEAN);
-
-        if ($openTsMin !== null) {
-            $stmt->bindValue('openTsMin', $openTsMin, ParameterType::INTEGER);
-        } else {
-            $stmt->bindValue('openTsMin', null, ParameterType::NULL);
-        }
+        // --- Bind communs (filtres de base partagés) ---
+        $this->bindBaseFilterParams($stmt, $params);
 
         if ($topN > 0) {
             $stmt->bindValue('midMaxTurnover', $midMaxTurnover);


### PR DESCRIPTION
Add GET|POST /api/mtf/selected-contracts returning the symbols actually
retained by the mtf_contracts selection (filters + top_n/mid_n limits)
without triggering a run. Supports profile, exchange/market_type and
ignore_limits parameters so the Python orchestrator can prepare its
payload sets from the real Symfony selection.

Document the endpoint in the python-orchestrator handbook.