### PR TITLE
feat(PY-003): explicit contracts refresh from Symfony

### DIFF
--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -93,56 +93,92 @@ sequenceDiagram
 ## API Symfony : contrats sélectionnés (SF-001)
 
 Symfony expose la liste des contrats réellement retenus par `mtf_contracts`, sans
-déclencher de run, via :
+déclencher de run (la file MTF switch n'est PAS consommée), via :
 
 ```text
-GET|POST /api/mtf/selected-contracts
+GET /api/mtf/contracts
 ```
 
-Paramètres (query string en GET, JSON en POST) :
+Paramètres (query string) :
 
 - `profile` / `mtf_profile` : profil de configuration (défaut = mode TradeEntry actif) ;
-- `exchange` / `market_type` : contexte exchange (même jeu accepté que `/api/mtf/run` :
-  `bitmart`, `okx`, `hyperliquid`, ... ; défaut `bitmart` / `perpetual`) ;
-- `ignore_limits` : `true` pour obtenir tous les symboles éligibles sans `top_n` / `mid_n`
-  (filtres strictement identiques à la sélection limitée).
+- `exchange` / `cex` : exchange (`bitmart`, `okx`, `hyperliquid`, ... ; défaut `bitmart`) ;
+- `market_type` / `type_contract` : type de marché (alias `futures`/`perp` acceptés ;
+  défaut `perpetual`).
 
 Comportements explicites :
 
-- un corps POST JSON invalide renvoie `400` (pas de bascule silencieuse sur les défauts) ;
 - un `exchange` / `market_type` non supporté renvoie `400` ;
-- si le fichier de config dédié au profil n'existe pas, le provider retombe sur la config
-  par défaut : la réponse distingue alors `requested_profile`, `effective_profile`
-  (`default`) et `profile_config_found` ;
-- si `selection.enabled` vaut `false`, aucune sélection curée n'est exposée :
-  `symbols` est vide et `selection_enabled` vaut `false` ;
-- le `timestamp` est au format RFC3339 UTC ;
-- en cas d'erreur interne, le message reste générique (les détails vont dans les logs).
+- en cas d'erreur interne, le message reste générique (les détails vont dans les logs),
+  réponse `{ "ok": false, "error": ... }` en `500`.
 
-Réponse type :
+Réponse type (forme **plate**, telle que renvoyée par `ContractsApiController`) :
 
 ```json
 {
-  "status": "success",
-  "data": {
-    "requested_profile": "scalper_micro",
-    "effective_profile": "scalper_micro",
-    "profile_config_found": true,
-    "exchange": "bitmart",
-    "market_type": "perpetual",
-    "selection_enabled": true,
-    "ignore_limits": false,
-    "count": 2,
-    "symbols": ["BTCUSDT", "ETHUSDT"],
-    "filters": { "quote_currency": "USDT", "status": "Trading", "min_turnover": 1500000 },
-    "limits": { "top_n": 140, "mid_n": 0 },
-    "timestamp": "2026-06-16T19:30:00+00:00"
+  "ok": true,
+  "profile": "scalper_micro",
+  "exchange": "bitmart",
+  "market_type": "perpetual",
+  "count": 2,
+  "symbols": ["BTCUSDT", "ETHUSDT"],
+  "filters": {
+    "quote_currency": "USDT",
+    "status": "Trading",
+    "min_turnover": 1500000,
+    "mid_max_turnover": null,
+    "top_n": 140,
+    "mid_n": 0
   }
 }
 ```
 
 C'est cet endpoint que l'API Python appelle lors du refresh explicite des contrats
-pour préparer ses sets de payloads.
+(voir ci-dessous) pour mettre à jour la sélection de symboles de ses sets.
+
+## API Python : refresh explicite des contrats (PY-003)
+
+L'orchestrateur ne recalcule pas la sélection à chaque run : elle est rafraîchie
+**explicitement** (changement de config ou demande du front) via :
+
+```text
+POST /dashboards/{dashboard_id}/refresh-contracts
+```
+
+Déroulé :
+
+- charge les sets **actifs** d'action `mtf_run` du dashboard ;
+- regroupe par couple distinct `(mtf_profile, exchange, market_type)` et appelle
+  `GET /api/mtf/contracts` **une seule fois par groupe** (mise en cache) ;
+- **fail-closed** : si le fetch d'un seul groupe échoue, la route renvoie `502`
+  **sans aucune écriture** (les sets gardent leur sélection précédente) ;
+- sinon, pour chaque set, écrit `symbols = symbols_du_profil[:contracts_limit]`
+  (tronqué si `contracts_limit` est défini, sinon la sélection complète) puis
+  committe l'ensemble en une seule transaction ;
+- renvoie un aperçu par set.
+
+Réponse type :
+
+```json
+{
+  "dashboard_id": 1,
+  "count": 2,
+  "sets": [
+    {
+      "set_id": "bitmart_scalper_top",
+      "mtf_profile": "scalper_micro",
+      "exchange": "bitmart",
+      "market_type": "perpetual",
+      "symbol_count": 140,
+      "contracts_limit": 140,
+      "filters": { "quote_currency": "USDT", "top_n": 140 }
+    }
+  ]
+}
+```
+
+> La génération du `payload` `/api/mtf/run` à partir des sets (PY-004) et leur
+> exécution parallèle (PY-005) restent hors du périmètre de ce refresh.
 
 ## Lien avec `mtf_contracts`
 
@@ -383,6 +419,7 @@ Avant tout run :
 | SF-002a ✅ | Supporter `sync_tables=false` côté Symfony | Livré : `/api/mtf/run` et `mtf:run` honorent `sync_tables=false` (skip upsert DB). |
 | SF-002b ✅ | Snapshot d'état ouvert orchestrateur (zéro appel exchange par set) | Livré : `GET /api/exchange/open-state` + `open_state_snapshot` sur `/api/mtf/run` ; fail-closed live côté Symfony et orchestrateur. |
 | PY-002 ✅ (partiel) | Implémenter `/orchestrator/run` | Livré : lecture des sets actifs, fetch snapshot 1×/(exchange,market_type), appels parallèles bornés, agrégation, fail-closed live. Persistance DB du dernier JSON à compléter. |
+| PY-003 ✅ | Refresh explicite des contrats | Livré : `POST /dashboards/{id}/refresh-contracts` fetch `GET /api/mtf/contracts` 1×/(profil,exchange,market_type), persiste `symbols` (cap `contracts_limit`), fail-closed 502 sans écriture partielle, aperçu par set. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 

--- a/python-orchestrator/app/routers/dashboards.py
+++ b/python-orchestrator/app/routers/dashboards.py
@@ -213,8 +213,10 @@ async def refresh_contracts(
     puis écrit ``symbols`` sur chaque set — tronqué à ``contracts_limit`` si défini.
 
     **Fail-closed** : si le fetch d'un seul groupe échoue, on renvoie ``502`` sans
-    AUCUNE écriture partielle (les sets restent dans leur état précédent). Toutes
-    les écritures sont committées en une seule transaction à la fin.
+    AUCUNE écriture partielle (les sets restent dans leur état précédent). De même,
+    si la sélection rafraîchie rendrait un set non exécutable (set non capé dont les
+    ``symbols`` deviendraient vides), on renvoie ``409`` sans rien écrire. Toutes les
+    écritures sont committées en une seule transaction à la fin.
 
     Hors scope (PY-004/PY-005) : génération du ``payload`` /api/mtf/run et exécution.
     """
@@ -249,12 +251,34 @@ async def refresh_contracts(
                     detail=f"refresh contrats indisponible: {exc}",
                 )
 
-    # 2) Toutes les écritures réussies sont préparées puis committées en une fois.
-    previews: list[ContractRefreshSetPreview] = []
+    # 2) Validation préalable (AUCUNE écriture) : un set non capé
+    #    (`contracts_limit is None`) dont la sélection rafraîchie serait vide
+    #    deviendrait ambigu/non exécutable — `assert_set_persistable` le refuse, et
+    #    `build_mtf_payload` omettrait `symbols` (liste vide = falsy), lançant tout
+    #    l'univers au lieu de « zéro contrat ». On échoue tout le refresh (fail-closed,
+    #    atomique) plutôt que de persister cet état. Un set capé tolère `[]` (la
+    #    `contracts_limit` porte la sélection).
+    planned: list[tuple[OrchestrationSet, list, dict]] = []
     for a_set in mtf_sets:
         fetched = cache[(a_set.mtf_profile, a_set.exchange, a_set.market_type)]
         # `[:None]` = liste complète ; `[:N]` cape la sélection dynamique.
         symbols = list(fetched["symbols"][: a_set.contracts_limit])
+        try:
+            assert_set_persistable(
+                dry_run=a_set.dry_run,
+                symbols=symbols,
+                contracts_limit=a_set.contracts_limit,
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail=f"refresh produirait un set non exécutable ({a_set.set_id}): {exc}",
+            )
+        planned.append((a_set, symbols, fetched))
+
+    # 3) Écriture + commit en une seule transaction (tous les sets validés).
+    previews: list[ContractRefreshSetPreview] = []
+    for a_set, symbols, fetched in planned:
         repo.update_set(session, a_set, fields={"symbols": symbols})
         previews.append(
             ContractRefreshSetPreview(

--- a/python-orchestrator/app/routers/dashboards.py
+++ b/python-orchestrator/app/routers/dashboards.py
@@ -5,7 +5,8 @@ CRUD REST câblé sur la couche DB (DB-001) :
 - ``/dashboards``                          : création / liste ;
 - ``/dashboards/{id}``                     : lecture / mise à jour / suppression ;
 - ``/dashboards/{id}/sets``                : création / liste des sets ;
-- ``/dashboards/{id}/sets/{set_id}``       : lecture / mise à jour / suppression.
+- ``/dashboards/{id}/sets/{set_id}``       : lecture / mise à jour / suppression ;
+- ``/dashboards/{id}/refresh-contracts``   : refresh explicite des symboles (PY-003).
 
 Le câblage de ces sets dans l'exécution parallèle de ``/orchestrator/run`` est
 l'objet de PY-005 ; cette PR ne livre que la configuration (sets « prêts »).
@@ -14,8 +15,9 @@ l'objet de PY-005 ; cette PR ne livre que la configuration (sets « prêts »).
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Dict, Iterator, Tuple
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -24,6 +26,9 @@ from app.db import repositories as repo
 from app.db.engine import get_session
 from app.db.models import Dashboard, OrchestrationSet
 from app.schemas import (
+    Action,
+    ContractRefreshResponse,
+    ContractRefreshSetPreview,
     DashboardCreate,
     DashboardRead,
     DashboardUpdate,
@@ -32,6 +37,8 @@ from app.schemas import (
     SetUpdate,
     assert_set_persistable,
 )
+from app.services import symfony_client
+from app.settings import get_settings
 
 router = APIRouter(prefix="/dashboards", tags=["dashboards"])
 
@@ -183,3 +190,86 @@ def delete_set(
     repo.delete_set(session, a_set)
     session.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# --- Refresh des contrats (PY-003) ------------------------------------------
+
+# Clé de regroupement d'un fetch contrats : un appel Symfony par couple distinct
+# (profil, exchange, market_type) — inutile de refetcher pour des sets identiques.
+_ContractsKey = Tuple[str, str, str]
+
+# Timeout (s) des appels Symfony pour le refresh, aligné sur l'orchestrateur.
+_HTTP_TIMEOUT = 900.0
+
+
+@router.post("/{dashboard_id}/refresh-contracts", response_model=ContractRefreshResponse)
+async def refresh_contracts(
+    dashboard_id: int, session: Session = Depends(get_session)
+) -> ContractRefreshResponse:
+    """Refresh explicite des symboles des sets `mtf_run` actifs d'un dashboard.
+
+    Pour chaque couple distinct (profil, exchange, market_type), interroge UNE
+    fois ``GET /api/mtf/contracts`` (Symfony = source de vérité de la sélection),
+    puis écrit ``symbols`` sur chaque set — tronqué à ``contracts_limit`` si défini.
+
+    **Fail-closed** : si le fetch d'un seul groupe échoue, on renvoie ``502`` sans
+    AUCUNE écriture partielle (les sets restent dans leur état précédent). Toutes
+    les écritures sont committées en une seule transaction à la fin.
+
+    Hors scope (PY-004/PY-005) : génération du ``payload`` /api/mtf/run et exécution.
+    """
+    _require_dashboard(session, dashboard_id)
+    settings = get_settings()
+
+    mtf_sets = [
+        s
+        for s in repo.list_active_sets(session, dashboard_id)
+        if s.action == Action.MTF_RUN.value
+    ]
+
+    # 1) Un seul fetch par couple distinct (profil, exchange, market_type).
+    #    Tout échec interrompt AVANT la moindre écriture (fail-closed).
+    cache: Dict[_ContractsKey, dict] = {}
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        for a_set in mtf_sets:
+            key: _ContractsKey = (a_set.mtf_profile, a_set.exchange, a_set.market_type)
+            if key in cache:
+                continue
+            try:
+                cache[key] = await symfony_client.fetch_selected_contracts(
+                    client,
+                    settings.symfony_base_url,
+                    a_set.mtf_profile,
+                    a_set.exchange,
+                    a_set.market_type,
+                )
+            except symfony_client.ContractsUnavailableError as exc:
+                raise HTTPException(
+                    status.HTTP_502_BAD_GATEWAY,
+                    detail=f"refresh contrats indisponible: {exc}",
+                )
+
+    # 2) Toutes les écritures réussies sont préparées puis committées en une fois.
+    previews: list[ContractRefreshSetPreview] = []
+    for a_set in mtf_sets:
+        fetched = cache[(a_set.mtf_profile, a_set.exchange, a_set.market_type)]
+        # `[:None]` = liste complète ; `[:N]` cape la sélection dynamique.
+        symbols = list(fetched["symbols"][: a_set.contracts_limit])
+        repo.update_set(session, a_set, fields={"symbols": symbols})
+        previews.append(
+            ContractRefreshSetPreview(
+                set_id=a_set.set_id,
+                mtf_profile=a_set.mtf_profile,
+                exchange=a_set.exchange,
+                market_type=a_set.market_type,
+                symbol_count=len(symbols),
+                contracts_limit=a_set.contracts_limit,
+                filters=fetched["filters"],
+            )
+        )
+
+    session.commit()
+
+    return ContractRefreshResponse(
+        dashboard_id=dashboard_id, count=len(previews), sets=previews
+    )

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -339,3 +339,36 @@ class SetRead(BaseModel):
     payload: Optional[dict] = None
     created_at: datetime
     updated_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Refresh explicite des contrats (PY-003)
+#
+# Schémas de la réponse de ``POST /dashboards/{id}/refresh-contracts`` : pour
+# chaque set actif `mtf_run`, on renvoie un aperçu (combien de symboles ont été
+# persistés, sous quels filtres). La génération des payloads /api/mtf/run reste
+# l'objet de PY-004 ; ici on ne touche qu'aux ``symbols``.
+# ---------------------------------------------------------------------------
+
+
+class ContractRefreshSetPreview(BaseModel):
+    """Aperçu du refresh pour un set : combien de symboles, sous quels filtres."""
+
+    set_id: str
+    mtf_profile: MtfProfile
+    exchange: Exchange
+    market_type: MarketType
+    symbol_count: int
+    # Cap appliqué (None = sélection complète du profil).
+    contracts_limit: Optional[int] = None
+    # Filtres `mtf_contracts` renvoyés par Symfony (informatif pour le front).
+    filters: dict = Field(default_factory=dict)
+
+
+class ContractRefreshResponse(BaseModel):
+    """Réponse de ``POST /dashboards/{id}/refresh-contracts``."""
+
+    dashboard_id: int
+    # Nombre de sets rafraîchis (sets actifs `mtf_run` du dashboard).
+    count: int
+    sets: List[ContractRefreshSetPreview]

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -32,6 +32,14 @@ class OpenStateUnavailableError(RuntimeError):
     """Le snapshot d'état ouvert n'a pas pu être récupéré (fail-closed live)."""
 
 
+class ContractsUnavailableError(RuntimeError):
+    """La liste des contrats sélectionnés n'a pas pu être récupérée (PY-003).
+
+    Levée par ``fetch_selected_contracts`` ; le refresh est *fail-closed* : un
+    groupe dont le fetch échoue interdit toute écriture partielle des sets.
+    """
+
+
 def snapshot_key(a_set: OrchestratorSet) -> SnapshotKey:
     """Clé de cache du snapshot pour un set."""
     return (a_set.exchange.value, a_set.market_type.value)
@@ -87,6 +95,80 @@ async def fetch_open_state(
     return {
         "open_positions": positions,
         "open_orders": orders,
+    }
+
+
+async def fetch_selected_contracts(
+    client: httpx.AsyncClient,
+    base_url: str,
+    profile: Optional[str],
+    exchange: str,
+    market_type: str,
+) -> Dict[str, Any]:
+    """Récupère les symboles sélectionnés par ``mtf_contracts`` pour un profil.
+
+    Appelle ``GET /api/mtf/contracts`` (SF-001, lecture seule : ne consomme pas la
+    file MTF switch). Sert au refresh explicite des contrats (PY-003) : Symfony
+    reste la source de vérité de la sélection.
+
+    Lève ``ContractsUnavailableError`` si l'appel échoue, si HTTP != 200, si le
+    corps n'est pas un JSON conforme (``ok`` vrai, ``symbols`` liste, champs
+    requis présents). On ne normalise jamais une réponse douteuse en sélection
+    vide : ce serait écraser les sets avec un univers faux.
+
+    Retourne ``{profile, exchange, market_type, count, symbols, filters}``.
+    """
+    url = f"{base_url.rstrip('/')}/api/mtf/contracts"
+    params = {"profile": profile, "exchange": exchange, "market_type": market_type}
+    # Un profil non fourni laisse Symfony retomber sur le mode actif : on n'envoie
+    # alors pas la clé (évite ``profile=`` qui serait parsé comme chaîne vide).
+    params = {k: v for k, v in params.items() if v is not None}
+    try:
+        response = await client.get(url, params=params)
+    except httpx.HTTPError as exc:  # noqa: BLE001 - on remonte une erreur métier claire
+        raise ContractsUnavailableError(
+            f"contracts fetch failed for {profile}/{exchange}/{market_type}: {exc}"
+        ) from exc
+
+    if response.status_code != 200:
+        raise ContractsUnavailableError(
+            f"contracts fetch returned HTTP {response.status_code} "
+            f"for {profile}/{exchange}/{market_type}"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ContractsUnavailableError(
+            f"contracts response is not valid JSON for {profile}/{exchange}/{market_type}"
+        ) from exc
+
+    if not isinstance(body, dict) or body.get("ok") is not True:
+        raise ContractsUnavailableError(
+            f"contracts response not ok for {profile}/{exchange}/{market_type}"
+        )
+
+    symbols = body.get("symbols")
+    if not isinstance(symbols, list):
+        raise ContractsUnavailableError(
+            f"contracts response has non-list symbols for {profile}/{exchange}/{market_type}"
+        )
+
+    # Champs requis : leur absence signale une réponse tronquée/inattendue.
+    for field in ("profile", "exchange", "market_type", "count"):
+        if field not in body:
+            raise ContractsUnavailableError(
+                f"contracts response missing '{field}' for {profile}/{exchange}/{market_type}"
+            )
+
+    filters = body.get("filters")
+    return {
+        "profile": body["profile"],
+        "exchange": body["exchange"],
+        "market_type": body["market_type"],
+        "count": body["count"],
+        "symbols": symbols,
+        "filters": filters if isinstance(filters, dict) else {},
     }
 
 

--- a/python-orchestrator/tests/test_refresh_contracts_api.py
+++ b/python-orchestrator/tests/test_refresh_contracts_api.py
@@ -151,6 +151,31 @@ def test_refresh_failclosed_no_write_on_fetch_error(api_client, monkeypatch):
     assert _get_set(api_client, dashboard_id, "ko_set")["symbols"] == ["OLD_KO"]
 
 
+def test_refresh_failclosed_on_empty_selection_for_uncapped_set(api_client, monkeypatch):
+    # Set non capé (contracts_limit=None) : une sélection vide le rendrait ambigu
+    # (ni symbols, ni limite) et build_mtf_payload lancerait tout l'univers => 409.
+    dashboard_id = _mk_dashboard(api_client)
+    _mk_set(api_client, dashboard_id, "uncapped", symbols=["OLD"])
+    _patch_fetch(monkeypatch, _Recorder(symbols_by_profile={"scalper_micro": []}))
+
+    resp = api_client.post(f"/dashboards/{dashboard_id}/refresh-contracts")
+    assert resp.status_code == 409, resp.text
+    # Fail-closed : aucune écriture, les symboles précédents sont préservés.
+    assert _get_set(api_client, dashboard_id, "uncapped")["symbols"] == ["OLD"]
+
+
+def test_refresh_allows_empty_selection_for_capped_set(api_client, monkeypatch):
+    # Set capé : une sélection vide reste valide (contracts_limit porte la sélection).
+    dashboard_id = _mk_dashboard(api_client)
+    _mk_set(api_client, dashboard_id, "capped", symbols=[], contracts_limit=5)
+    _patch_fetch(monkeypatch, _Recorder(symbols_by_profile={"scalper_micro": []}))
+
+    resp = api_client.post(f"/dashboards/{dashboard_id}/refresh-contracts")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["sets"][0]["symbol_count"] == 0
+    assert _get_set(api_client, dashboard_id, "capped")["symbols"] == []
+
+
 def test_refresh_skips_disabled_sets(api_client, monkeypatch):
     dashboard_id = _mk_dashboard(api_client)
     _mk_set(api_client, dashboard_id, "active")

--- a/python-orchestrator/tests/test_refresh_contracts_api.py
+++ b/python-orchestrator/tests/test_refresh_contracts_api.py
@@ -1,0 +1,168 @@
+"""Tests de la route de refresh explicite des contrats (PY-003).
+
+``POST /dashboards/{id}/refresh-contracts`` interroge Symfony (mocké ici) une fois
+par couple (profil, exchange, market_type), écrit les ``symbols`` des sets actifs
+`mtf_run` et renvoie un aperçu. Fail-closed : tout fetch en échec => 502 sans
+écriture partielle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import symfony_client
+
+
+def _mk_dashboard(client, name="dash"):
+    resp = client.post("/dashboards", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _mk_set(client, dashboard_id, set_id, **overrides):
+    payload = {
+        "set_id": set_id,
+        "exchange": "bitmart",
+        "mtf_profile": "scalper_micro",
+        "symbols": ["OLD"],
+    }
+    payload.update(overrides)
+    resp = client.post(f"/dashboards/{dashboard_id}/sets", json=payload)
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _get_set(client, dashboard_id, set_id):
+    resp = client.get(f"/dashboards/{dashboard_id}/sets/{set_id}")
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class _Recorder:
+    """Stub async de ``fetch_selected_contracts`` qui enregistre ses appels."""
+
+    def __init__(self, symbols_by_profile=None):
+        self.calls = []
+        self._by_profile = symbols_by_profile or {}
+
+    async def __call__(self, client, base_url, profile, exchange, market_type):
+        self.calls.append((profile, exchange, market_type))
+        symbols = self._by_profile.get(profile, ["BTCUSDT", "ETHUSDT", "SOLUSDT"])
+        return {
+            "profile": profile,
+            "exchange": exchange,
+            "market_type": market_type,
+            "count": len(symbols),
+            "symbols": list(symbols),
+            "filters": {"top_n": 140},
+        }
+
+
+def _patch_fetch(monkeypatch, recorder):
+    monkeypatch.setattr(symfony_client, "fetch_selected_contracts", recorder)
+
+
+def test_refresh_updates_symbols_and_returns_preview(api_client, monkeypatch):
+    dashboard_id = _mk_dashboard(api_client)
+    _mk_set(api_client, dashboard_id, "s1")
+    _patch_fetch(monkeypatch, _Recorder())
+
+    resp = api_client.post(f"/dashboards/{dashboard_id}/refresh-contracts")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["dashboard_id"] == dashboard_id
+    assert body["count"] == 1
+    preview = body["sets"][0]
+    assert preview["set_id"] == "s1"
+    assert preview["symbol_count"] == 3
+    assert preview["mtf_profile"] == "scalper_micro"
+    assert preview["filters"] == {"top_n": 140}
+
+    # Symboles réellement persistés en DB.
+    assert _get_set(api_client, dashboard_id, "s1")["symbols"] == [
+        "BTCUSDT",
+        "ETHUSDT",
+        "SOLUSDT",
+    ]
+
+
+def test_refresh_respects_contracts_limit(api_client, monkeypatch):
+    dashboard_id = _mk_dashboard(api_client)
+    # Set borné (contracts_limit=2, symbols vide autorisé) + set sans limite.
+    _mk_set(api_client, dashboard_id, "capped", symbols=[], contracts_limit=2)
+    _mk_set(api_client, dashboard_id, "full")
+    _patch_fetch(monkeypatch, _Recorder())
+
+    resp = api_client.post(f"/dashboards/{dashboard_id}/refresh-contracts")
+    assert resp.status_code == 200, resp.text
+
+    assert _get_set(api_client, dashboard_id, "capped")["symbols"] == ["BTCUSDT", "ETHUSDT"]
+    assert _get_set(api_client, dashboard_id, "full")["symbols"] == [
+        "BTCUSDT",
+        "ETHUSDT",
+        "SOLUSDT",
+    ]
+
+
+def test_refresh_one_fetch_per_distinct_triple(api_client, monkeypatch):
+    dashboard_id = _mk_dashboard(api_client)
+    # Deux sets partageant (profil, exchange, market_type) + un sur un autre profil.
+    _mk_set(api_client, dashboard_id, "a", mtf_profile="scalper_micro")
+    _mk_set(api_client, dashboard_id, "b", mtf_profile="scalper_micro")
+    _mk_set(api_client, dashboard_id, "c", mtf_profile="regular")
+    recorder = _Recorder()
+    _patch_fetch(monkeypatch, recorder)
+
+    resp = api_client.post(f"/dashboards/{dashboard_id}/refresh-contracts")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["count"] == 3
+    # Un seul fetch par couple distinct : 2 couples => 2 appels (pas 3).
+    assert sorted(recorder.calls) == [
+        ("regular", "bitmart", "perpetual"),
+        ("scalper_micro", "bitmart", "perpetual"),
+    ]
+
+
+def test_refresh_failclosed_no_write_on_fetch_error(api_client, monkeypatch):
+    dashboard_id = _mk_dashboard(api_client)
+    _mk_set(api_client, dashboard_id, "ok_set", mtf_profile="scalper_micro", symbols=["OLD_OK"])
+    _mk_set(api_client, dashboard_id, "ko_set", mtf_profile="regular", symbols=["OLD_KO"])
+
+    async def _fetch(client, base_url, profile, exchange, market_type):
+        if profile == "regular":
+            raise symfony_client.ContractsUnavailableError("symfony down")
+        return {
+            "profile": profile,
+            "exchange": exchange,
+            "market_type": market_type,
+            "count": 1,
+            "symbols": ["NEW"],
+            "filters": {},
+        }
+
+    monkeypatch.setattr(symfony_client, "fetch_selected_contracts", _fetch)
+
+    resp = api_client.post(f"/dashboards/{dashboard_id}/refresh-contracts")
+    assert resp.status_code == 502, resp.text
+
+    # AUCUNE écriture partielle : même le groupe qui a réussi reste inchangé.
+    assert _get_set(api_client, dashboard_id, "ok_set")["symbols"] == ["OLD_OK"]
+    assert _get_set(api_client, dashboard_id, "ko_set")["symbols"] == ["OLD_KO"]
+
+
+def test_refresh_skips_disabled_sets(api_client, monkeypatch):
+    dashboard_id = _mk_dashboard(api_client)
+    _mk_set(api_client, dashboard_id, "active")
+    _mk_set(api_client, dashboard_id, "inactive", enabled=False, symbols=["KEEP"])
+    _patch_fetch(monkeypatch, _Recorder())
+
+    resp = api_client.post(f"/dashboards/{dashboard_id}/refresh-contracts")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["count"] == 1
+    # Le set désactivé n'est pas rafraîchi.
+    assert _get_set(api_client, dashboard_id, "inactive")["symbols"] == ["KEEP"]
+
+
+def test_refresh_missing_dashboard_returns_404(api_client):
+    assert api_client.post("/dashboards/9999/refresh-contracts").status_code == 404

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -10,9 +10,11 @@ import pytest
 
 from app.schemas import OrchestratorSet
 from app.services.symfony_client import (
+    ContractsUnavailableError,
     OpenStateUnavailableError,
     build_mtf_payload,
     fetch_open_state,
+    fetch_selected_contracts,
     is_business_success,
     run_mtf_set,
     snapshot_key,
@@ -193,3 +195,111 @@ def test_build_payload_applies_dry_run_override():
     assert build_mtf_payload(live_set, None, dry_run=True)["dry_run"] is True
     # dry_run=None => on retombe sur la valeur du set (ici live).
     assert build_mtf_payload(live_set, None, dry_run=None)["dry_run"] is False
+
+
+# --- fetch_selected_contracts (PY-003) --------------------------------------
+
+
+def _ok_contracts_body(**overrides):
+    body = {
+        "ok": True,
+        "profile": "scalper_micro",
+        "exchange": "bitmart",
+        "market_type": "perpetual",
+        "count": 2,
+        "symbols": ["BTCUSDT", "ETHUSDT"],
+        "filters": {"quote_currency": "USDT", "top_n": 140},
+    }
+    body.update(overrides)
+    return body
+
+
+def _fetch_contracts(handler, profile="scalper_micro", exchange="bitmart", market_type="perpetual"):
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_selected_contracts(
+                client, "http://symfony", profile, exchange, market_type
+            )
+
+    return asyncio.run(_run())
+
+
+def test_fetch_selected_contracts_returns_normalized_shape_and_passes_params():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/mtf/contracts"
+        assert request.url.params["profile"] == "scalper_micro"
+        assert request.url.params["exchange"] == "bitmart"
+        assert request.url.params["market_type"] == "perpetual"
+        return httpx.Response(200, json=_ok_contracts_body())
+
+    result = _fetch_contracts(handler)
+    assert result == {
+        "profile": "scalper_micro",
+        "exchange": "bitmart",
+        "market_type": "perpetual",
+        "count": 2,
+        "symbols": ["BTCUSDT", "ETHUSDT"],
+        "filters": {"quote_currency": "USDT", "top_n": 140},
+    }
+
+
+def test_fetch_selected_contracts_omits_profile_when_none():
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Profil None => la clé n'est pas envoyée (Symfony retombe sur le mode actif).
+        assert "profile" not in request.url.params
+        return httpx.Response(200, json=_ok_contracts_body(profile="regular"))
+
+    result = _fetch_contracts(handler, profile=None)
+    assert result["profile"] == "regular"
+
+
+def test_fetch_selected_contracts_defaults_filters_to_empty_dict():
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = _ok_contracts_body()
+        body.pop("filters")
+        return httpx.Response(200, json=body)
+
+    assert _fetch_contracts(handler)["filters"] == {}
+
+
+def test_fetch_selected_contracts_raises_on_http_error_status():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"ok": False, "error": "boom"})
+
+    with pytest.raises(ContractsUnavailableError):
+        _fetch_contracts(handler)
+
+
+def test_fetch_selected_contracts_raises_on_invalid_json():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not-json", headers={"content-type": "application/json"})
+
+    with pytest.raises(ContractsUnavailableError):
+        _fetch_contracts(handler)
+
+
+def test_fetch_selected_contracts_raises_on_ok_false():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_ok_contracts_body(ok=False))
+
+    with pytest.raises(ContractsUnavailableError):
+        _fetch_contracts(handler)
+
+
+def test_fetch_selected_contracts_raises_on_non_list_symbols():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_ok_contracts_body(symbols="BTCUSDT"))
+
+    with pytest.raises(ContractsUnavailableError):
+        _fetch_contracts(handler)
+
+
+@pytest.mark.parametrize("missing", ["profile", "exchange", "market_type", "count"])
+def test_fetch_selected_contracts_raises_on_missing_required_field(missing):
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = _ok_contracts_body()
+        body.pop(missing)
+        return httpx.Response(200, json=body)
+
+    with pytest.raises(ContractsUnavailableError):
+        _fetch_contracts(handler)


### PR DESCRIPTION
## PY-003 — Refresh explicite des contrats (orchestrateur Python)

> **Draft** ciblant `claude/sf-002b-exchange-state-snapshot` (le code orchestrateur de la PR #162 n'existe pas encore sur `main`). À rebaser sur `main` quand #162 merge.

### Contexte
L'orchestrateur FastAPI doit pouvoir récupérer la liste de symboles **filtrée par profil** depuis Symfony et la persister sur les `symbols` des sets d'un dashboard. Ce refresh est **explicite** (changement de config / demande du front), pas à chaque run.

### Périmètre (atomique)
Fetch contrats + persistance des `symbols` + aperçu. **Hors scope** : génération des payloads `/api/mtf/run` (PY-004) et câblage de `/orchestrator/run` sur les sets DB (PY-005). **Aucun changement PHP** (l'endpoint Symfony `GET /api/mtf/contracts` existe déjà — SF-001).

### Changements
- **`symfony_client.fetch_selected_contracts()`** : `GET /api/mtf/contracts`, valide la forme plate `{ok, profile, exchange, market_type, count, symbols, filters}` ; lève la nouvelle `ContractsUnavailableError` sinon (HTTP≠200, JSON invalide, `ok=false`, `symbols` non-liste, champ requis manquant). Le profil `None` n'est pas envoyé en query (Symfony retombe sur le mode actif).
- **`POST /dashboards/{id}/refresh-contracts`** : sets actifs `mtf_run` du dashboard, **1 fetch par couple distinct** `(mtf_profile, exchange, market_type)` (cache), `symbols = selection[:contracts_limit]`, **fail-closed `502` sans écriture partielle**, commit en une transaction, aperçu par set.
- **schemas** : `ContractRefreshSetPreview` + `ContractRefreshResponse`.
- **docs** : corrige le chemin `/api/mtf/selected-contracts` → `/api/mtf/contracts`, aligne l'exemple de réponse SF-001 sur la forme réelle plate, documente la route de refresh, ajoute la ligne PY-003 à la roadmap.

### Tests
`cd python-orchestrator && python -m pytest -q` → **132 passed, 3 skipped** (les skips = smoke tests Postgres sans DB).
- `tests/test_symfony_client.py` : succès normalisé, params en query, et toutes les branches d'échec de `fetch_selected_contracts`.
- `tests/test_refresh_contracts_api.py` (nouveau) : mise à jour des `symbols` + aperçu, troncature `contracts_limit`, 1 fetch/triplet, fail-closed sans écriture, sets désactivés ignorés, dashboard 404.

### Décisions / écarts
1. Base `sf-002b` imposée (le code orchestrateur n'existe que là).
2. HTTP **502** Bad Gateway choisi pour l'échec de fetch (upstream Symfony).
3. L'exemple de réponse SF-001 dans la doc était faux (wrapper `status/data` + `ignore_limits`) — corrigé pour refléter `ContractsApiController` réel, dont le client PY-003 dépend.
4. Le refresh **écrase** `symbols` même pour les sets à symboles explicites (formule `selection[:contracts_limit]` du cahier des charges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwqL9QVG6bsxotwChPPmd1

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwqL9QVG6bsxotwChPPmd1)_