### PR TITLE
feat(SF-002b): orchestrator open-state snapshot (no exchange call per set)

### DIFF
--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -40,13 +40,33 @@ sequenceDiagram
 
     Trigger->>Python: POST /orchestrator/run
     Python->>Db: lire les sets actifs déjà prêts
+    loop une fois par (exchange, market_type) distinct
+        Python->>Symfony: GET /api/exchange/open-state
+        Symfony-->>Python: { open_positions, open_orders }
+    end
     loop appels parallèles bornés
-        Python->>Symfony: POST /api/mtf/run
+        Python->>Symfony: POST /api/mtf/run (sync_tables=false + open_state_snapshot)
         Symfony-->>Python: JSON existant
     end
     Python->>Db: sauvegarder dernier JSON global et par set
     Python-->>Trigger: { ok, run_id, summary }
 ```
+
+### Snapshot d'état ouvert partagé (SF-002b)
+
+Pour éviter un appel exchange par set, l'orchestrateur récupère l'état ouvert
+(positions/ordres) **une seule fois par couple `(exchange, market_type)` distinct**
+parmi les sets `mtf_run` actifs, via `GET /api/exchange/open-state`, puis transmet
+ce snapshot à chaque `POST /api/mtf/run` dans le champ `open_state_snapshot` avec
+`sync_tables=false`. Côté Symfony, la présence du snapshot **court-circuite**
+totalement le fetch exchange (priorité : snapshot > `sync_tables=true` > filtre).
+
+**Fail-closed live** : si le fetch du snapshot échoue pour un couple, les sets
+**live** (`dry_run=false`) de ce couple sont marqués en erreur et **ne sont pas
+exécutés** (on ne trade pas à l'aveugle). Les sets **dry-run** peuvent continuer
+sans snapshot. Ce garde-fou côté orchestrateur est doublé côté Symfony :
+`MtfRunnerService` rejette tout run live dépourvu de source d'état ouvert fiable
+(pas de snapshot ET `sync_tables=false` ET `skip_open_state_filter=true`).
 
 ## Mise à jour des contrats
 
@@ -213,6 +233,32 @@ Règles attendues :
 
 Sans ce contrat, chaque set pourrait encore déclencher une sync Symfony, ce qui annulerait le bénéfice du flux de refresh explicite.
 
+> ⚠️ **Portée de `sync_tables=false` seul (SF-002a).** `sync_tables=false` saute
+> uniquement l'upsert DB ; le filtre d'activité peut encore appeler l'exchange.
+> Le vrai mode « zéro appel exchange par set » est livré par **SF-002b** via le
+> snapshot orchestrateur ci-dessous.
+
+## Endpoint Symfony : état ouvert (SF-002b)
+
+```text
+GET /api/exchange/open-state?exchange=bitmart&market_type=perpetual
+```
+
+Endpoint **en lecture seule** qui produit l'instantané d'état ouvert que
+l'orchestrateur récupère une seule fois puis distribue à tous les sets. Réponse :
+
+```json
+{
+  "open_positions": [ { "symbol": "BTCUSDT", "side": "long", "size": "1.5", "...": "..." } ],
+  "open_orders":    [ { "symbol": "ETHUSDT", "order_id": "...", "side": "buy", "...": "..." } ]
+}
+```
+
+- `exchange` / `market_type` : optionnels (défauts `bitmart` / `perpetual`), même
+  jeu accepté que `/api/mtf/run` ; une valeur invalide renvoie `400`.
+- L'orchestrateur joint ce JSON tel quel dans `open_state_snapshot` du payload
+  `/api/mtf/run` (avec `sync_tables=false`).
+
 ## Déclenchement
 
 L'endpoint cible est :
@@ -322,8 +368,9 @@ Avant tout run :
 | SF-001 ✅ | Exposer les contrats filtrés par `mtf_contracts` | Livré : `GET /api/mtf/contracts` retourne les symboles réellement sélectionnés. |
 | PY-001 | Créer le squelette API Python | Service API lancé, endpoint healthcheck, structure projet. |
 | DB-001 | Persister dashboards, sets et derniers runs | Tables orchestration + dernier JSON global/par set. |
-| SF-002 | Supporter `sync_tables=false` côté Symfony | `/api/mtf/run` peut exécuter un set préparé sans sync par run. |
-| PY-002 | Implémenter `/orchestrator/run` | Lecture des sets actifs, appels parallèles bornés, agrégation. |
+| SF-002a ✅ | Supporter `sync_tables=false` côté Symfony | Livré : `/api/mtf/run` et `mtf:run` honorent `sync_tables=false` (skip upsert DB). |
+| SF-002b ✅ | Snapshot d'état ouvert orchestrateur (zéro appel exchange par set) | Livré : `GET /api/exchange/open-state` + `open_state_snapshot` sur `/api/mtf/run` ; fail-closed live côté Symfony et orchestrateur. |
+| PY-002 ✅ (partiel) | Implémenter `/orchestrator/run` | Livré : lecture des sets actifs, fetch snapshot 1×/(exchange,market_type), appels parallèles bornés, agrégation, fail-closed live. Persistance DB du dernier JSON à compléter. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -259,6 +259,18 @@ l'orchestrateur récupère une seule fois puis distribue à tous les sets. Répo
 - L'orchestrateur joint ce JSON tel quel dans `open_state_snapshot` du payload
   `/api/mtf/run` (avec `sync_tables=false`).
 
+> **Exchange `fake` (sets de démo).** Les sets simulés en mémoire
+> (`app/services/sets.py`) utilisent `exchange=fake` / `market_type=perpetual`.
+> Symfony enregistre désormais un **bundle de providers Fake** (contexte
+> `fake_perpetual` / `fake_spot`, voir `config/services.yaml`) : `MainProvider::forContext(FAKE, …)`
+> résout sans erreur. Le provider Fake modélise un exchange vide/neutre :
+> `GET /api/exchange/open-state?exchange=fake&market_type=perpetual` renvoie
+> `{"open_positions":[],"open_orders":[]}`, et le provider de contrats Fake
+> n'expose **aucun symbole actif** — un `POST /api/mtf/run` sur le contexte FAKE
+> résout 0 symbole et se termine en succès trivial, sans aucun appel HTTP réel ni
+> exécution live. C'est ce qui permet au chemin de démo (`exchange=fake`) de
+> tourner de bout en bout depuis `/orchestrator/run`.
+
 ## Déclenchement
 
 L'endpoint cible est :

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -128,10 +128,17 @@ async def run_orchestrator(request: Optional[RunRequest] = None) -> RunResponse:
         # 2) Exécution bornée des sets avec le snapshot en cache.
         semaphore = asyncio.Semaphore(max(1, settings.max_concurrency))
 
+        # Override run-level : un appelant peut FORCER le dry-run (sécurité). Le
+        # forçage ne peut que rendre un set plus sûr — il ne downgrade jamais un
+        # set dry en live. Appliqué AVANT le garde fail-closed et la construction
+        # du payload pour que `{"dry_run": true}` empêche réellement tout ordre live.
+        force_dry_run = request.dry_run is True if request is not None else False
+
         async def _execute(a_set: Any) -> Dict[str, Any]:
             snapshot = snapshots.get(snapshot_key(a_set))
-            # Fail-closed live : pas de snapshot fiable + set live => on n'exécute pas.
-            if snapshot is None and a_set.dry_run is False:
+            effective_dry_run = a_set.dry_run or force_dry_run
+            # Fail-closed live : pas de snapshot fiable + set (effectivement) live => on n'exécute pas.
+            if snapshot is None and effective_dry_run is False:
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -140,7 +147,9 @@ async def run_orchestrator(request: Optional[RunRequest] = None) -> RunResponse:
                 }
             async with semaphore:
                 try:
-                    return await run_mtf_set(client, settings.symfony_base_url, a_set, snapshot)
+                    return await run_mtf_set(
+                        client, settings.symfony_base_url, a_set, snapshot, effective_dry_run
+                    )
                 except httpx.HTTPError as exc:  # noqa: BLE001
                     return {
                         "set_id": a_set.set_id,

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -67,6 +67,38 @@ def _resolve_status(success: int, failed: int) -> RunStatus:
     return "partial_failure"
 
 
+def _symbols_overlap(a: Any, b: Any) -> bool:
+    """Indique si deux sets ciblent au moins un symbole commun.
+
+    Un ``symbols`` vide signifie « tout l'univers actif » (résolu côté Symfony),
+    donc il chevauche n'importe quel autre set du même couple.
+    """
+    if not a.symbols or not b.symbols:
+        return True
+    return bool(set(a.symbols) & set(b.symbols))
+
+
+def _conflicting_live_set_ids(mtf_sets: List[Any], force_dry_run: bool) -> set:
+    """``set_id`` des sets EFFECTIVEMENT live qui se chevauchent dans le batch.
+
+    Deux sets live partageant ``(exchange, market_type)`` et au moins un symbole
+    recevraient le même snapshot pré-run (``sync_tables=false``) : le second ne
+    verrait pas une position/un ordre ouvert par le premier → trade live dupliqué.
+    On rejette ces sets (fail-closed) plutôt que de dispatcher à l'aveugle. Les
+    sets dry-run (ou forcés dry) ne posent pas ce problème.
+    """
+    live = [s for s in mtf_sets if not (s.dry_run or force_dry_run)]
+    conflicting: set = set()
+    for i, a in enumerate(live):
+        for b in live[i + 1:]:
+            if (a.exchange, a.market_type) != (b.exchange, b.market_type):
+                continue
+            if _symbols_overlap(a, b):
+                conflicting.add(a.set_id)
+                conflicting.add(b.set_id)
+    return conflicting
+
+
 async def _collect_snapshots(
     client: httpx.AsyncClient,
     base_url: str,
@@ -121,6 +153,17 @@ async def run_orchestrator(request: Optional[RunRequest] = None) -> RunResponse:
     success = 0
     failed = 0
 
+    # Override run-level : un appelant peut FORCER le dry-run (sécurité). Le
+    # forçage ne peut que rendre un set plus sûr — il ne downgrade jamais un
+    # set dry en live. Appliqué AVANT le garde fail-closed et la construction
+    # du payload pour que `{"dry_run": true}` empêche réellement tout ordre live.
+    force_dry_run = request.dry_run is True if request is not None else False
+
+    # Fail-closed : des sets live chevauchants (même exchange/market + symbole
+    # partagé) partageraient le même snapshot pré-run et pourraient dupliquer un
+    # trade live ; on les rejette avant dispatch.
+    conflicting_live_ids = _conflicting_live_set_ids(mtf_sets, force_dry_run)
+
     async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
         # 1) Un seul fetch d'état ouvert par couple (exchange, market_type).
         snapshots = await _collect_snapshots(client, settings.symfony_base_url, mtf_sets)
@@ -128,13 +171,14 @@ async def run_orchestrator(request: Optional[RunRequest] = None) -> RunResponse:
         # 2) Exécution bornée des sets avec le snapshot en cache.
         semaphore = asyncio.Semaphore(max(1, settings.max_concurrency))
 
-        # Override run-level : un appelant peut FORCER le dry-run (sécurité). Le
-        # forçage ne peut que rendre un set plus sûr — il ne downgrade jamais un
-        # set dry en live. Appliqué AVANT le garde fail-closed et la construction
-        # du payload pour que `{"dry_run": true}` empêche réellement tout ordre live.
-        force_dry_run = request.dry_run is True if request is not None else False
-
         async def _execute(a_set: Any) -> Dict[str, Any]:
+            if a_set.set_id in conflicting_live_ids:
+                return {
+                    "set_id": a_set.set_id,
+                    "ok": False,
+                    "status": None,
+                    "body": "overlapping live set rejected (shared pre-run snapshot would miss sibling fills)",
+                }
             snapshot = snapshots.get(snapshot_key(a_set))
             effective_dry_run = a_set.dry_run or force_dry_run
             # Fail-closed live : pas de snapshot fiable + set (effectivement) live => on n'exécute pas.

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -1,24 +1,43 @@
 """Endpoint d'orchestration : ``POST /orchestrator/run``.
 
-PY-001 : squelette / stub. Le run lit les sets actifs simulés et retourne
-le contrat JSON cible (ok / run_id / status / summary) sans appel réseau.
+SF-002b / PY-002 : l'orchestrateur récupère l'état ouvert (positions/ordres)
+UNE seule fois par couple ``(exchange, market_type)`` via
+``GET /api/exchange/open-state``, puis exécute chaque set ``mtf_run`` en
+appelant ``POST /api/mtf/run`` avec ``sync_tables=false`` et le snapshot mis en
+cache. Symfony ne refait donc aucun fetch exchange par set.
 
-La vraie exécution parallèle bornée des appels Symfony, l'agrégation des
-réponses et la persistance du dernier JSON sont l'objet de PY-002.
+Concurrence bornée par ``asyncio.Semaphore(max_concurrency)``.
+
+Fail-closed live : si le fetch du snapshot échoue pour un couple, les sets
+**live** (``dry_run=false``) de ce couple sont marqués en erreur (on ne trade
+pas à l'aveugle). Les sets dry-run peuvent continuer sans snapshot.
 """
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
+import httpx
 from fastapi import APIRouter
 
-from app.schemas import RunRequest, RunResponse, RunStatus, RunSummary
+from app.schemas import Action, RunRequest, RunResponse, RunStatus, RunSummary
 from app.services.sets import list_active_sets
+from app.services.symfony_client import (
+    OpenStateUnavailableError,
+    SnapshotKey,
+    fetch_open_state,
+    run_mtf_set,
+    snapshot_key,
+)
+from app.settings import get_settings
 
 router = APIRouter(tags=["orchestrator"])
+
+# Timeout (s) des appels Symfony, aligné sur le worker Temporal historique.
+_HTTP_TIMEOUT = 900.0
 
 
 def _resolve_run_id(request: Optional[RunRequest]) -> str:
@@ -48,14 +67,34 @@ def _resolve_status(success: int, failed: int) -> RunStatus:
     return "partial_failure"
 
 
-@router.post("/orchestrator/run", response_model=RunResponse)
-def run_orchestrator(request: Optional[RunRequest] = None) -> RunResponse:
-    """Déclenche un run d'orchestration (stub PY-001).
+async def _collect_snapshots(
+    client: httpx.AsyncClient,
+    base_url: str,
+    mtf_sets: List[Any],
+) -> Dict[SnapshotKey, Dict[str, Any]]:
+    """Récupère un snapshot d'état ouvert par couple ``(exchange, market_type)``.
 
-    Étapes cibles (PY-002) : lire les sets actifs, appliquer les garde-fous,
-    lancer les appels Symfony en parallèle avec concurrence bornée, agréger,
-    sauvegarder le dernier JSON, retourner un statut court.
+    Un seul appel ``GET /api/exchange/open-state`` par couple distinct. Les
+    couples dont le fetch échoue restent absents du cache (fail-closed géré par
+    l'appelant pour les sets live).
     """
+    keys = {snapshot_key(s) for s in mtf_sets}
+    snapshots: Dict[SnapshotKey, Dict[str, Any]] = {}
+    for exchange, market_type in keys:
+        try:
+            snapshots[(exchange, market_type)] = await fetch_open_state(
+                client, base_url, exchange, market_type
+            )
+        except OpenStateUnavailableError:
+            # Pas de snapshot fiable pour ce couple : on ne met rien en cache.
+            continue
+    return snapshots
+
+
+@router.post("/orchestrator/run", response_model=RunResponse)
+async def run_orchestrator(request: Optional[RunRequest] = None) -> RunResponse:
+    """Déclenche un run d'orchestration (SF-002b)."""
+    settings = get_settings()
     run_id = _resolve_run_id(request)
     active_sets = list_active_sets()
 
@@ -69,14 +108,56 @@ def run_orchestrator(request: Optional[RunRequest] = None) -> RunResponse:
             summary=RunSummary(total_calls=0, success=0, failed=0),
         )
 
-    # TODO(PY-002): remplacer la simulation par l'exécution parallèle bornée
-    # des appels Symfony (httpx.AsyncClient + asyncio.Semaphore(max_concurrency)),
-    # puis agréger les réponses réelles et persister le dernier JSON (DB-001).
-    total_calls = len(active_sets)
-    success = total_calls
+    mtf_sets = [s for s in active_sets if s.action == Action.MTF_RUN]
+    if not mtf_sets:
+        # Sets actifs mais aucun à exécuter via /api/mtf/run (actions hors scope).
+        return RunResponse(
+            ok=False,
+            run_id=run_id,
+            status="no_sets",
+            summary=RunSummary(total_calls=0, success=0, failed=0),
+        )
+
+    success = 0
     failed = 0
 
-    summary = RunSummary(total_calls=total_calls, success=success, failed=failed)
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        # 1) Un seul fetch d'état ouvert par couple (exchange, market_type).
+        snapshots = await _collect_snapshots(client, settings.symfony_base_url, mtf_sets)
+
+        # 2) Exécution bornée des sets avec le snapshot en cache.
+        semaphore = asyncio.Semaphore(max(1, settings.max_concurrency))
+
+        async def _execute(a_set: Any) -> Dict[str, Any]:
+            snapshot = snapshots.get(snapshot_key(a_set))
+            # Fail-closed live : pas de snapshot fiable + set live => on n'exécute pas.
+            if snapshot is None and a_set.dry_run is False:
+                return {
+                    "set_id": a_set.set_id,
+                    "ok": False,
+                    "status": None,
+                    "body": "open_state_snapshot unavailable: live set skipped (fail-closed)",
+                }
+            async with semaphore:
+                try:
+                    return await run_mtf_set(client, settings.symfony_base_url, a_set, snapshot)
+                except httpx.HTTPError as exc:  # noqa: BLE001
+                    return {
+                        "set_id": a_set.set_id,
+                        "ok": False,
+                        "status": None,
+                        "body": f"mtf run failed: {exc}",
+                    }
+
+        results = await asyncio.gather(*(_execute(s) for s in mtf_sets))
+
+    for result in results:
+        if result.get("ok"):
+            success += 1
+        else:
+            failed += 1
+
+    summary = RunSummary(total_calls=len(results), success=success, failed=failed)
     status = _resolve_status(success, failed)
 
     return RunResponse(

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -75,7 +75,11 @@ def _symbols_overlap(a: Any, b: Any) -> bool:
     """
     if not a.symbols or not b.symbols:
         return True
-    return bool(set(a.symbols) & set(b.symbols))
+    # Symfony normalise les symboles en MAJUSCULES (SymbolUniverseResolver::resolve),
+    # donc BTCUSDT et btcusdt ciblent le même instrument : comparer normalisé.
+    norm_a = {s.strip().upper() for s in a.symbols}
+    norm_b = {s.strip().upper() for s in b.symbols}
+    return bool(norm_a & norm_b)
 
 
 def _conflicting_live_set_ids(mtf_sets: List[Any], force_dry_run: bool) -> set:

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -111,6 +111,29 @@ def build_mtf_payload(
     return payload
 
 
+# Statuts métier renvoyés par /api/mtf/run considérés comme un succès complet.
+_SUCCESS_STATUSES = frozenset({"success"})
+
+
+def is_business_success(body: Any) -> bool:
+    """Indique si la réponse ``/api/mtf/run`` est un succès métier.
+
+    Symfony renvoie HTTP 200 même pour des échecs métier : ``partial_success``
+    (errors non vides), ``completed_with_errors`` (runs parallèles), ``rejected``
+    (fail-closed SF-002b)... Un set n'est réussi que si le statut est un succès
+    explicite ET qu'aucune erreur n'est remontée — le contrôleur peut écraser
+    ``partial_success`` par ``summary.status``, donc on vérifie aussi ``errors``.
+    """
+    if not isinstance(body, dict):
+        return False
+    if body.get("status") not in _SUCCESS_STATUSES:
+        return False
+    errors = body.get("errors")
+    if errors is None and isinstance(body.get("data"), dict):
+        errors = body["data"].get("errors")
+    return not errors
+
+
 async def run_mtf_set(
     client: httpx.AsyncClient,
     base_url: str,
@@ -127,7 +150,10 @@ async def run_mtf_set(
         body = response.text
     return {
         "set_id": a_set.set_id,
-        "ok": response.is_success,
+        # Succès = HTTP 2xx ET succès métier (sinon un partial_success/rejected
+        # renvoyé en 200 serait compté à tort comme réussi).
+        "ok": response.is_success and is_business_success(body),
         "status": response.status_code,
+        "business_status": body.get("status") if isinstance(body, dict) else None,
         "body": body,
     }

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -89,6 +89,11 @@ def build_mtf_payload(
     SF-002b : ``sync_tables`` est toujours forcé à ``false`` et
     ``open_state_snapshot`` est joint (le snapshot remplace tout fetch exchange
     par set côté Symfony).
+
+    ``process_tp_sl`` est aussi forcé à ``false`` : le recalcul TP/SL post-run
+    refetch les positions/ordres depuis le provider pour chaque set (et a des
+    effets de bord live), ce qui réintroduirait les appels exchange par set que
+    le snapshot partagé vise justement à éliminer.
     """
     payload: Dict[str, Any] = {
         "dry_run": a_set.dry_run,
@@ -97,6 +102,7 @@ def build_mtf_payload(
         "market_type": a_set.market_type.value,
         "mtf_profile": a_set.mtf_profile.value,
         "sync_tables": False,
+        "process_tp_sl": False,
     }
     if a_set.symbols:
         payload["symbols"] = list(a_set.symbols)

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -1,0 +1,127 @@
+"""Client HTTP vers Symfony pour l'orchestrateur (SF-002b / PY-002).
+
+Deux responsabilités :
+
+1. **Snapshot d'état ouvert** — ``GET /api/exchange/open-state`` est appelé UNE
+   seule fois par couple ``(exchange, market_type)`` actif, en amont de la boucle
+   des sets. Le résultat (positions/ordres ouverts) est mis en cache et transmis
+   à chaque ``POST /api/mtf/run`` via ``open_state_snapshot`` : Symfony ne refait
+   donc aucun fetch exchange par set.
+
+2. **Exécution d'un set** — ``POST /api/mtf/run`` avec ``sync_tables=false`` et le
+   snapshot en cache. La concurrence est bornée par l'appelant (``asyncio.Semaphore``).
+
+Fail-closed live : si le fetch du snapshot échoue, les sets **live**
+(``dry_run=false``) ne doivent pas être exécutés (on ne trade pas à l'aveugle).
+Les sets dry-run peuvent continuer sans snapshot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+
+from app.schemas import OrchestratorSet
+
+# Clé de cache d'un snapshot : (exchange, market_type).
+SnapshotKey = Tuple[str, str]
+
+
+class OpenStateUnavailableError(RuntimeError):
+    """Le snapshot d'état ouvert n'a pas pu être récupéré (fail-closed live)."""
+
+
+def snapshot_key(a_set: OrchestratorSet) -> SnapshotKey:
+    """Clé de cache du snapshot pour un set."""
+    return (a_set.exchange.value, a_set.market_type.value)
+
+
+async def fetch_open_state(
+    client: httpx.AsyncClient,
+    base_url: str,
+    exchange: str,
+    market_type: str,
+) -> Dict[str, Any]:
+    """Récupère l'instantané d'état ouvert pour un couple (exchange, market_type).
+
+    Lève ``OpenStateUnavailableError`` si l'appel échoue ou si la réponse n'a pas
+    la forme attendue ``{"open_positions": [...], "open_orders": [...]}``.
+    """
+    url = f"{base_url.rstrip('/')}/api/exchange/open-state"
+    params = {"exchange": exchange, "market_type": market_type}
+    try:
+        response = await client.get(url, params=params)
+    except httpx.HTTPError as exc:  # noqa: BLE001 - on remonte une erreur métier claire
+        raise OpenStateUnavailableError(
+            f"open-state fetch failed for {exchange}/{market_type}: {exc}"
+        ) from exc
+
+    if response.status_code != 200:
+        raise OpenStateUnavailableError(
+            f"open-state fetch returned HTTP {response.status_code} for {exchange}/{market_type}"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise OpenStateUnavailableError(
+            f"open-state response is not valid JSON for {exchange}/{market_type}"
+        ) from exc
+
+    if not isinstance(body, dict) or "open_positions" not in body or "open_orders" not in body:
+        raise OpenStateUnavailableError(
+            f"open-state response has unexpected shape for {exchange}/{market_type}"
+        )
+
+    return {
+        "open_positions": body.get("open_positions") or [],
+        "open_orders": body.get("open_orders") or [],
+    }
+
+
+def build_mtf_payload(
+    a_set: OrchestratorSet,
+    snapshot: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Construit le payload ``/api/mtf/run`` pour un set.
+
+    SF-002b : ``sync_tables`` est toujours forcé à ``false`` et
+    ``open_state_snapshot`` est joint (le snapshot remplace tout fetch exchange
+    par set côté Symfony).
+    """
+    payload: Dict[str, Any] = {
+        "dry_run": a_set.dry_run,
+        "workers": a_set.workers,
+        "exchange": a_set.exchange.value,
+        "market_type": a_set.market_type.value,
+        "mtf_profile": a_set.mtf_profile.value,
+        "sync_tables": False,
+    }
+    if a_set.symbols:
+        payload["symbols"] = list(a_set.symbols)
+    if snapshot is not None:
+        payload["open_state_snapshot"] = snapshot
+    return payload
+
+
+async def run_mtf_set(
+    client: httpx.AsyncClient,
+    base_url: str,
+    a_set: OrchestratorSet,
+    snapshot: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Exécute un set via ``POST /api/mtf/run`` avec le snapshot en cache."""
+    url = f"{base_url.rstrip('/')}/api/mtf/run"
+    payload = build_mtf_payload(a_set, snapshot)
+    response = await client.post(url, json=payload)
+    try:
+        body = response.json()
+    except ValueError:
+        body = response.text
+    return {
+        "set_id": a_set.set_id,
+        "ok": response.is_success,
+        "status": response.status_code,
+        "body": body,
+    }

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -74,15 +74,26 @@ async def fetch_open_state(
             f"open-state response has unexpected shape for {exchange}/{market_type}"
         )
 
+    positions = body.get("open_positions")
+    orders = body.get("open_orders")
+    # Ne pas normaliser un null/non-liste en [] : ce serait un snapshot "vide fiable"
+    # alors que l'exchange n'a rien rapporté de valide. On rejette (fail-closed) pour
+    # que les sets live ne s'exécutent pas comme si aucune position n'était ouverte.
+    if not isinstance(positions, list) or not isinstance(orders, list):
+        raise OpenStateUnavailableError(
+            f"open-state response has non-list open_positions/open_orders for {exchange}/{market_type}"
+        )
+
     return {
-        "open_positions": body.get("open_positions") or [],
-        "open_orders": body.get("open_orders") or [],
+        "open_positions": positions,
+        "open_orders": orders,
     }
 
 
 def build_mtf_payload(
     a_set: OrchestratorSet,
     snapshot: Optional[Dict[str, Any]],
+    dry_run: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """Construit le payload ``/api/mtf/run`` pour un set.
 
@@ -94,9 +105,12 @@ def build_mtf_payload(
     refetch les positions/ordres depuis le provider pour chaque set (et a des
     effets de bord live), ce qui réintroduirait les appels exchange par set que
     le snapshot partagé vise justement à éliminer.
+
+    ``dry_run`` permet de transmettre la valeur effective résolue par l'appelant
+    (override run-level). Si ``None``, on retombe sur le ``dry_run`` du set.
     """
     payload: Dict[str, Any] = {
-        "dry_run": a_set.dry_run,
+        "dry_run": a_set.dry_run if dry_run is None else dry_run,
         "workers": a_set.workers,
         "exchange": a_set.exchange.value,
         "market_type": a_set.market_type.value,
@@ -139,10 +153,11 @@ async def run_mtf_set(
     base_url: str,
     a_set: OrchestratorSet,
     snapshot: Optional[Dict[str, Any]],
+    dry_run: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """Exécute un set via ``POST /api/mtf/run`` avec le snapshot en cache."""
     url = f"{base_url.rstrip('/')}/api/mtf/run"
-    payload = build_mtf_payload(a_set, snapshot)
+    payload = build_mtf_payload(a_set, snapshot, dry_run)
     response = await client.post(url, json=payload)
     try:
         body = response.json()

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -72,6 +72,7 @@ class _FakeAsyncClient:
         open_state: Dict[str, Any] | None = None,
         open_state_status: int = 200,
         mtf_status: int = 200,
+        mtf_body: Dict[str, Any] | None = None,
         **_: Any,
     ) -> None:
         self._open_state = open_state if open_state is not None else {
@@ -80,6 +81,7 @@ class _FakeAsyncClient:
         }
         self._open_state_status = open_state_status
         self._mtf_status = mtf_status
+        self._mtf_body = mtf_body if mtf_body is not None else {"status": "success"}
         self.get_calls: List[Dict[str, Any]] = []
         self.post_calls: List[Dict[str, Any]] = []
 
@@ -95,7 +97,7 @@ class _FakeAsyncClient:
 
     async def post(self, url: str, json: Dict[str, Any] | None = None) -> _FakeResponse:
         self.post_calls.append({"url": url, "json": json or {}})
-        return _FakeResponse(self._mtf_status, {"status": "success"})
+        return _FakeResponse(self._mtf_status, self._mtf_body)
 
 
 def _install_fake_client(monkeypatch, fake: _FakeAsyncClient) -> None:
@@ -124,6 +126,20 @@ def test_run_summary_matches_injected_sets(monkeypatch):
     assert body["summary"] == {"total_calls": 3, "success": 3, "failed": 0}
     assert body["ok"] is True
     assert body["status"] == "success"
+
+
+def test_business_failure_in_200_body_counts_as_failed(monkeypatch):
+    # /api/mtf/run renvoie HTTP 200 mais un statut métier d'échec : le run global
+    # ne doit pas être ok et le set doit être compté en échec.
+    monkeypatch.setattr(orch, "list_active_sets", lambda: [_make_set("a")])
+    _install_fake_client(
+        monkeypatch,
+        _FakeAsyncClient(mtf_body={"status": "partial_success", "data": {"errors": ["x"]}}),
+    )
+
+    body = client.post("/orchestrator/run").json()
+    assert body["ok"] is False
+    assert body["summary"] == {"total_calls": 1, "success": 0, "failed": 1}
 
 
 def test_run_with_no_active_sets_is_not_success(monkeypatch):

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -275,3 +275,20 @@ def test_dry_run_proceeds_without_snapshot(monkeypatch):
     assert len(mtf_posts) == 1
     assert "open_state_snapshot" not in mtf_posts[0]["json"]
     assert mtf_posts[0]["json"]["sync_tables"] is False
+
+
+def test_run_level_dry_run_override_forces_live_set_to_dry(monkeypatch):
+    # Set live + fetch open-state en échec : sans override il serait skippé
+    # (fail-closed). Avec {"dry_run": true}, il est forcé en dry-run, donc exécuté.
+    sets = [_make_set("live", dry_run=False, exchange="bitmart")]
+    monkeypatch.setattr(orch, "list_active_sets", lambda: sets)
+    fake = _FakeAsyncClient(open_state_status=503)
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dry_run": True}).json()
+
+    assert body["ok"] is True
+    assert body["summary"]["success"] == 1
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+    assert mtf_posts[0]["json"]["dry_run"] is True

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -292,3 +292,38 @@ def test_run_level_dry_run_override_forces_live_set_to_dry(monkeypatch):
     mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
     assert len(mtf_posts) == 1
     assert mtf_posts[0]["json"]["dry_run"] is True
+
+
+def test_conflicting_live_set_ids():
+    a = _make_set("a", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",))
+    b = _make_set("b", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",))
+    c = _make_set("c", dry_run=False, exchange="bitmart", symbols=("ETHUSDT",))
+    dry = _make_set("d", dry_run=True, exchange="bitmart", symbols=("BTCUSDT",))
+    empty = _make_set("e", dry_run=False, exchange="bitmart")  # symbols=() => univers complet
+
+    # a et b partagent BTCUSDT => conflit ; c (ETHUSDT) et dry (dry-run) hors conflit.
+    assert orch._conflicting_live_set_ids([a, b, c, dry], force_dry_run=False) == {"a", "b"}
+    # symbols vide chevauche tout le monde du même couple.
+    assert orch._conflicting_live_set_ids([empty, c], force_dry_run=False) == {"e", "c"}
+    # Override force-dry => plus aucun set effectivement live => aucun conflit.
+    assert orch._conflicting_live_set_ids([a, b], force_dry_run=True) == set()
+    # Symboles disjoints => pas de conflit.
+    assert orch._conflicting_live_set_ids([a, c], force_dry_run=False) == set()
+
+
+def test_overlapping_live_sets_rejected_before_dispatch(monkeypatch):
+    sets = [
+        _make_set("live1", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",)),
+        _make_set("live2", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",)),
+    ]
+    monkeypatch.setattr(orch, "list_active_sets", lambda: sets)
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run").json()
+
+    # Les deux sets live chevauchants sont rejetés (fail-closed), aucun POST mtf/run.
+    assert body["ok"] is False
+    assert body["summary"] == {"total_calls": 2, "success": 0, "failed": 2}
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 0

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -310,6 +310,10 @@ def test_conflicting_live_set_ids():
     # Symboles disjoints => pas de conflit.
     assert orch._conflicting_live_set_ids([a, c], force_dry_run=False) == set()
 
+    # Casse différente => même instrument (Symfony normalise en MAJUSCULES).
+    lower = _make_set("low", dry_run=False, exchange="bitmart", symbols=("btcusdt",))
+    assert orch._conflicting_live_set_ids([a, lower], force_dry_run=False) == {"a", "low"}
+
 
 def test_overlapping_live_sets_rejected_before_dispatch(monkeypatch):
     sets = [

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1,3 +1,17 @@
+"""Tests de ``POST /orchestrator/run`` (SF-002b).
+
+L'orchestrateur récupère l'état ouvert UNE fois par couple (exchange,
+market_type) via ``GET /api/exchange/open-state``, puis exécute chaque set
+``mtf_run`` via ``POST /api/mtf/run`` avec ``sync_tables=false`` +
+``open_state_snapshot``. Les appels HTTP sont mockés via un faux
+``httpx.AsyncClient`` (aucun Symfony requis).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -8,12 +22,89 @@ from app.schemas import OrchestratorSet
 client = TestClient(app)
 
 
-def _make_set(set_id: str, enabled: bool = True, priority: int = 0) -> OrchestratorSet:
-    return OrchestratorSet(set_id=set_id, exchange="fake", enabled=enabled, priority=priority)
+def _make_set(
+    set_id: str,
+    enabled: bool = True,
+    priority: int = 0,
+    *,
+    exchange: str = "fake",
+    market_type: str = "perpetual",
+    dry_run: bool = True,
+    symbols: tuple = (),
+) -> OrchestratorSet:
+    return OrchestratorSet(
+        set_id=set_id,
+        exchange=exchange,
+        market_type=market_type,
+        enabled=enabled,
+        priority=priority,
+        dry_run=dry_run,
+        symbols=symbols,
+    )
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = "" if payload is None else str(payload)
+
+    @property
+    def is_success(self) -> bool:
+        return 200 <= self.status_code < 300
+
+    def json(self) -> Any:
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Faux client httpx enregistrant les GET (open-state) et POST (mtf/run).
+
+    ``open_state`` : payload renvoyé par ``GET /api/exchange/open-state``.
+    ``open_state_status`` : code HTTP pour simuler un échec de fetch.
+    """
+
+    def __init__(
+        self,
+        *,
+        open_state: Dict[str, Any] | None = None,
+        open_state_status: int = 200,
+        mtf_status: int = 200,
+        **_: Any,
+    ) -> None:
+        self._open_state = open_state if open_state is not None else {
+            "open_positions": [],
+            "open_orders": [],
+        }
+        self._open_state_status = open_state_status
+        self._mtf_status = mtf_status
+        self.get_calls: List[Dict[str, Any]] = []
+        self.post_calls: List[Dict[str, Any]] = []
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        return None
+
+    async def get(self, url: str, params: Dict[str, Any] | None = None) -> _FakeResponse:
+        self.get_calls.append({"url": url, "params": params or {}})
+        return _FakeResponse(self._open_state_status, self._open_state)
+
+    async def post(self, url: str, json: Dict[str, Any] | None = None) -> _FakeResponse:
+        self.post_calls.append({"url": url, "json": json or {}})
+        return _FakeResponse(self._mtf_status, {"status": "success"})
+
+
+def _install_fake_client(monkeypatch, fake: _FakeAsyncClient) -> None:
+    monkeypatch.setattr(orch.httpx, "AsyncClient", lambda **kwargs: fake)
 
 
 def test_run_returns_contract_shape(monkeypatch):
     monkeypatch.setattr(orch, "list_active_sets", lambda: [_make_set("a"), _make_set("b")])
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
 
     response = client.post("/orchestrator/run")
     assert response.status_code == 200
@@ -24,10 +115,10 @@ def test_run_returns_contract_shape(monkeypatch):
 
 
 def test_run_summary_matches_injected_sets(monkeypatch):
-    # Oracle indépendant : on injecte explicitement 3 sets actifs.
     monkeypatch.setattr(
         orch, "list_active_sets", lambda: [_make_set("a"), _make_set("b"), _make_set("c")]
     )
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
 
     body = client.post("/orchestrator/run").json()
     assert body["summary"] == {"total_calls": 3, "success": 3, "failed": 0}
@@ -37,6 +128,7 @@ def test_run_summary_matches_injected_sets(monkeypatch):
 
 def test_run_with_no_active_sets_is_not_success(monkeypatch):
     monkeypatch.setattr(orch, "list_active_sets", lambda: [])
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
 
     body = client.post("/orchestrator/run").json()
     assert body["status"] == "no_sets"
@@ -46,6 +138,7 @@ def test_run_with_no_active_sets_is_not_success(monkeypatch):
 
 def test_run_id_is_idempotent_from_idempotency_key(monkeypatch):
     monkeypatch.setattr(orch, "list_active_sets", lambda: [_make_set("a")])
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
 
     payload = {"idempotency_key": "abc123"}
     first = client.post("/orchestrator/run", json=payload).json()["run_id"]
@@ -55,6 +148,7 @@ def test_run_id_is_idempotent_from_idempotency_key(monkeypatch):
 
 def test_run_id_is_idempotent_from_dashboard_and_tick(monkeypatch):
     monkeypatch.setattr(orch, "list_active_sets", lambda: [_make_set("a")])
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
 
     payload = {"dashboard_id": "dash1", "tick_timestamp": "2026-06-17T00:00:00Z"}
     first = client.post("/orchestrator/run", json=payload).json()["run_id"]
@@ -65,6 +159,7 @@ def test_run_id_is_idempotent_from_dashboard_and_tick(monkeypatch):
 
 def test_run_id_is_random_without_context(monkeypatch):
     monkeypatch.setattr(orch, "list_active_sets", lambda: [_make_set("a")])
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
 
     first = client.post("/orchestrator/run").json()["run_id"]
     second = client.post("/orchestrator/run").json()["run_id"]
@@ -82,3 +177,85 @@ def test_run_id_is_random_without_context(monkeypatch):
 )
 def test_resolve_status_branches(success, failed, expected):
     assert orch._resolve_status(success, failed) == expected
+
+
+# --------------------------------------------------------------------------
+# SF-002b — comportement spécifique snapshot / fail-closed
+# --------------------------------------------------------------------------
+
+
+def test_open_state_fetched_once_per_exchange_market_type(monkeypatch):
+    # Trois sets : deux partagent (fake, perpetual), un autre (bitmart, perpetual).
+    sets = [
+        _make_set("a", exchange="fake", market_type="perpetual"),
+        _make_set("b", exchange="fake", market_type="perpetual"),
+        _make_set("c", exchange="bitmart", market_type="perpetual"),
+    ]
+    monkeypatch.setattr(orch, "list_active_sets", lambda: sets)
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run").json()
+    assert body["summary"]["total_calls"] == 3
+
+    # Un seul GET open-state par couple distinct => 2 GET (fake, bitmart).
+    open_state_calls = [c for c in fake.get_calls if c["url"].endswith("/api/exchange/open-state")]
+    assert len(open_state_calls) == 2
+    pairs = {(c["params"]["exchange"], c["params"]["market_type"]) for c in open_state_calls}
+    assert pairs == {("fake", "perpetual"), ("bitmart", "perpetual")}
+
+
+def test_each_mtf_payload_has_sync_tables_false_and_snapshot(monkeypatch):
+    sets = [_make_set("a", symbols=("BTCUSDT",)), _make_set("b")]
+    monkeypatch.setattr(orch, "list_active_sets", lambda: sets)
+    snapshot = {"open_positions": [{"symbol": "BTCUSDT"}], "open_orders": []}
+    fake = _FakeAsyncClient(open_state=snapshot)
+    _install_fake_client(monkeypatch, fake)
+
+    client.post("/orchestrator/run")
+
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 2
+    for call in mtf_posts:
+        assert call["json"]["sync_tables"] is False
+        assert call["json"]["open_state_snapshot"] == snapshot
+
+
+def test_live_set_skipped_when_snapshot_fetch_fails(monkeypatch):
+    # Un set live et un set dry-run, même couple ; le fetch open-state échoue (503).
+    sets = [
+        _make_set("live", dry_run=False, exchange="bitmart"),
+        _make_set("dry", dry_run=True, exchange="bitmart"),
+    ]
+    monkeypatch.setattr(orch, "list_active_sets", lambda: sets)
+    fake = _FakeAsyncClient(open_state_status=503)
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run").json()
+
+    # Live échoue (fail-closed), dry-run réussit sans snapshot.
+    assert body["summary"]["total_calls"] == 2
+    assert body["summary"]["failed"] == 1
+    assert body["summary"]["success"] == 1
+    assert body["status"] == "partial_failure"
+
+    # Le set live n'a PAS déclenché de POST /api/mtf/run (skippé).
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+
+
+def test_dry_run_proceeds_without_snapshot(monkeypatch):
+    sets = [_make_set("dry", dry_run=True, exchange="bitmart")]
+    monkeypatch.setattr(orch, "list_active_sets", lambda: sets)
+    fake = _FakeAsyncClient(open_state_status=500)
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run").json()
+    assert body["ok"] is True
+    assert body["summary"]["success"] == 1
+
+    # Dry-run exécuté ; payload sans snapshot (couple sans cache).
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+    assert "open_state_snapshot" not in mtf_posts[0]["json"]
+    assert mtf_posts[0]["json"]["sync_tables"] is False

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -1,0 +1,92 @@
+"""Tests unitaires du client Symfony (SF-002b)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+
+from app.schemas import OrchestratorSet
+from app.services.symfony_client import (
+    OpenStateUnavailableError,
+    build_mtf_payload,
+    fetch_open_state,
+    snapshot_key,
+)
+
+
+def _make_set(**kwargs: Any) -> OrchestratorSet:
+    base = {"set_id": "s", "exchange": "fake"}
+    base.update(kwargs)
+    return OrchestratorSet(**base)
+
+
+def test_build_payload_forces_sync_tables_false_and_attaches_snapshot():
+    a_set = _make_set(symbols=("BTCUSDT", "ETHUSDT"), dry_run=True)
+    snapshot = {"open_positions": [], "open_orders": []}
+
+    payload = build_mtf_payload(a_set, snapshot)
+
+    assert payload["sync_tables"] is False
+    assert payload["open_state_snapshot"] == snapshot
+    assert payload["symbols"] == ["BTCUSDT", "ETHUSDT"]
+    assert payload["exchange"] == "fake"
+    assert payload["market_type"] == "perpetual"
+
+
+def test_build_payload_omits_snapshot_when_none():
+    payload = build_mtf_payload(_make_set(), None)
+
+    assert payload["sync_tables"] is False
+    assert "open_state_snapshot" not in payload
+
+
+def test_snapshot_key_uses_exchange_and_market_type():
+    assert snapshot_key(_make_set(exchange="bitmart", market_type="perpetual")) == (
+        "bitmart",
+        "perpetual",
+    )
+
+
+def _client_with(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_fetch_open_state_returns_normalized_shape():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/exchange/open-state"
+        assert request.url.params["exchange"] == "bitmart"
+        return httpx.Response(200, json={"open_positions": [{"symbol": "BTCUSDT"}], "open_orders": []})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_open_state(client, "http://symfony", "bitmart", "perpetual")
+
+    snapshot = asyncio.run(_run())
+    assert snapshot == {"open_positions": [{"symbol": "BTCUSDT"}], "open_orders": []}
+
+
+def test_fetch_open_state_raises_on_http_error_status():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"status": "error"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            await fetch_open_state(client, "http://symfony", "bitmart", "perpetual")
+
+    with pytest.raises(OpenStateUnavailableError):
+        asyncio.run(_run())
+
+
+def test_fetch_open_state_raises_on_unexpected_shape():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"unexpected": True})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            await fetch_open_state(client, "http://symfony", "bitmart", "perpetual")
+
+    with pytest.raises(OpenStateUnavailableError):
+        asyncio.run(_run())

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -13,6 +13,8 @@ from app.services.symfony_client import (
     OpenStateUnavailableError,
     build_mtf_payload,
     fetch_open_state,
+    is_business_success,
+    run_mtf_set,
     snapshot_key,
 )
 
@@ -37,6 +39,71 @@ def test_build_payload_forces_sync_tables_false_and_attaches_snapshot():
     assert payload["symbols"] == ["BTCUSDT", "ETHUSDT"]
     assert payload["exchange"] == "fake"
     assert payload["market_type"] == "perpetual"
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        ({"status": "success"}, True),
+        ({"status": "success", "data": {"errors": []}}, True),
+        ({"status": "partial_success"}, False),
+        ({"status": "completed_with_errors"}, False),
+        ({"status": "rejected"}, False),
+        ({"status": "error"}, False),
+        # Le contrôleur peut écraser le statut par summary.status : on vérifie errors.
+        ({"status": "success", "data": {"errors": ["BTCUSDT: boom"]}}, False),
+        ({"status": "success", "errors": ["x"]}, False),
+        ("not-json-string", False),
+        ({}, False),
+    ],
+)
+def test_is_business_success(body, expected):
+    assert is_business_success(body) is expected
+
+
+class _StubResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    @property
+    def is_success(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        return self._payload
+
+
+class _StubClient:
+    def __init__(self, response):
+        self._response = response
+
+    async def post(self, url, json=None):
+        return self._response
+
+
+def _run_set(status_code, payload):
+    client = _StubClient(_StubResponse(status_code, payload))
+    return asyncio.run(run_mtf_set(client, "http://sym", _make_set(), None))
+
+
+def test_run_mtf_set_ok_on_business_success():
+    result = _run_set(200, {"status": "success"})
+    assert result["ok"] is True
+    assert result["business_status"] == "success"
+
+
+def test_run_mtf_set_failed_on_business_failure_with_http_200():
+    # HTTP 200 mais statut métier d'échec : le set doit être compté en échec.
+    result = _run_set(200, {"status": "partial_success", "data": {"errors": ["x"]}})
+    assert result["ok"] is False
+    assert result["business_status"] == "partial_success"
+
+
+def test_run_mtf_set_failed_on_http_error():
+    result = _run_set(500, {"status": "error"})
+    assert result["ok"] is False
 
 
 def test_build_payload_omits_snapshot_when_none():

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -30,6 +30,9 @@ def test_build_payload_forces_sync_tables_false_and_attaches_snapshot():
     payload = build_mtf_payload(a_set, snapshot)
 
     assert payload["sync_tables"] is False
+    # TP/SL recalc per set refetcherait l'exchange et aurait des effets de bord live :
+    # désactivé pour préserver l'objectif "zéro appel exchange par set".
+    assert payload["process_tp_sl"] is False
     assert payload["open_state_snapshot"] == snapshot
     assert payload["symbols"] == ["BTCUSDT", "ETHUSDT"]
     assert payload["exchange"] == "fake"
@@ -40,6 +43,7 @@ def test_build_payload_omits_snapshot_when_none():
     payload = build_mtf_payload(_make_set(), None)
 
     assert payload["sync_tables"] is False
+    assert payload["process_tp_sl"] is False
     assert "open_state_snapshot" not in payload
 
 

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -161,3 +161,35 @@ def test_fetch_open_state_raises_on_unexpected_shape():
 
     with pytest.raises(OpenStateUnavailableError):
         asyncio.run(_run())
+
+
+@pytest.mark.parametrize(
+    "open_positions,open_orders",
+    [
+        (None, []),
+        ([], None),
+        ("nope", []),
+        ([], {"k": "v"}),
+    ],
+)
+def test_fetch_open_state_raises_on_non_list_arrays(open_positions, open_orders):
+    # Clés présentes mais valeurs non-listes : ne pas normaliser en [] (fail-closed).
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"open_positions": open_positions, "open_orders": open_orders}
+        )
+
+    async def _run():
+        async with _client_with(handler) as client:
+            await fetch_open_state(client, "http://symfony", "bitmart", "perpetual")
+
+    with pytest.raises(OpenStateUnavailableError):
+        asyncio.run(_run())
+
+
+def test_build_payload_applies_dry_run_override():
+    live_set = _make_set(dry_run=False)
+    # Override run-level dry_run=True => le payload force le dry-run.
+    assert build_mtf_payload(live_set, None, dry_run=True)["dry_run"] is True
+    # dry_run=None => on retombe sur la valeur du set (ici live).
+    assert build_mtf_payload(live_set, None, dry_run=None)["dry_run"] is False

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -229,15 +229,71 @@ services:
             $systemProvider: '@App\Provider\Bitmart\SystemProvider'
         public: false
 
+    # --- Fake exchange provider bundle ---
+    # Neutral/empty exchange used by the Python orchestrator demo sets
+    # (exchange=fake). It resolves a provider bundle so MainProvider::forContext()
+    # never fails for the FAKE context. The fake contract provider returns 0
+    # active contracts, so an MTF run on this context resolves 0 symbols and
+    # completes as a trivial success. No real HTTP / live execution occurs.
+
+    App\Provider\Context\ExchangeContext.fake_perpetual:
+        class: App\Provider\Context\ExchangeContext
+        arguments:
+            $exchange: !php/const App\Common\Enum\Exchange::FAKE
+            $marketType: !php/const App\Common\Enum\MarketType::PERPETUAL
+        public: false
+
+    App\Provider\Context\ExchangeContext.fake_spot:
+        class: App\Provider\Context\ExchangeContext
+        arguments:
+            $exchange: !php/const App\Common\Enum\Exchange::FAKE
+            $marketType: !php/const App\Common\Enum\MarketType::SPOT
+        public: false
+
+    # The fake provider classes themselves are autowired by the App\Provider\
+    # resource block above; only the contexts and bundles need explicit wiring.
+    App\Provider\Registry\ExchangeProviderBundle.fake_perpetual:
+        class: App\Provider\Registry\ExchangeProviderBundle
+        arguments:
+            $context: '@App\Provider\Context\ExchangeContext.fake_perpetual'
+            $klineProvider: '@App\Provider\Fake\FakeKlineProvider'
+            $contractProvider: '@App\Provider\Fake\FakeContractProvider'
+            $orderProvider: '@App\Provider\Fake\FakeOrderProvider'
+            $accountProvider: '@App\Provider\Fake\FakeAccountProvider'
+            $systemProvider: '@App\Provider\Fake\FakeSystemProvider'
+        public: false
+
+    App\Provider\Registry\ExchangeProviderBundle.fake_spot:
+        class: App\Provider\Registry\ExchangeProviderBundle
+        arguments:
+            $context: '@App\Provider\Context\ExchangeContext.fake_spot'
+            $klineProvider: '@App\Provider\Fake\FakeKlineProvider'
+            $contractProvider: '@App\Provider\Fake\FakeContractProvider'
+            $orderProvider: '@App\Provider\Fake\FakeOrderProvider'
+            $accountProvider: '@App\Provider\Fake\FakeAccountProvider'
+            $systemProvider: '@App\Provider\Fake\FakeSystemProvider'
+        public: false
+
     App\Provider\Registry\ExchangeProviderRegistry:
         arguments:
             $bundles:
                 - '@App\Provider\Registry\ExchangeProviderBundle.bitmart_perpetual'
                 - '@App\Provider\Registry\ExchangeProviderBundle.bitmart_spot'
+                - '@App\Provider\Registry\ExchangeProviderBundle.fake_perpetual'
+                - '@App\Provider\Registry\ExchangeProviderBundle.fake_spot'
             $defaultExchange: !php/const App\Common\Enum\Exchange::BITMART
             $defaultMarketType: !php/const App\Common\Enum\MarketType::PERPETUAL
 
     App\Contract\Provider\ExchangeProviderRegistryInterface: '@App\Provider\Registry\ExchangeProviderRegistry'
+
+    # Default interface aliases for autowiring. KlineProviderInterface,
+    # OrderProviderInterface and SystemProviderInterface are aliased via #[AsAlias]
+    # on their Bitmart classes. AccountProviderInterface and ContractProviderInterface
+    # previously resolved implicitly because Bitmart was the single implementation;
+    # registering the Fake providers added a second candidate, so the default
+    # (Bitmart) alias must now be declared explicitly.
+    App\Contract\Provider\AccountProviderInterface: '@App\Provider\Bitmart\BitmartAccountProvider'
+    App\Contract\Provider\ContractProviderInterface: '@App\Provider\Bitmart\BitmartContractProvider'
 
     # Provide a default context alias so autowiring of ExchangeContext resolves
     App\Provider\Context\ExchangeContext: '@App\Provider\Context\ExchangeContext.bitmart_perpetual'

--- a/trading-app/src/Application/Runner/OpenStateSnapshotSerializer.php
+++ b/trading-app/src/Application/Runner/OpenStateSnapshotSerializer.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Runner;
+
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\PositionDto;
+
+/**
+ * Sérialise l'état ouvert (positions/ordres) en tableaux JSON-safe pour le
+ * snapshot orchestrateur (SF-002b). Accepte aussi bien des DTO providers
+ * (PositionDto/OrderDto) que des tableaux déjà normalisés afin de rester
+ * tolérant aux différents providers.
+ */
+final class OpenStateSnapshotSerializer
+{
+    /**
+     * @param array<int, mixed> $openPositions
+     * @param array<int, mixed> $openOrders
+     * @return array{open_positions: array<int, array<string, mixed>>, open_orders: array<int, array<string, mixed>>}
+     */
+    public function serialize(array $openPositions, array $openOrders): array
+    {
+        return [
+            'open_positions' => array_values(array_map(
+                fn ($position): array => $this->serializePosition($position),
+                $openPositions,
+            )),
+            'open_orders' => array_values(array_map(
+                fn ($order): array => $this->serializeOrder($order),
+                $openOrders,
+            )),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializePosition(mixed $position): array
+    {
+        if ($position instanceof PositionDto) {
+            return [
+                'symbol' => $position->symbol,
+                'side' => $position->side->value,
+                'size' => $position->size->__toString(),
+                'entry_price' => $position->entryPrice->__toString(),
+                'mark_price' => $position->markPrice->__toString(),
+                'unrealized_pnl' => $position->unrealizedPnl->__toString(),
+                'realized_pnl' => $position->realizedPnl->__toString(),
+                'margin' => $position->margin->__toString(),
+                'leverage' => $position->leverage->__toString(),
+                'opened_at' => $position->openedAt->format(\DateTimeInterface::ATOM),
+            ];
+        }
+
+        if (is_array($position)) {
+            return $position;
+        }
+
+        return ['symbol' => $this->extractSymbol($position)];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeOrder(mixed $order): array
+    {
+        if ($order instanceof OrderDto) {
+            return [
+                'order_id' => $order->orderId,
+                'symbol' => $order->symbol,
+                'side' => $order->side->value,
+                'type' => $order->type->value,
+                'status' => $order->status->value,
+                'quantity' => $order->quantity->__toString(),
+                'price' => $order->price?->__toString(),
+                'stop_price' => $order->stopPrice?->__toString(),
+                'filled_quantity' => $order->filledQuantity->__toString(),
+                'remaining_quantity' => $order->remainingQuantity->__toString(),
+                'created_at' => $order->createdAt->format(\DateTimeInterface::ATOM),
+            ];
+        }
+
+        if (is_array($order)) {
+            return $order;
+        }
+
+        return ['symbol' => $this->extractSymbol($order)];
+    }
+
+    private function extractSymbol(mixed $payload): string
+    {
+        if (is_object($payload) && is_string($payload->symbol ?? null)) {
+            return $payload->symbol;
+        }
+
+        return '';
+    }
+}

--- a/trading-app/src/Contract/Provider/AccountProviderInterface.php
+++ b/trading-app/src/Contract/Provider/AccountProviderInterface.php
@@ -28,6 +28,17 @@ interface AccountProviderInterface
     public function getOpenPositions(?string $symbol = null): array;
 
     /**
+     * Récupère les positions ouvertes en propageant toute erreur de transport/parse
+     * au lieu de retourner [] (contrairement à getOpenPositions). Destiné aux
+     * consommateurs fail-closed (ex: endpoint /api/exchange/open-state) qui ne
+     * doivent PAS confondre « aucune position » et « fetch échoué ».
+     *
+     * @return PositionDto[]
+     * @throws \Throwable si la récupération échoue
+     */
+    public function getOpenPositionsOrFail(?string $symbol = null): array;
+
+    /**
      * Récupère une position spécifique
      */
     public function getPosition(string $symbol): ?PositionDto;

--- a/trading-app/src/Contract/Provider/OrderProviderInterface.php
+++ b/trading-app/src/Contract/Provider/OrderProviderInterface.php
@@ -43,6 +43,17 @@ interface OrderProviderInterface
     public function getOpenOrders(?string $symbol = null): array;
 
     /**
+     * Récupère les ordres ouverts en propageant toute erreur de transport/parse
+     * au lieu de retourner [] (contrairement à getOpenOrders). Destiné aux
+     * consommateurs fail-closed (ex: endpoint /api/exchange/open-state) qui ne
+     * doivent PAS confondre « aucun ordre » et « fetch échoué ».
+     *
+     * @return OrderDto[]
+     * @throws \Throwable si la récupération échoue
+     */
+    public function getOpenOrdersOrFail(?string $symbol = null): array;
+
+    /**
      * Récupère l'historique des ordres
      */
     public function getOrderHistory(string $symbol, int $limit = 100): array;

--- a/trading-app/src/Contract/Runner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/Contract/Runner/Dto/MtfRunnerRequestDto.php
@@ -28,6 +28,13 @@ final class MtfRunnerRequestDto
         public readonly int $workers = 1,
         public readonly bool $syncTables = true,
         public readonly bool $processTpSl = true,
+        /**
+         * Instantané de l'état ouvert (positions/ordres) fourni par l'orchestrateur
+         * pour éviter un appel exchange par set (SF-002b).
+         *
+         * @var array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
+         */
+        public readonly ?array $openStateSnapshot = null,
     ) {}
 
     public static function fromArray(array $data): self
@@ -50,6 +57,7 @@ final class MtfRunnerRequestDto
             workers: max(1, (int) ($data['workers'] ?? 1)),
             syncTables: (bool) ($data['sync_tables'] ?? true),
             processTpSl: (bool) ($data['process_tp_sl'] ?? true),
+            openStateSnapshot: self::extractOpenStateSnapshot($data),
         );
     }
 
@@ -71,6 +79,29 @@ final class MtfRunnerRequestDto
             'workers' => $this->workers,
             'sync_tables' => $this->syncTables,
             'process_tp_sl' => $this->processTpSl,
+            'open_state_snapshot' => $this->openStateSnapshot,
+        ];
+    }
+
+    /**
+     * Normalise l'instantané d'état ouvert fourni dans le payload.
+     *
+     * @param array<string,mixed> $data
+     * @return array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
+     */
+    private static function extractOpenStateSnapshot(array $data): ?array
+    {
+        $snapshot = $data['open_state_snapshot'] ?? null;
+        if (!is_array($snapshot)) {
+            return null;
+        }
+
+        $positions = $snapshot['open_positions'] ?? [];
+        $orders = $snapshot['open_orders'] ?? [];
+
+        return [
+            'open_positions' => is_array($positions) ? array_values($positions) : [],
+            'open_orders' => is_array($orders) ? array_values($orders) : [],
         ];
     }
 

--- a/trading-app/src/Contract/Runner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/Contract/Runner/Dto/MtfRunnerRequestDto.php
@@ -87,7 +87,7 @@ final class MtfRunnerRequestDto
      * Normalise l'instantané d'état ouvert fourni dans le payload.
      *
      * @param array<string,mixed> $data
-     * @return array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
+     * @return array{open_positions: array<int,mixed>, open_orders: array<int,mixed>}|null
      */
     private static function extractOpenStateSnapshot(array $data): ?array
     {
@@ -96,12 +96,21 @@ final class MtfRunnerRequestDto
             return null;
         }
 
-        $positions = $snapshot['open_positions'] ?? [];
-        $orders = $snapshot['open_orders'] ?? [];
+        $positions = $snapshot['open_positions'] ?? null;
+        $orders = $snapshot['open_orders'] ?? null;
+
+        // Un snapshot n'est une source fiable que s'il contient explicitement les deux
+        // clés sous forme de tableaux. Un payload mal formé ({} ou clés manquantes/
+        // non-tableaux) retourne null pour que le garde fail-closed en live se déclenche
+        // au lieu d'exécuter le run sans état d'ouverture réel. Un snapshot vide mais
+        // bien formé (open_positions/open_orders = []) reste valide.
+        if (!is_array($positions) || !is_array($orders)) {
+            return null;
+        }
 
         return [
-            'open_positions' => is_array($positions) ? array_values($positions) : [],
-            'open_orders' => is_array($orders) ? array_values($orders) : [],
+            'open_positions' => array_values($positions),
+            'open_orders' => array_values($orders),
         ];
     }
 

--- a/trading-app/src/Controller/ExchangeStateController.php
+++ b/trading-app/src/Controller/ExchangeStateController.php
@@ -47,8 +47,11 @@ final class ExchangeStateController extends AbstractController
             $accountProvider = $provider->getAccountProvider();
             $orderProvider = $provider->getOrderProvider();
 
-            $openPositions = $accountProvider !== null ? $accountProvider->getOpenPositions() : [];
-            $openOrders = $orderProvider !== null ? $orderProvider->getOpenOrders() : [];
+            // Variantes "OrFail" : une panne/erreur provider lève (au lieu de []),
+            // ce qui produit une réponse non-200 (cf. catch ci-dessous). L'orchestrateur
+            // fail-close alors les sets live au lieu de trader sur un snapshot vide trompeur.
+            $openPositions = $accountProvider !== null ? $accountProvider->getOpenPositionsOrFail() : [];
+            $openOrders = $orderProvider !== null ? $orderProvider->getOpenOrdersOrFail() : [];
 
             $snapshot = $this->serializer->serialize($openPositions, $openOrders);
 
@@ -65,10 +68,12 @@ final class ExchangeStateController extends AbstractController
                 'error' => $e->getMessage(),
             ]);
 
+            // 503 : panne/erreur exchange transitoire. Le client orchestrateur traite
+            // tout non-200 comme open-state indisponible (fail-closed des sets live).
             return $this->json([
                 'status' => 'error',
                 'message' => $e->getMessage(),
-            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+            ], Response::HTTP_SERVICE_UNAVAILABLE);
         }
     }
 }

--- a/trading-app/src/Controller/ExchangeStateController.php
+++ b/trading-app/src/Controller/ExchangeStateController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Application\Runner\OpenStateSnapshotSerializer;
+use App\Contract\Provider\MainProviderInterface;
+use App\Provider\Context\ExchangeContextResolver;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * SF-002b — endpoint en lecture seule produisant l'instantané d'état ouvert
+ * (positions/ordres) que l'orchestrateur récupère UNE seule fois puis transmet
+ * à chaque appel `/api/mtf/run` (open_state_snapshot), évitant un fetch exchange
+ * par set.
+ */
+final class ExchangeStateController extends AbstractController
+{
+    public function __construct(
+        private readonly MainProviderInterface $mainProvider,
+        private readonly ExchangeContextResolver $contextResolver,
+        private readonly OpenStateSnapshotSerializer $serializer,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    #[Route('/api/exchange/open-state', name: 'api_exchange_open_state', methods: ['GET'])]
+    public function openState(Request $request): JsonResponse
+    {
+        try {
+            $context = $this->contextResolver->resolve($request->query->all());
+        } catch (\InvalidArgumentException $e) {
+            return $this->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            $provider = $this->mainProvider->forContext($context);
+            $accountProvider = $provider->getAccountProvider();
+            $orderProvider = $provider->getOrderProvider();
+
+            $openPositions = $accountProvider !== null ? $accountProvider->getOpenPositions() : [];
+            $openOrders = $orderProvider !== null ? $orderProvider->getOpenOrders() : [];
+
+            $snapshot = $this->serializer->serialize($openPositions, $openOrders);
+
+            $this->logger->info('[Exchange State] Open-state snapshot produced', [
+                'exchange' => $context->exchange->value,
+                'market_type' => $context->marketType->value,
+                'positions_count' => count($snapshot['open_positions']),
+                'orders_count' => count($snapshot['open_orders']),
+            ]);
+
+            return $this->json($snapshot);
+        } catch (\Throwable $e) {
+            $this->logger->error('[Exchange State] Failed to produce open-state snapshot', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->json([
+                'status' => 'error',
+                'message' => $e->getMessage(),
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/trading-app/src/Controller/RunnerController.php
+++ b/trading-app/src/Controller/RunnerController.php
@@ -49,6 +49,11 @@ class RunnerController extends AbstractController
             $currentTf = is_string($currentTf) && $currentTf !== '' ? $currentTf : null;
             $workers = max(1, (int)($data['workers'] ?? 1));
 
+            // SF-002b : instantané d'état ouvert fourni par l'orchestrateur (un seul
+            // fetch exchange amont, partagé entre tous les sets) — array|null uniquement.
+            $openStateSnapshot = $data['open_state_snapshot'] ?? null;
+            $openStateSnapshot = is_array($openStateSnapshot) ? $openStateSnapshot : null;
+
             // Normaliser les symboles fournis sans appliquer de fallback/queue
             $symbols = [];
             if (is_string($symbolsInput)) {
@@ -99,6 +104,7 @@ class RunnerController extends AbstractController
                 'validation_mode' => $data['validation_mode'] ?? null,
                 'context_mode' => $data['context_mode'] ?? null,
                 'mode' => $data['mode'] ?? null,
+                'open_state_snapshot' => $openStateSnapshot,
             ]);
             $result = $runMtfCycle->run($runnerRequest);
 

--- a/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
@@ -31,6 +31,14 @@ final class MtfRunnerRequestDto
         public readonly bool $processTpSl = true,
         public readonly ?string $profile = null,
         public readonly ?string $validationMode = null,
+        /**
+         * Instantané de l'état ouvert (positions/ordres) fourni par l'orchestrateur
+         * pour éviter un appel exchange par set (SF-002b). Forme attendue :
+         * ['open_positions' => array<int,mixed>, 'open_orders' => array<int,mixed>].
+         *
+         * @var array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
+         */
+        public readonly ?array $openStateSnapshot = null,
     ) {}
 
     public static function fromArray(array $data): self
@@ -56,6 +64,7 @@ final class MtfRunnerRequestDto
             processTpSl: (bool) ($data['process_tp_sl'] ?? true),
             profile: $profile,
             validationMode: $validationMode,
+            openStateSnapshot: self::extractOpenStateSnapshot($data),
         );
     }
 
@@ -79,6 +88,29 @@ final class MtfRunnerRequestDto
             'process_tp_sl' => $this->processTpSl,
             'profile' => $this->profile,
             'validation_mode' => $this->validationMode,
+            'open_state_snapshot' => $this->openStateSnapshot,
+        ];
+    }
+
+    /**
+     * Normalise l'instantané d'état ouvert fourni dans le payload.
+     *
+     * @param array<string,mixed> $data
+     * @return array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
+     */
+    private static function extractOpenStateSnapshot(array $data): ?array
+    {
+        $snapshot = $data['open_state_snapshot'] ?? null;
+        if (!is_array($snapshot)) {
+            return null;
+        }
+
+        $positions = $snapshot['open_positions'] ?? [];
+        $orders = $snapshot['open_orders'] ?? [];
+
+        return [
+            'open_positions' => is_array($positions) ? array_values($positions) : [],
+            'open_orders' => is_array($orders) ? array_values($orders) : [],
         ];
     }
 

--- a/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
@@ -96,7 +96,7 @@ final class MtfRunnerRequestDto
      * Normalise l'instantané d'état ouvert fourni dans le payload.
      *
      * @param array<string,mixed> $data
-     * @return array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
+     * @return array{open_positions: array<int,mixed>, open_orders: array<int,mixed>}|null
      */
     private static function extractOpenStateSnapshot(array $data): ?array
     {
@@ -105,12 +105,21 @@ final class MtfRunnerRequestDto
             return null;
         }
 
-        $positions = $snapshot['open_positions'] ?? [];
-        $orders = $snapshot['open_orders'] ?? [];
+        $positions = $snapshot['open_positions'] ?? null;
+        $orders = $snapshot['open_orders'] ?? null;
+
+        // Un snapshot n'est une source fiable que s'il contient explicitement les deux
+        // clés sous forme de tableaux. Un payload mal formé ({} ou clés manquantes/
+        // non-tableaux) retourne null pour que le garde fail-closed en live se déclenche
+        // au lieu d'exécuter le run sans état d'ouverture réel. Un snapshot vide mais
+        // bien formé (open_positions/open_orders = []) reste valide.
+        if (!is_array($positions) || !is_array($orders)) {
+            return null;
+        }
 
         return [
-            'open_positions' => is_array($positions) ? array_values($positions) : [],
-            'open_orders' => is_array($orders) ? array_values($orders) : [],
+            'open_positions' => array_values($positions),
+            'open_orders' => array_values($orders),
         ];
     }
 

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -102,6 +102,31 @@ final class MtfRunnerService
             'workers' => $request->workers,
         ]);
 
+        // SF-002b : fail-closed en live. Si aucune source d'état ouvert fiable n'est
+        // disponible (pas de snapshot orchestrateur, sync_tables=false ET filtre désactivé),
+        // on refuse le run plutôt que de trader à l'aveugle sur des symboles peut-être déjà
+        // en position/ordre. Miroir du garde-fou CLI de SF-002a.
+        $hasSnapshot = $this->snapshotIsUsable($request->openStateSnapshot);
+        if (!$request->dryRun && !$hasSnapshot && !$request->syncTables && $request->skipOpenStateFilter) {
+            $reason = 'no_reliable_open_state_source';
+            $this->mtfLogger->error('[MTF Runner] Refusing live run without reliable open-state source', [
+                'run_id' => $runId,
+                'reason' => $reason,
+                'has_snapshot' => false,
+                'sync_tables' => false,
+                'skip_open_state_filter' => true,
+            ]);
+
+            return $this->buildRejectedRun(
+                $runId,
+                'En live, refus du run sans source d\'état ouvert fiable '
+                . '(open_state_snapshot absent, sync_tables=false et skip_open_state_filter=true). '
+                . 'Le filtre protège contre le trading sur un symbole déjà en position/ordre.',
+                $reason,
+                count($request->symbols),
+            );
+        }
+
         try {
             // 1. Créer le contexte
             $context = $this->createContext($request);
@@ -111,8 +136,21 @@ final class MtfRunnerService
             $symbols = $this->resolveSymbols($request->symbols, $request->profile, $context);
             $profiler->increment('runner', 'resolve_symbols', microtime(true) - $resolveStart);
 
-            // 3. Synchroniser les tables depuis l'exchange (si demandé)
-            if ($request->syncTables) {
+            // 3. Source de l'état ouvert (priorité) :
+            //    (1) snapshot orchestrateur (SF-002b) → aucun appel exchange par set ;
+            //    (2) sinon syncTables() si sync_tables=true (upsert DB + fetch amont) ;
+            //    (3) sinon null → le filtre d'activité refera son propre fetch si actif.
+            if ($hasSnapshot) {
+                /** @var array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>} $snapshot */
+                $snapshot = $request->openStateSnapshot;
+                $openPositions = array_values($snapshot['open_positions'] ?? []);
+                $openOrders = array_values($snapshot['open_orders'] ?? []);
+                $this->mtfLogger->info('[MTF Runner] Using orchestrator open-state snapshot (no exchange fetch per set)', [
+                    'run_id' => $runId,
+                    'positions_count' => count($openPositions),
+                    'orders_count' => count($openOrders),
+                ]);
+            } elseif ($request->syncTables) {
                 $syncStart = microtime(true);
                 [
                     'open_positions' => $openPositions,
@@ -122,8 +160,7 @@ final class MtfRunnerService
             } else {
                 // Portée limitée (SF-002a) : on saute uniquement l'upsert DB des
                 // positions/ordres. Le filtre d'activité (OpenActivityFilter) peut
-                // encore appeler l'exchange si skip_open_state_filter=false. Le vrai
-                // mode « no exchange per set » est traité par SF-002b (snapshot orchestrateur).
+                // encore appeler l'exchange si skip_open_state_filter=false.
                 $this->mtfLogger->debug('[MTF Runner] Skipping exchange table upsert (sync_tables=false)', [
                     'run_id' => $runId,
                 ]);
@@ -916,6 +953,62 @@ final class MtfRunnerService
         $marketType = $request->marketType ?? MarketType::PERPETUAL;
 
         return new ExchangeContext($exchange, $marketType);
+    }
+
+    /**
+     * Indique si un instantané d'état ouvert orchestrateur est exploitable.
+     * Un snapshot vide (aucune position ni ordre) reste une source FIABLE :
+     * l'orchestrateur a bien interrogé l'exchange, simplement rien n'était ouvert.
+     *
+     * @param array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null $snapshot
+     */
+    private function snapshotIsUsable(?array $snapshot): bool
+    {
+        if ($snapshot === null) {
+            return false;
+        }
+
+        return array_key_exists('open_positions', $snapshot)
+            || array_key_exists('open_orders', $snapshot);
+    }
+
+    /**
+     * Construit un résultat de run rejeté (fail-closed) sans toucher l'exchange.
+     *
+     * @return array{
+     *     summary: array<string,mixed>,
+     *     results: array<string,mixed>,
+     *     errors: array<int,string>,
+     *     summary_by_tf: array<string,mixed>,
+     *     rejected_by: array<string,mixed>,
+     *     last_validated: array<string,mixed>,
+     *     orders_placed: array<string,mixed>,
+     *     performance: array<string,mixed>
+     * }
+     */
+    private function buildRejectedRun(string $runId, string $message, string $reason, int $symbolsRequested): array
+    {
+        return [
+            'summary' => [
+                'run_id' => $runId,
+                'status' => 'rejected',
+                'reason' => $reason,
+                'message' => $message,
+                'symbols_requested' => $symbolsRequested,
+                'symbols_processed' => 0,
+                'timestamp' => date('Y-m-d H:i:s'),
+            ],
+            'results' => [],
+            'errors' => [$message],
+            'summary_by_tf' => [],
+            'rejected_by' => [],
+            'last_validated' => [],
+            'orders_placed' => [
+                'count' => ['total' => 0, 'submitted' => 0, 'simulated' => 0],
+                'orders' => [],
+            ],
+            'performance' => [],
+        ];
     }
 
 }

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -957,8 +957,11 @@ final class MtfRunnerService
 
     /**
      * Indique si un instantané d'état ouvert orchestrateur est exploitable.
-     * Un snapshot vide (aucune position ni ordre) reste une source FIABLE :
-     * l'orchestrateur a bien interrogé l'exchange, simplement rien n'était ouvert.
+     * Un snapshot vide mais bien formé (open_positions/open_orders = []) reste une
+     * source FIABLE : l'orchestrateur a bien interrogé l'exchange, rien n'était ouvert.
+     * En revanche un snapshot mal formé (clés manquantes ou non-tableaux, ex: {}) n'est
+     * PAS fiable : on exige les deux clés sous forme de tableaux pour que le garde
+     * fail-closed en live ne soit pas contourné par un payload vide/incomplet.
      *
      * @param array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null $snapshot
      */
@@ -968,8 +971,8 @@ final class MtfRunnerService
             return false;
         }
 
-        return array_key_exists('open_positions', $snapshot)
-            || array_key_exists('open_orders', $snapshot);
+        return is_array($snapshot['open_positions'] ?? null)
+            && is_array($snapshot['open_orders'] ?? null);
     }
 
     /**

--- a/trading-app/src/Provider/Bitmart/BitmartAccountProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartAccountProvider.php
@@ -64,40 +64,7 @@ final class BitmartAccountProvider implements AccountProviderInterface
     public function getOpenPositions(?string $symbol = null): array
     {
         try {
-            $response = $this->bitmartClient->getPositions($symbol);
-
-            // Log pour debug : structure de la réponse
-            $this->logger->debug("BitMart positions response structure", [
-                'symbol' => $symbol,
-                'has_data' => isset($response['data']),
-                'data_keys' => isset($response['data']) ? array_keys($response['data']) : [],
-                'code' => $response['code'] ?? null,
-                'message' => $response['message'] ?? null,
-            ]);
-
-            // Pour position-v2, la structure peut être directement dans 'data' ou dans 'data.positions'
-            $positions = [];
-            if (isset($response['data']['positions'])) {
-                $positions = $response['data']['positions'];
-            } elseif (isset($response['data']) && is_array($response['data']) && !empty($response['data'])) {
-                // Fallback : parfois position-v2 retourne directement un tableau dans 'data'
-                $firstItem = reset($response['data']);
-                if (is_array($firstItem) && isset($firstItem['symbol'])) {
-                    $positions = $response['data'];
-                }
-            }
-            
-            // Filtrer les positions avec amount > 0 (BitMart retourne toujours long+short même si vides)
-            $positions = array_filter($positions, function($position) {
-                $amount = $position['current_amount'] ?? $position['size'] ?? 0;
-                return (float)$amount > 0;
-            });
-            
-            if (empty($positions)) {
-                return [];
-            }
-            
-            return array_map(fn($position) => PositionDto::fromArray($position), $positions);
+            return $this->fetchOpenPositions($symbol);
         } catch (\Exception $e) {
             $msg = $e->getMessage();
             $isRateLimited = (stripos($msg, '429') !== false) || (stripos($msg, '30013') !== false) || str_contains($msg, 'Too Many Requests');
@@ -115,6 +82,59 @@ final class BitmartAccountProvider implements AccountProviderInterface
             }
             return [];
         }
+    }
+
+    /**
+     * @return PositionDto[]
+     */
+    public function getOpenPositionsOrFail(?string $symbol = null): array
+    {
+        // Propage toute erreur (pas de catch → []) pour les consommateurs fail-closed.
+        return $this->fetchOpenPositions($symbol);
+    }
+
+    /**
+     * Cœur de récupération des positions ouvertes. Lève en cas d'échec de
+     * transport/parse (à la différence de getOpenPositions qui retourne []).
+     *
+     * @return PositionDto[]
+     */
+    private function fetchOpenPositions(?string $symbol = null): array
+    {
+        $response = $this->bitmartClient->getPositions($symbol);
+
+        // Log pour debug : structure de la réponse
+        $this->logger->debug("BitMart positions response structure", [
+            'symbol' => $symbol,
+            'has_data' => isset($response['data']),
+            'data_keys' => isset($response['data']) ? array_keys($response['data']) : [],
+            'code' => $response['code'] ?? null,
+            'message' => $response['message'] ?? null,
+        ]);
+
+        // Pour position-v2, la structure peut être directement dans 'data' ou dans 'data.positions'
+        $positions = [];
+        if (isset($response['data']['positions'])) {
+            $positions = $response['data']['positions'];
+        } elseif (isset($response['data']) && is_array($response['data']) && !empty($response['data'])) {
+            // Fallback : parfois position-v2 retourne directement un tableau dans 'data'
+            $firstItem = reset($response['data']);
+            if (is_array($firstItem) && isset($firstItem['symbol'])) {
+                $positions = $response['data'];
+            }
+        }
+
+        // Filtrer les positions avec amount > 0 (BitMart retourne toujours long+short même si vides)
+        $positions = array_filter($positions, function($position) {
+            $amount = $position['current_amount'] ?? $position['size'] ?? 0;
+            return (float)$amount > 0;
+        });
+
+        if (empty($positions)) {
+            return [];
+        }
+
+        return array_map(fn($position) => PositionDto::fromArray($position), $positions);
     }
 
     public function getPosition(string $symbol): ?PositionDto

--- a/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
+++ b/trading-app/src/Provider/Bitmart/BitmartOrderProvider.php
@@ -474,6 +474,28 @@ final class BitmartOrderProvider implements ContextualOrderProviderInterface
 
     public function getOpenOrders(?string $symbol = null, ?ExchangeContext $context = null): array
     {
+        return $this->fetchOpenOrders($symbol, $context, false);
+    }
+
+    /**
+     * @return OrderDto[]
+     */
+    public function getOpenOrdersOrFail(?string $symbol = null): array
+    {
+        // Propage la dernière erreur après épuisement des retries (pas de [] silencieux)
+        // pour les consommateurs fail-closed (ex: endpoint /api/exchange/open-state).
+        return $this->fetchOpenOrders($symbol, null, true);
+    }
+
+    /**
+     * Cœur de récupération des ordres ouverts avec retries. Si $orFail est vrai,
+     * relève la dernière erreur au lieu de retourner [] (distinction « aucun
+     * ordre » vs « fetch échoué »).
+     *
+     * @return OrderDto[]
+     */
+    private function fetchOpenOrders(?string $symbol, ?ExchangeContext $context, bool $orFail): array
+    {
         $lastError = null;
         for ($i = 0; $i < self::RETRY_ATTEMPTS; $i++) {
             try {
@@ -547,6 +569,9 @@ final class BitmartOrderProvider implements ContextualOrderProviderInterface
                 'error' => $lastError->getMessage(),
                 'trace' => $lastError->getTraceAsString(),
             ]);
+            if ($orFail) {
+                throw $lastError;
+            }
         }
         return [];
     }

--- a/trading-app/src/Provider/ContextualOrderProvider.php
+++ b/trading-app/src/Provider/ContextualOrderProvider.php
@@ -73,6 +73,15 @@ final readonly class ContextualOrderProvider implements OrderProviderDecoratorIn
         return $this->inner->getOpenOrders($symbol);
     }
 
+    /**
+     * @return OrderDto[]
+     */
+    public function getOpenOrdersOrFail(?string $symbol = null): array
+    {
+        // Variante fail-closed : on délègue à l'inner, l'erreur éventuelle se propage.
+        return $this->inner->getOpenOrdersOrFail($symbol);
+    }
+
     public function getOrderHistory(string $symbol, int $limit = 100): array
     {
         if ($this->inner instanceof ContextualOrderProviderInterface) {

--- a/trading-app/src/Provider/Fake/FakeAccountProvider.php
+++ b/trading-app/src/Provider/Fake/FakeAccountProvider.php
@@ -36,6 +36,15 @@ final class FakeAccountProvider implements AccountProviderInterface
         return [];
     }
 
+    /**
+     * @return PositionDto[]
+     */
+    public function getOpenPositionsOrFail(?string $symbol = null): array
+    {
+        // Contexte fake : aucune position, ne lève jamais (source fiable et vide).
+        return [];
+    }
+
     public function getPosition(string $symbol): ?PositionDto
     {
         return null;

--- a/trading-app/src/Provider/Fake/FakeAccountProvider.php
+++ b/trading-app/src/Provider/Fake/FakeAccountProvider.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Fake;
+
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\Dto\AccountDto;
+use App\Contract\Provider\Dto\PositionDto;
+
+/**
+ * Minimal fake account provider modelling an empty exchange account.
+ *
+ * Every read returns a neutral/empty value (zero balance, no positions,
+ * no trades). Nothing throws. This makes the FAKE context safe for the
+ * orchestrator demo path (exchange=fake) where no live state exists.
+ */
+final class FakeAccountProvider implements AccountProviderInterface
+{
+    public function getAccountInfo(): ?AccountDto
+    {
+        // No account on the fake exchange.
+        return null;
+    }
+
+    public function getAccountBalance(string $basicCurrency = 'USDT'): float
+    {
+        return 0.0;
+    }
+
+    /**
+     * @return PositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return [];
+    }
+
+    public function getPosition(string $symbol): ?PositionDto
+    {
+        return null;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getTradeHistory(string $symbol, int $limit = 100): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getTrades(?string $symbol = null, int $limit = 100, ?int $startTime = null, ?int $endTime = null): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getTransactionHistory(?string $symbol = null, ?int $flowType = null, int $limit = 100, ?int $startTime = null, ?int $endTime = null): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getTradingFees(string $symbol): array
+    {
+        return [];
+    }
+
+    /**
+     * Convenience health probe consumed by MainProvider's detailed health check.
+     */
+    public function healthCheck(): bool
+    {
+        return true;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'Fake';
+    }
+}

--- a/trading-app/src/Provider/Fake/FakeContractProvider.php
+++ b/trading-app/src/Provider/Fake/FakeContractProvider.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Fake;
+
+use App\Contract\Provider\ContractProviderInterface;
+use App\Contract\Provider\Dto\ContractDto;
+
+/**
+ * Minimal fake contract provider exposing NO contracts/symbols.
+ *
+ * Because the fake exchange advertises zero active contracts, an MTF run on the
+ * FAKE context resolves 0 symbols and completes as a trivial success — the
+ * intended behaviour for the orchestrator demo (exchange=fake). All reads
+ * return empty/neutral values and never throw.
+ */
+final class FakeContractProvider implements ContractProviderInterface
+{
+    /**
+     * @return array<int, mixed>
+     */
+    public function getContracts(): array
+    {
+        return [];
+    }
+
+    public function getContractDetails(string $symbol): ?ContractDto
+    {
+        return null;
+    }
+
+    public function getLastPrice(string $symbol): ?float
+    {
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOrderBook(string $symbol, int $limit = 50): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getRecentTrades(string $symbol, int $limit = 100): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getMarkPriceKline(string $symbol, int $step = 1, int $limit = 1, ?int $startTime = null, ?int $endTime = null): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function getLeverageBrackets(string $symbol): array
+    {
+        return [];
+    }
+
+    /**
+     * No-op sync: the fake exchange has no contracts to fetch or upsert.
+     *
+     * @param array<string>|null $symbols
+     * @return array{upserted: int, total_fetched: int, errors: array<string>}
+     */
+    public function syncContracts(?array $symbols = null): array
+    {
+        return [
+            'upserted' => 0,
+            'total_fetched' => 0,
+            'errors' => [],
+        ];
+    }
+
+    /**
+     * Convenience health probe consumed by MainProvider's health check.
+     */
+    public function healthCheck(): bool
+    {
+        return true;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'Fake';
+    }
+}

--- a/trading-app/src/Provider/Fake/FakeKlineProvider.php
+++ b/trading-app/src/Provider/Fake/FakeKlineProvider.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Fake;
+
+use App\Common\Enum\Timeframe;
+use App\Contract\Provider\Dto\KlineDto;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Provider\Context\ExchangeContext;
+
+/**
+ * Minimal fake kline provider returning empty kline sets.
+ *
+ * The fake exchange has no market data. Reads return empty/neutral values and
+ * saves are no-ops. In practice this provider is never exercised on the demo
+ * path because the fake contract provider resolves 0 symbols, but it remains a
+ * valid, non-throwing implementation of the interface.
+ */
+final class FakeKlineProvider implements KlineProviderInterface
+{
+    /**
+     * @return KlineDto[]
+     */
+    public function getKlines(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 490,
+        ?ExchangeContext $context = null,
+    ): array {
+        return [];
+    }
+
+    /**
+     * @return KlineDto[]
+     */
+    public function getKlinesInWindow(
+        string $symbol,
+        Timeframe $timeframe,
+        \DateTimeImmutable $start,
+        \DateTimeImmutable $end,
+        int $limit = 500,
+        ?ExchangeContext $context = null,
+    ): array {
+        return [];
+    }
+
+    public function getLastKline(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?KlineDto {
+        return null;
+    }
+
+    public function saveKline(KlineDto $kline, ?ExchangeContext $context = null): void
+    {
+        // No-op: the fake exchange does not persist klines.
+    }
+
+    /**
+     * @param KlineDto[] $klines
+     */
+    public function saveKlines(
+        array $klines,
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): void {
+        // No-op: the fake exchange does not persist klines.
+    }
+
+    public function hasGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): bool {
+        return false;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): array {
+        return [];
+    }
+
+    /**
+     * Convenience health probe consumed by MainProvider's health check.
+     */
+    public function healthCheck(): bool
+    {
+        return true;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'Fake';
+    }
+}

--- a/trading-app/src/Provider/Fake/FakeOrderProvider.php
+++ b/trading-app/src/Provider/Fake/FakeOrderProvider.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Fake;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Contract\Provider\OrderProviderInterface;
+
+/**
+ * Minimal fake order provider modelling an empty exchange.
+ *
+ * Order placement is a no-op that returns null (no order is created), and all
+ * lookups return empty/neutral results without throwing. This keeps the FAKE
+ * context safe for the orchestrator demo path (exchange=fake): the open-state
+ * snapshot is always empty and no live order is ever submitted.
+ */
+final class FakeOrderProvider implements OrderProviderInterface
+{
+    /**
+     * No-op placement: the fake exchange never accepts orders.
+     *
+     * @param array<string, mixed> $options
+     */
+    public function placeOrder(
+        string $symbol,
+        OrderSide $side,
+        OrderType $type,
+        float $quantity,
+        ?float $price = null,
+        ?float $stopPrice = null,
+        array $options = []
+    ): ?OrderDto {
+        return null;
+    }
+
+    public function cancelOrder(string $symbol, string $orderId): bool
+    {
+        // Nothing to cancel on the fake exchange; treat as a successful no-op.
+        return true;
+    }
+
+    public function getOrder(string $symbol, string $orderId): ?OrderDto
+    {
+        return null;
+    }
+
+    /**
+     * @return OrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getOrderHistory(string $symbol, int $limit = 100): array
+    {
+        return [];
+    }
+
+    public function cancelAllOrders(string $symbol): bool
+    {
+        // No open orders to cancel; treat as a successful no-op.
+        return true;
+    }
+
+    /**
+     * Returns a neutral top-of-book quote (zero bid/ask) so callers never crash.
+     * The fake exchange has no real market data.
+     */
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        return new SymbolBidAskDto(
+            symbol: $symbol,
+            bid: 0.0,
+            ask: 0.0,
+            timestamp: new \DateTimeImmutable('now', new \DateTimeZone('UTC')),
+        );
+    }
+
+    public function submitLeverage(string $symbol, int $leverage, string $openType = 'isolated'): bool
+    {
+        // Accept any leverage request without side effects.
+        return true;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'Fake';
+    }
+}

--- a/trading-app/src/Provider/Fake/FakeOrderProvider.php
+++ b/trading-app/src/Provider/Fake/FakeOrderProvider.php
@@ -57,6 +57,15 @@ final class FakeOrderProvider implements OrderProviderInterface
     }
 
     /**
+     * @return OrderDto[]
+     */
+    public function getOpenOrdersOrFail(?string $symbol = null): array
+    {
+        // Contexte fake : aucun ordre, ne lève jamais (source fiable et vide).
+        return [];
+    }
+
+    /**
      * @return array<int, mixed>
      */
     public function getOrderHistory(string $symbol, int $limit = 100): array

--- a/trading-app/src/Provider/Fake/FakeSystemProvider.php
+++ b/trading-app/src/Provider/Fake/FakeSystemProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Fake;
+
+use App\Contract\Provider\SystemProviderInterface;
+
+/**
+ * Minimal fake system provider.
+ *
+ * Returns the current wall-clock time in milliseconds. No external calls.
+ * Used by the FAKE exchange context so the orchestrator demo (exchange=fake)
+ * resolves a provider bundle without hitting any real exchange.
+ */
+final class FakeSystemProvider implements SystemProviderInterface
+{
+    public function getSystemTimeMs(): int
+    {
+        return (int) (microtime(true) * 1000);
+    }
+}

--- a/trading-app/tests/Application/Runner/OpenStateSnapshotSerializerTest.php
+++ b/trading-app/tests/Application/Runner/OpenStateSnapshotSerializerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Runner;
+
+use App\Application\Runner\OpenStateSnapshotSerializer;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderStatus;
+use App\Common\Enum\OrderType;
+use App\Common\Enum\PositionSide;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\PositionDto;
+use Brick\Math\BigDecimal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OpenStateSnapshotSerializer::class)]
+final class OpenStateSnapshotSerializerTest extends TestCase
+{
+    public function testSerializesProviderDtosIntoJsonSafeArrays(): void
+    {
+        $serializer = new OpenStateSnapshotSerializer();
+
+        $position = new PositionDto(
+            symbol: 'BTCUSDT',
+            side: PositionSide::LONG,
+            size: BigDecimal::of('1.5'),
+            entryPrice: BigDecimal::of('60000'),
+            markPrice: BigDecimal::of('61000'),
+            unrealizedPnl: BigDecimal::of('1500'),
+            realizedPnl: BigDecimal::of('0'),
+            margin: BigDecimal::of('900'),
+            leverage: BigDecimal::of('20'),
+            openedAt: new \DateTimeImmutable('2026-01-01T00:00:00+00:00'),
+        );
+
+        $order = new OrderDto(
+            orderId: 'ORD-1',
+            symbol: 'ETHUSDT',
+            side: OrderSide::BUY,
+            type: OrderType::LIMIT,
+            status: OrderStatus::PENDING,
+            quantity: BigDecimal::of('10'),
+            price: BigDecimal::of('3000'),
+            stopPrice: null,
+            filledQuantity: BigDecimal::of('0'),
+            remainingQuantity: BigDecimal::of('10'),
+            averagePrice: null,
+            createdAt: new \DateTimeImmutable('2026-01-01T00:00:00+00:00'),
+        );
+
+        $snapshot = $serializer->serialize([$position], [$order]);
+
+        self::assertSame(['open_positions', 'open_orders'], array_keys($snapshot));
+        self::assertSame('BTCUSDT', $snapshot['open_positions'][0]['symbol']);
+        self::assertSame('long', $snapshot['open_positions'][0]['side']);
+        self::assertSame('ETHUSDT', $snapshot['open_orders'][0]['symbol']);
+        self::assertSame('ORD-1', $snapshot['open_orders'][0]['order_id']);
+        self::assertNull($snapshot['open_orders'][0]['stop_price']);
+
+        // Doit être strictement encodable en JSON (aucun objet résiduel).
+        self::assertJson(json_encode($snapshot, JSON_THROW_ON_ERROR));
+    }
+
+    public function testReturnsEmptyShapeWhenNothingOpen(): void
+    {
+        $serializer = new OpenStateSnapshotSerializer();
+
+        self::assertSame(
+            ['open_positions' => [], 'open_orders' => []],
+            $serializer->serialize([], []),
+        );
+    }
+
+    public function testPassesThroughPreNormalizedArrays(): void
+    {
+        $serializer = new OpenStateSnapshotSerializer();
+
+        $snapshot = $serializer->serialize(
+            [['symbol' => 'ADAUSDT', 'side' => 'short']],
+            [['symbol' => 'ADAUSDT', 'order_id' => 'X']],
+        );
+
+        self::assertSame('ADAUSDT', $snapshot['open_positions'][0]['symbol']);
+        self::assertSame('X', $snapshot['open_orders'][0]['order_id']);
+    }
+}

--- a/trading-app/tests/Controller/ExchangeStateControllerFakeTest.php
+++ b/trading-app/tests/Controller/ExchangeStateControllerFakeTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Controller;
 use App\Application\Runner\OpenStateSnapshotSerializer;
 use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
+use App\Contract\Provider\AccountProviderInterface;
 use App\Controller\ExchangeStateController;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Context\ExchangeContextResolver;
@@ -86,5 +87,45 @@ final class ExchangeStateControllerFakeTest extends TestCase
         $response = $controller->openState($request);
 
         self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    public function testProviderFailureReturnsServiceUnavailable(): void
+    {
+        // Une panne exchange fait lever getOpenPositionsOrFail : l'endpoint doit
+        // répondre non-200 (503) au lieu d'un snapshot vide trompeur, pour que
+        // l'orchestrateur fail-close les sets live.
+        $throwingAccount = $this->createMock(AccountProviderInterface::class);
+        $throwingAccount->method('getOpenPositionsOrFail')
+            ->willThrowException(new \RuntimeException('bitmart unavailable'));
+
+        $registry = new ExchangeProviderRegistry(
+            [
+                new ExchangeProviderBundle(
+                    new ExchangeContext(Exchange::FAKE, MarketType::PERPETUAL),
+                    new FakeKlineProvider(),
+                    new FakeContractProvider(),
+                    new FakeOrderProvider(),
+                    $throwingAccount,
+                    new FakeSystemProvider(),
+                ),
+            ],
+            Exchange::FAKE,
+            MarketType::PERPETUAL,
+        );
+
+        $controller = new ExchangeStateController(
+            new MainProvider($registry),
+            new ExchangeContextResolver(),
+            new OpenStateSnapshotSerializer(),
+            new NullLogger(),
+        );
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(false);
+        $controller->setContainer($container);
+
+        $request = new Request(['exchange' => 'fake', 'market_type' => 'perpetual']);
+        $response = $controller->openState($request);
+
+        self::assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $response->getStatusCode());
     }
 }

--- a/trading-app/tests/Controller/ExchangeStateControllerFakeTest.php
+++ b/trading-app/tests/Controller/ExchangeStateControllerFakeTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Application\Runner\OpenStateSnapshotSerializer;
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Controller\ExchangeStateController;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Context\ExchangeContextResolver;
+use App\Provider\Fake\FakeAccountProvider;
+use App\Provider\Fake\FakeContractProvider;
+use App\Provider\Fake\FakeKlineProvider;
+use App\Provider\Fake\FakeOrderProvider;
+use App\Provider\Fake\FakeSystemProvider;
+use App\Provider\MainProvider;
+use App\Provider\Registry\ExchangeProviderBundle;
+use App\Provider\Registry\ExchangeProviderRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Exercises GET /api/exchange/open-state for the FAKE exchange context using a
+ * registry wired only with the fake provider bundle (no Bitmart / no env). The
+ * snapshot must be an empty {open_positions: [], open_orders: []}.
+ */
+#[CoversClass(ExchangeStateController::class)]
+final class ExchangeStateControllerFakeTest extends TestCase
+{
+    private function buildController(): ExchangeStateController
+    {
+        $registry = new ExchangeProviderRegistry(
+            [
+                new ExchangeProviderBundle(
+                    new ExchangeContext(Exchange::FAKE, MarketType::PERPETUAL),
+                    new FakeKlineProvider(),
+                    new FakeContractProvider(),
+                    new FakeOrderProvider(),
+                    new FakeAccountProvider(),
+                    new FakeSystemProvider(),
+                ),
+            ],
+            Exchange::FAKE,
+            MarketType::PERPETUAL,
+        );
+
+        $controller = new ExchangeStateController(
+            new MainProvider($registry),
+            new ExchangeContextResolver(),
+            new OpenStateSnapshotSerializer(),
+            new NullLogger(),
+        );
+
+        // AbstractController::json() needs a container with the serializer flag.
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(false);
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    public function testOpenStateForFakeContextReturnsEmptySnapshot(): void
+    {
+        $controller = $this->buildController();
+
+        $request = new Request(['exchange' => 'fake', 'market_type' => 'perpetual']);
+        $response = $controller->openState($request);
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $payload = json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['open_positions' => [], 'open_orders' => []], $payload);
+    }
+
+    public function testInvalidExchangeReturnsBadRequest(): void
+    {
+        $controller = $this->buildController();
+
+        $request = new Request(['exchange' => 'nope']);
+        $response = $controller->openState($request);
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+}

--- a/trading-app/tests/Controller/ExchangeStateControllerTest.php
+++ b/trading-app/tests/Controller/ExchangeStateControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Controller\ExchangeStateController;
+use App\Kernel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+#[CoversClass(ExchangeStateController::class)]
+final class ExchangeStateControllerTest extends KernelTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $_ENV['DEFAULT_URI'] = 'http://localhost';
+        $_SERVER['DEFAULT_URI'] = 'http://localhost';
+        putenv('DEFAULT_URI=http://localhost');
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    public function testOpenStateRouteIsRegisteredAsGet(): void
+    {
+        self::bootKernel();
+
+        $router = self::$kernel?->getContainer()->get('router');
+        self::assertInstanceOf(RouterInterface::class, $router);
+
+        self::assertSame('/api/exchange/open-state', $router->generate('api_exchange_open_state'));
+
+        $route = $router->getRouteCollection()->get('api_exchange_open_state');
+        self::assertNotNull($route);
+        self::assertSame(['GET'], $route->getMethods());
+    }
+}

--- a/trading-app/tests/Controller/ExchangeStateRouteTest.php
+++ b/trading-app/tests/Controller/ExchangeStateRouteTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Controller;
+
+use App\Controller\ExchangeStateController;
+use App\Kernel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+#[CoversClass(ExchangeStateController::class)]
+final class ExchangeStateRouteTest extends KernelTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $_ENV['DEFAULT_URI'] = 'http://localhost';
+        $_SERVER['DEFAULT_URI'] = 'http://localhost';
+        putenv('DEFAULT_URI=http://localhost');
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    public function testOpenStateRouteIsRegistered(): void
+    {
+        self::bootKernel();
+
+        $router = self::$kernel?->getContainer()->get('router');
+        self::assertInstanceOf(RouterInterface::class, $router);
+
+        self::assertSame('/api/exchange/open-state', $router->generate('api_exchange_open_state'));
+
+        $route = $router->getRouteCollection()->get('api_exchange_open_state');
+        self::assertNotNull($route);
+        self::assertSame(['GET'], $route->getMethods());
+    }
+}

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -549,6 +549,11 @@ final readonly class PlanOrderProviderStub implements OrderProviderInterface
         return [];
     }
 
+    public function getOpenOrdersOrFail(?string $symbol = null): array
+    {
+        return [];
+    }
+
     public function getOrderHistory(string $symbol, int $limit = 100): array
     {
         return [];

--- a/trading-app/tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php
+++ b/trading-app/tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php
@@ -367,6 +367,11 @@ final class ContractBitmartOrderProvider implements OrderProviderInterface
         ));
     }
 
+    public function getOpenOrdersOrFail(?string $symbol = null): array
+    {
+        return $this->getOpenOrders($symbol);
+    }
+
     public function getOrderHistory(string $symbol, int $limit = 100): array
     {
         return array_slice(array_values($this->orders), 0, $limit);

--- a/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+++ b/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
@@ -82,14 +82,38 @@ final class MtfRunnerRequestDtoTest extends TestCase
         self::assertNull(MtfRunnerRequestDto::fromArray([])->openStateSnapshot);
     }
 
-    public function testFromArrayNormalizesPartialOpenStateSnapshot(): void
+    public function testFromArrayKeepsWellFormedEmptyOpenStateSnapshot(): void
     {
+        // Snapshot vide mais bien formé : l'orchestrateur a interrogé l'exchange,
+        // rien n'était ouvert. Reste une source fiable (les deux clés sont des tableaux).
         $request = MtfRunnerRequestDto::fromArray([
-            'open_state_snapshot' => ['open_positions' => [['symbol' => 'BTCUSDT']]],
+            'open_state_snapshot' => ['open_positions' => [], 'open_orders' => []],
         ]);
 
-        self::assertSame([['symbol' => 'BTCUSDT']], $request->openStateSnapshot['open_positions']);
+        self::assertNotNull($request->openStateSnapshot);
+        self::assertSame([], $request->openStateSnapshot['open_positions']);
         self::assertSame([], $request->openStateSnapshot['open_orders']);
+    }
+
+    public function testFromArrayRejectsPartialOpenStateSnapshot(): void
+    {
+        // Clé open_orders manquante => snapshot mal formé => null, pour que le garde
+        // fail-closed en live ne soit pas contourné par un payload incomplet.
+        self::assertNull(MtfRunnerRequestDto::fromArray([
+            'open_state_snapshot' => ['open_positions' => [['symbol' => 'BTCUSDT']]],
+        ])->openStateSnapshot);
+    }
+
+    public function testFromArrayRejectsEmptyObjectOpenStateSnapshot(): void
+    {
+        self::assertNull(MtfRunnerRequestDto::fromArray(['open_state_snapshot' => []])->openStateSnapshot);
+    }
+
+    public function testFromArrayRejectsNonArraySnapshotKeys(): void
+    {
+        self::assertNull(MtfRunnerRequestDto::fromArray([
+            'open_state_snapshot' => ['open_positions' => 'nope', 'open_orders' => []],
+        ])->openStateSnapshot);
     }
 
     public function testFromArrayIgnoresNonArrayOpenStateSnapshot(): void

--- a/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+++ b/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
@@ -62,4 +62,38 @@ final class MtfRunnerRequestDtoTest extends TestCase
 
         self::assertSame($expected, $request->marketType);
     }
+
+    public function testFromArrayParsesOpenStateSnapshot(): void
+    {
+        $request = MtfRunnerRequestDto::fromArray([
+            'open_state_snapshot' => [
+                'open_positions' => [['symbol' => 'BTCUSDT']],
+                'open_orders' => [['symbol' => 'ETHUSDT']],
+            ],
+        ]);
+
+        self::assertNotNull($request->openStateSnapshot);
+        self::assertSame('BTCUSDT', $request->openStateSnapshot['open_positions'][0]['symbol']);
+        self::assertSame('ETHUSDT', $request->openStateSnapshot['open_orders'][0]['symbol']);
+    }
+
+    public function testFromArrayDefaultsOpenStateSnapshotToNull(): void
+    {
+        self::assertNull(MtfRunnerRequestDto::fromArray([])->openStateSnapshot);
+    }
+
+    public function testFromArrayNormalizesPartialOpenStateSnapshot(): void
+    {
+        $request = MtfRunnerRequestDto::fromArray([
+            'open_state_snapshot' => ['open_positions' => [['symbol' => 'BTCUSDT']]],
+        ]);
+
+        self::assertSame([['symbol' => 'BTCUSDT']], $request->openStateSnapshot['open_positions']);
+        self::assertSame([], $request->openStateSnapshot['open_orders']);
+    }
+
+    public function testFromArrayIgnoresNonArrayOpenStateSnapshot(): void
+    {
+        self::assertNull(MtfRunnerRequestDto::fromArray(['open_state_snapshot' => 'nope'])->openStateSnapshot);
+    }
 }

--- a/trading-app/tests/MtfRunner/Service/MtfRunnerServiceSyncTablesTest.php
+++ b/trading-app/tests/MtfRunner/Service/MtfRunnerServiceSyncTablesTest.php
@@ -73,6 +73,91 @@ final class MtfRunnerServiceSyncTablesTest extends TestCase
         self::assertTrue($skipLogged, 'Le skip de la synchro doit être tracé quand sync_tables=false.');
     }
 
+    /**
+     * SF-002b — quand l'orchestrateur fournit open_state_snapshot, le runner ne doit
+     * PAS interroger l'exchange pour synchroniser les tables, même si sync_tables=true.
+     */
+    public function testOpenStateSnapshotSkipsExchangeSync(): void
+    {
+        $syncProvider = $this->createMock(MainProviderInterface::class);
+        $syncProvider->expects(self::never())->method('forContext');
+
+        $service = $this->buildService($syncProvider);
+
+        $request = new MtfRunnerRequestDto(
+            symbols: ['BTCUSDT', 'ETHUSDT'],
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            workers: 1,
+            syncTables: true, // le snapshot prime sur sync_tables
+            processTpSl: false,
+            openStateSnapshot: [
+                'open_positions' => [['symbol' => 'BTCUSDT']],
+                'open_orders' => [],
+            ],
+        );
+
+        $result = $service->run($request);
+
+        self::assertArrayHasKey('summary', $result);
+        self::assertNotSame('rejected', $result['summary']['status'] ?? null);
+    }
+
+    /**
+     * SF-002b — fail-closed en live : sans source d'état ouvert fiable (pas de snapshot,
+     * sync_tables=false, filtre désactivé), le run doit être rejeté sans toucher l'exchange.
+     */
+    public function testLiveRunRejectedWithoutReliableOpenStateSource(): void
+    {
+        $syncProvider = $this->createMock(MainProviderInterface::class);
+        $syncProvider->expects(self::never())->method('forContext');
+
+        $service = $this->buildService($syncProvider);
+
+        $request = new MtfRunnerRequestDto(
+            symbols: ['BTCUSDT'],
+            dryRun: false,
+            skipOpenStateFilter: true,
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            workers: 1,
+            syncTables: false,
+            processTpSl: false,
+        );
+
+        $result = $service->run($request);
+
+        self::assertSame('rejected', $result['summary']['status'] ?? null);
+        self::assertSame('no_reliable_open_state_source', $result['summary']['reason'] ?? null);
+        self::assertNotEmpty($result['errors']);
+    }
+
+    /**
+     * En dry-run, l'absence de source fiable ne bloque pas (diagnostic autorisé).
+     */
+    public function testDryRunAllowedWithoutReliableOpenStateSource(): void
+    {
+        $syncProvider = $this->createMock(MainProviderInterface::class);
+        $syncProvider->expects(self::never())->method('forContext');
+
+        $service = $this->buildService($syncProvider);
+
+        $request = new MtfRunnerRequestDto(
+            symbols: ['BTCUSDT'],
+            dryRun: true,
+            skipOpenStateFilter: true,
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            workers: 1,
+            syncTables: false,
+            processTpSl: false,
+        );
+
+        $result = $service->run($request);
+
+        self::assertNotSame('rejected', $result['summary']['status'] ?? null);
+    }
+
     private function request(bool $syncTables): MtfRunnerRequestDto
     {
         // Pas de profil : couvre aussi le chemin sans profil (cf. guard resolveTimeframes).
@@ -92,8 +177,11 @@ final class MtfRunnerServiceSyncTablesTest extends TestCase
      * déclarés `final` et ne peuvent donc pas être doublés : on les instancie réellement
      * en mockant uniquement leurs dépendances feuilles (interfaces / repositories).
      */
-    private function buildService(MainProviderInterface $syncProvider, ?LoggerInterface $mtfLogger = null): MtfRunnerService
-    {
+    private function buildService(
+        MainProviderInterface $syncProvider,
+        ?LoggerInterface $mtfLogger = null,
+        ?MainProviderInterface $filterProvider = null,
+    ): MtfRunnerService {
         $logger = $this->createMock(LoggerInterface::class);
         $mtfLogger ??= $this->createMock(LoggerInterface::class);
         $switchRepository = $this->createMock(MtfSwitchRepository::class);
@@ -113,10 +201,12 @@ final class MtfRunnerServiceSyncTablesTest extends TestCase
         );
 
         // Provider neutre (aucun account/order provider) → le filtre laisse passer les symboles.
-        $filterProvider = $this->createMock(MainProviderInterface::class);
-        $filterProvider->method('forContext')->willReturnSelf();
-        $filterProvider->method('getAccountProvider')->willReturn(null);
-        $filterProvider->method('getOrderProvider')->willReturn(null);
+        if ($filterProvider === null) {
+            $filterProvider = $this->createMock(MainProviderInterface::class);
+            $filterProvider->method('forContext')->willReturnSelf();
+            $filterProvider->method('getAccountProvider')->willReturn(null);
+            $filterProvider->method('getOrderProvider')->willReturn(null);
+        }
 
         $openActivityFilter = new OpenActivityFilter(
             $filterProvider,

--- a/trading-app/tests/Provider/ContextualOrderProviderTest.php
+++ b/trading-app/tests/Provider/ContextualOrderProviderTest.php
@@ -57,6 +57,11 @@ final class ContextualOrderProviderTest extends TestCase
                 return [];
             }
 
+            public function getOpenOrdersOrFail(?string $symbol = null): array
+            {
+                return [];
+            }
+
             public function getOrderHistory(string $symbol, int $limit = 100, ?ExchangeContext $context = null): array
             {
                 $this->lastContext = $context;

--- a/trading-app/tests/Provider/Fake/FakeExchangeBundleRegistryTest.php
+++ b/trading-app/tests/Provider/Fake/FakeExchangeBundleRegistryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Provider\Fake;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\Fake\FakeAccountProvider;
+use App\Provider\Fake\FakeContractProvider;
+use App\Provider\Fake\FakeKlineProvider;
+use App\Provider\Fake\FakeOrderProvider;
+use App\Provider\Fake\FakeSystemProvider;
+use App\Provider\MainProvider;
+use App\Provider\Registry\ExchangeProviderBundle;
+use App\Provider\Registry\ExchangeProviderRegistry;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that the FAKE exchange context resolves to a working provider bundle
+ * through the registry and the MainProvider facade — the wiring that lets the
+ * Python orchestrator demo sets (exchange=fake) run without a provider lookup
+ * crash.
+ */
+#[CoversNothing]
+final class FakeExchangeBundleRegistryTest extends TestCase
+{
+    private function fakeBundle(MarketType $marketType): ExchangeProviderBundle
+    {
+        return new ExchangeProviderBundle(
+            new ExchangeContext(Exchange::FAKE, $marketType),
+            new FakeKlineProvider(),
+            new FakeContractProvider(),
+            new FakeOrderProvider(),
+            new FakeAccountProvider(),
+            new FakeSystemProvider(),
+        );
+    }
+
+    public function testRegistryResolvesFakePerpetualContext(): void
+    {
+        $registry = new ExchangeProviderRegistry(
+            [
+                $this->fakeBundle(MarketType::PERPETUAL),
+                $this->fakeBundle(MarketType::SPOT),
+            ],
+            Exchange::BITMART,
+            MarketType::PERPETUAL,
+        );
+
+        $bundle = $registry->get(new ExchangeContext(Exchange::FAKE, MarketType::PERPETUAL));
+
+        self::assertTrue(
+            $bundle->context()->equals(new ExchangeContext(Exchange::FAKE, MarketType::PERPETUAL))
+        );
+        self::assertInstanceOf(FakeOrderProvider::class, $bundle->order());
+        self::assertInstanceOf(FakeAccountProvider::class, $bundle->account());
+
+        // Default context is left unchanged (Bitmart/perpetual).
+        self::assertTrue(
+            $registry->getDefaultContext()->equals(new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL))
+        );
+    }
+
+    public function testMainProviderForFakeContextReturnsEmptyOpenState(): void
+    {
+        $registry = new ExchangeProviderRegistry(
+            [$this->fakeBundle(MarketType::PERPETUAL)],
+            Exchange::FAKE,
+            MarketType::PERPETUAL,
+        );
+
+        $mainProvider = new MainProvider($registry);
+        $scoped = $mainProvider->forContext(new ExchangeContext(Exchange::FAKE, MarketType::PERPETUAL));
+
+        self::assertSame([], $scoped->getAccountProvider()->getOpenPositions());
+        self::assertSame([], $scoped->getOrderProvider()->getOpenOrders());
+        self::assertSame(0.0, $scoped->getAccountProvider()->getAccountBalance());
+    }
+}

--- a/trading-app/tests/Provider/Fake/FakeProvidersTest.php
+++ b/trading-app/tests/Provider/Fake/FakeProvidersTest.php
@@ -31,6 +31,8 @@ final class FakeProvidersTest extends TestCase
         self::assertNull($provider->getAccountInfo());
         self::assertSame(0.0, $provider->getAccountBalance());
         self::assertSame([], $provider->getOpenPositions());
+        // Variante fail-closed : retourne [] sans jamais lever (source fiable, vide).
+        self::assertSame([], $provider->getOpenPositionsOrFail());
         self::assertNull($provider->getPosition('BTCUSDT'));
         self::assertSame([], $provider->getTradeHistory('BTCUSDT'));
         self::assertSame([], $provider->getTrades());
@@ -44,6 +46,8 @@ final class FakeProvidersTest extends TestCase
 
         self::assertSame([], $provider->getOpenOrders());
         self::assertSame([], $provider->getOpenOrders('BTCUSDT'));
+        // Variante fail-closed : retourne [] sans jamais lever (source fiable, vide).
+        self::assertSame([], $provider->getOpenOrdersOrFail());
         self::assertNull($provider->getOrder('BTCUSDT', '123'));
         self::assertSame([], $provider->getOrderHistory('BTCUSDT'));
 

--- a/trading-app/tests/Provider/Fake/FakeProvidersTest.php
+++ b/trading-app/tests/Provider/Fake/FakeProvidersTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Provider\Fake;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Common\Enum\Timeframe;
+use App\Contract\Provider\Dto\KlineDto;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Provider\Fake\FakeAccountProvider;
+use App\Provider\Fake\FakeContractProvider;
+use App\Provider\Fake\FakeKlineProvider;
+use App\Provider\Fake\FakeOrderProvider;
+use App\Provider\Fake\FakeSystemProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FakeAccountProvider::class)]
+#[CoversClass(FakeOrderProvider::class)]
+#[CoversClass(FakeContractProvider::class)]
+#[CoversClass(FakeKlineProvider::class)]
+#[CoversClass(FakeSystemProvider::class)]
+final class FakeProvidersTest extends TestCase
+{
+    public function testAccountProviderReportsEmptyState(): void
+    {
+        $provider = new FakeAccountProvider();
+
+        self::assertNull($provider->getAccountInfo());
+        self::assertSame(0.0, $provider->getAccountBalance());
+        self::assertSame([], $provider->getOpenPositions());
+        self::assertNull($provider->getPosition('BTCUSDT'));
+        self::assertSame([], $provider->getTradeHistory('BTCUSDT'));
+        self::assertSame([], $provider->getTrades());
+        self::assertSame([], $provider->getTransactionHistory());
+        self::assertSame([], $provider->getTradingFees('BTCUSDT'));
+    }
+
+    public function testOrderProviderIsAnEmptyNoOpExchange(): void
+    {
+        $provider = new FakeOrderProvider();
+
+        self::assertSame([], $provider->getOpenOrders());
+        self::assertSame([], $provider->getOpenOrders('BTCUSDT'));
+        self::assertNull($provider->getOrder('BTCUSDT', '123'));
+        self::assertSame([], $provider->getOrderHistory('BTCUSDT'));
+
+        // Placement is a no-op that never creates an order.
+        self::assertNull(
+            $provider->placeOrder('BTCUSDT', OrderSide::BUY, OrderType::LIMIT, 1.0, 100.0)
+        );
+
+        // Cancel/leverage operations succeed without side effects (no throw).
+        self::assertTrue($provider->cancelOrder('BTCUSDT', '123'));
+        self::assertTrue($provider->cancelAllOrders('BTCUSDT'));
+        self::assertTrue($provider->submitLeverage('BTCUSDT', 10));
+
+        $top = $provider->getOrderBookTop('BTCUSDT');
+        self::assertInstanceOf(SymbolBidAskDto::class, $top);
+        self::assertSame('BTCUSDT', $top->symbol);
+        self::assertSame(0.0, $top->bid);
+        self::assertSame(0.0, $top->ask);
+    }
+
+    public function testContractProviderExposesNoContracts(): void
+    {
+        $provider = new FakeContractProvider();
+
+        self::assertSame([], $provider->getContracts());
+        self::assertNull($provider->getContractDetails('BTCUSDT'));
+        self::assertNull($provider->getLastPrice('BTCUSDT'));
+        self::assertSame([], $provider->getOrderBook('BTCUSDT'));
+        self::assertSame([], $provider->getRecentTrades('BTCUSDT'));
+        self::assertSame([], $provider->getMarkPriceKline('BTCUSDT'));
+        self::assertSame([], $provider->getLeverageBrackets('BTCUSDT'));
+
+        self::assertSame(
+            ['upserted' => 0, 'total_fetched' => 0, 'errors' => []],
+            $provider->syncContracts(),
+        );
+    }
+
+    public function testKlineProviderReturnsEmptySets(): void
+    {
+        $provider = new FakeKlineProvider();
+
+        self::assertSame([], $provider->getKlines('BTCUSDT', Timeframe::TF_1M));
+        self::assertSame(
+            [],
+            $provider->getKlinesInWindow(
+                'BTCUSDT',
+                Timeframe::TF_1M,
+                new \DateTimeImmutable('-1 hour'),
+                new \DateTimeImmutable('now'),
+            ),
+        );
+        self::assertNull($provider->getLastKline('BTCUSDT', Timeframe::TF_1M));
+        self::assertFalse($provider->hasGaps('BTCUSDT', Timeframe::TF_1M));
+        self::assertSame([], $provider->getGaps('BTCUSDT', Timeframe::TF_1M));
+
+        // Saves are no-ops and must not throw.
+        $kline = new KlineDto(
+            'BTCUSDT',
+            Timeframe::TF_1M,
+            new \DateTimeImmutable('now'),
+            \Brick\Math\BigDecimal::of('1'),
+            \Brick\Math\BigDecimal::of('1'),
+            \Brick\Math\BigDecimal::of('1'),
+            \Brick\Math\BigDecimal::of('1'),
+            \Brick\Math\BigDecimal::of('1'),
+        );
+        $provider->saveKline($kline);
+        $provider->saveKlines([$kline], 'BTCUSDT', Timeframe::TF_1M);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testSystemProviderReturnsCurrentTime(): void
+    {
+        $provider = new FakeSystemProvider();
+
+        $before = (int) (microtime(true) * 1000);
+        $now = $provider->getSystemTimeMs();
+        $after = (int) (microtime(true) * 1000);
+
+        self::assertGreaterThanOrEqual($before, $now);
+        self::assertLessThanOrEqual($after, $now);
+    }
+}


### PR DESCRIPTION
## SF-002b — Orchestrator open-state snapshot

Today every MTF run fetches open positions/orders from the exchange. SF-002b lets the **orchestrator fetch the open-state once** and pass it as a snapshot to every `/api/mtf/run` set call, so Symfony does not re-fetch per set. In live mode the run **fails closed** if there is no reliable open-state source.

### Symfony
- **DTOs (both copies)** — `src/MtfRunner/Dto/MtfRunnerRequestDto.php` and `src/Contract/Runner/Dto/MtfRunnerRequestDto.php` gain `?array $openStateSnapshot` (shape `{open_positions, open_orders}`) parsed from `open_state_snapshot` in `fromArray()` / serialized in `toArray()`.
- **RunnerController** — reads `data['open_state_snapshot']` (array|null) and forwards it to the DTO.
- **MtfRunnerService::run()** — open-state source priority: (1) `openStateSnapshot` → hydrate positions/orders and skip the `syncTables()` fetch entirely; (2) else `syncTables()` when `sync_tables=true`; (3) else `null` (filter may fetch). Behaviour is identical when no snapshot is sent.
- **Fail-closed (live)** — in live (`!dryRun`), when there is no reliable open-state source (no snapshot AND `sync_tables=false` AND `skip_open_state_filter=true`) the run is **rejected** with a clear error result (`status=rejected`, `reason=no_reliable_open_state_source`) without touching the exchange. Mirrors the SF-002a CLI guard.
- **New read-only endpoint** — `GET /api/exchange/open-state?exchange=&market_type=` (defaults bitmart/perpetual) returns `{"open_positions":[...],"open_orders":[...]}` via the provider through `ExchangeContext`. `OpenStateSnapshotSerializer` serializes provider DTOs to JSON-safe arrays.
- **Tests** — DTO snapshot parsing, runner snapshot/fail-closed/dry-run paths, serializer shape, endpoint route registration. `phpunit tests/MtfRunner tests/Application/Runner tests/Controller` → **38 passed, 110 assertions**. PHPStan on touched files introduces **no new errors** (pre-existing `no value type` / nullsafe warnings unchanged; new files are clean).

### Python orchestrator (advances PY-002)
- `/orchestrator/run` now, before the sets loop, fetches `GET /api/exchange/open-state` **once per distinct `(exchange, market_type)`** among active `mtf_run` sets and caches the snapshot.
- Each `mtf_run` set is POSTed to `/api/mtf/run` with `sync_tables=false` + matching cached `open_state_snapshot`, under bounded concurrency (`asyncio.Semaphore(settings.max_concurrency)`).
- **Live fail-closed**: if the snapshot fetch fails, live sets (`dry_run=false`) are marked errored and skipped; dry-run sets proceed without snapshot.
- New `app/services/symfony_client.py` (open-state fetch + payload build + set run). `python -m pytest` → **93 passed, 3 skipped** (skipped = Postgres smoke).

### Docs
- `docs/handbook/technical/python-orchestrator.md` updated: snapshot flow diagram, `GET /api/exchange/open-state` endpoint, fail-closed live, PR-plan status (SF-002a/SF-002b done, PY-002 partial).

### Decisions / deviations
- **DB persistence of the last run JSON**: the existing `/orchestrator/run` was a stub that did not wire the `runs`/`run_sets` repositories. To avoid changing the established `RunResponse` contract (and breaking existing tests), this PR keeps the existing return shape and leaves DB persistence of the last JSON to a follow-up. Documented in the docs PR-plan as "PY-002 (partial)".
- **Open-state endpoint is read-only**: it calls the provider's `getOpenPositions()/getOpenOrders()` directly rather than `ExchangeStateSynchronizer::sync()`, to avoid DB upserts on a GET.
- **Empty snapshot is a reliable source**: a snapshot with empty positions/orders still counts as a valid open-state source (the orchestrator did query the exchange; nothing was open), so it does not trip the live fail-closed guard.
- SF-002a CLI files (`MtfRunCommand.php`) were not modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ePV5CxFsjWsNwEUYYSHsv

---
_Generated by [Claude Code](https://claude.ai/code/session_013ePV5CxFsjWsNwEUYYSHsv)_