### PR TITLE
Expose effective /api/mtf/run payload via API (PY-007)

### DIFF
--- a/frontend/src/pages/OrchestrationCockpitPage.js
+++ b/frontend/src/pages/OrchestrationCockpitPage.js
@@ -12,44 +12,6 @@ import api from '../services/api';
 // Exchanges verrouillés en dry-run uniquement (cf. garde-fous fonctionnels).
 const LIVE_FORBIDDEN_EXCHANGES = ['okx', 'hyperliquid'];
 
-// Borne workers côté Symfony, alignée sur `MAX_WORKERS_PER_SET` du runner Python
-// (python-orchestrator/app/schemas.py). Aucune contrainte CHECK en base : le
-// runtime clampe à l'exécution, donc la preview clampe pareil pour ne pas afficher
-// un payload divergent de l'envoi réel.
-const MAX_WORKERS_PER_SET = 1;
-
-// Nettoie les symbols comme le runner / Symfony : trim puis écarte les vides et
-// blancs. Une sélection qui se réduit à du vide vaut « tout l'univers actif » côté
-// Symfony, ce que la matérialisation interdit ; on la traite donc comme non
-// matérialisée (cf. generate_set_payload, app/services/symfony_client.py).
-const cleanSymbols = (symbols) =>
-    (Array.isArray(symbols) ? symbols : [])
-        .filter((s) => typeof s === 'string')
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-
-// Reconstruit le payload /api/mtf/run depuis les COLONNES du set (allow-list),
-// exactement comme `generate_set_payload` + le clamp workers de `run_persisted_set`
-// côté Python — plutôt que de faire confiance au JSON `payload` persisté, qui peut
-// être périmé (symbols vidés depuis) ou porter des flags de contrôle runner. On ne
-// montre ainsi dans la preview que ce qui partira réellement à Symfony.
-// Renvoie `null` si la sélection n'a aucun symbole concret (non matérialisé :
-// fail-closed, aucun appel). `open_state_snapshot` est joint au runtime, pas ici.
-const buildSetPayload = (s, { dryRun } = {}) => {
-    const symbols = cleanSymbols(s.symbols);
-    if (symbols.length === 0) return null;
-    return {
-        dry_run: dryRun === undefined ? s.dry_run : dryRun,
-        workers: Math.max(1, Math.min(s.workers || 1, MAX_WORKERS_PER_SET)),
-        exchange: s.exchange,
-        market_type: s.market_type,
-        mtf_profile: s.mtf_profile,
-        sync_tables: false,
-        process_tp_sl: false,
-        symbols
-    };
-};
-
 const STATUS_BADGE_CLASS = {
     success: 'badge-success',
     partial_failure: 'badge-warning',
@@ -175,11 +137,12 @@ const OrchestrationCockpitPage = () => {
     // Parmi les sets effectivement dry, on distingue matérialisé / non matérialisé.
     // Un set non matérialisé n'a aucun symbole concret (sélection capée pas encore
     // rafraîchie, ou symbols tous blancs) : le runner renvoie `payload=null` et
-    // n'appelle pas Symfony. On juge la matérialisation sur les COLONNES (comme le
-    // runner), pas sur le JSON `payload` persisté qui pourrait être périmé.
+    // n'appelle pas Symfony. On juge la matérialisation sur `effective_payload`,
+    // LE payload effectif calculé par l'API Python (SetRead.effective_payload,
+    // PY-007) : `null` ⇔ non matérialisé, exactement comme côté runner.
     const effectiveDrySets = enabledMtfSets.filter((s) => effectiveDryRun(s));
-    const runnableSets = effectiveDrySets.filter((s) => cleanSymbols(s.symbols).length > 0);
-    const pendingMaterializationSets = effectiveDrySets.filter((s) => cleanSymbols(s.symbols).length === 0);
+    const runnableSets = effectiveDrySets.filter((s) => s.effective_payload != null);
+    const pendingMaterializationSets = effectiveDrySets.filter((s) => s.effective_payload == null);
     // Les deux autres états de set, à distinguer dans la preview : les sets
     // désactivés (jamais exécutés) et les sets actifs dont l'action n'est pas
     // `mtf_run` (l'orchestrateur ne dispatche aujourd'hui que des `mtf_run`).
@@ -188,9 +151,12 @@ const OrchestrationCockpitPage = () => {
     const disabledSets = sets.filter((s) => !s.enabled);
     const nonMtfRunSets = sets.filter((s) => s.enabled && s.action !== 'mtf_run');
     const exchanges = [...new Set(runnableSets.map((s) => s.exchange))];
-    // Payload /api/mtf/run effectivement envoyé : reconstruit depuis les colonnes
-    // (comme le runner), avec `dry_run` recalé sur la valeur effective.
-    const effectivePayload = (s) => buildSetPayload(s, { dryRun: effectiveDryRun(s) });
+    // Payload /api/mtf/run effectivement envoyé : LE payload calculé par l'API
+    // (SetRead.effective_payload, PY-007), seul `dry_run` étant recalé localement
+    // sur la valeur effective car « Forcer dry-run » est une décision run-level
+    // côté front (transformation triviale, le reste vient de l'API).
+    const effectivePayload = (s) =>
+        s.effective_payload && { ...s.effective_payload, dry_run: effectiveDryRun(s) };
 
     const handleRefreshContracts = async () => {
         if (!selectedDashboardId) return;
@@ -396,8 +362,8 @@ const OrchestrationCockpitPage = () => {
                                                     <span className="cockpit-hint"> (forcé)</span>
                                                 )}
                                             </td>
-                                            <td>{Math.max(1, Math.min(s.workers || 1, MAX_WORKERS_PER_SET))}</td>
-                                            <td>{cleanSymbols(s.symbols).length}</td>
+                                            <td>{s.effective_payload.workers}</td>
+                                            <td>{s.effective_payload.symbols.length}</td>
                                             <td>
                                                 <details>
                                                     <summary>payload</summary>

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Literal, Optional, Tuple
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
 from app import __version__
 
@@ -441,6 +441,32 @@ class SetRead(BaseModel):
     payload: Optional[dict] = None
     created_at: datetime
     updated_at: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def effective_payload(self) -> Optional[dict]:
+        """Payload ``/api/mtf/run`` réellement envoyé pour ce set (PY-007).
+
+        Champ calculé en lecture seule, exposé pour que le cockpit (preview UI-002)
+        affiche LE payload effectif plutôt que de le reconstruire côté front. Délègue
+        à la fonction canonique ``effective_set_payload`` — exactement celle qu'utilise
+        ``run_persisted_set`` au dispatch (forme + clamp ``workers``), **hors** couche
+        runtime (``open_state_snapshot`` et override ``dry_run`` run-level). Garantit
+        donc l'identité preview ⇆ envoi réel, sans second chemin de construction.
+
+        ``null`` quand la sélection n'est pas matérialisée (symbols vide/blanc),
+        comme ``generate_set_payload`` : le front en déduit « set non matérialisé ».
+
+        Le champ persisté ``payload`` (PY-004) reste exposé tel quel ; ``effective_
+        payload`` y ajoute le clamp ``workers`` appliqué au dispatch et tolère les
+        enums du schéma comme les chaînes ORM.
+
+        Import différé pour éviter le cycle ``schemas`` ⇆ ``services.symfony_client``
+        (ce dernier importe déjà ``MAX_WORKERS_PER_SET``/``OrchestratorSet`` d'ici).
+        """
+        from app.services.symfony_client import effective_set_payload
+
+        return effective_set_payload(self)
 
 
 # ---------------------------------------------------------------------------

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -272,6 +272,18 @@ def build_mtf_payload(
     return payload
 
 
+def _enum_value(value: Any) -> Any:
+    """Déplie un membre d'enum en sa ``value``, laisse les chaînes inchangées.
+
+    ``generate_set_payload`` est appelé à la fois sur un ``OrchestrationSet`` ORM
+    (``exchange``/``market_type``/``mtf_profile`` y sont des **chaînes**) et sur le
+    schéma de lecture ``SetRead`` (où ce sont des **enums** ``str``). On normalise
+    en chaîne dans les deux cas pour que le payload effectif d'un même set soit
+    identique quelle que soit la source (cf. ``effective_set_payload``).
+    """
+    return getattr(value, "value", value)
+
+
 def generate_set_payload(a_set: Any) -> Optional[Dict[str, Any]]:
     """Prépare le payload ``/api/mtf/run`` **persisté** d'un set (PY-004).
 
@@ -302,11 +314,41 @@ def generate_set_payload(a_set: Any) -> Optional[Dict[str, Any]]:
     return _base_mtf_payload(
         dry_run=a_set.dry_run,
         workers=a_set.workers,
-        exchange=a_set.exchange,
-        market_type=a_set.market_type,
-        mtf_profile=a_set.mtf_profile,
+        exchange=_enum_value(a_set.exchange),
+        market_type=_enum_value(a_set.market_type),
+        mtf_profile=_enum_value(a_set.mtf_profile),
         symbols=symbols,
     )
+
+
+def _clamp_workers(workers: Any) -> int:
+    """Borne ``workers`` dans ``[1, MAX_WORKERS_PER_SET]``.
+
+    La borne ``MAX_WORKERS_PER_SET`` n'est imposée qu'au schéma de persistance
+    (aucune contrainte CHECK en base) : une ligne écrite hors API pourrait porter
+    ``workers>1``. On clampe donc au dispatch pour respecter la politique
+    « workers=1 côté Symfony ». Source unique du clamp (``effective_set_payload``).
+    """
+    return max(1, min(workers or 1, MAX_WORKERS_PER_SET))
+
+
+def effective_set_payload(a_set: Any) -> Optional[Dict[str, Any]]:
+    """Payload ``/api/mtf/run`` **effectif** d'un set persisté (PY-007).
+
+    Source unique du payload réellement envoyé par ``run_persisted_set``, **hors**
+    couche runtime : sans ``open_state_snapshot`` (récupéré à chaque run) et sans
+    l'override ``dry_run`` run-level. C'est exactement ``generate_set_payload`` +
+    le clamp ``workers`` — ni plus, ni moins — afin que la preview du cockpit
+    (``SetRead.effective_payload``) ne puisse pas dériver de l'envoi réel.
+
+    Renvoie ``None`` quand la sélection n'est pas matérialisée (symbols vide/blanc),
+    comme ``generate_set_payload`` : le front juge alors le set « non matérialisé ».
+    """
+    payload = generate_set_payload(a_set)
+    if payload is None:
+        return None
+    payload["workers"] = _clamp_workers(payload.get("workers"))
+    return payload
 
 
 # Statuts métier renvoyés par /api/mtf/run considérés comme un succès complet.
@@ -382,7 +424,7 @@ async def run_persisted_set(
     """Exécute un ``OrchestrationSet`` ORM persisté via ``POST /api/mtf/run`` (PY-005).
 
     Reconstruit **toujours** le payload depuis les COLONNES ORM via la forme
-    canonique ``generate_set_payload`` (allow-list de clés : ``dry_run``,
+    canonique ``effective_set_payload`` (allow-list de clés : ``dry_run``,
     ``workers``, ``exchange``, ``market_type``, ``mtf_profile``, ``symbols`` +
     ``sync_tables``/``process_tp_sl=false``) — plutôt que de faire confiance au JSON
     ``orm_set.payload`` stocké. Une ligne écrite hors API pourrait y avoir laissé
@@ -402,8 +444,11 @@ async def run_persisted_set(
     l'univers actif).
     """
     # Allow-list : repart des colonnes ORM, jamais du JSON stocké (anti control-flag
-    # et anti-divergence). `None` ⇔ symbols vide ⇒ non matérialisé.
-    payload = generate_set_payload(orm_set)
+    # et anti-divergence). Forme + clamp workers délégués à `effective_set_payload`,
+    # la fonction canonique partagée avec `SetRead.effective_payload` (PY-007) : la
+    # preview du cockpit ne peut donc pas dériver de l'envoi réel. `None` ⇔ symbols
+    # vide ⇒ non matérialisé.
+    payload = effective_set_payload(orm_set)
     if payload is None:
         return {
             "set_id": orm_set.set_id,
@@ -413,13 +458,8 @@ async def run_persisted_set(
             "body": "set payload not materialized (no concrete symbols)",
             "payload_sent": None,
         }
-    # Garde runtime workers : la borne MAX_WORKERS_PER_SET n'est imposée qu'au
-    # schéma de persistance (aucune contrainte CHECK en base). Une ligne écrite hors
-    # API avec `workers>1` passerait Symfony en mode parallèle ; on clampe dans
-    # [1, MAX] pour respecter la politique « workers=1 côté Symfony ».
-    payload["workers"] = max(1, min(payload.get("workers") or 1, MAX_WORKERS_PER_SET))
-    # Override run-level (sinon le dry_run de la colonne, déjà posé par
-    # generate_set_payload) puis snapshot runtime.
+    # On n'overlay ensuite que le runtime, exclu d'`effective_set_payload` : override
+    # run-level `dry_run` (sinon le dry_run de la colonne) puis snapshot runtime.
     if dry_run is not None:
         payload["dry_run"] = dry_run
     if snapshot is not None:

--- a/python-orchestrator/tests/test_dashboards_api.py
+++ b/python-orchestrator/tests/test_dashboards_api.py
@@ -196,6 +196,40 @@ def test_create_set_generates_payload(api_client):
     }
 
 
+def test_set_read_exposes_effective_payload(api_client):
+    # PY-007 : la lecture d'un set expose le payload /api/mtf/run EFFECTIF (ce qui
+    # part réellement à Symfony), pour que le cockpit n'ait plus à le reconstruire.
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())
+
+    body = api_client.get(f"/dashboards/{dashboard_id}/sets/bitmart_regular_top").json()
+
+    assert body["effective_payload"] == {
+        "dry_run": True,
+        "workers": 1,
+        "exchange": "bitmart",
+        "market_type": "perpetual",
+        "mtf_profile": "regular",
+        "sync_tables": False,
+        "process_tp_sl": False,
+        "symbols": ["BTCUSDT", "ETHUSDT"],
+    }
+
+
+def test_set_read_effective_payload_null_when_not_materialized(api_client):
+    # Set capé sans symboles concrets (sélection pas encore rafraîchie) : le payload
+    # effectif est null, et le front en déduit « set non matérialisé ».
+    dashboard_id = _create_dashboard(api_client).json()["id"]
+    api_client.post(
+        f"/dashboards/{dashboard_id}/sets",
+        json=_set_payload(symbols=[], contracts_limit=5),
+    )
+
+    body = api_client.get(f"/dashboards/{dashboard_id}/sets/bitmart_regular_top").json()
+
+    assert body["effective_payload"] is None
+
+
 def test_patch_set_regenerates_payload(api_client):
     dashboard_id = _create_dashboard(api_client).json()["id"]
     api_client.post(f"/dashboards/{dashboard_id}/sets", json=_set_payload())

--- a/python-orchestrator/tests/test_schemas.py
+++ b/python-orchestrator/tests/test_schemas.py
@@ -1,7 +1,17 @@
+from datetime import datetime
+
 import pytest
 from pydantic import ValidationError
 
-from app.schemas import OrchestratorSet
+from app.schemas import (
+    Action,
+    Environment,
+    Exchange,
+    MarketType,
+    MtfProfile,
+    OrchestratorSet,
+    SetRead,
+)
 
 
 def test_okx_live_is_forbidden():
@@ -50,3 +60,54 @@ def test_symbols_are_immutable():
     assert isinstance(a_set.symbols, tuple)
     with pytest.raises(AttributeError):
         a_set.symbols.append("ETHUSDT")  # type: ignore[attr-defined]
+
+
+# --- SetRead.effective_payload (PY-007) -------------------------------------
+
+
+def _set_read(**kwargs) -> SetRead:
+    base = dict(
+        id=1,
+        dashboard_id=1,
+        set_id="s1",
+        enabled=True,
+        action=Action.MTF_RUN,
+        exchange=Exchange.BITMART,
+        market_type=MarketType.PERPETUAL,
+        mtf_profile=MtfProfile.SCALPER_MICRO,
+        environment=Environment.DEMO,
+        dry_run=True,
+        workers=1,
+        sync_tables=False,
+        symbols=["BTCUSDT", "ETHUSDT"],
+        contracts_limit=None,
+        priority=0,
+        payload=None,
+        created_at=datetime(2026, 1, 1),
+        updated_at=datetime(2026, 1, 1),
+    )
+    base.update(kwargs)
+    return SetRead(**base)
+
+
+def test_set_read_exposes_effective_payload_when_materialized():
+    # Le champ calculé reflète le payload /api/mtf/run effectif (enums déballés en
+    # chaînes, sync_tables/process_tp_sl forcés false), sérialisé dans la réponse.
+    dumped = _set_read().model_dump()
+    assert dumped["effective_payload"] == {
+        "dry_run": True,
+        "workers": 1,
+        "exchange": "bitmart",
+        "market_type": "perpetual",
+        "mtf_profile": "scalper_micro",
+        "sync_tables": False,
+        "process_tp_sl": False,
+        "symbols": ["BTCUSDT", "ETHUSDT"],
+    }
+
+
+def test_set_read_effective_payload_null_when_not_materialized():
+    # Sélection capée pas encore résolue (symbols vide) ou symbols blancs => null :
+    # le front en déduit « set non matérialisé ».
+    assert _set_read(symbols=[], contracts_limit=5).effective_payload is None
+    assert _set_read(symbols=[" ", "\t"]).effective_payload is None

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -15,6 +15,7 @@ from app.services.symfony_client import (
     ContractsUnavailableError,
     OpenStateUnavailableError,
     build_mtf_payload,
+    effective_set_payload,
     fetch_open_state,
     fetch_selected_contracts,
     generate_set_payload,
@@ -399,6 +400,74 @@ def test_generate_set_payload_matches_build_mtf_payload_shape():
         dry_run=True,
     )
     assert generate_set_payload(orm) == build_mtf_payload(pyd, None)
+
+
+# --- effective_set_payload (PY-007) -----------------------------------------
+
+
+def test_effective_set_payload_matches_generate_when_within_bounds():
+    # Cas nominal (workers déjà dans la borne) : le payload effectif est identique
+    # au payload persisté généré — pas de clamp à appliquer.
+    orm = _orm_set()
+    assert effective_set_payload(orm) == generate_set_payload(orm)
+
+
+def test_effective_set_payload_clamps_oversized_workers():
+    # Ligne écrite hors API avec workers>1 (aucune contrainte DB) : le payload
+    # effectif clampe à la borne, comme l'envoi réel de run_persisted_set.
+    payload = effective_set_payload(_orm_set(symbols=["BTCUSDT"], workers=8))
+    assert payload["workers"] == 1
+
+
+def test_effective_set_payload_none_when_not_materialized():
+    # Sélection non matérialisée (symbols vide/blanc) => null, comme
+    # generate_set_payload : le front en déduit « set non matérialisé ».
+    assert effective_set_payload(_orm_set(symbols=[])) is None
+    assert effective_set_payload(_orm_set(symbols=[" ", "\t"])) is None
+
+
+def test_effective_set_payload_tolerates_enum_fields():
+    # SetRead porte des enums str (exchange/market_type/mtf_profile) là où l'ORM
+    # porte des chaînes : le payload effectif doit être identique dans les deux cas
+    # (mêmes valeurs string), pour que la preview du cockpit colle à l'envoi réel.
+    from app.schemas import Exchange, MarketType, MtfProfile
+
+    enum_set = _orm_set(
+        exchange=Exchange.BITMART,
+        market_type=MarketType.PERPETUAL,
+        mtf_profile=MtfProfile.SCALPER_MICRO,
+    )
+    assert effective_set_payload(enum_set) == effective_set_payload(_orm_set())
+
+
+def test_effective_set_payload_equals_payload_sent_by_run_persisted_set():
+    # Invariant central PY-007 : effective_set_payload == le payload réellement
+    # envoyé par run_persisted_set, une fois retirés open_state_snapshot (runtime)
+    # et l'override dry_run run-level. Garanti par la fonction partagée.
+    orm = _orm_set(set_id="s", symbols=["BTCUSDT"], workers=8)
+    snapshot = {"open_positions": [], "open_orders": []}
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["json"] = json.loads(request.content)
+        return httpx.Response(200, json={"status": "success"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            # On force un dry_run run-level différent du set pour vérifier que
+            # effective_set_payload ne porte PAS cet override (il reste run-level).
+            return await run_persisted_set(client, "http://sym", orm, snapshot, dry_run=False)
+
+    result = asyncio.run(_run())
+    sent = dict(captured["json"])
+    # Retire la couche runtime exclue de effective_set_payload.
+    sent.pop("open_state_snapshot", None)
+    sent.pop("dry_run", None)
+    expected = dict(effective_set_payload(orm))
+    expected.pop("dry_run", None)
+    assert sent == expected
+    # Et le payload effectif a bien clampé workers, comme l'envoi réel.
+    assert expected["workers"] == 1 == result["payload_sent"]["workers"]
 
 
 # --- run_persisted_set (PY-005) ---------------------------------------------


### PR DESCRIPTION
Make the Python API the single source of truth for the effective
/api/mtf/run payload of a persisted set, so the cockpit preview can no
longer drift from what `run_persisted_set` actually sends.

- Add `effective_set_payload()` in symfony_client: the canonical payload
  (form + workers clamp), excluding the runtime layer
  (`open_state_snapshot` and the run-level `dry_run` override). Returns
  `None` when the selection is not materialized (blank symbols), like
  `generate_set_payload`.
- Route `run_persisted_set` through `effective_set_payload` so there is a
  single construction path (no second code path to drift).
- Make `generate_set_payload` tolerate enum-or-string fields so the same
  function works on ORM rows (strings) and the SetRead schema (str enums).
- Expose a read-only computed field `SetRead.effective_payload` that
  delegates to `effective_set_payload`, guaranteeing preview == real send.
- Tests: effective payload equals the payload sent by run_persisted_set
  (snapshot/override removed), null when not materialized, workers clamped,
  enum/string parity, plus schema and HTTP-level coverage.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Bp7jFreB2Er4PNwGPV5B5