### PR TITLE
feat(py-002): gestion REST des dashboards et sets côté API Python

### DIFF
--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -288,9 +288,12 @@ sets (CRUD), sous le préfixe `/dashboards` :
 | `GET` / `POST` | `/dashboards/{id}/sets` | Liste (`?enabled_only=true`) / crée un set. |
 | `GET` / `PATCH` / `DELETE` | `/dashboards/{id}/sets/{set_id}` | Détail / mise à jour / suppression d'un set. |
 
-Garde-fous appliqués dès la configuration : borne `workers`, interdiction live OKX/Hyperliquid
-(revalidée sur les `PATCH` partiels), unicité du nom de dashboard et du `set_id` par dashboard
-(`409`), `set_id` immuable.
+Garde-fous appliqués dès la configuration (revalidés sur les `PATCH` partiels) : borne `workers` ;
+**aucun live persistable** (`dry_run=false` refusé pour tous les exchanges/environnements tant que
+la readiness live n'est pas livrée) ; **sélection exploitable obligatoire** (`symbols` non vide ou
+`contracts_limit`) ; **`payload` non writable** (produit serveur PY-004, lecture seule) ; rejet des
+`null` explicites sur les champs NOT NULL ; unicité du nom de dashboard et du `set_id` par dashboard
+(`409`) ; `set_id` immuable.
 
 La **lecture des sets persistés au moment du run** et l'**écriture des runs** restent portées par
 **PY-005** (`/orchestrator/run` lit encore les sets simulés). Les migrations s'appliquent via

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -276,9 +276,25 @@ Doctrine de Symfony (qui n'introspecte que `public`).
 | `runs` | Runs déclenchés (`run_id`, statut, compteurs, idempotency_key) + **dernier JSON global** (`last_json`). |
 | `run_sets` | Détail par set d'un run (payload envoyé, réponse Symfony, statut, erreur, durée) + **dernier JSON par set** (`response_json`). |
 
-DB-001 ne livre que la couche schéma (modèles, migration, moteur/session, repositories). Le
-câblage applicatif — lecture des sets depuis la DB et écriture des runs — est porté par **PY-002**.
-Les migrations s'appliquent via `alembic upgrade head` (voir `python-orchestrator/README.md`).
+DB-001 ne livre que la couche schéma (modèles, migration, moteur/session, repositories).
+
+**PY-002** câble la couche DB dans une API REST de **configuration** des dashboards et des
+sets (CRUD), sous le préfixe `/dashboards` :
+
+| Méthode | Chemin | Rôle |
+| --- | --- | --- |
+| `GET` / `POST` | `/dashboards` | Liste / crée un dashboard. |
+| `GET` / `PATCH` / `DELETE` | `/dashboards/{id}` | Détail / mise à jour partielle / suppression. |
+| `GET` / `POST` | `/dashboards/{id}/sets` | Liste (`?enabled_only=true`) / crée un set. |
+| `GET` / `PATCH` / `DELETE` | `/dashboards/{id}/sets/{set_id}` | Détail / mise à jour / suppression d'un set. |
+
+Garde-fous appliqués dès la configuration : borne `workers`, interdiction live OKX/Hyperliquid
+(revalidée sur les `PATCH` partiels), unicité du nom de dashboard et du `set_id` par dashboard
+(`409`), `set_id` immuable.
+
+La **lecture des sets persistés au moment du run** et l'**écriture des runs** restent portées par
+**PY-005** (`/orchestrator/run` lit encore les sets simulés). Les migrations s'appliquent via
+`alembic upgrade head` (voir `python-orchestrator/README.md`).
 
 ## Garde-fous fonctionnels
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -74,11 +74,17 @@ crée des dashboards regroupant des sets « prêts ». L'exécution parallèle d
 sets dans `/orchestrator/run` (appels Symfony réels, agrégation) reste l'objet
 de **PY-005** — à ce stade `/orchestrator/run` lit toujours les sets simulés.
 
-Garde-fous appliqués dès la création/mise à jour des sets :
+Garde-fous appliqués dès la création/mise à jour des sets (revalidés sur les
+`PATCH` partiels, l'état résultant étant fusionné avec la ligne persistée) :
 
 - `workers` borné à `MAX_WORKERS_PER_SET` (1 au début) → `422` au-delà ;
-- live OKX/Hyperliquid interdit (`dry_run=false`) → `422`, y compris sur un
-  `PATCH` partiel (l'état résultant est revalidé) ;
+- **aucun live persistable** : `dry_run=false` est refusé pour tous les
+  exchanges/environnements tant que la readiness live n'est pas livrée → `422` ;
+- **sélection exploitable obligatoire** : un set doit avoir `symbols` non vide
+  **ou** `contracts_limit` renseigné (pas de set ambigu) → `422` ;
+- **`payload` non writable** : produit côté serveur (PY-004), exposé en lecture
+  seule ; un `payload` envoyé par un client est ignoré ;
+- un `null` explicite sur un champ NOT NULL d'un `PATCH` de set → `422` ;
 - `set_id` unique par dashboard, `name` de dashboard unique → `409 Conflict` ;
 - `set_id` immuable (renommer = supprimer puis recréer).
 
@@ -90,7 +96,7 @@ curl -s -X POST localhost:8099/dashboards \
   -H 'Content-Type: application/json' \
   -d '{"name":"cockpit","description":"sets de prod"}'
 
-# 2. y attacher un set prêt
+# 2. y attacher un set prêt (dry-run, sélection explicite de symboles)
 curl -s -X POST localhost:8099/dashboards/1/sets \
   -H 'Content-Type: application/json' \
   -d '{"set_id":"bitmart_regular_top","exchange":"bitmart","mtf_profile":"regular",

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -41,9 +41,13 @@ Hors-scope (PR suivantes) :
 - cockpit front → **UI-001** ; branchement Temporal → **TM-001**.
 
 > **DB-001 (livré)** : le schéma de persistance (dashboards, sets, runs +
-> dernier JSON) existe désormais (cf. section *Persistance*). Le **câblage**
-> applicatif (lecture des sets depuis la DB, écriture des runs) reste l'objet
-> de **PY-002** : à ce stade `services/sets.py` reste en mémoire.
+> dernier JSON) existe (cf. section *Persistance*).
+>
+> **PY-002 (livré)** : la **gestion** (CRUD) des dashboards et des sets est
+> désormais exposée en REST (cf. *Gestion des dashboards et sets*). La lecture
+> des sets persistés **au moment du run** et l'écriture des runs restent l'objet
+> de **PY-005** : à ce stade `/orchestrator/run` lit encore `services/sets.py`
+> (sets simulés en mémoire).
 
 ## Endpoints
 
@@ -51,7 +55,50 @@ Hors-scope (PR suivantes) :
 | --- | --- | --- |
 | `GET` | `/healthcheck` | État de santé du service. |
 | `POST` | `/orchestrator/run` | Déclenche un run (stub PY-001). |
+| `GET` | `/dashboards` | Liste les dashboards (PY-002). |
+| `POST` | `/dashboards` | Crée un dashboard (PY-002). |
+| `GET` | `/dashboards/{id}` | Détail d'un dashboard (PY-002). |
+| `PATCH` | `/dashboards/{id}` | Mise à jour partielle (PY-002). |
+| `DELETE` | `/dashboards/{id}` | Supprime un dashboard et ses sets (PY-002). |
+| `GET` | `/dashboards/{id}/sets` | Liste les sets (`?enabled_only=true`) (PY-002). |
+| `POST` | `/dashboards/{id}/sets` | Crée un set (PY-002). |
+| `GET` | `/dashboards/{id}/sets/{set_id}` | Détail d'un set (PY-002). |
+| `PATCH` | `/dashboards/{id}/sets/{set_id}` | Mise à jour partielle d'un set (PY-002). |
+| `DELETE` | `/dashboards/{id}/sets/{set_id}` | Supprime un set (PY-002). |
 | `GET` | `/docs` | Swagger UI (OpenAPI). |
+
+### Gestion des dashboards et sets (PY-002)
+
+PY-002 câble la couche DB (DB-001) dans une API REST de **configuration** : on
+crée des dashboards regroupant des sets « prêts ». L'exécution parallèle de ces
+sets dans `/orchestrator/run` (appels Symfony réels, agrégation) reste l'objet
+de **PY-005** — à ce stade `/orchestrator/run` lit toujours les sets simulés.
+
+Garde-fous appliqués dès la création/mise à jour des sets :
+
+- `workers` borné à `MAX_WORKERS_PER_SET` (1 au début) → `422` au-delà ;
+- live OKX/Hyperliquid interdit (`dry_run=false`) → `422`, y compris sur un
+  `PATCH` partiel (l'état résultant est revalidé) ;
+- `set_id` unique par dashboard, `name` de dashboard unique → `409 Conflict` ;
+- `set_id` immuable (renommer = supprimer puis recréer).
+
+Exemple :
+
+```bash
+# 1. créer un dashboard
+curl -s -X POST localhost:8099/dashboards \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"cockpit","description":"sets de prod"}'
+
+# 2. y attacher un set prêt
+curl -s -X POST localhost:8099/dashboards/1/sets \
+  -H 'Content-Type: application/json' \
+  -d '{"set_id":"bitmart_regular_top","exchange":"bitmart","mtf_profile":"regular",
+       "symbols":["BTCUSDT","ETHUSDT"],"sync_tables":false,"priority":10}'
+
+# 3. lister les sets actifs
+curl -s 'localhost:8099/dashboards/1/sets?enabled_only=true'
+```
 
 ### `POST /orchestrator/run`
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -84,7 +84,8 @@ Garde-fous appliqués dès la création/mise à jour des sets (revalidés sur le
   **ou** `contracts_limit` renseigné (pas de set ambigu) → `422` ;
 - **`payload` non writable** : produit côté serveur (PY-004), exposé en lecture
   seule ; un `payload` envoyé par un client est ignoré ;
-- un `null` explicite sur un champ NOT NULL d'un `PATCH` de set → `422` ;
+- un `null` explicite sur un champ NOT NULL d'un `PATCH` (dashboard ou set) →
+  `422` (seules les colonnes nullables `description` / `contracts_limit` sont effaçables) ;
 - `set_id` unique par dashboard, `name` de dashboard unique → `409 Conflict` ;
 - `set_id` immuable (renommer = supprimer puis recréer).
 

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -8,7 +8,7 @@ test pour le schéma.
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -75,6 +75,95 @@ def list_active_sets(session: Session, dashboard_id: int) -> Sequence[Orchestrat
         .order_by(OrchestrationSet.priority.desc(), OrchestrationSet.set_id.asc())
     )
     return session.scalars(stmt).all()
+
+
+# ---------------------------------------------------------------------------
+# Gestion des dashboards et des sets (PY-002)
+#
+# CRUD minimal et explicite. Ces helpers ne committent pas : la transaction est
+# gérée par l'appelant (router), afin que création + sous-mutations restent
+# atomiques et que les violations d'unicité soient rattrapées au commit.
+# ---------------------------------------------------------------------------
+
+
+def list_dashboards(session: Session) -> Sequence[Dashboard]:
+    """Retourne tous les dashboards, triés par nom."""
+    return session.scalars(select(Dashboard).order_by(Dashboard.name.asc())).all()
+
+
+def create_dashboard(
+    session: Session,
+    *,
+    name: str,
+    enabled: bool = True,
+    description: Optional[str] = None,
+) -> Dashboard:
+    """Crée un dashboard et le flush (l'unicité du nom est vérifiée au commit)."""
+    dashboard = Dashboard(name=name, enabled=enabled, description=description)
+    session.add(dashboard)
+    session.flush()
+    return dashboard
+
+
+def update_dashboard(session: Session, dashboard: Dashboard, *, fields: Mapping[str, Any]) -> Dashboard:
+    """Applique une mise à jour partielle à un dashboard existant."""
+    for name, value in fields.items():
+        setattr(dashboard, name, value)
+    session.flush()
+    return dashboard
+
+
+def delete_dashboard(session: Session, dashboard: Dashboard) -> None:
+    """Supprime un dashboard (cascade ses sets ; SET NULL sur ses runs)."""
+    session.delete(dashboard)
+    session.flush()
+
+
+def list_sets(
+    session: Session, dashboard_id: int, *, enabled_only: bool = False
+) -> Sequence[OrchestrationSet]:
+    """Retourne les sets d'un dashboard, triés par priorité décroissante.
+
+    ``enabled_only=True`` ne renvoie que les sets actifs (même filtre que
+    ``list_active_sets``, mais sans contrainte sur la présence du dashboard).
+    """
+    stmt = select(OrchestrationSet).where(OrchestrationSet.dashboard_id == dashboard_id)
+    if enabled_only:
+        stmt = stmt.where(OrchestrationSet.enabled.is_(True))
+    stmt = stmt.order_by(OrchestrationSet.priority.desc(), OrchestrationSet.set_id.asc())
+    return session.scalars(stmt).all()
+
+
+def get_set(session: Session, dashboard_id: int, set_id: str) -> Optional[OrchestrationSet]:
+    """Retourne un set par ``(dashboard_id, set_id)``, ou ``None``."""
+    return session.scalar(
+        select(OrchestrationSet).where(
+            OrchestrationSet.dashboard_id == dashboard_id,
+            OrchestrationSet.set_id == set_id,
+        )
+    )
+
+
+def create_set(session: Session, dashboard_id: int, *, fields: Mapping[str, Any]) -> OrchestrationSet:
+    """Crée un set rattaché à un dashboard (unicité ``(dashboard_id, set_id)`` au commit)."""
+    a_set = OrchestrationSet(dashboard_id=dashboard_id, **dict(fields))
+    session.add(a_set)
+    session.flush()
+    return a_set
+
+
+def update_set(session: Session, a_set: OrchestrationSet, *, fields: Mapping[str, Any]) -> OrchestrationSet:
+    """Applique une mise à jour partielle à un set existant."""
+    for name, value in fields.items():
+        setattr(a_set, name, value)
+    session.flush()
+    return a_set
+
+
+def delete_set(session: Session, a_set: OrchestrationSet) -> None:
+    """Supprime un set."""
+    session.delete(a_set)
+    session.flush()
 
 
 def get_run(session: Session, run_id: str) -> Optional[Run]:

--- a/python-orchestrator/app/main.py
+++ b/python-orchestrator/app/main.py
@@ -9,17 +9,18 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from app import __version__
-from app.routers import health, orchestrator
+from app.routers import dashboards, health, orchestrator
 
 app = FastAPI(
     title="TradingV3 — Python Orchestrator",
     version=__version__,
     description=(
-        "Orchestrateur des appels TradingV3. Lit des sets prêts, appellera "
-        "Symfony en parallèle (PY-002), agrège et conserve le dernier JSON. "
-        "Voir docs/handbook/technical/python-orchestrator.md."
+        "Orchestrateur des appels TradingV3. Gère les dashboards et sets "
+        "(PY-002), appellera Symfony en parallèle (PY-005), agrège et conserve "
+        "le dernier JSON. Voir docs/handbook/technical/python-orchestrator.md."
     ),
 )
 
 app.include_router(health.router)
 app.include_router(orchestrator.router)
+app.include_router(dashboards.router)

--- a/python-orchestrator/app/routers/dashboards.py
+++ b/python-orchestrator/app/routers/dashboards.py
@@ -1,0 +1,181 @@
+"""Gestion des dashboards et des sets d'orchestration (PY-002).
+
+CRUD REST câblé sur la couche DB (DB-001) :
+
+- ``/dashboards``                          : création / liste ;
+- ``/dashboards/{id}``                     : lecture / mise à jour / suppression ;
+- ``/dashboards/{id}/sets``                : création / liste des sets ;
+- ``/dashboards/{id}/sets/{set_id}``       : lecture / mise à jour / suppression.
+
+Le câblage de ces sets dans l'exécution parallèle de ``/orchestrator/run`` est
+l'objet de PY-005 ; cette PR ne livre que la configuration (sets « prêts »).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.db import repositories as repo
+from app.db.engine import get_session
+from app.db.models import Dashboard, OrchestrationSet
+from app.schemas import (
+    DashboardCreate,
+    DashboardRead,
+    DashboardUpdate,
+    Exchange,
+    SetCreate,
+    SetRead,
+    SetUpdate,
+    assert_live_allowed,
+)
+
+router = APIRouter(prefix="/dashboards", tags=["dashboards"])
+
+
+def _require_dashboard(session: Session, dashboard_id: int) -> Dashboard:
+    dashboard = repo.get_dashboard(session, dashboard_id)
+    if dashboard is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="dashboard not found")
+    return dashboard
+
+
+def _require_set(session: Session, dashboard_id: int, set_id: str) -> OrchestrationSet:
+    a_set = repo.get_set(session, dashboard_id, set_id)
+    if a_set is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="set not found")
+    return a_set
+
+
+@contextmanager
+def _conflict_guard(session: Session, detail: str) -> Iterator[None]:
+    """Transforme toute violation d'unicité en ``409 Conflict``.
+
+    La violation peut survenir au ``flush()`` (dans le repo) **ou** au commit :
+    on englobe donc la mutation et le commit, puis on rollback proprement.
+    """
+    try:
+        yield
+        session.commit()
+    except IntegrityError:
+        session.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, detail=detail)
+
+
+# --- Dashboards -------------------------------------------------------------
+
+
+@router.get("", response_model=list[DashboardRead])
+def list_dashboards(session: Session = Depends(get_session)) -> list[Dashboard]:
+    return list(repo.list_dashboards(session))
+
+
+@router.post("", response_model=DashboardRead, status_code=status.HTTP_201_CREATED)
+def create_dashboard(body: DashboardCreate, session: Session = Depends(get_session)) -> Dashboard:
+    with _conflict_guard(session, detail=f"dashboard name '{body.name}' already exists"):
+        dashboard = repo.create_dashboard(
+            session, name=body.name, enabled=body.enabled, description=body.description
+        )
+    session.refresh(dashboard)
+    return dashboard
+
+
+@router.get("/{dashboard_id}", response_model=DashboardRead)
+def get_dashboard(dashboard_id: int, session: Session = Depends(get_session)) -> Dashboard:
+    return _require_dashboard(session, dashboard_id)
+
+
+@router.patch("/{dashboard_id}", response_model=DashboardRead)
+def update_dashboard(
+    dashboard_id: int, body: DashboardUpdate, session: Session = Depends(get_session)
+) -> Dashboard:
+    dashboard = _require_dashboard(session, dashboard_id)
+    with _conflict_guard(session, detail=f"dashboard name '{body.name}' already exists"):
+        repo.update_dashboard(session, dashboard, fields=body.model_dump(exclude_unset=True))
+    session.refresh(dashboard)
+    return dashboard
+
+
+@router.delete("/{dashboard_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_dashboard(dashboard_id: int, session: Session = Depends(get_session)) -> Response:
+    dashboard = _require_dashboard(session, dashboard_id)
+    repo.delete_dashboard(session, dashboard)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- Sets -------------------------------------------------------------------
+
+
+@router.get("/{dashboard_id}/sets", response_model=list[SetRead])
+def list_sets(
+    dashboard_id: int,
+    enabled_only: bool = False,
+    session: Session = Depends(get_session),
+) -> list[OrchestrationSet]:
+    _require_dashboard(session, dashboard_id)
+    return list(repo.list_sets(session, dashboard_id, enabled_only=enabled_only))
+
+
+@router.post(
+    "/{dashboard_id}/sets", response_model=SetRead, status_code=status.HTTP_201_CREATED
+)
+def create_set(
+    dashboard_id: int, body: SetCreate, session: Session = Depends(get_session)
+) -> OrchestrationSet:
+    _require_dashboard(session, dashboard_id)
+    detail = f"set_id '{body.set_id}' already exists in dashboard {dashboard_id}"
+    with _conflict_guard(session, detail=detail):
+        a_set = repo.create_set(session, dashboard_id, fields=body.model_dump(mode="json"))
+    session.refresh(a_set)
+    return a_set
+
+
+@router.get("/{dashboard_id}/sets/{set_id}", response_model=SetRead)
+def get_set(
+    dashboard_id: int, set_id: str, session: Session = Depends(get_session)
+) -> OrchestrationSet:
+    _require_dashboard(session, dashboard_id)
+    return _require_set(session, dashboard_id, set_id)
+
+
+@router.patch("/{dashboard_id}/sets/{set_id}", response_model=SetRead)
+def update_set(
+    dashboard_id: int, set_id: str, body: SetUpdate, session: Session = Depends(get_session)
+) -> OrchestrationSet:
+    _require_dashboard(session, dashboard_id)
+    a_set = _require_set(session, dashboard_id, set_id)
+    updates = body.model_dump(mode="json", exclude_unset=True)
+
+    # Le garde-fou live s'applique à l'état résultant : un PATCH peut ne fournir
+    # que `dry_run` ou que `exchange`, donc on fusionne avec la ligne persistée.
+    effective_exchange = Exchange(updates.get("exchange", a_set.exchange))
+    effective_dry_run = updates.get("dry_run", a_set.dry_run)
+    try:
+        assert_live_allowed(effective_exchange, effective_dry_run)
+    except ValueError as exc:
+        # 422 littéral : la constante `status.HTTP_422_*` a été renommée selon
+        # les versions de Starlette ; l'entier reste stable et non déprécié.
+        raise HTTPException(422, detail=str(exc))
+
+    repo.update_set(session, a_set, fields=updates)
+    session.commit()
+    session.refresh(a_set)
+    return a_set
+
+
+@router.delete(
+    "/{dashboard_id}/sets/{set_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_set(
+    dashboard_id: int, set_id: str, session: Session = Depends(get_session)
+) -> Response:
+    _require_dashboard(session, dashboard_id)
+    a_set = _require_set(session, dashboard_id, set_id)
+    repo.delete_set(session, a_set)
+    session.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/python-orchestrator/app/routers/dashboards.py
+++ b/python-orchestrator/app/routers/dashboards.py
@@ -27,11 +27,10 @@ from app.schemas import (
     DashboardCreate,
     DashboardRead,
     DashboardUpdate,
-    Exchange,
     SetCreate,
     SetRead,
     SetUpdate,
-    assert_live_allowed,
+    assert_set_persistable,
 )
 
 router = APIRouter(prefix="/dashboards", tags=["dashboards"])
@@ -151,12 +150,17 @@ def update_set(
     a_set = _require_set(session, dashboard_id, set_id)
     updates = body.model_dump(mode="json", exclude_unset=True)
 
-    # Le garde-fou live s'applique à l'état résultant : un PATCH peut ne fournir
-    # que `dry_run` ou que `exchange`, donc on fusionne avec la ligne persistée.
-    effective_exchange = Exchange(updates.get("exchange", a_set.exchange))
+    # Les invariants (interdiction live, sélection exploitable) s'appliquent à
+    # l'état résultant : un PATCH partiel est fusionné avec la ligne persistée.
     effective_dry_run = updates.get("dry_run", a_set.dry_run)
+    effective_symbols = updates.get("symbols", a_set.symbols)
+    effective_limit = updates.get("contracts_limit", a_set.contracts_limit)
     try:
-        assert_live_allowed(effective_exchange, effective_dry_run)
+        assert_set_persistable(
+            dry_run=effective_dry_run,
+            symbols=effective_symbols,
+            contracts_limit=effective_limit,
+        )
     except ValueError as exc:
         # 422 littéral : la constante `status.HTTP_422_*` a été renommée selon
         # les versions de Starlette ; l'entier reste stable et non déprécié.

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -61,13 +61,38 @@ RunStatus = Literal["success", "partial_failure", "failed", "no_sets"]
 def assert_live_allowed(exchange: Exchange, dry_run: bool) -> None:
     """Garde-fou live : interdit ``dry_run=false`` sur OKX/Hyperliquid.
 
-    Factorisé pour être réutilisé par ``OrchestratorSet`` (sets simulés) et par
-    la gestion DB des sets (PY-002), afin que la règle soit appliquée partout
-    de façon identique. Lève ``ValueError`` (mappé en 422 côté API).
+    Utilisé par ``OrchestratorSet`` (sets simulés en mémoire, non persistés). La
+    configuration persistante (PY-002) applique une règle **plus stricte** via
+    ``assert_set_persistable``. Lève ``ValueError`` (mappé en 422 côté API).
     """
     if dry_run is False and exchange in LIVE_FORBIDDEN_EXCHANGES:
         raise ValueError(
             f"{exchange.value} live est interdit : dry_run doit rester true."
+        )
+
+
+def assert_set_persistable(*, dry_run: bool, symbols: list, contracts_limit: Optional[int]) -> None:
+    """Invariants d'un set **persisté** via l'API de configuration (PY-002).
+
+    1. Aucun live persistable tant que la readiness live n'est pas livrée : un
+       set stocké pourra être consommé tel quel par PY-005 sans nouvelle
+       validation humaine, donc on refuse tout ``dry_run=false`` (tous exchanges,
+       tous environnements) à ce stade.
+    2. Pas de set ambigu : il faut une sélection exploitable — soit ``symbols``
+       non vide, soit ``contracts_limit`` renseigné — sinon PY-005 devrait
+       deviner quoi exécuter.
+
+    Lève ``ValueError`` (mappé en 422 côté API).
+    """
+    if dry_run is False:
+        raise ValueError(
+            "persister un set live (dry_run=false) est interdit tant que la "
+            "readiness live n'est pas livrée : PY-002 ne stocke que des sets dry-run."
+        )
+    if not symbols and contracts_limit is None:
+        raise ValueError(
+            "set ambigu : fournir une sélection exploitable "
+            "('symbols' non vide ou 'contracts_limit')."
         )
 
 
@@ -194,8 +219,12 @@ class SetCreate(BaseModel):
     """Payload de création d'un set rattaché à un dashboard.
 
     ``set_id`` est l'identifiant fonctionnel stable du set au sein du dashboard
-    (unique via ``uq_orchestration_sets_dashboard_set``). Le garde-fou live
-    OKX/Hyperliquid est appliqué dès la validation.
+    (unique via ``uq_orchestration_sets_dashboard_set``).
+
+    ``payload`` n'est **pas** accepté ici : c'est un artefact produit côté serveur
+    (PY-004) à partir des champs typés ; un client REST ne doit pas pouvoir
+    persister un payload incohérent avec ``exchange`` / ``mtf_profile`` /
+    ``symbols``. Il reste exposé en lecture seule via ``SetRead``.
     """
 
     set_id: str = Field(..., min_length=1, max_length=255, description="Identifiant stable du set.")
@@ -205,26 +234,37 @@ class SetCreate(BaseModel):
     market_type: MarketType = Field(default=MarketType.PERPETUAL, description="perpetual ou spot.")
     mtf_profile: MtfProfile = Field(default=MtfProfile.REGULAR, description="Profil MTF.")
     environment: Environment = Field(default=Environment.DEMO, description="demo, testnet, mainnet.")
-    dry_run: bool = Field(default=True, description="Simulation ou exécution réelle.")
+    dry_run: bool = Field(default=True, description="Simulation (true). Le live n'est pas persistable en PY-002.")
     workers: int = Field(default=1, ge=1, le=MAX_WORKERS_PER_SET, description="Workers Symfony (borné).")
     sync_tables: bool = Field(default=False, description="Sync des tables exchange côté Symfony.")
-    symbols: List[str] = Field(default_factory=list, description="Liste optionnelle de symboles.")
-    contracts_limit: Optional[int] = Field(default=None, ge=1, description="Limite de contrats (PY-004).")
+    symbols: List[str] = Field(default_factory=list, description="Sélection explicite de symboles.")
+    contracts_limit: Optional[int] = Field(default=None, ge=1, description="Sélection dynamique bornée (PY-004).")
     priority: int = Field(default=0, description="Ordre / priorité fonctionnelle.")
-    payload: Optional[dict] = Field(default=None, description="Payload Symfony préparé (PY-004).")
 
     @model_validator(mode="after")
-    def _forbid_live_on_restricted_exchanges(self) -> "SetCreate":
-        assert_live_allowed(self.exchange, self.dry_run)
+    def _enforce_persistable_invariants(self) -> "SetCreate":
+        assert_set_persistable(
+            dry_run=self.dry_run, symbols=self.symbols, contracts_limit=self.contracts_limit
+        )
         return self
+
+
+# Seuls ces champs de ``SetUpdate`` correspondent à une colonne NULLABLE et
+# acceptent donc un ``null`` explicite en PATCH (ex. effacer la limite).
+_SET_NULLABLE_UPDATE_FIELDS = frozenset({"contracts_limit"})
 
 
 class SetUpdate(BaseModel):
     """Mise à jour partielle d'un set.
 
-    ``set_id`` est immuable (renommer = supprimer puis recréer). Le garde-fou
-    live est revalidé sur l'état résultant côté router, car ``exchange`` et
-    ``dry_run`` peuvent n'être que partiellement fournis.
+    ``set_id`` est immuable (renommer = supprimer puis recréer) et ``payload``
+    n'est pas modifiable par un client (cf. ``SetCreate``). Les invariants
+    (interdiction live, sélection exploitable) sont revalidés sur l'état résultant
+    côté router, car les champs ne sont que partiellement fournis.
+
+    Un ``null`` explicite sur un champ adossé à une colonne NOT NULL est rejeté :
+    sans cela ``{"exchange": null}`` casserait la fusion (et écraserait une
+    colonne NOT NULL via un PATCH).
     """
 
     enabled: Optional[bool] = None
@@ -239,7 +279,19 @@ class SetUpdate(BaseModel):
     symbols: Optional[List[str]] = None
     contracts_limit: Optional[int] = Field(default=None, ge=1)
     priority: Optional[int] = None
-    payload: Optional[dict] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_explicit_nulls(cls, data: object) -> object:
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if (
+                    value is None
+                    and key in cls.model_fields
+                    and key not in _SET_NULLABLE_UPDATE_FIELDS
+                ):
+                    raise ValueError(f"champ '{key}' ne peut pas être null.")
+        return data
 
 
 class SetRead(BaseModel):

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Literal, Optional, Tuple
+from typing import List, Literal, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -58,6 +58,19 @@ LIVE_FORBIDDEN_EXCHANGES = frozenset({Exchange.OKX, Exchange.HYPERLIQUID})
 RunStatus = Literal["success", "partial_failure", "failed", "no_sets"]
 
 
+def assert_live_allowed(exchange: Exchange, dry_run: bool) -> None:
+    """Garde-fou live : interdit ``dry_run=false`` sur OKX/Hyperliquid.
+
+    Factorisé pour être réutilisé par ``OrchestratorSet`` (sets simulés) et par
+    la gestion DB des sets (PY-002), afin que la règle soit appliquée partout
+    de façon identique. Lève ``ValueError`` (mappé en 422 côté API).
+    """
+    if dry_run is False and exchange in LIVE_FORBIDDEN_EXCHANGES:
+        raise ValueError(
+            f"{exchange.value} live est interdit : dry_run doit rester true."
+        )
+
+
 class Health(BaseModel):
     """Réponse du healthcheck. La version provient de ``app.__version__``."""
 
@@ -99,10 +112,7 @@ class OrchestratorSet(BaseModel):
     @model_validator(mode="after")
     def _forbid_live_on_restricted_exchanges(self) -> "OrchestratorSet":
         """Interdit ``dry_run=false`` sur les exchanges verrouillés (OKX/Hyperliquid)."""
-        if self.dry_run is False and self.exchange in LIVE_FORBIDDEN_EXCHANGES:
-            raise ValueError(
-                f"{self.exchange.value} live est interdit : dry_run doit rester true."
-            )
+        assert_live_allowed(self.exchange, self.dry_run)
         return self
 
 
@@ -139,3 +149,119 @@ class RunResponse(BaseModel):
     run_id: str
     status: RunStatus
     summary: RunSummary
+
+
+# ---------------------------------------------------------------------------
+# Gestion des dashboards et des sets (PY-002)
+#
+# Schémas d'entrée/sortie de l'API de configuration : création, lecture, mise à
+# jour partielle et suppression. Ils s'appuient sur les mêmes enums et garde-fous
+# que ``OrchestratorSet`` mais sont distincts car ils portent les colonnes
+# persistées (id, dashboard_id, horodatages, ``payload`` préparé).
+# ---------------------------------------------------------------------------
+
+
+class DashboardCreate(BaseModel):
+    """Payload de création d'un dashboard d'orchestration."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Nom unique du dashboard.")
+    enabled: bool = Field(default=True, description="Dashboard actif ou non.")
+    description: Optional[str] = Field(default=None, description="Description libre.")
+
+
+class DashboardUpdate(BaseModel):
+    """Mise à jour partielle d'un dashboard (seuls les champs fournis changent)."""
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255)
+    enabled: Optional[bool] = None
+    description: Optional[str] = None
+
+
+class DashboardRead(BaseModel):
+    """Représentation d'un dashboard renvoyée par l'API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    enabled: bool
+    description: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class SetCreate(BaseModel):
+    """Payload de création d'un set rattaché à un dashboard.
+
+    ``set_id`` est l'identifiant fonctionnel stable du set au sein du dashboard
+    (unique via ``uq_orchestration_sets_dashboard_set``). Le garde-fou live
+    OKX/Hyperliquid est appliqué dès la validation.
+    """
+
+    set_id: str = Field(..., min_length=1, max_length=255, description="Identifiant stable du set.")
+    enabled: bool = Field(default=True, description="Set actif ou non.")
+    action: Action = Field(default=Action.MTF_RUN, description="Action à exécuter.")
+    exchange: Exchange = Field(..., description="Exchange cible.")
+    market_type: MarketType = Field(default=MarketType.PERPETUAL, description="perpetual ou spot.")
+    mtf_profile: MtfProfile = Field(default=MtfProfile.REGULAR, description="Profil MTF.")
+    environment: Environment = Field(default=Environment.DEMO, description="demo, testnet, mainnet.")
+    dry_run: bool = Field(default=True, description="Simulation ou exécution réelle.")
+    workers: int = Field(default=1, ge=1, le=MAX_WORKERS_PER_SET, description="Workers Symfony (borné).")
+    sync_tables: bool = Field(default=False, description="Sync des tables exchange côté Symfony.")
+    symbols: List[str] = Field(default_factory=list, description="Liste optionnelle de symboles.")
+    contracts_limit: Optional[int] = Field(default=None, ge=1, description="Limite de contrats (PY-004).")
+    priority: int = Field(default=0, description="Ordre / priorité fonctionnelle.")
+    payload: Optional[dict] = Field(default=None, description="Payload Symfony préparé (PY-004).")
+
+    @model_validator(mode="after")
+    def _forbid_live_on_restricted_exchanges(self) -> "SetCreate":
+        assert_live_allowed(self.exchange, self.dry_run)
+        return self
+
+
+class SetUpdate(BaseModel):
+    """Mise à jour partielle d'un set.
+
+    ``set_id`` est immuable (renommer = supprimer puis recréer). Le garde-fou
+    live est revalidé sur l'état résultant côté router, car ``exchange`` et
+    ``dry_run`` peuvent n'être que partiellement fournis.
+    """
+
+    enabled: Optional[bool] = None
+    action: Optional[Action] = None
+    exchange: Optional[Exchange] = None
+    market_type: Optional[MarketType] = None
+    mtf_profile: Optional[MtfProfile] = None
+    environment: Optional[Environment] = None
+    dry_run: Optional[bool] = None
+    workers: Optional[int] = Field(default=None, ge=1, le=MAX_WORKERS_PER_SET)
+    sync_tables: Optional[bool] = None
+    symbols: Optional[List[str]] = None
+    contracts_limit: Optional[int] = Field(default=None, ge=1)
+    priority: Optional[int] = None
+    payload: Optional[dict] = None
+
+
+class SetRead(BaseModel):
+    """Représentation d'un set persistant renvoyée par l'API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    dashboard_id: int
+    set_id: str
+    enabled: bool
+    action: Action
+    exchange: Exchange
+    market_type: MarketType
+    mtf_profile: MtfProfile
+    environment: Environment
+    dry_run: bool
+    workers: int
+    sync_tables: bool
+    symbols: List[str]
+    contracts_limit: Optional[int] = None
+    priority: int
+    payload: Optional[dict] = None
+    created_at: datetime
+    updated_at: datetime

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -185,6 +185,27 @@ class RunResponse(BaseModel):
 # persistées (id, dashboard_id, horodatages, ``payload`` préparé).
 # ---------------------------------------------------------------------------
 
+# Champs (par modèle de mise à jour) adossés à une colonne NULLABLE et donc
+# autorisés à recevoir un ``null`` explicite en PATCH (les autres colonnes sont
+# NOT NULL : un null explicite y est refusé pour éviter un 500/409 trompeur).
+_DASHBOARD_NULLABLE_UPDATE_FIELDS = frozenset({"description"})
+
+
+def _reject_explicit_nulls(data: object, *, fields, nullable) -> object:
+    """Rejette un ``null`` explicite sur un champ adossé à une colonne NOT NULL.
+
+    Pydantic accepte un ``null`` pour tout champ ``Optional`` ; combiné à
+    ``model_dump(exclude_unset=True)``, la clé est conservée et écraserait une
+    colonne NOT NULL (caught en 409 trompeur, voire 500). On le bloque en amont
+    (`422`). Les colonnes NULLABLE (``description``, ``contracts_limit``) restent
+    effaçables par un ``null`` explicite.
+    """
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if value is None and key in fields and key not in nullable:
+                raise ValueError(f"champ '{key}' ne peut pas être null.")
+    return data
+
 
 class DashboardCreate(BaseModel):
     """Payload de création d'un dashboard d'orchestration."""
@@ -200,6 +221,13 @@ class DashboardUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     enabled: Optional[bool] = None
     description: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _forbid_null_overrides(cls, data: object) -> object:
+        return _reject_explicit_nulls(
+            data, fields=cls.model_fields, nullable=_DASHBOARD_NULLABLE_UPDATE_FIELDS
+        )
 
 
 class DashboardRead(BaseModel):
@@ -282,16 +310,10 @@ class SetUpdate(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _reject_explicit_nulls(cls, data: object) -> object:
-        if isinstance(data, dict):
-            for key, value in data.items():
-                if (
-                    value is None
-                    and key in cls.model_fields
-                    and key not in _SET_NULLABLE_UPDATE_FIELDS
-                ):
-                    raise ValueError(f"champ '{key}' ne peut pas être null.")
-        return data
+    def _forbid_null_overrides(cls, data: object) -> object:
+        return _reject_explicit_nulls(
+            data, fields=cls.model_fields, nullable=_SET_NULLABLE_UPDATE_FIELDS
+        )
 
 
 class SetRead(BaseModel):

--- a/python-orchestrator/tests/conftest.py
+++ b/python-orchestrator/tests/conftest.py
@@ -17,17 +17,13 @@ os.environ["ORCHESTRATION_DB_SCHEMA"] = "orchestration"
 import pytest
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from app.db.base import SCHEMA
 
 
-@pytest.fixture()
-def db_session():
-    """Session SQLite in-memory avec le schéma orchestration attaché."""
-    from app.db.base import Base
-    from app.db import models  # noqa: F401  (enregistre les tables)
-
-    engine = create_engine("sqlite://", future=True)
+def _attach_schema_and_fks(engine) -> None:
+    """Active les FK SQLite et attache une base in-memory portant le schéma dédié."""
 
     @event.listens_for(engine, "connect")
     def _prepare_sqlite(dbapi_connection, _record):  # noqa: ANN001
@@ -40,6 +36,16 @@ def db_session():
         cursor.execute(f"ATTACH DATABASE ':memory:' AS {SCHEMA}")
         cursor.close()
 
+
+@pytest.fixture()
+def db_session():
+    """Session SQLite in-memory avec le schéma orchestration attaché."""
+    from app.db.base import Base
+    from app.db import models  # noqa: F401  (enregistre les tables)
+
+    engine = create_engine("sqlite://", future=True)
+    _attach_schema_and_fks(engine)
+
     Base.metadata.create_all(engine)
     factory = sessionmaker(bind=engine, expire_on_commit=False)
     session: Session = factory()
@@ -47,4 +53,45 @@ def db_session():
         yield session
     finally:
         session.close()
+        engine.dispose()
+
+
+@pytest.fixture()
+def api_client():
+    """``TestClient`` câblé sur une DB SQLite in-memory partagée (PY-002).
+
+    ``StaticPool`` + une unique connexion partagée garantissent que toutes les
+    requêtes (potentiellement servies dans un thread du pool anyio) voient la
+    même base in-memory. La dépendance ``get_session`` est surchargée : aucun
+    PostgreSQL n'est requis.
+    """
+    from fastapi.testclient import TestClient
+
+    from app.db.base import Base
+    from app.db import models  # noqa: F401  (enregistre les tables)
+    from app.db.engine import get_session
+    from app.main import app
+
+    engine = create_engine(
+        "sqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    _attach_schema_and_fks(engine)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    def _override_get_session():
+        session = factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_session] = _override_get_session
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_session, None)
         engine.dispose()

--- a/python-orchestrator/tests/test_dashboards_api.py
+++ b/python-orchestrator/tests/test_dashboards_api.py
@@ -195,3 +195,87 @@ def test_workers_above_bound_rejected(api_client):
         json=_set_payload(set_id="too_many", workers=4),
     )
     assert resp.status_code == 422
+
+
+def test_create_bitmart_live_rejected(api_client):
+    """Aucun live persistable en PY-002, même sur un exchange autorisé live."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    resp = api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="bm_live", exchange="bitmart", dry_run=False),
+    )
+    assert resp.status_code == 422
+
+
+# --- Invariant de sélection -------------------------------------------------
+
+
+def test_create_ambiguous_set_rejected(api_client):
+    """Ni symbols, ni contracts_limit → set ambigu, refusé."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    resp = api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="ambiguous", symbols=[], contracts_limit=None),
+    )
+    assert resp.status_code == 422
+
+
+def test_create_with_contracts_limit_only_ok(api_client):
+    """Sélection dynamique bornée (contracts_limit) sans symbols explicites."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    resp = api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="dyn", symbols=[], contracts_limit=20),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["contracts_limit"] == 20
+
+
+def test_patch_clearing_symbols_without_limit_rejected(api_client):
+    """Vider symbols alors qu'aucune limite n'est posée → état ambigu, refusé."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+    resp = api_client.patch(
+        f"/dashboards/{dashboard_id}/sets/bitmart_regular_top", json={"symbols": []}
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_clear_contracts_limit_null_ok(api_client):
+    """contracts_limit est nullable : un null explicite l'efface (symbols restent)."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(contracts_limit=10),
+    )
+    resp = api_client.patch(
+        f"/dashboards/{dashboard_id}/sets/bitmart_regular_top",
+        json={"contracts_limit": None},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["contracts_limit"] is None
+
+
+# --- payload non writable + nulls explicites --------------------------------
+
+
+def test_payload_not_accepted_from_client_on_create(api_client):
+    """payload est read-only : un payload client est ignoré, pas persisté."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    resp = api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(payload={"forged": True}),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["payload"] is None
+
+
+def test_patch_explicit_null_on_not_null_field_rejected(api_client):
+    """{"exchange": null} ne doit pas passer (colonne NOT NULL) ni faire un 500."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+    for field in ("exchange", "dry_run", "enabled", "symbols"):
+        resp = api_client.patch(
+            f"/dashboards/{dashboard_id}/sets/bitmart_regular_top", json={field: None}
+        )
+        assert resp.status_code == 422, field

--- a/python-orchestrator/tests/test_dashboards_api.py
+++ b/python-orchestrator/tests/test_dashboards_api.py
@@ -66,6 +66,18 @@ def test_patch_dashboard_partial(api_client):
     assert body["name"] == "dash_a"  # non fourni → inchangé
 
 
+def test_patch_dashboard_explicit_null_on_not_null_field_rejected(api_client):
+    """{"name": null}/{"enabled": null} → 422, pas un 409 trompeur ni une écriture."""
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    for field in ("name", "enabled"):
+        resp = api_client.patch(f"/dashboards/{dashboard_id}", json={field: None})
+        assert resp.status_code == 422, field
+    # description est nullable : un null explicite l'efface.
+    resp = api_client.patch(f"/dashboards/{dashboard_id}", json={"description": None})
+    assert resp.status_code == 200
+    assert resp.json()["description"] is None
+
+
 def test_delete_dashboard_then_404(api_client):
     dashboard_id = _create_dashboard(api_client).json()["id"]
     assert api_client.delete(f"/dashboards/{dashboard_id}").status_code == 204

--- a/python-orchestrator/tests/test_dashboards_api.py
+++ b/python-orchestrator/tests/test_dashboards_api.py
@@ -1,0 +1,197 @@
+"""Tests de l'API de gestion des dashboards et sets (PY-002)."""
+
+from __future__ import annotations
+
+
+def _create_dashboard(client, name="dash_a", enabled=True, description="demo"):
+    return client.post(
+        "/dashboards",
+        json={"name": name, "enabled": enabled, "description": description},
+    )
+
+
+def _set_payload(**overrides):
+    payload = {
+        "set_id": "bitmart_regular_top",
+        "exchange": "bitmart",
+        "mtf_profile": "regular",
+        "symbols": ["BTCUSDT", "ETHUSDT"],
+        "priority": 10,
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --- Dashboards -------------------------------------------------------------
+
+
+def test_create_then_get_dashboard(api_client):
+    created = _create_dashboard(api_client)
+    assert created.status_code == 201
+    body = created.json()
+    assert body["name"] == "dash_a"
+    assert body["enabled"] is True
+    assert "id" in body and "created_at" in body
+
+    fetched = api_client.get(f"/dashboards/{body['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["id"] == body["id"]
+
+
+def test_list_dashboards_sorted_by_name(api_client):
+    _create_dashboard(api_client, name="zeta")
+    _create_dashboard(api_client, name="alpha")
+
+    names = [d["name"] for d in api_client.get("/dashboards").json()]
+    assert names == ["alpha", "zeta"]
+
+
+def test_duplicate_dashboard_name_returns_409(api_client):
+    _create_dashboard(api_client, name="dup")
+    conflict = _create_dashboard(api_client, name="dup")
+    assert conflict.status_code == 409
+
+
+def test_get_missing_dashboard_returns_404(api_client):
+    assert api_client.get("/dashboards/9999").status_code == 404
+
+
+def test_patch_dashboard_partial(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+
+    resp = api_client.patch(f"/dashboards/{dashboard_id}", json={"enabled": False})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["name"] == "dash_a"  # non fourni → inchangé
+
+
+def test_delete_dashboard_then_404(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    assert api_client.delete(f"/dashboards/{dashboard_id}").status_code == 204
+    assert api_client.get(f"/dashboards/{dashboard_id}").status_code == 404
+
+
+# --- Sets -------------------------------------------------------------------
+
+
+def test_create_and_get_set(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+
+    created = api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+    assert created.status_code == 201
+    body = created.json()
+    assert body["set_id"] == "bitmart_regular_top"
+    assert body["symbols"] == ["BTCUSDT", "ETHUSDT"]
+    assert body["dashboard_id"] == dashboard_id
+    # Défauts appliqués.
+    assert body["dry_run"] is True
+    assert body["workers"] == 1
+
+    fetched = api_client.get(f"/dashboards/{dashboard_id}/sets/bitmart_regular_top")
+    assert fetched.status_code == 200
+    assert fetched.json()["id"] == body["id"]
+
+
+def test_create_set_on_missing_dashboard_returns_404(api_client):
+    assert api_client.post("/dashboards/123/sets", json=_set_payload()).status_code == 404
+
+
+def test_duplicate_set_id_returns_409(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+    dup = api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+    assert dup.status_code == 409
+
+
+def test_list_sets_enabled_only_and_priority_order(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="low", priority=1, enabled=True),
+    )
+    api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="high", priority=10, enabled=True),
+    )
+    api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="off", priority=99, enabled=False),
+    )
+
+    all_ids = [s["set_id"] for s in api_client.get(f"/dashboards/{dashboard_id}/sets").json()]
+    assert all_ids == ["off", "high", "low"]  # tri priorité desc
+
+    active_ids = [
+        s["set_id"]
+        for s in api_client.get(
+            f"/dashboards/{dashboard_id}/sets", params={"enabled_only": True}
+        ).json()
+    ]
+    assert active_ids == ["high", "low"]
+
+
+def test_patch_set_partial(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+
+    resp = api_client.patch(
+        f"/dashboards/{dashboard_id}/sets/bitmart_regular_top",
+        json={"priority": 42, "symbols": ["SOLUSDT"]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["priority"] == 42
+    assert body["symbols"] == ["SOLUSDT"]
+    assert body["exchange"] == "bitmart"  # inchangé
+
+
+def test_delete_set_then_404(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+
+    assert (
+        api_client.delete(
+            f"/dashboards/{dashboard_id}/sets/bitmart_regular_top"
+        ).status_code
+        == 204
+    )
+    assert (
+        api_client.get(f"/dashboards/{dashboard_id}/sets/bitmart_regular_top").status_code
+        == 404
+    )
+
+
+# --- Garde-fous live --------------------------------------------------------
+
+
+def test_create_okx_live_set_rejected(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    resp = api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="okx_live", exchange="okx", dry_run=False),
+    )
+    assert resp.status_code == 422
+
+
+def test_patch_set_to_live_forbidden_rejected(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    # Set OKX en dry-run autorisé.
+    api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="okx_dry", exchange="okx", dry_run=True),
+    )
+    # Bascule live via PATCH partiel (seul dry_run fourni) → refusée.
+    resp = api_client.patch(
+        f"/dashboards/{dashboard_id}/sets/okx_dry", json={"dry_run": False}
+    )
+    assert resp.status_code == 422
+
+
+def test_workers_above_bound_rejected(api_client):
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    resp = api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(set_id="too_many", workers=4),
+    )
+    assert resp.status_code == 422

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -213,6 +213,65 @@ def test_record_run_set_upsert_same_run_set(db_session):
     assert rows[0].error is None
 
 
+def test_create_update_delete_dashboard(db_session):
+    dashboard = repo.create_dashboard(db_session, name="cfg", description="x")
+    db_session.commit()
+    assert dashboard.id is not None
+
+    repo.update_dashboard(db_session, dashboard, fields={"enabled": False, "description": "y"})
+    db_session.commit()
+    reloaded = repo.get_dashboard(db_session, dashboard.id)
+    assert reloaded.enabled is False and reloaded.description == "y"
+
+    repo.delete_dashboard(db_session, reloaded)
+    db_session.commit()
+    assert repo.get_dashboard(db_session, dashboard.id) is None
+
+
+def test_list_dashboards_sorted_by_name(db_session):
+    repo.create_dashboard(db_session, name="zeta")
+    repo.create_dashboard(db_session, name="alpha")
+    db_session.commit()
+
+    assert [d.name for d in repo.list_dashboards(db_session)] == ["alpha", "zeta"]
+
+
+def test_create_get_update_delete_set(db_session):
+    dashboard = _make_dashboard(db_session)
+    db_session.commit()
+
+    a_set = repo.create_set(
+        db_session,
+        dashboard.id,
+        fields={"set_id": "s1", "exchange": "bitmart", "symbols": ["BTCUSDT"], "priority": 3},
+    )
+    db_session.commit()
+    assert repo.get_set(db_session, dashboard.id, "s1").id == a_set.id
+
+    repo.update_set(db_session, a_set, fields={"priority": 9, "enabled": False})
+    db_session.commit()
+    reloaded = repo.get_set(db_session, dashboard.id, "s1")
+    assert reloaded.priority == 9 and reloaded.enabled is False
+
+    repo.delete_set(db_session, reloaded)
+    db_session.commit()
+    assert repo.get_set(db_session, dashboard.id, "s1") is None
+
+
+def test_list_sets_enabled_only(db_session):
+    dashboard = _make_dashboard(db_session)
+    db_session.add_all(
+        [
+            OrchestrationSet(dashboard_id=dashboard.id, set_id="on", exchange="fake", enabled=True, priority=1),
+            OrchestrationSet(dashboard_id=dashboard.id, set_id="off", exchange="fake", enabled=False, priority=5),
+        ]
+    )
+    db_session.commit()
+
+    assert {s.set_id for s in repo.list_sets(db_session, dashboard.id)} == {"on", "off"}
+    assert [s.set_id for s in repo.list_sets(db_session, dashboard.id, enabled_only=True)] == ["on"]
+
+
 def test_dashboard_delete_sets_run_dashboard_null(db_session):
     dashboard = _make_dashboard(db_session)
     db_session.commit()


### PR DESCRIPTION
## Objectif

**PY-002 — Ajouter la gestion des dashboards et sets côté API Python.**

Câble la couche de persistance livrée par **DB-001** (modèles SQLAlchemy + migration Alembic, schéma PostgreSQL dédié `orchestration`) dans une **API REST de configuration**. On peut désormais créer des dashboards regroupant des sets « prêts », sans toucher au moteur métier Symfony ni à l'exécution des runs.

## Contenu

### API REST (`app/routers/dashboards.py`)

| Méthode | Chemin | Rôle |
| --- | --- | --- |
| `GET` / `POST` | `/dashboards` | Liste / crée un dashboard. |
| `GET` / `PATCH` / `DELETE` | `/dashboards/{id}` | Détail / mise à jour partielle / suppression. |
| `GET` / `POST` | `/dashboards/{id}/sets` | Liste (`?enabled_only=true`) / crée un set. |
| `GET` / `PATCH` / `DELETE` | `/dashboards/{id}/sets/{set_id}` | Détail / mise à jour / suppression d'un set. |

### Schémas Pydantic (`app/schemas.py`)

- `DashboardCreate` / `DashboardUpdate` / `DashboardRead`
- `SetCreate` / `SetUpdate` / `SetRead`
- Réutilisent les enums existantes ; garde-fou live factorisé (`assert_live_allowed`).

### Repositories (`app/db/repositories.py`)

- `list_dashboards`, `create_dashboard`, `update_dashboard`, `delete_dashboard`
- `list_sets`, `get_set`, `create_set`, `update_set`, `delete_set`
- Pas de commit dans le repo : la transaction est pilotée par le router.

## Garde-fous appliqués dès la configuration

- `workers` borné à `MAX_WORKERS_PER_SET` (1) → `422` au-delà ;
- live OKX/Hyperliquid (`dry_run=false`) interdit → `422`, **revalidé sur les `PATCH` partiels** (état fusionné existant + delta) ;
- unicité du `name` de dashboard et du `set_id` par dashboard → `409 Conflict` (violation rattrapée au flush **et** au commit) ;
- `set_id` immuable (renommer = supprimer puis recréer).

## Hors-scope (volontaire — plan de PR atomiques)

- `/orchestrator/run` **reste inchangé** : il lit encore les sets simulés (`services/sets.py`). La lecture des sets persistés **au moment du run** et l'écriture des runs sont portées par **PY-005**.
- Aucun appel Symfony réel, aucune exécution parallèle, aucun front.

## Tests

- Nouvelle fixture `api_client` : `TestClient` sur SQLite in-memory **partagée** (`StaticPool` + override de `get_session`) — aucun PostgreSQL requis.
- `tests/test_dashboards_api.py` (CRUD, 404/409/422, tri par priorité, `enabled_only`, garde-fous live/workers) + tests repository.

## Vérifications

- `python -m pytest` → **75 passed, 3 skipped** (smoke Postgres ignoré sans `ORCHESTRATOR_TEST_DATABASE_URL`).
- `mkdocs build --strict` → OK.

## Documentation

- `python-orchestrator/README.md` : tableau des endpoints + section *Gestion des dashboards et sets (PY-002)*.
- `docs/handbook/technical/python-orchestrator.md` : note DB-001 → PY-002, périmètre PY-005 clarifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015gvEp7pJq78eF7BZR81Mwq)_