### PR TITLE
DB-001: schéma orchestration (dashboards, sets, runs)

### DIFF
--- a/.github/workflows/python-orchestrator.yml
+++ b/.github/workflows/python-orchestrator.yml
@@ -1,0 +1,60 @@
+name: Python Orchestrator
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/python-orchestrator.yml'
+      - 'python-orchestrator/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/python-orchestrator.yml'
+      - 'python-orchestrator/**'
+
+jobs:
+  tests:
+    name: pytest (+ PostgreSQL smoke)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: python-orchestrator
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: orchestrator_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Active le smoke test Alembic/PostgreSQL (upgrade/downgrade, isolation
+      # `public`, drift autogenerate). Sans cette variable, le smoke test skip.
+      ORCHESTRATOR_TEST_DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/orchestrator_test
+      ORCHESTRATION_DB_SCHEMA: orchestration
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: python -m pytest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,11 +170,19 @@ services:
       - SYMFONY_BASE_URL=http://trading-app-nginx:80
       - ORCHESTRATOR_PORT=8099
       - MAX_CONCURRENCY=2
+      # Persistance orchestration (DB-001) : réutilise la base trading_app dans
+      # un schéma dédié `orchestration` (isolé des tables Doctrine de Symfony).
+      # Appliquer les migrations avec `alembic upgrade head` (cf. README).
+      - DATABASE_URL=postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app
+      - ORCHESTRATION_DB_SCHEMA=orchestration
     # Bridge interne appelé par Temporal/front : pas de port hôte par défaut
     # (aucun auth/secret pour l'instant). Pour un accès dev local, publier via
     # un override (docker-compose.override.yml) ou `docker compose run --service-ports`.
     expose:
       - "8099"
+    depends_on:
+      trading-app-db:
+        condition: service_healthy
     networks:
       - trading-app-net
       - shared-net

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -262,6 +262,24 @@ L'API Python garde toujours :
 
 Le front peut donc afficher le même type de retour que le retour existant de Symfony, avec une vue supplémentaire par set.
 
+## Schéma de persistance (DB-001)
+
+La persistance est implémentée dans `python-orchestrator/` avec **SQLAlchemy 2.0 + Alembic**
+(driver `psycopg` sync). Les tables vivent dans un **schéma PostgreSQL dédié `orchestration`**
+au sein de la base `trading_app` existante, afin de ne pas interférer avec les migrations
+Doctrine de Symfony (qui n'introspecte que `public`).
+
+| Table | Rôle |
+| --- | --- |
+| `dashboards` | Configurations d'orchestration (nom, statut actif). |
+| `orchestration_sets` | Sets prêts à exécuter (miroir d'`OrchestratorSet`, dont `sync_tables`, `symbols`, `contracts_limit`, et le `payload` préparé). |
+| `runs` | Runs déclenchés (`run_id`, statut, compteurs, idempotency_key) + **dernier JSON global** (`last_json`). |
+| `run_sets` | Détail par set d'un run (payload envoyé, réponse Symfony, statut, erreur, durée) + **dernier JSON par set** (`response_json`). |
+
+DB-001 ne livre que la couche schéma (modèles, migration, moteur/session, repositories). Le
+câblage applicatif — lecture des sets depuis la DB et écriture des runs — est porté par **PY-002**.
+Les migrations s'appliquent via `alembic upgrade head` (voir `python-orchestrator/README.md`).
+
 ## Garde-fous fonctionnels
 
 Avant tout run :

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -130,9 +130,21 @@ ni les dépendances de test.
 cd python-orchestrator
 pip install -r requirements-dev.txt
 python -m pytest
-# ou depuis la racine :
-make test-orchestrator
 ```
+
+Les tests DB tournent sur **SQLite in-memory** (aucun Postgres requis) en attachant
+le schéma `orchestration`. Un **smoke test PostgreSQL** (`tests/test_db_postgres_smoke.py`)
+valide en plus le vrai contrat Alembic (upgrade/downgrade, isolation `public`,
+absence de drift ORM↔migration) ; il est **ignoré** tant que
+`ORCHESTRATOR_TEST_DATABASE_URL` n'est pas défini :
+
+```bash
+export ORCHESTRATOR_TEST_DATABASE_URL=postgresql+psycopg://postgres:postgres@127.0.0.1:5432/orchestrator_test
+python -m pytest
+```
+
+La CI (`.github/workflows/python-orchestrator.yml`) l'exécute automatiquement avec
+un service `postgres:15`.
 
 ## Dépendances
 
@@ -147,7 +159,7 @@ make test-orchestrator
 | `ORCHESTRATOR_PORT` | `8099` | Port d'écoute HTTP (1..65535). |
 | `MAX_CONCURRENCY` | `2` | Concurrence globale bornée, ≥ 1 (PY-002+). |
 | `DATABASE_URL` | `postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app` | URL SQLAlchemy de la base orchestration (DB-001). |
-| `ORCHESTRATION_DB_SCHEMA` | `orchestration` | Schéma PostgreSQL dédié (DB-001). `none` le neutralise (tests SQLite). |
+| `ORCHESTRATION_DB_SCHEMA` | `orchestration` | Schéma PostgreSQL dédié (DB-001). Identifiant SQL simple validé (`^[A-Za-z_][A-Za-z0-9_]*$`). |
 
 Une valeur non entière ou hors borne lève une erreur explicite au démarrage
 (pas de repli silencieux sur le défaut).

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -37,9 +37,13 @@ Inclus :
 Hors-scope (PR suivantes) :
 
 - vraie exécution parallèle + appels Symfony réels → **PY-002** ;
-- persistance DB des sets et runs → **DB-001** ;
 - refresh des contrats, gestion live, idempotence/locks serveur ;
 - cockpit front → **UI-001** ; branchement Temporal → **TM-001**.
+
+> **DB-001 (livré)** : le schéma de persistance (dashboards, sets, runs +
+> dernier JSON) existe désormais (cf. section *Persistance*). Le **câblage**
+> applicatif (lecture des sets depuis la DB, écriture des runs) reste l'objet
+> de **PY-002** : à ce stade `services/sets.py` reste en mémoire.
 
 ## Endpoints
 
@@ -142,6 +146,43 @@ make test-orchestrator
 | `SYMFONY_BASE_URL` | `http://trading-app-nginx:80` | URL de base Symfony (PY-002+). |
 | `ORCHESTRATOR_PORT` | `8099` | Port d'écoute HTTP (1..65535). |
 | `MAX_CONCURRENCY` | `2` | Concurrence globale bornée, ≥ 1 (PY-002+). |
+| `DATABASE_URL` | `postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app` | URL SQLAlchemy de la base orchestration (DB-001). |
+| `ORCHESTRATION_DB_SCHEMA` | `orchestration` | Schéma PostgreSQL dédié (DB-001). `none` le neutralise (tests SQLite). |
 
 Une valeur non entière ou hors borne lève une erreur explicite au démarrage
 (pas de repli silencieux sur le défaut).
+
+## Persistance (DB-001)
+
+L'orchestrateur persiste sa configuration et ses résultats dans PostgreSQL via
+**SQLAlchemy 2.0 + Alembic** (driver `psycopg` sync). Pour ne pas interférer
+avec les migrations Doctrine de Symfony, tout vit dans un **schéma PostgreSQL
+dédié `orchestration`** au sein de la base `trading_app` existante (Symfony
+n'introspecte que `public`).
+
+Tables (`app/db/models.py`) :
+
+| Table | Rôle |
+| --- | --- |
+| `dashboards` | Configurations d'orchestration (nom, statut). |
+| `orchestration_sets` | Sets prêts à exécuter (miroir d'`OrchestratorSet` + `payload` préparé). |
+| `runs` | Runs déclenchés + **dernier JSON global** (`last_json`). |
+| `run_sets` | Résultat par set + **dernier JSON par set** (`response_json`). |
+
+La couche DB (`app/db/`) est **découplée** des routers/services : le câblage
+applicatif (CRUD, lecture des sets au run) est l'objet de **PY-002**.
+
+### Migrations
+
+```bash
+cd python-orchestrator
+export DATABASE_URL=postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app
+alembic upgrade head        # crée le schéma `orchestration` + les 4 tables
+alembic downgrade base      # supprime les tables (laisse le schéma)
+alembic upgrade head --sql  # prévisualise le DDL sans l'appliquer
+```
+
+Le schéma `orchestration` (et la table de version Alembic qui y réside) est créé
+automatiquement par `alembic/env.py` au premier `upgrade`. L'`entrypoint` du
+conteneur n'exécute **pas** les migrations au boot (service expérimental derrière
+le profile `orchestrator`) : les appliquer explicitement.

--- a/python-orchestrator/alembic.ini
+++ b/python-orchestrator/alembic.ini
@@ -1,0 +1,44 @@
+# Configuration Alembic pour l'orchestrateur Python (DB-001).
+# L'URL de connexion n'est PAS définie ici : env.py la lit depuis app.settings
+# (variable DATABASE_URL), pour une source unique de configuration.
+
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+version_path_separator = os
+# La date des fichiers de version est en UTC.
+timezone = UTC
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/python-orchestrator/alembic/env.py
+++ b/python-orchestrator/alembic/env.py
@@ -1,0 +1,89 @@
+"""Environnement Alembic de l'orchestrateur (DB-001).
+
+L'URL et le schéma cible proviennent d'``app.settings`` : une seule source de
+configuration (variables ``DATABASE_URL`` / ``ORCHESTRATION_DB_SCHEMA``). Les
+migrations gèrent uniquement le schéma dédié ``orchestration`` ; la table de
+version Alembic y est également stockée pour ne pas polluer ``public``.
+"""
+
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool, text
+
+from app.db.base import SCHEMA, Base
+from app.db import models  # noqa: F401  (enregistre les tables sur Base.metadata)
+from app.settings import get_settings
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+target_metadata = Base.metadata
+
+# Schéma dédié : aussi utilisé pour stocker la table de version Alembic.
+_version_table_schema = SCHEMA
+
+
+def _include_object(obj, name, type_, reflected, compare_to):  # noqa: ANN001
+    """Ne gère que les objets du schéma orchestration (ignore public/Doctrine)."""
+    if type_ == "table" and _version_table_schema is not None:
+        return getattr(obj, "schema", None) == _version_table_schema
+    return True
+
+
+def _create_schema_sql() -> str:
+    return f'CREATE SCHEMA IF NOT EXISTS "{_version_table_schema}"'
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        include_schemas=True,
+        version_table_schema=_version_table_schema,
+        include_object=_include_object,
+    )
+    with context.begin_transaction():
+        # Le schéma doit exister avant la table de version Alembic.
+        if _version_table_schema:
+            context.execute(_create_schema_sql())
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        # Crée le schéma dédié avant qu'Alembic n'y matérialise sa table de
+        # version : sans cela, ``alembic upgrade`` échoue au premier run.
+        if _version_table_schema:
+            connection.execute(text(_create_schema_sql()))
+            connection.commit()
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            include_schemas=True,
+            version_table_schema=_version_table_schema,
+            include_object=_include_object,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/python-orchestrator/alembic/env.py
+++ b/python-orchestrator/alembic/env.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool, text
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.schema import CreateSchema
 
 from app.db.base import SCHEMA, Base
 from app.db import models  # noqa: F401  (enregistre les tables sur Base.metadata)
@@ -27,19 +28,16 @@ config.set_main_option("sqlalchemy.url", settings.database_url)
 
 target_metadata = Base.metadata
 
-# Schéma dédié : aussi utilisé pour stocker la table de version Alembic.
+# Schéma dédié (toujours défini et validé) : aussi utilisé pour stocker la table
+# de version Alembic, afin de ne pas polluer ``public``.
 _version_table_schema = SCHEMA
 
 
 def _include_object(obj, name, type_, reflected, compare_to):  # noqa: ANN001
     """Ne gère que les objets du schéma orchestration (ignore public/Doctrine)."""
-    if type_ == "table" and _version_table_schema is not None:
+    if type_ == "table":
         return getattr(obj, "schema", None) == _version_table_schema
     return True
-
-
-def _create_schema_sql() -> str:
-    return f'CREATE SCHEMA IF NOT EXISTS "{_version_table_schema}"'
 
 
 def run_migrations_offline() -> None:
@@ -54,8 +52,7 @@ def run_migrations_offline() -> None:
     )
     with context.begin_transaction():
         # Le schéma doit exister avant la table de version Alembic.
-        if _version_table_schema:
-            context.execute(_create_schema_sql())
+        context.execute(CreateSchema(_version_table_schema, if_not_exists=True))
         context.run_migrations()
 
 
@@ -68,10 +65,11 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         # Crée le schéma dédié avant qu'Alembic n'y matérialise sa table de
-        # version : sans cela, ``alembic upgrade`` échoue au premier run.
-        if _version_table_schema:
-            connection.execute(text(_create_schema_sql()))
-            connection.commit()
+        # version : sans cela, ``alembic upgrade`` échoue au premier run. Le nom
+        # est validé en amont (app.db.base) et quoté par le dialecte via
+        # CreateSchema → pas d'interpolation SQL manuelle.
+        connection.execute(CreateSchema(_version_table_schema, if_not_exists=True))
+        connection.commit()
         context.configure(
             connection=connection,
             target_metadata=target_metadata,

--- a/python-orchestrator/alembic/script.py.mako
+++ b/python-orchestrator/alembic/script.py.mako
@@ -1,0 +1,25 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/python-orchestrator/alembic/versions/0001_init_orchestration_schema.py
+++ b/python-orchestrator/alembic/versions/0001_init_orchestration_schema.py
@@ -1,0 +1,156 @@
+"""init orchestration schema (dashboards, sets, runs, run_sets)
+
+Revision ID: 0001_orchestration
+Revises:
+Create Date: 2026-06-17
+
+Crée le schéma PostgreSQL dédié ``orchestration`` et ses quatre tables. Isolé de
+``public`` pour ne pas interférer avec les migrations Doctrine de Symfony.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from app.db.base import SCHEMA
+
+# revision identifiers, used by Alembic.
+revision: str = "0001_orchestration"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA_KW = {"schema": SCHEMA} if SCHEMA else {}
+
+
+def upgrade() -> None:
+    # Le schéma dédié est créé par env.py avant la table de version Alembic.
+    op.create_table(
+        "dashboards",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_dashboards"),
+        sa.UniqueConstraint("name", name="uq_dashboards_name"),
+        **SCHEMA_KW,
+    )
+
+    op.create_table(
+        "orchestration_sets",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("dashboard_id", sa.BigInteger(), nullable=False),
+        sa.Column("set_id", sa.String(length=255), nullable=False),
+        sa.Column("enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("action", sa.String(length=32), server_default="mtf_run", nullable=False),
+        sa.Column("exchange", sa.String(length=32), nullable=False),
+        sa.Column("market_type", sa.String(length=32), server_default="perpetual", nullable=False),
+        sa.Column("mtf_profile", sa.String(length=32), server_default="regular", nullable=False),
+        sa.Column("environment", sa.String(length=32), server_default="demo", nullable=False),
+        sa.Column("dry_run", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("workers", sa.Integer(), server_default=sa.text("1"), nullable=False),
+        sa.Column("sync_tables", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("symbols", postgresql.JSONB(), server_default=sa.text("'[]'::jsonb"), nullable=False),
+        sa.Column("contracts_limit", sa.Integer(), nullable=True),
+        sa.Column("priority", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("payload", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_orchestration_sets"),
+        sa.ForeignKeyConstraint(
+            ["dashboard_id"],
+            [f"{SCHEMA + '.' if SCHEMA else ''}dashboards.id"],
+            name="fk_orchestration_sets_dashboard_id_dashboards",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint("dashboard_id", "set_id", name="uq_orchestration_sets_dashboard_set"),
+        **SCHEMA_KW,
+    )
+    op.create_index(
+        "ix_orchestration_sets_dashboard_enabled_priority",
+        "orchestration_sets",
+        ["dashboard_id", "enabled", "priority"],
+        **SCHEMA_KW,
+    )
+
+    op.create_table(
+        "runs",
+        sa.Column("run_id", sa.String(length=255), nullable=False),
+        sa.Column("dashboard_id", sa.BigInteger(), nullable=True),
+        sa.Column("ok", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=255), nullable=True),
+        sa.Column("total_calls", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("success_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("failed_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_json", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("run_id", name="pk_runs"),
+        sa.ForeignKeyConstraint(
+            ["dashboard_id"],
+            [f"{SCHEMA + '.' if SCHEMA else ''}dashboards.id"],
+            name="fk_runs_dashboard_id_dashboards",
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint("idempotency_key", name="uq_runs_idempotency_key"),
+        **SCHEMA_KW,
+    )
+    op.create_index(
+        "ix_runs_dashboard_created_at",
+        "runs",
+        ["dashboard_id", "created_at"],
+        **SCHEMA_KW,
+    )
+
+    op.create_table(
+        "run_sets",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("run_id", sa.String(length=255), nullable=False),
+        sa.Column("set_id", sa.String(length=255), nullable=False),
+        sa.Column("set_ref_id", sa.BigInteger(), nullable=True),
+        sa.Column("payload_sent", postgresql.JSONB(), nullable=True),
+        sa.Column("response_json", postgresql.JSONB(), nullable=True),
+        sa.Column("ok", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_run_sets"),
+        sa.ForeignKeyConstraint(
+            ["run_id"],
+            [f"{SCHEMA + '.' if SCHEMA else ''}runs.run_id"],
+            name="fk_run_sets_run_id_runs",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["set_ref_id"],
+            [f"{SCHEMA + '.' if SCHEMA else ''}orchestration_sets.id"],
+            name="fk_run_sets_set_ref_id_orchestration_sets",
+            ondelete="SET NULL",
+        ),
+        sa.UniqueConstraint("run_id", "set_id", name="uq_run_sets_run_set"),
+        **SCHEMA_KW,
+    )
+    op.create_index("ix_run_sets_run_id", "run_sets", ["run_id"], **SCHEMA_KW)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_run_sets_run_id", table_name="run_sets", **SCHEMA_KW)
+    op.drop_table("run_sets", **SCHEMA_KW)
+    op.drop_index("ix_runs_dashboard_created_at", table_name="runs", **SCHEMA_KW)
+    op.drop_table("runs", **SCHEMA_KW)
+    op.drop_index(
+        "ix_orchestration_sets_dashboard_enabled_priority",
+        table_name="orchestration_sets",
+        **SCHEMA_KW,
+    )
+    op.drop_table("orchestration_sets", **SCHEMA_KW)
+    op.drop_table("dashboards", **SCHEMA_KW)
+    # On ne supprime PAS le schéma : la table de version Alembic
+    # (``orchestration.alembic_version``) y réside. Un teardown complet relève
+    # de l'opérateur : DROP SCHEMA "orchestration" CASCADE.

--- a/python-orchestrator/app/db/__init__.py
+++ b/python-orchestrator/app/db/__init__.py
@@ -1,0 +1,10 @@
+"""Couche de persistance de l'orchestrateur (DB-001).
+
+Schéma SQLAlchemy + accès DB pour les dashboards, sets et runs d'orchestration.
+La couche est volontairement découplée des routers/services existants : le
+branchement (CRUD, lecture des sets depuis la DB) est l'objet de PY-002.
+"""
+
+from app.db.base import SCHEMA, Base
+
+__all__ = ["Base", "SCHEMA"]

--- a/python-orchestrator/app/db/base.py
+++ b/python-orchestrator/app/db/base.py
@@ -19,6 +19,10 @@ from sqlalchemy.orm import DeclarativeBase
 DEFAULT_SCHEMA = "orchestration"
 # Identifiant SQL simple : évite toute injection DDL via le nom de schéma.
 _SCHEMA_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+# Schémas réservés interdits : poser les tables d'orchestration dans `public`
+# (schéma Symfony/Doctrine) ou un schéma système romprait l'isolation centrale
+# de la PR. On les refuse même s'ils sont syntaxiquement valides.
+_FORBIDDEN_SCHEMAS = frozenset({"public", "pg_catalog", "information_schema"})
 
 
 class SchemaError(ValueError):
@@ -26,12 +30,18 @@ class SchemaError(ValueError):
 
 
 def _resolve_schema() -> str:
-    """Résout et valide le schéma cible (jamais ``None``, jamais ``public`` implicite)."""
+    """Résout et valide le schéma cible (jamais ``None``, jamais ``public``)."""
     raw = os.getenv("ORCHESTRATION_DB_SCHEMA", DEFAULT_SCHEMA).strip()
     if not _SCHEMA_RE.match(raw):
         raise SchemaError(
             f"ORCHESTRATION_DB_SCHEMA invalide : {raw!r}. "
             "Attendu un identifiant SQL simple (^[A-Za-z_][A-Za-z0-9_]*$)."
+        )
+    if raw.lower() in _FORBIDDEN_SCHEMAS:
+        raise SchemaError(
+            f"ORCHESTRATION_DB_SCHEMA interdit : {raw!r}. Le schéma d'orchestration "
+            "doit être dédié (ni `public`, ni un schéma système) pour préserver "
+            "l'isolation vis-à-vis de Doctrine/Symfony."
         )
     return raw
 

--- a/python-orchestrator/app/db/base.py
+++ b/python-orchestrator/app/db/base.py
@@ -1,0 +1,43 @@
+"""Base déclarative SQLAlchemy et schéma des tables d'orchestration.
+
+Le schéma PostgreSQL est dédié (``orchestration`` par défaut) pour isoler ces
+tables de celles gérées par Doctrine côté Symfony (qui n'introspecte que
+``public``). Le nom est lu depuis l'environnement pour pouvoir être neutralisé
+dans les tests SQLite — qui ne supportent pas les schémas — via
+``ORCHESTRATION_DB_SCHEMA=none`` (ou vide).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+
+def _resolve_schema() -> Optional[str]:
+    """Résout le schéma cible ; ``None`` désactive le préfixe (tests SQLite)."""
+    raw = os.getenv("ORCHESTRATION_DB_SCHEMA", "orchestration").strip()
+    if raw.lower() in {"", "none"}:
+        return None
+    return raw
+
+
+# Schéma figé à l'import : les tables le portent via ``MetaData(schema=...)``.
+SCHEMA: Optional[str] = _resolve_schema()
+
+# Convention de nommage explicite des contraintes/index : noms stables et
+# déterministes, indispensables pour des migrations Alembic propres.
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    """Base déclarative commune à tous les modèles d'orchestration."""
+
+    metadata = MetaData(schema=SCHEMA, naming_convention=NAMING_CONVENTION)

--- a/python-orchestrator/app/db/base.py
+++ b/python-orchestrator/app/db/base.py
@@ -2,30 +2,42 @@
 
 Le schéma PostgreSQL est dédié (``orchestration`` par défaut) pour isoler ces
 tables de celles gérées par Doctrine côté Symfony (qui n'introspecte que
-``public``). Le nom est lu depuis l'environnement pour pouvoir être neutralisé
-dans les tests SQLite — qui ne supportent pas les schémas — via
-``ORCHESTRATION_DB_SCHEMA=none`` (ou vide).
+``public``). Le nom est lu depuis l'environnement et **strictement validé** : il
+n'existe aucun chemin runtime qui retombe sur le schéma par défaut/``public``.
+Les tests SQLite conservent le schéma et attachent une base in-memory du même
+nom (cf. ``tests/conftest.py``) plutôt que de le neutraliser.
 """
 
 from __future__ import annotations
 
 import os
-from typing import Optional
+import re
 
 from sqlalchemy import MetaData
 from sqlalchemy.orm import DeclarativeBase
 
+DEFAULT_SCHEMA = "orchestration"
+# Identifiant SQL simple : évite toute injection DDL via le nom de schéma.
+_SCHEMA_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-def _resolve_schema() -> Optional[str]:
-    """Résout le schéma cible ; ``None`` désactive le préfixe (tests SQLite)."""
-    raw = os.getenv("ORCHESTRATION_DB_SCHEMA", "orchestration").strip()
-    if raw.lower() in {"", "none"}:
-        return None
+
+class SchemaError(ValueError):
+    """Nom de schéma d'orchestration invalide."""
+
+
+def _resolve_schema() -> str:
+    """Résout et valide le schéma cible (jamais ``None``, jamais ``public`` implicite)."""
+    raw = os.getenv("ORCHESTRATION_DB_SCHEMA", DEFAULT_SCHEMA).strip()
+    if not _SCHEMA_RE.match(raw):
+        raise SchemaError(
+            f"ORCHESTRATION_DB_SCHEMA invalide : {raw!r}. "
+            "Attendu un identifiant SQL simple (^[A-Za-z_][A-Za-z0-9_]*$)."
+        )
     return raw
 
 
 # Schéma figé à l'import : les tables le portent via ``MetaData(schema=...)``.
-SCHEMA: Optional[str] = _resolve_schema()
+SCHEMA: str = _resolve_schema()
 
 # Convention de nommage explicite des contraintes/index : noms stables et
 # déterministes, indispensables pour des migrations Alembic propres.

--- a/python-orchestrator/app/db/engine.py
+++ b/python-orchestrator/app/db/engine.py
@@ -1,0 +1,59 @@
+"""Moteur SQLAlchemy et fabrique de sessions (DB-001).
+
+Création **paresseuse** : importer ce module n'ouvre aucune connexion. Le moteur
+n'est instancié qu'au premier appel à ``get_engine()`` / ``get_sessionmaker()``,
+si bien que l'application, le ``/healthcheck`` et les tests démarrent sans
+PostgreSQL. Le câblage FastAPI réel (dépendance ``get_session``) sera consommé
+par PY-002.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, Optional
+
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from app.settings import Settings, get_settings
+
+_engine: Optional[Engine] = None
+_session_factory: Optional[sessionmaker[Session]] = None
+
+
+def get_engine(settings: Optional[Settings] = None) -> Engine:
+    """Retourne le moteur partagé, en le créant au premier appel."""
+    global _engine
+    if _engine is None:
+        settings = settings or get_settings()
+        # pool_pre_ping : évite les connexions mortes après un idle long.
+        _engine = create_engine(settings.database_url, pool_pre_ping=True, future=True)
+    return _engine
+
+
+def get_sessionmaker(settings: Optional[Settings] = None) -> sessionmaker[Session]:
+    """Retourne la fabrique de sessions partagée."""
+    global _session_factory
+    if _session_factory is None:
+        _session_factory = sessionmaker(
+            bind=get_engine(settings), autoflush=False, expire_on_commit=False
+        )
+    return _session_factory
+
+
+def get_session() -> Iterator[Session]:
+    """Dépendance FastAPI : ouvre une session et la ferme en fin de requête (PY-002)."""
+    factory = get_sessionmaker()
+    session = factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def reset_engine() -> None:
+    """Réinitialise le moteur/fabrique (utile pour les tests)."""
+    global _engine, _session_factory
+    if _engine is not None:
+        _engine.dispose()
+    _engine = None
+    _session_factory = None

--- a/python-orchestrator/app/db/models.py
+++ b/python-orchestrator/app/db/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import (
     Boolean,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -69,11 +70,19 @@ class OrchestrationSet(Base):
     __tablename__ = "orchestration_sets"
     __table_args__ = (
         UniqueConstraint("dashboard_id", "set_id", name="uq_orchestration_sets_dashboard_set"),
+        # Index composite explicite (couvre aussi les lookups FK dashboard_id en
+        # colonne de gauche). Nom aligné sur la migration pour éviter tout drift.
+        Index(
+            "ix_orchestration_sets_dashboard_enabled_priority",
+            "dashboard_id",
+            "enabled",
+            "priority",
+        ),
     )
 
     id: Mapped[int] = mapped_column(BigIntPK, primary_key=True, autoincrement=True)
     dashboard_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("dashboards.id", ondelete="CASCADE"), nullable=False, index=True
+        BigInteger, ForeignKey("dashboards.id", ondelete="CASCADE"), nullable=False
     )
     set_id: Mapped[str] = mapped_column(String(255), nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
@@ -104,13 +113,18 @@ class Run(Base):
     """Run d'orchestration déclenché + dernier JSON global."""
 
     __tablename__ = "runs"
+    __table_args__ = (
+        # Index composite explicite (couvre les lookups FK dashboard_id). Nom
+        # aligné sur la migration pour éviter tout drift autogenerate.
+        Index("ix_runs_dashboard_created_at", "dashboard_id", "created_at"),
+    )
 
     # run_id = identifiant dérivé par l'orchestrateur (cf. _resolve_run_id).
     run_id: Mapped[str] = mapped_column(String(255), primary_key=True)
     # Nullable + SET NULL : on conserve l'historique des runs même si le
     # dashboard d'origine est supprimé.
     dashboard_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("dashboards.id", ondelete="SET NULL"), nullable=True, index=True
+        BigInteger, ForeignKey("dashboards.id", ondelete="SET NULL"), nullable=True
     )
     ok: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     status: Mapped[str] = mapped_column(String(32), nullable=False)
@@ -138,11 +152,13 @@ class RunSet(Base):
     __tablename__ = "run_sets"
     __table_args__ = (
         UniqueConstraint("run_id", "set_id", name="uq_run_sets_run_set"),
+        # Index explicite aligné sur la migration (évite le drift autogenerate).
+        Index("ix_run_sets_run_id", "run_id"),
     )
 
     id: Mapped[int] = mapped_column(BigIntPK, primary_key=True, autoincrement=True)
     run_id: Mapped[str] = mapped_column(
-        String(255), ForeignKey("runs.run_id", ondelete="CASCADE"), nullable=False, index=True
+        String(255), ForeignKey("runs.run_id", ondelete="CASCADE"), nullable=False
     )
     # Snapshot textuel du set_id (le set peut être supprimé après le run).
     set_id: Mapped[str] = mapped_column(String(255), nullable=False)

--- a/python-orchestrator/app/db/models.py
+++ b/python-orchestrator/app/db/models.py
@@ -1,0 +1,162 @@
+"""Modèles ORM des tables d'orchestration (DB-001).
+
+Quatre tables alignées sur la cible documentée :
+
+- ``dashboards``           : configurations d'orchestration ;
+- ``orchestration_sets``   : sets prêts à exécuter (cf. ``OrchestratorSet``) ;
+- ``runs``                 : runs déclenchés + dernier JSON global ;
+- ``run_sets``             : résultat par set + dernier JSON par set.
+
+Les colonnes JSON utilisent ``JSONB`` sur PostgreSQL et retombent sur ``JSON``
+sur SQLite (tests). Aucun branchement avec les routers/services existants :
+ces modèles ne servent que la persistance, le câblage applicatif est PY-002.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+# JSONB côté PostgreSQL, JSON générique côté SQLite (tests).
+JSONVariant = JSONB().with_variant(JSON(), "sqlite")
+
+# BIGINT côté PostgreSQL ; INTEGER côté SQLite, car SQLite n'auto-incrémente
+# que les colonnes ``INTEGER PRIMARY KEY`` (pas ``BIGINT``).
+BigIntPK = BigInteger().with_variant(Integer(), "sqlite")
+
+
+class Dashboard(Base):
+    """Configuration d'orchestration regroupant des sets."""
+
+    __tablename__ = "dashboards"
+
+    id: Mapped[int] = mapped_column(BigIntPK, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    sets: Mapped[list["OrchestrationSet"]] = relationship(
+        back_populates="dashboard", cascade="all, delete-orphan", passive_deletes=True
+    )
+
+
+class OrchestrationSet(Base):
+    """Unité fonctionnelle prête à exécuter (miroir persistant d'``OrchestratorSet``)."""
+
+    __tablename__ = "orchestration_sets"
+    __table_args__ = (
+        UniqueConstraint("dashboard_id", "set_id", name="uq_orchestration_sets_dashboard_set"),
+    )
+
+    id: Mapped[int] = mapped_column(BigIntPK, primary_key=True, autoincrement=True)
+    dashboard_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("dashboards.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    set_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    action: Mapped[str] = mapped_column(String(32), nullable=False, default="mtf_run", server_default="mtf_run")
+    exchange: Mapped[str] = mapped_column(String(32), nullable=False)
+    market_type: Mapped[str] = mapped_column(String(32), nullable=False, default="perpetual", server_default="perpetual")
+    mtf_profile: Mapped[str] = mapped_column(String(32), nullable=False, default="regular", server_default="regular")
+    environment: Mapped[str] = mapped_column(String(32), nullable=False, default="demo", server_default="demo")
+    dry_run: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    workers: Mapped[int] = mapped_column(Integer, nullable=False, default=1, server_default="1")
+    sync_tables: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    symbols: Mapped[list] = mapped_column(JSONVariant, nullable=False, default=list)
+    contracts_limit: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    # Payload prêt envoyé à Symfony (préparé par PY-004). Null tant que non préparé.
+    payload: Mapped[Optional[dict]] = mapped_column(JSONVariant, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    dashboard: Mapped[Dashboard] = relationship(back_populates="sets")
+
+
+class Run(Base):
+    """Run d'orchestration déclenché + dernier JSON global."""
+
+    __tablename__ = "runs"
+
+    # run_id = identifiant dérivé par l'orchestrateur (cf. _resolve_run_id).
+    run_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    # Nullable + SET NULL : on conserve l'historique des runs même si le
+    # dashboard d'origine est supprimé.
+    dashboard_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("dashboards.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    ok: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    # Clé d'idempotence (SAFE-002) : unique quand fournie.
+    idempotency_key: Mapped[Optional[str]] = mapped_column(String(255), nullable=True, unique=True)
+    total_calls: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    success_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
+    started_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Dernier JSON global du run.
+    last_json: Mapped[Optional[dict]] = mapped_column(JSONVariant, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    run_sets: Mapped[list["RunSet"]] = relationship(
+        back_populates="run", cascade="all, delete-orphan", passive_deletes=True
+    )
+
+
+class RunSet(Base):
+    """Résultat d'un set dans un run + dernier JSON par set."""
+
+    __tablename__ = "run_sets"
+    __table_args__ = (
+        UniqueConstraint("run_id", "set_id", name="uq_run_sets_run_set"),
+    )
+
+    id: Mapped[int] = mapped_column(BigIntPK, primary_key=True, autoincrement=True)
+    run_id: Mapped[str] = mapped_column(
+        String(255), ForeignKey("runs.run_id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # Snapshot textuel du set_id (le set peut être supprimé après le run).
+    set_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Lien optionnel vers le set persistant (rompu sans casser le run).
+    set_ref_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("orchestration_sets.id", ondelete="SET NULL"), nullable=True
+    )
+    payload_sent: Mapped[Optional[dict]] = mapped_column(JSONVariant, nullable=True)
+    response_json: Mapped[Optional[dict]] = mapped_column(JSONVariant, nullable=True)
+    ok: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+    error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    duration_ms: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    run: Mapped[Run] = relationship(back_populates="run_sets")

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -15,6 +15,28 @@ from sqlalchemy.orm import Session
 
 from app.db.models import Dashboard, OrchestrationSet, Run, RunSet
 
+# Colonnes mutables recopiées lors d'un upsert (la PK et created_at sont exclus).
+_RUN_UPDATABLE = (
+    "dashboard_id", "ok", "status", "idempotency_key", "total_calls",
+    "success_count", "failed_count", "started_at", "finished_at", "last_json",
+)
+_RUN_SET_UPDATABLE = (
+    "set_ref_id", "payload_sent", "response_json", "ok", "error", "duration_ms",
+)
+
+
+def _apply(target: object, source: object, fields: Sequence[str]) -> None:
+    """Recopie ``fields`` de ``source`` vers ``target`` en ignorant les ``None``.
+
+    Ignorer ``None`` évite d'écraser une valeur existante (ou un server_default)
+    avec un champ simplement non renseigné sur l'instance transitoire ; ``0`` et
+    ``False`` (non ``None``) sont bien propagés.
+    """
+    for name in fields:
+        value = getattr(source, name)
+        if value is not None:
+            setattr(target, name, value)
+
 
 def get_dashboard(session: Session, dashboard_id: int) -> Optional[Dashboard]:
     """Retourne un dashboard par son id, ou ``None``."""
@@ -48,15 +70,49 @@ def get_run(session: Session, run_id: str) -> Optional[Run]:
     return session.get(Run, run_id)
 
 
+def get_run_by_idempotency_key(session: Session, idempotency_key: str) -> Optional[Run]:
+    """Retourne un run par sa clé d'idempotence, ou ``None``."""
+    return session.scalar(select(Run).where(Run.idempotency_key == idempotency_key))
+
+
 def record_run(session: Session, run: Run) -> Run:
-    """Persiste (ou met à jour) un run et le renvoie après flush."""
-    merged = session.merge(run)
+    """Upsert idempotent d'un run.
+
+    Résout l'existant par ``run_id`` puis, à défaut, par ``idempotency_key`` :
+    un retry réutilisant la même clé met à jour le run existant au lieu de violer
+    ``uq_runs_idempotency_key``. Retourne l'instance persistée après flush.
+    """
+    existing = session.get(Run, run.run_id)
+    if existing is None and run.idempotency_key:
+        existing = get_run_by_idempotency_key(session, run.idempotency_key)
+
+    if existing is not None:
+        _apply(existing, run, _RUN_UPDATABLE)
+        session.flush()
+        return existing
+
+    session.add(run)
     session.flush()
-    return merged
+    return run
 
 
 def record_run_set(session: Session, run_set: RunSet) -> RunSet:
-    """Persiste le résultat d'un set dans un run et le renvoie après flush."""
+    """Upsert idempotent du résultat d'un set dans un run.
+
+    Résout l'existant par ``(run_id, set_id)`` : un retry du même set dans le même
+    run met à jour le dernier résultat au lieu de violer ``uq_run_sets_run_set``.
+    """
+    existing = session.scalar(
+        select(RunSet).where(
+            RunSet.run_id == run_set.run_id,
+            RunSet.set_id == run_set.set_id,
+        )
+    )
+    if existing is not None:
+        _apply(existing, run_set, _RUN_SET_UPDATABLE)
+        session.flush()
+        return existing
+
     session.add(run_set)
     session.flush()
     return run_set

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -25,19 +25,26 @@ _RUN_SET_UPDATABLE = (
 )
 
 
-def _apply(target: object, source: object, fields: Sequence[str]) -> None:
+def _apply(target: object, source: object, fields: Sequence[str], *, clear_nullable: bool) -> None:
     """Recopie ``fields`` de ``source`` vers ``target`` lors d'un upsert.
 
-    Une colonne **NULLABLE** est toujours écrasée — y compris remise à ``None`` :
-    c'est le « dernier résultat » qui fait foi (ex. ``error`` effacée quand un
-    set repasse au succès). Une colonne **NOT NULL** n'est pas écrasée par un
-    ``None`` (champ simplement non renseigné sur l'instance transitoire), pour ne
-    pas violer la contrainte ni effacer un ``server_default``.
+    Une valeur non ``None`` est toujours recopiée. Le traitement d'un ``None``
+    dépend du mode :
+
+    - ``clear_nullable=True`` (snapshot complet, ex. résultat d'un set) : une
+      colonne **NULLABLE** est remise à ``None`` — le dernier résultat fait foi
+      (ex. ``error`` effacée quand un set repasse au succès).
+    - ``clear_nullable=False`` (mise à jour partielle, ex. transition de statut
+      d'un run) : un ``None`` n'écrase jamais — on préserve les champs
+      d'identité/contexte non renseignés (``idempotency_key``, ``dashboard_id``…).
+
+    Dans tous les cas, une colonne **NOT NULL** n'est jamais écrasée par un
+    ``None`` (pas de violation de contrainte ni d'effacement de ``server_default``).
     """
     columns = target.__table__.c
     for name in fields:
         value = getattr(source, name)
-        if value is None and not columns[name].nullable:
+        if value is None and not (clear_nullable and columns[name].nullable):
             continue
         setattr(target, name, value)
 
@@ -91,7 +98,9 @@ def record_run(session: Session, run: Run) -> Run:
         existing = get_run_by_idempotency_key(session, run.idempotency_key)
 
     if existing is not None:
-        _apply(existing, run, _RUN_UPDATABLE)
+        # Mise à jour partielle : un champ non renseigné (None) ne doit pas
+        # effacer l'idempotency_key/dashboard_id déjà stockés.
+        _apply(existing, run, _RUN_UPDATABLE, clear_nullable=False)
         session.flush()
         return existing
 
@@ -113,7 +122,9 @@ def record_run_set(session: Session, run_set: RunSet) -> RunSet:
         )
     )
     if existing is not None:
-        _apply(existing, run_set, _RUN_SET_UPDATABLE)
+        # Snapshot du dernier résultat : les champs nullable obsolètes
+        # (ex. error d'un échec précédent) doivent pouvoir être effacés.
+        _apply(existing, run_set, _RUN_SET_UPDATABLE, clear_nullable=True)
         session.flush()
         return existing
 

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -26,16 +26,20 @@ _RUN_SET_UPDATABLE = (
 
 
 def _apply(target: object, source: object, fields: Sequence[str]) -> None:
-    """Recopie ``fields`` de ``source`` vers ``target`` en ignorant les ``None``.
+    """Recopie ``fields`` de ``source`` vers ``target`` lors d'un upsert.
 
-    Ignorer ``None`` évite d'écraser une valeur existante (ou un server_default)
-    avec un champ simplement non renseigné sur l'instance transitoire ; ``0`` et
-    ``False`` (non ``None``) sont bien propagés.
+    Une colonne **NULLABLE** est toujours écrasée — y compris remise à ``None`` :
+    c'est le « dernier résultat » qui fait foi (ex. ``error`` effacée quand un
+    set repasse au succès). Une colonne **NOT NULL** n'est pas écrasée par un
+    ``None`` (champ simplement non renseigné sur l'instance transitoire), pour ne
+    pas violer la contrainte ni effacer un ``server_default``.
     """
+    columns = target.__table__.c
     for name in fields:
         value = getattr(source, name)
-        if value is not None:
-            setattr(target, name, value)
+        if value is None and not columns[name].nullable:
+            continue
+        setattr(target, name, value)
 
 
 def get_dashboard(session: Session, dashboard_id: int) -> Optional[Dashboard]:

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Optional, Sequence
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db.models import Dashboard, OrchestrationSet, Run, RunSet
@@ -86,27 +87,69 @@ def get_run_by_idempotency_key(session: Session, idempotency_key: str) -> Option
     return session.scalar(select(Run).where(Run.idempotency_key == idempotency_key))
 
 
+def _resolve_existing_run(session: Session, run: Run) -> Optional[Run]:
+    """Cherche le run existant par ``run_id`` puis, à défaut, par ``idempotency_key``."""
+    existing = session.get(Run, run.run_id)
+    if existing is None and run.idempotency_key:
+        existing = get_run_by_idempotency_key(session, run.idempotency_key)
+    return existing
+
+
+def _update_existing_run(session: Session, existing: Run, run: Run) -> Run:
+    # Mise à jour partielle : un champ non renseigné (None) ne doit pas effacer
+    # l'idempotency_key/dashboard_id déjà stockés.
+    _apply(existing, run, _RUN_UPDATABLE, clear_nullable=False)
+    session.flush()
+    return existing
+
+
 def record_run(session: Session, run: Run) -> Run:
     """Upsert idempotent d'un run.
 
     Résout l'existant par ``run_id`` puis, à défaut, par ``idempotency_key`` :
     un retry réutilisant la même clé met à jour le run existant au lieu de violer
-    ``uq_runs_idempotency_key``. Retourne l'instance persistée après flush.
+    ``uq_runs_idempotency_key``.
+
+    Le chemin d'insertion est protégé contre une **course concurrente** : si deux
+    writers manquent tous deux le lookup puis insèrent la même clé, le flush en
+    conflit (`uq_runs_idempotency_key` ou PK) est rattrapé via un savepoint, et on
+    recharge la ligne gagnante pour la mettre à jour — l'idempotence est donc
+    réellement garantie sous retry/concurrence. Retourne l'instance persistée.
     """
-    existing = session.get(Run, run.run_id)
-    if existing is None and run.idempotency_key:
-        existing = get_run_by_idempotency_key(session, run.idempotency_key)
-
+    existing = _resolve_existing_run(session, run)
     if existing is not None:
-        # Mise à jour partielle : un champ non renseigné (None) ne doit pas
-        # effacer l'idempotency_key/dashboard_id déjà stockés.
-        _apply(existing, run, _RUN_UPDATABLE, clear_nullable=False)
-        session.flush()
-        return existing
+        return _update_existing_run(session, existing, run)
 
-    session.add(run)
+    try:
+        with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
+            session.add(run)
+            session.flush()
+        return run
+    except IntegrityError:
+        # Un autre writer a inséré la même clé/PK entre le lookup et le flush.
+        if run in session:
+            session.expunge(run)
+        existing = _resolve_existing_run(session, run)
+        if existing is None:
+            raise  # conflit sur une autre contrainte : ne pas masquer
+        return _update_existing_run(session, existing, run)
+
+
+def _resolve_existing_run_set(session: Session, run_set: RunSet) -> Optional[RunSet]:
+    return session.scalar(
+        select(RunSet).where(
+            RunSet.run_id == run_set.run_id,
+            RunSet.set_id == run_set.set_id,
+        )
+    )
+
+
+def _update_existing_run_set(session: Session, existing: RunSet, run_set: RunSet) -> RunSet:
+    # Snapshot du dernier résultat : les champs nullable obsolètes
+    # (ex. error d'un échec précédent) doivent pouvoir être effacés.
+    _apply(existing, run_set, _RUN_SET_UPDATABLE, clear_nullable=True)
     session.flush()
-    return run
+    return existing
 
 
 def record_run_set(session: Session, run_set: RunSet) -> RunSet:
@@ -114,20 +157,22 @@ def record_run_set(session: Session, run_set: RunSet) -> RunSet:
 
     Résout l'existant par ``(run_id, set_id)`` : un retry du même set dans le même
     run met à jour le dernier résultat au lieu de violer ``uq_run_sets_run_set``.
+    Le chemin d'insertion est protégé contre une course concurrente (savepoint +
+    rattrapage de la violation d'unicité, puis rechargement) comme ``record_run``.
     """
-    existing = session.scalar(
-        select(RunSet).where(
-            RunSet.run_id == run_set.run_id,
-            RunSet.set_id == run_set.set_id,
-        )
-    )
+    existing = _resolve_existing_run_set(session, run_set)
     if existing is not None:
-        # Snapshot du dernier résultat : les champs nullable obsolètes
-        # (ex. error d'un échec précédent) doivent pouvoir être effacés.
-        _apply(existing, run_set, _RUN_SET_UPDATABLE, clear_nullable=True)
-        session.flush()
-        return existing
+        return _update_existing_run_set(session, existing, run_set)
 
-    session.add(run_set)
-    session.flush()
-    return run_set
+    try:
+        with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
+            session.add(run_set)
+            session.flush()
+        return run_set
+    except IntegrityError:
+        if run_set in session:
+            session.expunge(run_set)
+        existing = _resolve_existing_run_set(session, run_set)
+        if existing is None:
+            raise
+        return _update_existing_run_set(session, existing, run_set)

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -1,0 +1,62 @@
+"""Helpers d'accès aux tables d'orchestration (DB-001).
+
+Fonctions volontairement minimales et testables. Elles ne sont **pas** câblées
+dans les routers/services existants : la gestion applicative (CRUD, lecture des
+sets au run) est l'objet de PY-002. Elles servent de fondation et de surface de
+test pour le schéma.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db.models import Dashboard, OrchestrationSet, Run, RunSet
+
+
+def get_dashboard(session: Session, dashboard_id: int) -> Optional[Dashboard]:
+    """Retourne un dashboard par son id, ou ``None``."""
+    return session.get(Dashboard, dashboard_id)
+
+
+def get_dashboard_by_name(session: Session, name: str) -> Optional[Dashboard]:
+    """Retourne un dashboard par son nom unique, ou ``None``."""
+    return session.scalar(select(Dashboard).where(Dashboard.name == name))
+
+
+def list_active_sets(session: Session, dashboard_id: int) -> Sequence[OrchestrationSet]:
+    """Retourne les sets actifs d'un dashboard, triés par priorité décroissante.
+
+    Reproduit le tri du fournisseur in-memory (``services/sets.list_active_sets``)
+    pour que PY-002 puisse basculer la source sans changer le comportement.
+    """
+    stmt = (
+        select(OrchestrationSet)
+        .where(
+            OrchestrationSet.dashboard_id == dashboard_id,
+            OrchestrationSet.enabled.is_(True),
+        )
+        .order_by(OrchestrationSet.priority.desc(), OrchestrationSet.set_id.asc())
+    )
+    return session.scalars(stmt).all()
+
+
+def get_run(session: Session, run_id: str) -> Optional[Run]:
+    """Retourne un run par son ``run_id``, ou ``None``."""
+    return session.get(Run, run_id)
+
+
+def record_run(session: Session, run: Run) -> Run:
+    """Persiste (ou met à jour) un run et le renvoie après flush."""
+    merged = session.merge(run)
+    session.flush()
+    return merged
+
+
+def record_run_set(session: Session, run_set: RunSet) -> RunSet:
+    """Persiste le résultat d'un set dans un run et le renvoie après flush."""
+    session.add(run_set)
+    session.flush()
+    return run_set

--- a/python-orchestrator/app/settings.py
+++ b/python-orchestrator/app/settings.py
@@ -38,12 +38,24 @@ class Settings:
     port: int = 8099
     # Concurrence globale bornée des appels Symfony (utilisée par PY-002+).
     max_concurrency: int = 2
+    # URL SQLAlchemy de la base orchestration (DB-001). On réutilise la base
+    # `trading_app` mais dans un schéma dédié `orchestration` (cf. db_schema)
+    # pour ne pas interférer avec les migrations Doctrine de Symfony.
+    database_url: str = (
+        "postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app"
+    )
+    # Schéma PostgreSQL dédié aux tables d'orchestration.
+    db_schema: str = "orchestration"
 
     def __post_init__(self) -> None:
         if not 1 <= self.port <= 65535:
             raise SettingsError(f"ORCHESTRATOR_PORT hors plage : {self.port} (attendu 1..65535).")
         if self.max_concurrency < 1:
             raise SettingsError(f"MAX_CONCURRENCY doit être >= 1 (reçu {self.max_concurrency}).")
+        if not self.database_url.strip():
+            raise SettingsError("DATABASE_URL ne doit pas être vide.")
+        if not self.db_schema.strip():
+            raise SettingsError("ORCHESTRATION_DB_SCHEMA ne doit pas être vide.")
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -51,6 +63,8 @@ class Settings:
             symfony_base_url=os.getenv("SYMFONY_BASE_URL", cls.symfony_base_url),
             port=_int_env("ORCHESTRATOR_PORT", cls.port),
             max_concurrency=_int_env("MAX_CONCURRENCY", cls.max_concurrency),
+            database_url=os.getenv("DATABASE_URL", cls.database_url),
+            db_schema=os.getenv("ORCHESTRATION_DB_SCHEMA", cls.db_schema),
         )
 
 

--- a/python-orchestrator/requirements.txt
+++ b/python-orchestrator/requirements.txt
@@ -5,3 +5,9 @@ fastapi==0.137.1
 uvicorn[standard]==0.49.0
 pydantic==2.13.4
 httpx==0.28.1
+# Persistance orchestration (DB-001). psycopg[binary] fournit des wheels :
+# pas besoin de build-essential dans l'image. alembic en runtime pour appliquer
+# les migrations dans le conteneur (alembic upgrade head).
+sqlalchemy==2.0.36
+psycopg[binary]==3.2.3
+alembic==1.14.0

--- a/python-orchestrator/tests/conftest.py
+++ b/python-orchestrator/tests/conftest.py
@@ -1,9 +1,10 @@
 """Fixtures de test pour la couche DB (DB-001).
 
-Les tests tournent sur **SQLite in-memory** (aucun PostgreSQL requis). Le schéma
-dédié ``orchestration`` n'existe pas sous SQLite : on le neutralise en
-positionnant ``ORCHESTRATION_DB_SCHEMA=none`` **avant** l'import des modèles,
-puisque le schéma est figé à l'import de ``app.db.base``.
+Les tests tournent sur **SQLite in-memory** (aucun PostgreSQL requis). Plutôt que
+de neutraliser le schéma dédié ``orchestration`` (ce qui n'existe pas en
+runtime), on **attache** une base in-memory portant ce nom : les modèles
+tournent dans le *vrai* schéma, identique au runtime PostgreSQL. Le nom de schéma
+est figé à l'import de ``app.db.base`` — on le force donc avant tout import.
 """
 
 from __future__ import annotations
@@ -11,28 +12,32 @@ from __future__ import annotations
 import os
 
 # Doit être positionné avant tout import de app.db.* (schéma figé à l'import).
-# Forcé (et non setdefault) pour rester sur SQLite même si la CI exporte un schéma.
-os.environ["ORCHESTRATION_DB_SCHEMA"] = "none"
+os.environ["ORCHESTRATION_DB_SCHEMA"] = "orchestration"
 
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.db.base import SCHEMA
+
 
 @pytest.fixture()
 def db_session():
-    """Session SQLite in-memory avec le schéma orchestration créé à la volée."""
+    """Session SQLite in-memory avec le schéma orchestration attaché."""
     from app.db.base import Base
     from app.db import models  # noqa: F401  (enregistre les tables)
 
     engine = create_engine("sqlite://", future=True)
 
-    # SQLite n'applique pas les FK par défaut : on les active pour tester les
-    # ON DELETE CASCADE / SET NULL définis sur les tables.
     @event.listens_for(engine, "connect")
-    def _enable_sqlite_fk(dbapi_connection, _record):  # noqa: ANN001
+    def _prepare_sqlite(dbapi_connection, _record):  # noqa: ANN001
         cursor = dbapi_connection.cursor()
+        # SQLite n'applique pas les FK par défaut : on les active pour tester les
+        # ON DELETE CASCADE / SET NULL.
         cursor.execute("PRAGMA foreign_keys=ON")
+        # Schéma dédié : on attache une base in-memory du même nom pour que les
+        # tables `orchestration.*` soient résolues comme en PostgreSQL.
+        cursor.execute(f"ATTACH DATABASE ':memory:' AS {SCHEMA}")
         cursor.close()
 
     Base.metadata.create_all(engine)
@@ -42,5 +47,4 @@ def db_session():
         yield session
     finally:
         session.close()
-        Base.metadata.drop_all(engine)
         engine.dispose()

--- a/python-orchestrator/tests/conftest.py
+++ b/python-orchestrator/tests/conftest.py
@@ -1,0 +1,46 @@
+"""Fixtures de test pour la couche DB (DB-001).
+
+Les tests tournent sur **SQLite in-memory** (aucun PostgreSQL requis). Le schéma
+dédié ``orchestration`` n'existe pas sous SQLite : on le neutralise en
+positionnant ``ORCHESTRATION_DB_SCHEMA=none`` **avant** l'import des modèles,
+puisque le schéma est figé à l'import de ``app.db.base``.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Doit être positionné avant tout import de app.db.* (schéma figé à l'import).
+# Forcé (et non setdefault) pour rester sur SQLite même si la CI exporte un schéma.
+os.environ["ORCHESTRATION_DB_SCHEMA"] = "none"
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+
+
+@pytest.fixture()
+def db_session():
+    """Session SQLite in-memory avec le schéma orchestration créé à la volée."""
+    from app.db.base import Base
+    from app.db import models  # noqa: F401  (enregistre les tables)
+
+    engine = create_engine("sqlite://", future=True)
+
+    # SQLite n'applique pas les FK par défaut : on les active pour tester les
+    # ON DELETE CASCADE / SET NULL définis sur les tables.
+    @event.listens_for(engine, "connect")
+    def _enable_sqlite_fk(dbapi_connection, _record):  # noqa: ANN001
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    session: Session = factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()

--- a/python-orchestrator/tests/test_db_models.py
+++ b/python-orchestrator/tests/test_db_models.py
@@ -123,3 +123,13 @@ def test_schema_resolution_rejects_invalid(monkeypatch, bad):
     monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", bad)
     with pytest.raises(base_module.SchemaError):
         base_module._resolve_schema()
+
+
+@pytest.mark.parametrize("reserved", ["public", "PUBLIC", "pg_catalog", "information_schema"])
+def test_schema_resolution_rejects_reserved(monkeypatch, reserved):
+    """`public` et les schémas système sont refusés même s'ils sont syntaxiquement valides."""
+    import app.db.base as base_module
+
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", reserved)
+    with pytest.raises(base_module.SchemaError):
+        base_module._resolve_schema()

--- a/python-orchestrator/tests/test_db_models.py
+++ b/python-orchestrator/tests/test_db_models.py
@@ -6,7 +6,7 @@ résolution du schéma PostgreSQL, indépendamment de toute connexion.
 
 from __future__ import annotations
 
-import importlib
+import pytest
 
 from app.db.base import Base
 from app.db import models  # noqa: F401  (enregistre les tables sur Base.metadata)
@@ -88,21 +88,38 @@ def test_run_sets_fks_and_unique():
     assert ("run_id", "set_id") in uniques
 
 
-def test_schema_resolution(monkeypatch):
-    """Le schéma par défaut est ``orchestration`` ; ``none``/vide le neutralise."""
+def test_index_names_match_migration():
+    """Les index ORM portent exactement les noms créés par la migration 0001.
+
+    Évite le drift autogenerate (index mono-colonne fantômes via la convention).
+    """
+    all_indexes = {idx.name for t in Base.metadata.tables.values() for idx in t.indexes}
+    assert {
+        "ix_orchestration_sets_dashboard_enabled_priority",
+        "ix_runs_dashboard_created_at",
+        "ix_run_sets_run_id",
+    } <= all_indexes
+    # Aucun index mono-colonne fantôme issu de `index=True`.
+    assert "ix_orchestration_sets_dashboard_id" not in all_indexes
+    assert "ix_runs_dashboard_id" not in all_indexes
+
+
+def test_schema_resolution_default_and_custom(monkeypatch):
+    """Défaut ``orchestration`` ; un identifiant SQL valide est accepté tel quel."""
     import app.db.base as base_module
 
-    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "orchestration")
+    monkeypatch.delenv("ORCHESTRATION_DB_SCHEMA", raising=False)
     assert base_module._resolve_schema() == "orchestration"
-
-    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "none")
-    assert base_module._resolve_schema() is None
-
-    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "")
-    assert base_module._resolve_schema() is None
 
     monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "custom_schema")
     assert base_module._resolve_schema() == "custom_schema"
 
-    monkeypatch.delenv("ORCHESTRATION_DB_SCHEMA", raising=False)
-    assert base_module._resolve_schema() == "orchestration"
+
+@pytest.mark.parametrize("bad", ["", "  ", "public schema", "orch;DROP", 'a"b', "1abc", "a-b"])
+def test_schema_resolution_rejects_invalid(monkeypatch, bad):
+    """Tout nom qui n'est pas un identifiant SQL simple est refusé (anti-injection)."""
+    import app.db.base as base_module
+
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", bad)
+    with pytest.raises(base_module.SchemaError):
+        base_module._resolve_schema()

--- a/python-orchestrator/tests/test_db_models.py
+++ b/python-orchestrator/tests/test_db_models.py
@@ -1,0 +1,108 @@
+"""Tests niveau métadonnées du schéma orchestration (sans DB).
+
+Vérifie la structure (tables, colonnes, FKs, contraintes, defaults) et la
+résolution du schéma PostgreSQL, indépendamment de toute connexion.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from app.db.base import Base
+from app.db import models  # noqa: F401  (enregistre les tables sur Base.metadata)
+
+
+def _table(name: str):
+    """Retourne la table par son nom court, quel que soit le schéma résolu."""
+    for table in Base.metadata.tables.values():
+        if table.name == name:
+            return table
+    raise AssertionError(f"table {name!r} absente des métadonnées")
+
+
+def test_four_tables_registered():
+    names = {t.name for t in Base.metadata.tables.values()}
+    assert {"dashboards", "orchestration_sets", "runs", "run_sets"} <= names
+
+
+def test_orchestration_sets_columns_and_constraints():
+    table = _table("orchestration_sets")
+    expected = {
+        "id", "dashboard_id", "set_id", "enabled", "action", "exchange",
+        "market_type", "mtf_profile", "environment", "dry_run", "workers",
+        "sync_tables", "symbols", "contracts_limit", "priority", "payload",
+        "created_at", "updated_at",
+    }
+    assert expected <= set(table.columns.keys())
+
+    # FK vers dashboards avec ON DELETE CASCADE.
+    fk = next(iter(table.c.dashboard_id.foreign_keys))
+    assert fk.column.table.name == "dashboards"
+    assert fk.ondelete == "CASCADE"
+
+    # Unicité (dashboard_id, set_id).
+    uniques = {
+        tuple(sorted(c.name for c in con.columns))
+        for con in table.constraints
+        if con.__class__.__name__ == "UniqueConstraint"
+    }
+    assert ("dashboard_id", "set_id") in uniques
+
+
+def test_runs_columns_and_dashboard_fk_set_null():
+    table = _table("runs")
+    expected = {
+        "run_id", "dashboard_id", "ok", "status", "idempotency_key",
+        "total_calls", "success_count", "failed_count", "started_at",
+        "finished_at", "last_json", "created_at",
+    }
+    assert expected <= set(table.columns.keys())
+    assert table.c.run_id.primary_key
+    assert table.c.dashboard_id.nullable is True
+
+    fk = next(iter(table.c.dashboard_id.foreign_keys))
+    assert fk.ondelete == "SET NULL"
+
+
+def test_run_sets_fks_and_unique():
+    table = _table("run_sets")
+    expected = {
+        "id", "run_id", "set_id", "set_ref_id", "payload_sent",
+        "response_json", "ok", "error", "duration_ms", "created_at",
+    }
+    assert expected <= set(table.columns.keys())
+
+    run_fk = next(iter(table.c.run_id.foreign_keys))
+    assert run_fk.column.table.name == "runs"
+    assert run_fk.ondelete == "CASCADE"
+
+    set_fk = next(iter(table.c.set_ref_id.foreign_keys))
+    assert set_fk.column.table.name == "orchestration_sets"
+    assert set_fk.ondelete == "SET NULL"
+
+    uniques = {
+        tuple(sorted(c.name for c in con.columns))
+        for con in table.constraints
+        if con.__class__.__name__ == "UniqueConstraint"
+    }
+    assert ("run_id", "set_id") in uniques
+
+
+def test_schema_resolution(monkeypatch):
+    """Le schéma par défaut est ``orchestration`` ; ``none``/vide le neutralise."""
+    import app.db.base as base_module
+
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "orchestration")
+    assert base_module._resolve_schema() == "orchestration"
+
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "none")
+    assert base_module._resolve_schema() is None
+
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "")
+    assert base_module._resolve_schema() is None
+
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "custom_schema")
+    assert base_module._resolve_schema() == "custom_schema"
+
+    monkeypatch.delenv("ORCHESTRATION_DB_SCHEMA", raising=False)
+    assert base_module._resolve_schema() == "orchestration"

--- a/python-orchestrator/tests/test_db_postgres_smoke.py
+++ b/python-orchestrator/tests/test_db_postgres_smoke.py
@@ -1,0 +1,121 @@
+"""Smoke test PostgreSQL/Alembic du schéma orchestration (DB-001).
+
+Contrairement aux tests SQLite, ce test valide le **vrai contrat PostgreSQL** :
+cycle ``alembic upgrade head`` / ``downgrade base``, présence des 4 tables +
+``alembic_version`` dans le schéma dédié, schéma ``public`` intact, et absence de
+drift entre les modèles ORM et la migration (``compare_metadata``).
+
+Il est **gated** par ``ORCHESTRATOR_TEST_DATABASE_URL`` : ignoré proprement en
+local sans Postgres, exécuté automatiquement en CI (cf.
+``.github/workflows/python-orchestrator.yml``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+TEST_DB_URL = os.getenv("ORCHESTRATOR_TEST_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not TEST_DB_URL,
+    reason="ORCHESTRATOR_TEST_DATABASE_URL non défini (smoke test PostgreSQL ignoré).",
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = "orchestration"
+EXPECTED_TABLES = {"dashboards", "orchestration_sets", "runs", "run_sets"}
+
+
+def _alembic_config():
+    from alembic.config import Config
+
+    cfg = Config(str(ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(ROOT / "alembic"))
+    return cfg
+
+
+@pytest.fixture()
+def pg_engine(monkeypatch):
+    """Engine PostgreSQL de test ; nettoie le schéma avant/après pour des reruns."""
+    from sqlalchemy import create_engine, text
+
+    # env.py lit l'URL/le schéma depuis l'environnement.
+    monkeypatch.setenv("DATABASE_URL", TEST_DB_URL)
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", SCHEMA)
+
+    engine = create_engine(TEST_DB_URL, future=True)
+    with engine.begin() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{SCHEMA}" CASCADE'))
+    try:
+        yield engine
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS "{SCHEMA}" CASCADE'))
+        engine.dispose()
+
+
+def _tables_in_schema(engine, schema):
+    from sqlalchemy import inspect
+
+    return set(inspect(engine).get_table_names(schema=schema))
+
+
+def test_upgrade_creates_schema_and_keeps_public_intact(pg_engine):
+    from alembic import command
+
+    public_before = _tables_in_schema(pg_engine, "public")
+
+    command.upgrade(_alembic_config(), "head")
+
+    orch_tables = _tables_in_schema(pg_engine, SCHEMA)
+    assert EXPECTED_TABLES <= orch_tables
+    assert "alembic_version" in orch_tables
+
+    # public ne doit contenir aucune table d'orchestration (isolation Symfony).
+    public_after = _tables_in_schema(pg_engine, "public")
+    assert public_after == public_before
+    assert EXPECTED_TABLES.isdisjoint(public_after)
+    assert "alembic_version" not in public_after
+
+
+def test_no_autogenerate_drift(pg_engine):
+    """Après upgrade, les modèles ORM ne diffèrent pas de la base (anti-drift)."""
+    from alembic import command
+    from alembic.autogenerate import compare_metadata
+    from alembic.runtime.migration import MigrationContext
+
+    from app.db.base import Base
+
+    command.upgrade(_alembic_config(), "head")
+
+    def include_object(obj, name, type_, reflected, compare_to):
+        if type_ == "table":
+            return getattr(obj, "schema", None) == SCHEMA
+        return True
+
+    with pg_engine.connect() as connection:
+        mc = MigrationContext.configure(
+            connection,
+            opts={
+                "include_schemas": True,
+                "version_table_schema": SCHEMA,
+                "include_object": include_object,
+                "target_metadata": Base.metadata,
+            },
+        )
+        diff = compare_metadata(mc, Base.metadata)
+
+    assert diff == [], f"Drift ORM/migration détecté : {diff}"
+
+
+def test_downgrade_removes_tables(pg_engine):
+    from alembic import command
+
+    command.upgrade(_alembic_config(), "head")
+    command.downgrade(_alembic_config(), "base")
+
+    orch_tables = _tables_in_schema(pg_engine, SCHEMA)
+    assert EXPECTED_TABLES.isdisjoint(orch_tables)

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -148,6 +148,8 @@ def test_record_run_set_upsert_same_run_set(db_session):
     assert rows[0].ok is True
     assert rows[0].duration_ms == 20
     assert rows[0].response_json == {"status": "ok"}
+    # L'ancienne erreur d'un échec précédent doit être effacée (champ nullable).
+    assert rows[0].error is None
 
 
 def test_dashboard_delete_sets_run_dashboard_null(db_session):

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -128,6 +128,36 @@ def test_record_run_idempotent_by_idempotency_key(db_session):
     assert run.ok is True and run.status == "success"
 
 
+def test_record_run_partial_update_preserves_context(db_session):
+    """Une mise à jour partielle par run_id ne doit pas effacer idempotency_key / dashboard_id."""
+    dashboard = _make_dashboard(db_session)
+    repo.record_run(
+        db_session,
+        Run(
+            run_id="run_p",
+            dashboard_id=dashboard.id,
+            status="partial_failure",
+            ok=False,
+            idempotency_key="key-99",
+        ),
+    )
+    db_session.commit()
+
+    # Update de statut final : ne fournit ni idempotency_key ni dashboard_id.
+    repo.record_run(
+        db_session,
+        Run(run_id="run_p", status="success", ok=True, total_calls=5, success_count=5),
+    )
+    db_session.commit()
+    db_session.expire_all()
+
+    run = repo.get_run(db_session, "run_p")
+    assert run.status == "success" and run.total_calls == 5
+    # Champs de contexte préservés → l'idempotence reste résoluble.
+    assert run.idempotency_key == "key-99"
+    assert run.dashboard_id == dashboard.id
+
+
 def test_record_run_set_upsert_same_run_set(db_session):
     """Deux appels sur le même (run_id, set_id) mettent à jour le dernier résultat."""
     repo.record_run(db_session, Run(run_id="run_u", status="success", ok=True))

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -96,6 +96,60 @@ def test_record_run_and_run_set_then_cascade(db_session):
     assert db_session.query(RunSet).filter_by(run_id=run.run_id).count() == 0
 
 
+def test_record_run_idempotent_by_run_id(db_session):
+    """Deux appels avec le même run_id mettent à jour, sans doublon."""
+    repo.record_run(db_session, Run(run_id="run_1", ok=False, status="failed", total_calls=1))
+    repo.record_run(db_session, Run(run_id="run_1", ok=True, status="success", total_calls=3))
+    db_session.commit()
+
+    assert db_session.query(Run).count() == 1
+    run = repo.get_run(db_session, "run_1")
+    assert run.ok is True and run.status == "success" and run.total_calls == 3
+
+
+def test_record_run_idempotent_by_idempotency_key(db_session):
+    """Un retry avec une nouvelle run_id mais la même idempotency_key réutilise le run."""
+    repo.record_run(
+        db_session,
+        Run(run_id="run_a", status="partial_failure", ok=False, idempotency_key="key-42"),
+    )
+    db_session.commit()
+
+    # Retry : run_id différent, même clé → pas d'IntegrityError, mise à jour.
+    repo.record_run(
+        db_session,
+        Run(run_id="run_b", status="success", ok=True, idempotency_key="key-42"),
+    )
+    db_session.commit()
+
+    assert db_session.query(Run).count() == 1
+    run = repo.get_run_by_idempotency_key(db_session, "key-42")
+    assert run.run_id == "run_a"  # l'existant est conservé
+    assert run.ok is True and run.status == "success"
+
+
+def test_record_run_set_upsert_same_run_set(db_session):
+    """Deux appels sur le même (run_id, set_id) mettent à jour le dernier résultat."""
+    repo.record_run(db_session, Run(run_id="run_u", status="success", ok=True))
+    repo.record_run_set(
+        db_session,
+        RunSet(run_id="run_u", set_id="s1", ok=False, error="boom", duration_ms=10),
+    )
+    db_session.commit()
+
+    repo.record_run_set(
+        db_session,
+        RunSet(run_id="run_u", set_id="s1", ok=True, response_json={"status": "ok"}, duration_ms=20),
+    )
+    db_session.commit()
+
+    rows = db_session.query(RunSet).filter_by(run_id="run_u", set_id="s1").all()
+    assert len(rows) == 1
+    assert rows[0].ok is True
+    assert rows[0].duration_ms == 20
+    assert rows[0].response_json == {"status": "ok"}
+
+
 def test_dashboard_delete_sets_run_dashboard_null(db_session):
     dashboard = _make_dashboard(db_session)
     db_session.commit()

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -158,6 +158,37 @@ def test_record_run_partial_update_preserves_context(db_session):
     assert run.dashboard_id == dashboard.id
 
 
+def test_record_run_insert_race_falls_back_to_existing(db_session, monkeypatch):
+    """Course concurrente : si le lookup rate puis l'insert entre en conflit sur
+    `idempotency_key`, la violation est rattrapée et la ligne gagnante renvoyée."""
+    repo.record_run(
+        db_session,
+        Run(run_id="winner", status="success", ok=True, idempotency_key="race"),
+    )
+    db_session.commit()
+
+    real_resolve = repo._resolve_existing_run
+    calls = {"n": 0}
+
+    def flaky_resolve(session, run):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None  # simule un lookup qui rate avant le commit concurrent
+        return real_resolve(session, run)
+
+    monkeypatch.setattr(repo, "_resolve_existing_run", flaky_resolve)
+
+    # Nouveau run_id, même clé → insert → IntegrityError → rattrapage + reload.
+    result = repo.record_run(
+        db_session,
+        Run(run_id="loser", status="failed", ok=False, idempotency_key="race"),
+    )
+    db_session.commit()
+
+    assert result.run_id == "winner"            # ligne gagnante récupérée
+    assert db_session.query(Run).count() == 1   # pas de doublon créé
+
+
 def test_record_run_set_upsert_same_run_set(db_session):
     """Deux appels sur le même (run_id, set_id) mettent à jour le dernier résultat."""
     repo.record_run(db_session, Run(run_id="run_u", status="success", ok=True))

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -1,0 +1,113 @@
+"""Tests round-trip de la couche DB sur SQLite in-memory (DB-001)."""
+
+from __future__ import annotations
+
+from app.db import repositories as repo
+from app.db.models import Dashboard, OrchestrationSet, Run, RunSet
+
+
+def _make_dashboard(session) -> Dashboard:
+    dashboard = Dashboard(name="dash_a", enabled=True, description="demo")
+    session.add(dashboard)
+    session.flush()
+    return dashboard
+
+
+def test_dashboard_round_trip(db_session):
+    dashboard = _make_dashboard(db_session)
+    db_session.commit()
+
+    assert repo.get_dashboard(db_session, dashboard.id) is not None
+    assert repo.get_dashboard_by_name(db_session, "dash_a").id == dashboard.id
+    assert repo.get_dashboard(db_session, 999999) is None
+
+
+def test_list_active_sets_excludes_disabled_and_sorts_by_priority(db_session):
+    dashboard = _make_dashboard(db_session)
+    db_session.add_all(
+        [
+            OrchestrationSet(dashboard_id=dashboard.id, set_id="low", exchange="fake", priority=1, enabled=True),
+            OrchestrationSet(dashboard_id=dashboard.id, set_id="high", exchange="fake", priority=10, enabled=True),
+            OrchestrationSet(dashboard_id=dashboard.id, set_id="off", exchange="fake", priority=99, enabled=False),
+        ]
+    )
+    db_session.commit()
+
+    active = repo.list_active_sets(db_session, dashboard.id)
+    ids = [s.set_id for s in active]
+    assert ids == ["high", "low"]  # désactivé exclu, tri priorité desc
+    assert all(s.enabled for s in active)
+
+
+def test_symbols_jsonb_round_trip(db_session):
+    dashboard = _make_dashboard(db_session)
+    a_set = OrchestrationSet(
+        dashboard_id=dashboard.id,
+        set_id="btc_eth",
+        exchange="fake",
+        symbols=["BTCUSDT", "ETHUSDT"],
+        payload={"action": "mtf_run", "dry_run": True},
+    )
+    db_session.add(a_set)
+    db_session.commit()
+    db_session.expire_all()
+
+    reloaded = db_session.get(OrchestrationSet, a_set.id)
+    assert reloaded.symbols == ["BTCUSDT", "ETHUSDT"]
+    assert reloaded.payload == {"action": "mtf_run", "dry_run": True}
+
+
+def test_record_run_and_run_set_then_cascade(db_session):
+    dashboard = _make_dashboard(db_session)
+    db_session.commit()
+
+    run = repo.record_run(
+        db_session,
+        Run(
+            run_id="run_dashA_20260617T083000Z",
+            dashboard_id=dashboard.id,
+            ok=False,
+            status="partial_failure",
+            total_calls=2,
+            success_count=1,
+            failed_count=1,
+            last_json={"ok": False, "summary": {"total_calls": 2}},
+        ),
+    )
+    repo.record_run_set(
+        db_session,
+        RunSet(
+            run_id=run.run_id,
+            set_id="fake_regular_demo_btc",
+            payload_sent={"dry_run": True},
+            response_json={"status": "success"},
+            ok=True,
+            duration_ms=42,
+        ),
+    )
+    db_session.commit()
+
+    assert repo.get_run(db_session, run.run_id).last_json["ok"] is False
+    assert db_session.query(RunSet).filter_by(run_id=run.run_id).count() == 1
+
+    # ON DELETE CASCADE : supprimer le run supprime ses run_sets.
+    db_session.delete(repo.get_run(db_session, run.run_id))
+    db_session.commit()
+    assert db_session.query(RunSet).filter_by(run_id=run.run_id).count() == 0
+
+
+def test_dashboard_delete_sets_run_dashboard_null(db_session):
+    dashboard = _make_dashboard(db_session)
+    db_session.commit()
+    repo.record_run(
+        db_session,
+        Run(run_id="run_x", dashboard_id=dashboard.id, ok=True, status="success"),
+    )
+    db_session.commit()
+
+    db_session.delete(db_session.get(Dashboard, dashboard.id))
+    db_session.commit()
+    db_session.expire_all()
+
+    # SET NULL : le run survit, son dashboard_id est nul.
+    assert repo.get_run(db_session, "run_x").dashboard_id is None

--- a/python-orchestrator/tests/test_settings.py
+++ b/python-orchestrator/tests/test_settings.py
@@ -6,10 +6,29 @@ from app.settings import Settings, SettingsError
 def test_defaults(monkeypatch):
     monkeypatch.delenv("MAX_CONCURRENCY", raising=False)
     monkeypatch.delenv("ORCHESTRATOR_PORT", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("ORCHESTRATION_DB_SCHEMA", raising=False)
 
     settings = Settings.from_env()
     assert settings.max_concurrency == 2
     assert settings.port == 8099
+    assert settings.database_url.startswith("postgresql+psycopg://")
+    assert settings.db_schema == "orchestration"
+
+
+def test_database_url_and_schema_from_env(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql+psycopg://u:p@host:5432/db")
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "orch_test")
+
+    settings = Settings.from_env()
+    assert settings.database_url == "postgresql+psycopg://u:p@host:5432/db"
+    assert settings.db_schema == "orch_test"
+
+
+def test_blank_schema_raises(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATION_DB_SCHEMA", "   ")
+    with pytest.raises(SettingsError):
+        Settings.from_env()
 
 
 def test_invalid_integer_raises(monkeypatch):


### PR DESCRIPTION
## Objectif

**DB-001** — Ajouter le schéma orchestration pour dashboards, sets et runs (cf. plan de #155).

Ajoute la **couche de persistance PostgreSQL** à l'orchestrateur Python (`python-orchestrator/`), qui n'avait jusqu'ici aucune DB (sets simulés en mémoire). La doc impose que PostgreSQL stocke « la configuration d'orchestration, les sets prêts, les runs et le dernier JSON » (global + par set).

## Décisions produit (validées)

- **Base** : réutilisation de `trading_app` (service `trading-app-db`), mais dans un **schéma PostgreSQL dédié `orchestration`** → aucune interférence avec les migrations Doctrine de Symfony (qui n'introspecte que `public`). **Aucun changement Symfony.**
- **Périmètre** : couche schéma uniquement. Les sets in-memory **restent le fournisseur par défaut** ; le câblage des endpoints/CRUD est laissé à **PY-002** (`routers/orchestrator.py` et `services/sets.py` non modifiés).
- **Outillage** : **SQLAlchemy 2.0 + Alembic**, driver **psycopg 3 sync**.

## Schéma `orchestration`

| Table | Rôle |
| --- | --- |
| `dashboards` | Configurations d'orchestration (nom, statut actif). |
| `orchestration_sets` | Sets prêts (miroir d'`OrchestratorSet` + `payload`, `sync_tables`, `symbols`, `contracts_limit`, `priority`). Unicité `(dashboard_id, set_id)`. |
| `runs` | Runs déclenchés (`run_id`, statut, compteurs, `idempotency_key`) + **dernier JSON global** (`last_json`). |
| `run_sets` | Détail par set d'un run (payload envoyé, réponse Symfony, statut, erreur, durée) + **dernier JSON par set** (`response_json`). Unicité `(run_id, set_id)`. |

FK : `orchestration_sets`→`dashboards` (CASCADE), `run_sets`→`runs` (CASCADE), `run_sets`→`orchestration_sets` (SET NULL), `runs`→`dashboards` (SET NULL, conserve l'historique).

## Contenu

- `app/db/` : `models.py`, `base.py` (schéma dédié configurable), `engine.py` (moteur **paresseux** — l'app et le `/healthcheck` bootent sans Postgres), `repositories.py` (helpers minimaux, non câblés).
- Migration Alembic `0001` + `env.py` (crée le schéma **avant** la table de version Alembic).
- `settings.py` : `DATABASE_URL` + `ORCHESTRATION_DB_SCHEMA`.
- `docker-compose.yml` : env DB + `depends_on: trading-app-db`.
- Dépendances runtime : `sqlalchemy`, `psycopg[binary]`, `alembic` (wheels → pas de `build-essential`).
- Docs : README orchestrateur + handbook technique.

## Vérifications

- ✅ **39 tests pytest** verts (métadonnées + round-trip SQLite : cascades ON DELETE, JSONB, tri par priorité), **sans** Postgres requis.
- ✅ Cycle réel `alembic upgrade head` / `downgrade base` exécuté sur **PostgreSQL 16** : 4 tables + `alembic_version` dans le schéma `orchestration`, FK `CASCADE`/`SET NULL` correctes, JSONB OK, schéma `public` (Symfony) **totalement intact**.
- ✅ Imports sans connexion DB confirmés.

> Note : l'`entrypoint` n'exécute pas les migrations au boot (service expérimental derrière le profile `orchestrator`) — appliquer via `alembic upgrade head` (documenté).

## Hors-scope (PR suivantes)

- Lecture des sets depuis la DB + écriture des runs → **PY-002**.
- Endpoints CRUD dashboards/sets → **PY-002**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017dYwqAKNXuwgnSGt83FLaa)_