### PR TITLE
feat(UI-001): cockpit minimal d'orchestration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,9 +175,14 @@ services:
       # Appliquer les migrations avec `alembic upgrade head` (cf. README).
       - DATABASE_URL=postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app
       - ORCHESTRATION_DB_SCHEMA=orchestration
-    # Bridge interne appelé par Temporal/front : pas de port hôte par défaut
-    # (aucun auth/secret pour l'instant). Pour un accès dev local, publier via
-    # un override (docker-compose.override.yml) ou `docker compose run --service-ports`.
+      # Origines autorisées par CORS pour le cockpit (UI-001) : front CRA (:3000)
+      # ou nginx (:8082). Ajuster selon l'origine réelle du front déployé.
+      - CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8082,http://127.0.0.1:8082
+    # Appelé par Temporal/front. Port publié sur l'hôte pour que le cockpit
+    # (UI-001) puisse joindre l'orchestrateur depuis le navigateur. Service sans
+    # auth pour l'instant : ne pas exposer hors d'un réseau de confiance.
+    ports:
+      - "8099:8099"
     expose:
       - "8099"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,11 +178,13 @@ services:
       # Origines autorisées par CORS pour le cockpit (UI-001) : front CRA (:3000)
       # ou nginx (:8082). Ajuster selon l'origine réelle du front déployé.
       - CORS_ALLOW_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8082,http://127.0.0.1:8082
-    # Appelé par Temporal/front. Port publié sur l'hôte pour que le cockpit
-    # (UI-001) puisse joindre l'orchestrateur depuis le navigateur. Service sans
-    # auth pour l'instant : ne pas exposer hors d'un réseau de confiance.
+    # Appelé par Temporal/front. Port publié pour que le cockpit (UI-001)
+    # joigne l'orchestrateur depuis le navigateur. Service sans auth : on le
+    # lie explicitement à la loopback (127.0.0.1) pour ne pas l'exposer sur le
+    # LAN (la syntaxe courte `8099:8099` bind sur 0.0.0.0). Pour un accès
+    # distant, passer par un proxy authentifié.
     ports:
-      - "8099:8099"
+      - "127.0.0.1:8099:8099"
     expose:
       - "8099"
     depends_on:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -22,6 +22,7 @@ import MissingKlinesPage from './pages/MissingKlinesPage';
 import GlobalSearchPage from './pages/GlobalSearchPage';
 import HealthMonitoringPage from './pages/HealthMonitoringPage';
 import RuntimeHistoryPage from './pages/RuntimeHistoryPage';
+import OrchestrationCockpitPage from './pages/OrchestrationCockpitPage';
 import './styles/app.css';
 
 function App() {
@@ -32,6 +33,7 @@ function App() {
                     <ul>
                         <li><Link to="/">Dashboard</Link></li>
                         <li><Link to="/mtf-dashboard">Dashboard MTF</Link></li>
+                        <li><Link to="/orchestration">Cockpit Orchestration</Link></li>
                         <li><Link to="/search">Recherche Globale</Link></li>
                         <li><Link to="/graph">Graphiques</Link></li>
                         <li><Link to="/contracts">Contrats</Link></li>
@@ -57,6 +59,7 @@ function App() {
                     <Routes>
                         <Route path="/" element={<DashboardPage />} />
                         <Route path="/mtf-dashboard" element={<MtfDashboardPage />} />
+                        <Route path="/orchestration" element={<OrchestrationCockpitPage />} />
                         <Route path="/search" element={<GlobalSearchPage />} />
                         <Route path="/graph" element={<ChartsPage />} />
                         <Route path="/contracts/:contractId?" element={<ContractPage />} />

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -2,6 +2,9 @@
 const config = {
     apiUrl: process.env.REACT_APP_API_URL || 'http://localhost:8080',
     pythonApiUrl: process.env.REACT_APP_PYTHON_API_URL || 'http://localhost:8888',
+    // API Python Orchestrator (FastAPI, port interne 8099) : dashboards, sets,
+    // déclenchement des runs et lecture du dernier JSON pour le cockpit (UI-001).
+    orchestratorApiUrl: process.env.REACT_APP_ORCHESTRATOR_API_URL || 'http://localhost:8099',
     positionsRealtimeBaseUrl: process.env.REACT_APP_POSITIONS_WS_BASE_URL
         || process.env.REACT_APP_PYTHON_API_URL
         || 'http://localhost:9000',

--- a/frontend/src/pages/OrchestrationCockpitPage.js
+++ b/frontend/src/pages/OrchestrationCockpitPage.js
@@ -6,7 +6,7 @@
 // configurés, preview du plan d'exécution, déclenchement d'un run et lecture du
 // dernier JSON (résumé global + détail / erreurs par set). Conforme à
 // docs/handbook/functional/orchestration-dashboard.md.
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import api from '../services/api';
 
 // Exchanges verrouillés en dry-run uniquement (cf. garde-fous fonctionnels).
@@ -42,6 +42,11 @@ const OrchestrationCockpitPage = () => {
     const [error, setError] = useState(null);
     const [notice, setNotice] = useState(null);
 
+    // Jeton monotone de requête : un chargement de détail (sets + dernier run)
+    // n'applique son résultat que s'il est toujours le plus récent. Évite qu'une
+    // réponse lente d'un dashboard précédent écrase celle du dashboard courant.
+    const detailRequestRef = useRef(0);
+
     // 1) Chargement initial de la liste des dashboards.
     useEffect(() => {
         let cancelled = false;
@@ -72,6 +77,8 @@ const OrchestrationCockpitPage = () => {
             setLatestRun(null);
             return;
         }
+        const token = ++detailRequestRef.current;
+        const isStale = () => token !== detailRequestRef.current;
         setLoadingSets(true);
         setError(null);
         try {
@@ -79,12 +86,15 @@ const OrchestrationCockpitPage = () => {
                 api.getOrchestrationSets(dashboardId),
                 api.getOrchestrationLatestRun(dashboardId)
             ]);
+            // Une sélection plus récente a été lancée entre-temps : on ignore.
+            if (isStale()) return;
             setSets(Array.isArray(setsData) ? setsData : []);
             setLatestRun(runData);
         } catch (err) {
+            if (isStale()) return;
             setError(`Impossible de charger le dashboard : ${err.message}`);
         } finally {
-            setLoadingSets(false);
+            if (!isStale()) setLoadingSets(false);
         }
     }, []);
 

--- a/frontend/src/pages/OrchestrationCockpitPage.js
+++ b/frontend/src/pages/OrchestrationCockpitPage.js
@@ -79,6 +79,12 @@ const OrchestrationCockpitPage = () => {
         }
         const token = ++detailRequestRef.current;
         const isStale = () => token !== detailRequestRef.current;
+        // Vide le détail dès le début du chargement : sinon la preview et
+        // `runnableSets` refléteraient l'ancien dashboard pendant la requête (ou
+        // indéfiniment si elle échoue), au risque de lancer un run sur des données
+        // périmées. Combiné au gating sur `loadingSets`, les actions sont neutres.
+        setSets([]);
+        setLatestRun(null);
         setLoadingSets(true);
         setError(null);
         try {
@@ -202,14 +208,14 @@ const OrchestrationCockpitPage = () => {
                     <button
                         className="btn btn-secondary"
                         onClick={handleRefreshContracts}
-                        disabled={!selectedDashboardId || busy}
+                        disabled={!selectedDashboardId || busy || loadingSets}
                     >
                         {refreshing ? 'Refresh…' : 'Rafraîchir les contrats'}
                     </button>
                     <button
                         className="btn btn-primary"
                         onClick={handleRun}
-                        disabled={!selectedDashboardId || busy || runnableSets.length === 0}
+                        disabled={!selectedDashboardId || busy || loadingSets || runnableSets.length === 0}
                     >
                         {running ? 'Run en cours…' : 'Lancer un run'}
                     </button>

--- a/frontend/src/pages/OrchestrationCockpitPage.js
+++ b/frontend/src/pages/OrchestrationCockpitPage.js
@@ -103,9 +103,15 @@ const OrchestrationCockpitPage = () => {
     }, [selectedDashboardId, loadDashboardDetail]);
 
     const selectedDashboard = dashboards.find((d) => String(d.id) === String(selectedDashboardId));
+    // Le flag `enabled` du dashboard est un interrupteur de pause global côté
+    // orchestrateur : un dashboard désactivé renvoie toujours `no_sets` (0 appel).
+    // On le reflète dans la preview / le bouton pour ne pas proposer un run vide.
+    const dashboardEnabled = selectedDashboard ? selectedDashboard.enabled : false;
 
-    // Preview : seuls les sets actifs `mtf_run` sont effectivement exécutés.
-    const runnableSets = sets.filter((s) => s.enabled && s.action === 'mtf_run');
+    // Preview : seuls les sets actifs `mtf_run` d'un dashboard actif sont exécutés.
+    const runnableSets = dashboardEnabled
+        ? sets.filter((s) => s.enabled && s.action === 'mtf_run')
+        : [];
     const exchanges = [...new Set(runnableSets.map((s) => s.exchange))];
     const liveSets = runnableSets.filter((s) => !s.dry_run && !forceDryRun);
     const bitmartLiveSets = liveSets.filter((s) => s.exchange === 'bitmart');
@@ -171,7 +177,10 @@ const OrchestrationCockpitPage = () => {
                         className="form-control"
                         value={selectedDashboardId}
                         onChange={(e) => setSelectedDashboardId(e.target.value)}
-                        disabled={loadingDashboards || dashboards.length === 0}
+                        // Verrouillé pendant un refresh/run : empêche de changer de
+                        // dashboard en cours d'action, ce qui ferait recharger le
+                        // détail de l'ancien dashboard après coup (réponse périmée).
+                        disabled={loadingDashboards || dashboards.length === 0 || busy}
                     >
                         {dashboards.length === 0 && <option value="">Aucun dashboard</option>}
                         {dashboards.map((d) => (
@@ -216,6 +225,12 @@ const OrchestrationCockpitPage = () => {
                     {/* Preview du plan d'exécution */}
                     <div className="card">
                         <h3>Preview du plan d'exécution</h3>
+                        {!dashboardEnabled && (
+                            <div className="alert alert-warning">
+                                Ce dashboard est <strong>inactif</strong> : un run renverrait
+                                <code> no_sets</code> (0 appel). Activez-le pour l'exécuter.
+                            </div>
+                        )}
                         <ul className="cockpit-preview">
                             <li>{runnableSets.length} set(s) actif(s) à exécuter (action <code>mtf_run</code>)</li>
                             <li>{runnableSets.length} appel(s) Symfony prévu(s)</li>

--- a/frontend/src/pages/OrchestrationCockpitPage.js
+++ b/frontend/src/pages/OrchestrationCockpitPage.js
@@ -1,0 +1,376 @@
+// src/pages/OrchestrationCockpitPage.js
+//
+// Cockpit minimal d'orchestration (UI-001).
+//
+// Pilote l'API Python Orchestrator : sélection d'un dashboard, liste des sets
+// configurés, preview du plan d'exécution, déclenchement d'un run et lecture du
+// dernier JSON (résumé global + détail / erreurs par set). Conforme à
+// docs/handbook/functional/orchestration-dashboard.md.
+import React, { useCallback, useEffect, useState } from 'react';
+import api from '../services/api';
+
+// Exchanges verrouillés en dry-run uniquement (cf. garde-fous fonctionnels).
+const LIVE_FORBIDDEN_EXCHANGES = ['okx', 'hyperliquid'];
+
+const STATUS_BADGE_CLASS = {
+    success: 'badge-success',
+    partial_failure: 'badge-warning',
+    failed: 'badge-danger',
+    no_sets: 'badge-secondary'
+};
+
+const formatDate = (value) => (value ? new Date(value).toLocaleString('fr-FR') : '-');
+
+const formatDuration = (ms) => {
+    if (ms === null || ms === undefined) return '-';
+    if (ms < 1000) return `${ms} ms`;
+    return `${(ms / 1000).toFixed(1)} s`;
+};
+
+const OrchestrationCockpitPage = () => {
+    const [dashboards, setDashboards] = useState([]);
+    const [selectedDashboardId, setSelectedDashboardId] = useState('');
+    const [sets, setSets] = useState([]);
+    const [latestRun, setLatestRun] = useState(null);
+
+    const [loadingDashboards, setLoadingDashboards] = useState(true);
+    const [loadingSets, setLoadingSets] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
+    const [running, setRunning] = useState(false);
+
+    const [forceDryRun, setForceDryRun] = useState(false);
+    const [error, setError] = useState(null);
+    const [notice, setNotice] = useState(null);
+
+    // 1) Chargement initial de la liste des dashboards.
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            setLoadingDashboards(true);
+            setError(null);
+            try {
+                const data = await api.getOrchestrationDashboards();
+                if (cancelled) return;
+                const list = Array.isArray(data) ? data : [];
+                setDashboards(list);
+                if (list.length > 0) {
+                    setSelectedDashboardId(String(list[0].id));
+                }
+            } catch (err) {
+                if (!cancelled) setError(`Impossible de charger les dashboards : ${err.message}`);
+            } finally {
+                if (!cancelled) setLoadingDashboards(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, []);
+
+    // 2) Chargement des sets + dernier run du dashboard sélectionné.
+    const loadDashboardDetail = useCallback(async (dashboardId) => {
+        if (!dashboardId) {
+            setSets([]);
+            setLatestRun(null);
+            return;
+        }
+        setLoadingSets(true);
+        setError(null);
+        try {
+            const [setsData, runData] = await Promise.all([
+                api.getOrchestrationSets(dashboardId),
+                api.getOrchestrationLatestRun(dashboardId)
+            ]);
+            setSets(Array.isArray(setsData) ? setsData : []);
+            setLatestRun(runData);
+        } catch (err) {
+            setError(`Impossible de charger le dashboard : ${err.message}`);
+        } finally {
+            setLoadingSets(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadDashboardDetail(selectedDashboardId);
+    }, [selectedDashboardId, loadDashboardDetail]);
+
+    const selectedDashboard = dashboards.find((d) => String(d.id) === String(selectedDashboardId));
+
+    // Preview : seuls les sets actifs `mtf_run` sont effectivement exécutés.
+    const runnableSets = sets.filter((s) => s.enabled && s.action === 'mtf_run');
+    const exchanges = [...new Set(runnableSets.map((s) => s.exchange))];
+    const liveSets = runnableSets.filter((s) => !s.dry_run && !forceDryRun);
+    const bitmartLiveSets = liveSets.filter((s) => s.exchange === 'bitmart');
+    const forbiddenLiveSets = liveSets.filter((s) => LIVE_FORBIDDEN_EXCHANGES.includes(s.exchange));
+
+    const handleRefreshContracts = async () => {
+        if (!selectedDashboardId) return;
+        setRefreshing(true);
+        setError(null);
+        setNotice(null);
+        try {
+            const result = await api.refreshOrchestrationContracts(selectedDashboardId);
+            setNotice(`Contrats rafraîchis : ${result.count} set(s) mis à jour.`);
+            await loadDashboardDetail(selectedDashboardId);
+        } catch (err) {
+            setError(`Refresh des contrats échoué : ${err.message}`);
+        } finally {
+            setRefreshing(false);
+        }
+    };
+
+    const handleRun = async () => {
+        if (!selectedDashboardId) return;
+        setRunning(true);
+        setError(null);
+        setNotice(null);
+        try {
+            const result = await api.triggerOrchestrationRun(selectedDashboardId, { forceDryRun });
+            const { ok, run_id: runId, status, summary } = result;
+            setNotice(
+                `Run ${runId} terminé (${status}) — ${ok ? 'OK' : 'NON OK'} : ` +
+                `${summary.success}/${summary.total_calls} réussis, ${summary.failed} échec(s).`
+            );
+            await loadDashboardDetail(selectedDashboardId);
+        } catch (err) {
+            setError(`Déclenchement du run échoué : ${err.message}`);
+        } finally {
+            setRunning(false);
+        }
+    };
+
+    const busy = refreshing || running;
+
+    return (
+        <div className="orchestration-cockpit-page">
+            <div className="page-header">
+                <h1>Cockpit d'orchestration</h1>
+                <p className="page-subtitle">
+                    Configurer les sets, déclencher un run et visualiser le dernier résultat JSON
+                    de l'API Python Orchestrator.
+                </p>
+            </div>
+
+            {error && <div className="alert alert-danger">{error}</div>}
+            {notice && <div className="alert alert-success">{notice}</div>}
+
+            {/* Sélection du dashboard */}
+            <div className="card cockpit-toolbar">
+                <div className="filter-group">
+                    <label htmlFor="dashboard-select">Dashboard</label>
+                    <select
+                        id="dashboard-select"
+                        className="form-control"
+                        value={selectedDashboardId}
+                        onChange={(e) => setSelectedDashboardId(e.target.value)}
+                        disabled={loadingDashboards || dashboards.length === 0}
+                    >
+                        {dashboards.length === 0 && <option value="">Aucun dashboard</option>}
+                        {dashboards.map((d) => (
+                            <option key={d.id} value={d.id}>
+                                {d.name} {d.enabled ? '' : '(inactif)'}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+                <div className="cockpit-actions">
+                    <label className="cockpit-checkbox">
+                        <input
+                            type="checkbox"
+                            checked={forceDryRun}
+                            onChange={(e) => setForceDryRun(e.target.checked)}
+                        />
+                        Forcer dry-run
+                    </label>
+                    <button
+                        className="btn btn-secondary"
+                        onClick={handleRefreshContracts}
+                        disabled={!selectedDashboardId || busy}
+                    >
+                        {refreshing ? 'Refresh…' : 'Rafraîchir les contrats'}
+                    </button>
+                    <button
+                        className="btn btn-primary"
+                        onClick={handleRun}
+                        disabled={!selectedDashboardId || busy || runnableSets.length === 0}
+                    >
+                        {running ? 'Run en cours…' : 'Lancer un run'}
+                    </button>
+                </div>
+            </div>
+
+            {loadingDashboards ? (
+                <div className="card"><div className="loading">Chargement des dashboards…</div></div>
+            ) : dashboards.length === 0 ? (
+                <div className="card"><div className="no-data">Aucun dashboard d'orchestration configuré.</div></div>
+            ) : (
+                <>
+                    {/* Preview du plan d'exécution */}
+                    <div className="card">
+                        <h3>Preview du plan d'exécution</h3>
+                        <ul className="cockpit-preview">
+                            <li>{runnableSets.length} set(s) actif(s) à exécuter (action <code>mtf_run</code>)</li>
+                            <li>{runnableSets.length} appel(s) Symfony prévu(s)</li>
+                            <li>Exchanges : {exchanges.length > 0 ? exchanges.join(', ') : '—'}</li>
+                            <li>Mode : {forceDryRun ? 'dry-run forcé (run-level)' : 'tel que configuré par set'}</li>
+                            <li>Concurrence : bornée côté serveur (MAX_CONCURRENCY)</li>
+                        </ul>
+                        {bitmartLiveSets.length > 0 && (
+                            <div className="alert alert-warning">
+                                ⚠️ {bitmartLiveSets.length} set(s) Bitmart en <strong>live</strong> : à confirmer.
+                            </div>
+                        )}
+                        {forbiddenLiveSets.length > 0 && (
+                            <div className="alert alert-danger">
+                                {forbiddenLiveSets.length} set(s) OKX/Hyperliquid en live :
+                                seront <strong>refusés</strong> (live interdit, fail-closed).
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Liste des sets */}
+                    <div className="card">
+                        <h3>Sets configurés{selectedDashboard ? ` — ${selectedDashboard.name}` : ''}</h3>
+                        {loadingSets ? (
+                            <div className="loading">Chargement des sets…</div>
+                        ) : (
+                            <table className="data-table">
+                                <thead>
+                                    <tr>
+                                        <th>Enabled</th>
+                                        <th>Set ID</th>
+                                        <th>Action</th>
+                                        <th>Exchange</th>
+                                        <th>Marché</th>
+                                        <th>Profil</th>
+                                        <th>Env.</th>
+                                        <th>Dry-run</th>
+                                        <th>Workers</th>
+                                        <th>Contrats</th>
+                                        <th>Priorité</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {sets.length === 0 ? (
+                                        <tr><td colSpan="11" className="text-center">Aucun set configuré.</td></tr>
+                                    ) : (
+                                        sets.map((s) => (
+                                            <tr key={s.id}>
+                                                <td>
+                                                    <span className={`badge ${s.enabled ? 'badge-success' : 'badge-secondary'}`}>
+                                                        {s.enabled ? 'on' : 'off'}
+                                                    </span>
+                                                </td>
+                                                <td>{s.set_id}</td>
+                                                <td>{s.action}</td>
+                                                <td>{s.exchange}</td>
+                                                <td>{s.market_type}</td>
+                                                <td>{s.mtf_profile}</td>
+                                                <td>{s.environment}</td>
+                                                <td>
+                                                    <span className={`badge ${s.dry_run ? 'badge-info' : 'badge-danger'}`}>
+                                                        {s.dry_run ? 'dry' : 'live'}
+                                                    </span>
+                                                </td>
+                                                <td>{s.workers}</td>
+                                                <td>
+                                                    {s.symbols && s.symbols.length > 0
+                                                        ? `${s.symbols.length} sym.`
+                                                        : (s.contracts_limit ? `≤ ${s.contracts_limit}` : '—')}
+                                                </td>
+                                                <td>{s.priority}</td>
+                                            </tr>
+                                        ))
+                                    )}
+                                </tbody>
+                            </table>
+                        )}
+                    </div>
+
+                    {/* Dernier run */}
+                    <div className="card">
+                        <h3>Dernier run</h3>
+                        {!latestRun ? (
+                            <div className="no-data">Aucun run persisté pour ce dashboard.</div>
+                        ) : (
+                            <>
+                                <div className="contract-info">
+                                    <div><strong>Run ID</strong><br />{latestRun.run_id}</div>
+                                    <div>
+                                        <strong>Statut</strong><br />
+                                        <span className={`badge ${STATUS_BADGE_CLASS[latestRun.status] || 'badge-secondary'}`}>
+                                            {latestRun.status}
+                                        </span>
+                                    </div>
+                                    <div><strong>OK</strong><br />{latestRun.ok ? 'oui' : 'non'}</div>
+                                    <div><strong>Début</strong><br />{formatDate(latestRun.started_at)}</div>
+                                    <div><strong>Fin</strong><br />{formatDate(latestRun.finished_at)}</div>
+                                    <div><strong>Appels</strong><br />{latestRun.total_calls}</div>
+                                    <div><strong>Réussis</strong><br />{latestRun.success_count}</div>
+                                    <div><strong>Échoués</strong><br />{latestRun.failed_count}</div>
+                                </div>
+
+                                <h4>Détail par set</h4>
+                                <table className="data-table">
+                                    <thead>
+                                        <tr>
+                                            <th>Set ID</th>
+                                            <th>Statut</th>
+                                            <th>Durée</th>
+                                            <th>Erreur</th>
+                                            <th>JSON</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {(latestRun.sets || []).length === 0 ? (
+                                            <tr><td colSpan="5" className="text-center">Aucun set dans ce run.</td></tr>
+                                        ) : (
+                                            (latestRun.sets || []).map((rs) => (
+                                                <tr key={rs.id}>
+                                                    <td>{rs.set_id}</td>
+                                                    <td>
+                                                        <span className={`badge ${rs.ok ? 'badge-success' : 'badge-danger'}`}>
+                                                            {rs.ok ? 'OK' : 'KO'}
+                                                        </span>
+                                                    </td>
+                                                    <td>{formatDuration(rs.duration_ms)}</td>
+                                                    <td className="cockpit-error">{rs.error || '—'}</td>
+                                                    <td>
+                                                        <details>
+                                                            <summary>payload / réponse</summary>
+                                                            <div className="cockpit-json-pair">
+                                                                <div>
+                                                                    <strong>Payload envoyé</strong>
+                                                                    <pre className="cockpit-json">
+                                                                        {JSON.stringify(rs.payload_sent, null, 2)}
+                                                                    </pre>
+                                                                </div>
+                                                                <div>
+                                                                    <strong>Réponse Symfony</strong>
+                                                                    <pre className="cockpit-json">
+                                                                        {JSON.stringify(rs.response_json, null, 2)}
+                                                                    </pre>
+                                                                </div>
+                                                            </div>
+                                                        </details>
+                                                    </td>
+                                                </tr>
+                                            ))
+                                        )}
+                                    </tbody>
+                                </table>
+
+                                <details className="cockpit-last-json">
+                                    <summary>Dernier JSON global</summary>
+                                    <pre className="cockpit-json">
+                                        {JSON.stringify(latestRun.last_json, null, 2)}
+                                    </pre>
+                                </details>
+                            </>
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default OrchestrationCockpitPage;

--- a/frontend/src/pages/OrchestrationCockpitPage.js
+++ b/frontend/src/pages/OrchestrationCockpitPage.js
@@ -220,7 +220,17 @@ const OrchestrationCockpitPage = () => {
                     <button
                         className="btn btn-primary"
                         onClick={handleRun}
-                        disabled={!selectedDashboardId || busy || loadingSets || runnableSets.length === 0}
+                        disabled={
+                            !selectedDashboardId
+                            || busy
+                            || loadingSets
+                            || runnableSets.length === 0
+                            // `/orchestrator/run` exécute TOUS les sets actifs du
+                            // dashboard (pas de sélection par set côté backend) : un
+                            // set non matérialisé partirait et serait compté en échec.
+                            // On bloque donc le run tant qu'un refresh est requis.
+                            || pendingMaterializationSets.length > 0
+                        }
                     >
                         {running ? 'Run en cours…' : 'Lancer un run'}
                     </button>
@@ -245,8 +255,11 @@ const OrchestrationCockpitPage = () => {
                         {dashboardEnabled && pendingMaterializationSets.length > 0 && (
                             <div className="alert alert-warning">
                                 {pendingMaterializationSets.length} set(s) actif(s) <strong>non
-                                matérialisé(s)</strong> (contrats pas encore résolus) : exclus du
-                                run tant que « Rafraîchir les contrats » n'a pas été lancé.
+                                matérialisé(s)</strong> (contrats pas encore résolus). Le run est
+                                <strong> bloqué</strong> : <code>/orchestrator/run</code> exécute
+                                tous les sets actifs du dashboard, donc ces sets partiraient et
+                                seraient comptés en échec <code>not materialized</code>. Lancez
+                                « Rafraîchir les contrats » avant de relancer.
                             </div>
                         )}
                         <ul className="cockpit-preview">

--- a/frontend/src/pages/OrchestrationCockpitPage.js
+++ b/frontend/src/pages/OrchestrationCockpitPage.js
@@ -115,9 +115,14 @@ const OrchestrationCockpitPage = () => {
     const dashboardEnabled = selectedDashboard ? selectedDashboard.enabled : false;
 
     // Preview : seuls les sets actifs `mtf_run` d'un dashboard actif sont exécutés.
-    const runnableSets = dashboardEnabled
+    const enabledMtfSets = dashboardEnabled
         ? sets.filter((s) => s.enabled && s.action === 'mtf_run')
         : [];
+    // Un set capé non encore rafraîchi a `payload: null` (symbols vide) :
+    // l'orchestrateur le marque « not materialized » et n'appelle pas Symfony.
+    // On l'exclut donc des sets exécutables et on signale qu'un refresh manque.
+    const runnableSets = enabledMtfSets.filter((s) => s.payload);
+    const pendingMaterializationSets = enabledMtfSets.filter((s) => !s.payload);
     const exchanges = [...new Set(runnableSets.map((s) => s.exchange))];
     const liveSets = runnableSets.filter((s) => !s.dry_run && !forceDryRun);
     const bitmartLiveSets = liveSets.filter((s) => s.exchange === 'bitmart');
@@ -235,6 +240,13 @@ const OrchestrationCockpitPage = () => {
                             <div className="alert alert-warning">
                                 Ce dashboard est <strong>inactif</strong> : un run renverrait
                                 <code> no_sets</code> (0 appel). Activez-le pour l'exécuter.
+                            </div>
+                        )}
+                        {dashboardEnabled && pendingMaterializationSets.length > 0 && (
+                            <div className="alert alert-warning">
+                                {pendingMaterializationSets.length} set(s) actif(s) <strong>non
+                                matérialisé(s)</strong> (contrats pas encore résolus) : exclus du
+                                run tant que « Rafraîchir les contrats » n'a pas été lancé.
                             </div>
                         )}
                         <ul className="cockpit-preview">

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -4,7 +4,8 @@ import config from '../config';
 const handleResponse = async (response) => {
     if (!response.ok) {
         const error = await response.json().catch(() => ({ message: 'Erreur réseau' }));
-        throw new Error(error.message || `Erreur ${response.status}`);
+        // FastAPI (API Python Orchestrator) renvoie le message d'erreur dans `detail`.
+        throw new Error(error.message || error.detail || `Erreur ${response.status}`);
     }
     return await response.json();
 };
@@ -338,6 +339,54 @@ const api = {
         });
         const queryString = queryParams.toString() ? `?${queryParams.toString()}` : '';
         const response = await fetch(`${config.apiUrl}/api/runtime-history${queryString}`);
+        return handleResponse(response);
+    },
+
+    // --- Orchestration cockpit (API Python Orchestrator, UI-001) -------------
+
+    // Liste des dashboards d'orchestration.
+    async getOrchestrationDashboards() {
+        const response = await fetch(`${config.orchestratorApiUrl}/dashboards`);
+        return handleResponse(response);
+    },
+
+    // Sets configurés d'un dashboard (option `enabledOnly` pour ne garder que les actifs).
+    async getOrchestrationSets(dashboardId, { enabledOnly = false } = {}) {
+        const query = enabledOnly ? '?enabled_only=true' : '';
+        const response = await fetch(`${config.orchestratorApiUrl}/dashboards/${dashboardId}/sets${query}`);
+        return handleResponse(response);
+    },
+
+    // Refresh explicite des contrats des sets `mtf_run` actifs (PY-003).
+    async refreshOrchestrationContracts(dashboardId) {
+        const response = await fetch(
+            `${config.orchestratorApiUrl}/dashboards/${dashboardId}/refresh-contracts`,
+            { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+        );
+        return handleResponse(response);
+    },
+
+    // Déclenche un run d'orchestration (PY-005). `forceDryRun` force le dry-run au niveau run.
+    async triggerOrchestrationRun(dashboardId, { forceDryRun = false } = {}) {
+        const body = { dashboard_id: String(dashboardId) };
+        if (forceDryRun) {
+            body.dry_run = true;
+        }
+        const response = await fetch(`${config.orchestratorApiUrl}/orchestrator/run`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        return handleResponse(response);
+    },
+
+    // Dernier run d'un dashboard : dernier JSON global + détail par set (PY-006).
+    // Retourne `null` si aucun run n'a encore été persisté (404).
+    async getOrchestrationLatestRun(dashboardId) {
+        const response = await fetch(`${config.orchestratorApiUrl}/dashboards/${dashboardId}/runs/latest`);
+        if (response.status === 404) {
+            return null;
+        }
         return handleResponse(response);
     }
 };

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -825,3 +825,148 @@ h1, h2, h3, h4, h5, h6 {
         margin-left: 0;
     }
 }
+
+/* ============================================================
+   Cockpit d'orchestration (UI-001)
+   Inclut quelques classes utilitaires partagées (page-header,
+   alert, form-control, badges de statut) référencées par
+   plusieurs pages mais jusqu'ici non stylées.
+   ============================================================ */
+
+.page-header {
+    margin-bottom: 20px;
+}
+
+.page-subtitle {
+    color: var(--dark-gray);
+    margin-bottom: 0;
+}
+
+.alert {
+    padding: 12px 16px;
+    border-radius: var(--border-radius);
+    margin-bottom: 20px;
+    border: 1px solid transparent;
+}
+
+.alert-danger {
+    background-color: rgba(231, 76, 60, 0.1);
+    border-color: var(--danger-color);
+    color: var(--danger-color);
+}
+
+.alert-success {
+    background-color: rgba(46, 204, 113, 0.1);
+    border-color: var(--success-color);
+    color: #1e8449;
+}
+
+.alert-warning {
+    background-color: rgba(243, 156, 18, 0.1);
+    border-color: var(--warning-color);
+    color: #b9770e;
+}
+
+.form-control {
+    padding: 10px 12px;
+    border: 1px solid var(--mid-gray);
+    border-radius: 4px;
+    font-size: 15px;
+    transition: var(--transition);
+}
+
+.form-control:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 14px;
+}
+
+.btn-secondary {
+    background-color: var(--secondary-color);
+    color: white;
+}
+
+/* Badges de statut */
+.badge-success { background-color: var(--success-color); }
+.badge-warning { background-color: var(--warning-color); }
+.badge-danger  { background-color: var(--danger-color); }
+.badge-info    { background-color: var(--primary-color); }
+.badge-secondary { background-color: var(--dark-gray); }
+
+.text-center { text-align: center; }
+
+/* Barre d'outils du cockpit */
+.cockpit-toolbar {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.cockpit-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.cockpit-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+}
+
+.cockpit-preview {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 8px 20px;
+    margin-bottom: 12px;
+}
+
+.cockpit-preview li {
+    padding: 6px 0;
+    border-bottom: 1px solid var(--mid-gray);
+}
+
+.cockpit-error {
+    color: var(--danger-color);
+    max-width: 360px;
+    word-break: break-word;
+}
+
+.cockpit-json {
+    background-color: #1e1e1e;
+    color: #d4d4d4;
+    padding: 12px;
+    border-radius: 4px;
+    font-size: 12px;
+    overflow: auto;
+    max-height: 320px;
+}
+
+.cockpit-json-pair {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-top: 8px;
+}
+
+.cockpit-last-json {
+    margin-top: 16px;
+}
+
+@media (max-width: 768px) {
+    .cockpit-json-pair {
+        grid-template-columns: 1fr;
+    }
+}

--- a/python-orchestrator/app/main.py
+++ b/python-orchestrator/app/main.py
@@ -7,9 +7,11 @@ Lancement local :
 from __future__ import annotations
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
 from app.routers import dashboards, health, orchestrator, runs
+from app.settings import get_settings
 
 app = FastAPI(
     title="TradingV3 — Python Orchestrator",
@@ -20,6 +22,17 @@ app = FastAPI(
         "le dernier JSON global et par set (PY-006). "
         "Voir docs/handbook/technical/python-orchestrator.md."
     ),
+)
+
+# CORS : le cockpit (UI-001) appelle cette API directement depuis le navigateur.
+# Origines restreintes par config (CORS_ALLOW_ORIGINS) — pas de wildcard par défaut.
+# Pas de credentials (cookies) : authentification hors périmètre à ce stade.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=list(get_settings().cors_allow_origins),
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(health.router)

--- a/python-orchestrator/app/settings.py
+++ b/python-orchestrator/app/settings.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Tuple
 
 
 class SettingsError(ValueError):
@@ -25,6 +26,19 @@ def _int_env(name: str, default: int) -> int:
         return int(raw)
     except ValueError as exc:
         raise SettingsError(f"Variable {name!r} invalide : {raw!r} n'est pas un entier.") from exc
+
+
+def _csv_env(name: str, default: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Lit une liste CSV depuis l'environnement (vides ignorés), ou le défaut.
+
+    Utilisé pour ``CORS_ALLOW_ORIGINS`` : ``"http://a, http://b"`` -> ``("http://a", "http://b")``.
+    Une valeur vide/absente retombe sur le défaut ; ``"*"`` reste possible (autorise
+    toute origine, acceptable car le service n'utilise pas de cookies/credentials).
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    return tuple(item.strip() for item in raw.split(",") if item.strip())
 
 
 @dataclass(frozen=True)
@@ -46,6 +60,15 @@ class Settings:
     )
     # Schéma PostgreSQL dédié aux tables d'orchestration.
     db_schema: str = "orchestration"
+    # Origines autorisées par CORS pour les appels navigateur du cockpit (UI-001).
+    # Défauts = front servi par CRA (:3000) ou nginx (:8082). Surchargeable via
+    # CORS_ALLOW_ORIGINS (CSV) ; ``"*"`` autorise toute origine.
+    cors_allow_origins: Tuple[str, ...] = (
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://localhost:8082",
+        "http://127.0.0.1:8082",
+    )
 
     def __post_init__(self) -> None:
         if not 1 <= self.port <= 65535:
@@ -65,6 +88,7 @@ class Settings:
             max_concurrency=_int_env("MAX_CONCURRENCY", cls.max_concurrency),
             database_url=os.getenv("DATABASE_URL", cls.database_url),
             db_schema=os.getenv("ORCHESTRATION_DB_SCHEMA", cls.db_schema),
+            cors_allow_origins=_csv_env("CORS_ALLOW_ORIGINS", cls.cors_allow_origins),
         )
 
 


### PR DESCRIPTION
## Objectif

Ajouter le **cockpit minimal d'orchestration** (UI-001), première brique front du plan figé par #155, et le câblage de connectivité nécessaire pour que le cockpit joigne l'API Python Orchestrator depuis le navigateur.

Conforme à `docs/handbook/functional/orchestration-dashboard.md` et `docs/handbook/technical/python-orchestrator.md`.

## Contenu

### Front — cockpit (`frontend/`)

Nouvelle page `OrchestrationCockpitPage.js` (route `/orchestration`, lien sidebar) :

- **Sélection du dashboard** — `GET /dashboards`.
- **Liste des sets configurés** — `GET /dashboards/{id}/sets` : enabled, set_id, action, exchange, marché, profil, environnement, dry-run, workers, contrats, priorité.
- **Preview du plan d'exécution** — sets actifs `mtf_run`, appels Symfony prévus, exchanges, mode dry-run ; alertes **Bitmart live** (à confirmer) et **OKX/Hyperliquid live** (refusés, fail-closed) ; notice **dashboard inactif** (run = `no_sets`).
- **Rafraîchir les contrats** — `POST /dashboards/{id}/refresh-contracts`.
- **Lancer un run** — `POST /orchestrator/run` avec override **« Forcer dry-run »**.
- **Dernier run** — `GET /dashboards/{id}/runs/latest` : résumé global + détail/erreurs par set + dernier JSON global.

Garde-fous front : jeton de requête monotone contre les réponses périmées, sélecteur verrouillé pendant un refresh/run, état `enabled` du dashboard pris en compte dans la preview/CTA.

Câblage : `orchestratorApiUrl` (`REACT_APP_ORCHESTRATOR_API_URL`, défaut `:8099`), méthodes orchestrateur dans `services/api.js` (gestion du `detail` FastAPI, 404 → pas de run), styles cockpit + utilitaires partagés.

### Connectivité orchestrateur (P1 — review)

Le cockpit appelle l'orchestrateur **depuis le navigateur** : le service doit donc être joignable et CORS-friendly.

- `python-orchestrator/app/main.py` : `CORSMiddleware` FastAPI piloté par une config.
- `python-orchestrator/app/settings.py` : `CORS_ALLOW_ORIGINS` (CSV, défaut origines front CRA `:3000` / nginx `:8082`, **pas de wildcard**, pas de credentials).
- `docker-compose.yml` : publication du port `8099` sur l'hôte + passage des origines CORS.

> ⚠️ Le service n'a pas encore d'authentification : à ne pas exposer hors d'un réseau de confiance. Un durcissement (auth / proxy same-origin) pourra suivre.

## Vérifications

- Front : `npm run build` **OK**, aucun warning sur la nouvelle page.
- Orchestrateur : `pytest tests/test_settings.py tests/test_health.py` **OK** ; `CORSMiddleware` présent et `CORS_ALLOW_ORIGINS` parsé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)