### PR TITLE
feat(temporal): add minimal orchestrator cron activity + workflow (TM-001)

### DIFF
--- a/cron_symfony_mtf_workers/README.md
+++ b/cron_symfony_mtf_workers/README.md
@@ -74,6 +74,49 @@ Chaque schedule définit ses propres overrides via `job.payload`. Voir `models/m
 
 ## 4. Schedules disponibles
 
+### 4.0 Schedule cible — Orchestrateur Python (TM-001)
+
+- **Objectif** : déclencheur cron minimal vers l'orchestrateur Python. Un schedule unique démarre `OrchestratorCronWorkflow`, qui exécute l'unique activity `orchestrator_run` : un seul `POST /orchestrator/run`. **Aucune logique de sélection de contrats côté Temporal** — la sélection des sets, la concurrence, l'agrégation et la conservation du JSON sont portées par l'API Python (PY-005/PY-006).
+- **Fichier CLI** : `scripts/manage_orchestrator_schedule.py`.
+- **Statut** : cible. C'est le chemin à privilégier pour les nouveaux déploiements (les schedules MTF multi-jobs ci-dessous restent en transition, CLEAN-001).
+- **Composants** : `activities/orchestrator_http.py` (`orchestrator_run`) + `workflows/orchestrator_cron.py` (`OrchestratorCronWorkflow`), enregistrés à côté du legacy dans `worker.py` sur la même task queue `cron_symfony_mtf_workers`.
+
+L'activity POST le `RunRequest` minimal et retourne le `RunResponse` tel quel :
+
+```json
+{
+  "ok": true,
+  "run_id": "run_20260619_001",
+  "status": "success",
+  "summary": { "total_calls": 6, "success": 6, "failed": 0 }
+}
+```
+
+Paramètres via env (surchargés par les options CLI `--url`, `--dashboard-id`, `--cron`, `--schedule-id`, `--workflow-id`) :
+
+| Variable | Défaut |
+| --- | --- |
+| `ORCHESTRATOR_RUN_URL` | `http://python-orchestrator:8099/orchestrator/run` |
+| `ORCHESTRATOR_DASHBOARD_ID` | _(aucun)_ |
+| `ORCHESTRATOR_SCHEDULE_ID` | `cron-orchestrator-run-1m` |
+| `ORCHESTRATOR_WORKFLOW_ID` | `cron-orchestrator-run-runner` |
+| `ORCHESTRATOR_CRON` | `*/1 * * * *` |
+
+Commandes principales (overlap `BUFFER_ONE`) :
+
+```bash
+# Prévisualiser le schedule cible sans rien créer
+python scripts/manage_orchestrator_schedule.py create --dry-run --dashboard-id 7
+
+python scripts/manage_orchestrator_schedule.py create --dashboard-id 7
+python scripts/manage_orchestrator_schedule.py status
+python scripts/manage_orchestrator_schedule.py pause
+python scripts/manage_orchestrator_schedule.py resume
+python scripts/manage_orchestrator_schedule.py delete
+```
+
+> `ok=false` n'est pas un succès Temporal. TM-001 se contente de propager le `RunResponse` complet ; l'échec explicite du workflow sur `ok=false` est livré par **TM-002**.
+
 ### 4.1 Runtime Matrix Exchange/Profile
 
 - **Objectif** : gérer les schedules MTF explicites par couple `exchange/market_type/profile`.

--- a/cron_symfony_mtf_workers/activities/orchestrator_http.py
+++ b/cron_symfony_mtf_workers/activities/orchestrator_http.py
@@ -73,7 +73,24 @@ async def orchestrator_run(
             "error": f"non-JSON response (HTTP {response.status_code}): {response.text[:500]}",
         }
 
-    # Réponse JSON valide : on la retourne telle quelle. C'est le contrat
+    if not response.is_success:
+        # Corps JSON mais statut HTTP d'erreur : ce n'est PAS un RunResponse.
+        # L'orchestrateur renvoie toujours HTTP 200 pour un vrai run (y compris
+        # ok=false : no_sets / failed / partial_failure). Un non-2xx JSON est
+        # donc un échec d'appel (404 mauvais chemin, 422 validation, 401/403,
+        # 500…), p.ex. le `{"detail": "..."}` de FastAPI. On le normalise en
+        # dict explicite ok=false pour que TM-002 puisse distinguer un appel HTTP
+        # échoué d'un run réellement exécuté, plutôt que de propager un corps qui
+        # n'a pas la forme RunResponse.
+        return {
+            "ok": False,
+            "run_id": None,
+            "status": "error",
+            "summary": {"total_calls": 0, "success": 0, "failed": 0},
+            "error": f"HTTP {response.status_code}: {json.dumps(body)[:500]}",
+        }
+
+    # Réponse JSON valide et 2xx : on la retourne telle quelle. C'est le contrat
     # RunResponse de l'API Python (ok / run_id / status / summary). On ne
     # reconstruit rien — TM-002 décidera de l'échec sur ok=false.
     return body

--- a/cron_symfony_mtf_workers/activities/orchestrator_http.py
+++ b/cron_symfony_mtf_workers/activities/orchestrator_http.py
@@ -1,0 +1,79 @@
+"""Temporal activity calling the Python orchestrator (``POST /orchestrator/run``).
+
+TM-001 : cron supervisé basique. L'activity POST le ``RunRequest`` minimal
+(``dashboard_id``, ``schedule_id``, ``tick_timestamp``, et éventuellement
+``idempotency_key`` / ``dry_run``) vers l'orchestrateur Python et retourne tel
+quel le ``RunResponse`` (``ok``, ``run_id``, ``status``, ``summary``).
+
+Aucune logique métier ici : la sélection des sets, la concurrence, l'agrégation
+et la conservation du JSON sont portées par l'API Python (PY-005/PY-006). On
+réutilise simplement le pattern httpx de ``mtf_http.py`` (timeout, gestion
+d'exception → dict explicite).
+
+Hors-scope TM-001 : ne PAS lever d'exception sur ``ok=false`` (c'est TM-002).
+L'activity remonte le ``RunResponse`` complet pour que TM-002 puisse s'appuyer
+dessus.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+import httpx
+from temporalio import activity
+
+
+@activity.defn(name="orchestrator_run")
+async def orchestrator_run(
+    url: str,
+    request: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """POST le ``RunRequest`` vers ``/orchestrator/run`` et retourne le ``RunResponse``.
+
+    Args:
+        url: URL complète de l'orchestrateur (ex.
+            ``http://python-orchestrator:8099/orchestrator/run``).
+        request: Corps ``RunRequest`` optionnel (``dashboard_id``,
+            ``schedule_id``, ``tick_timestamp``, ``idempotency_key``,
+            ``dry_run``). ``None`` → corps vide ``{}``.
+
+    Returns:
+        Le ``RunResponse`` parsé (``{ok, run_id, status, summary}``) tel que
+        renvoyé par l'API Python. En cas d'erreur HTTP/réseau ou de corps non
+        JSON, un dict explicite ``ok=false`` est retourné (jamais d'exception),
+        pour que l'appelant (workflow / TM-002) puisse décider de la suite.
+    """
+    # Timeout aligné sur le worker MTF historique : l'orchestrateur peut fan-out
+    # plusieurs appels Symfony (jusqu'à 900s côté API).
+    timeout = 900
+    payload = request or {}
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(url, json=payload)
+    except Exception as exc:  # noqa: BLE001 - propager l'échec en dict explicite
+        return {
+            "ok": False,
+            "run_id": None,
+            "status": "error",
+            "summary": {"total_calls": 0, "success": 0, "failed": 0},
+            "error": str(exc),
+        }
+
+    try:
+        body = response.json()
+    except json.JSONDecodeError:
+        # Corps non JSON (proxy, 5xx HTML…) : on ne peut pas remonter un
+        # RunResponse exploitable, on signale l'échec sans masquer le statut HTTP.
+        return {
+            "ok": False,
+            "run_id": None,
+            "status": "error",
+            "summary": {"total_calls": 0, "success": 0, "failed": 0},
+            "error": f"non-JSON response (HTTP {response.status_code}): {response.text[:500]}",
+        }
+
+    # Réponse JSON valide : on la retourne telle quelle. C'est le contrat
+    # RunResponse de l'API Python (ok / run_id / status / summary). On ne
+    # reconstruit rien — TM-002 décidera de l'échec sur ok=false.
+    return body

--- a/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
@@ -212,7 +212,9 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
 
 
 async def pause_schedule(handle: Any, config: ScheduleConfig) -> None:
-    await handle.pause("manual pause")
+    # ``note`` est keyword-only sur ScheduleHandle.pause (SDK Temporal Python) :
+    # le passer en positionnel lève TypeError.
+    await handle.pause(note="manual pause")
     print(f"schedule '{config.schedule_id}' paused")
 
 

--- a/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
@@ -1,0 +1,250 @@
+"""Gestion du schedule cron cible vers l'orchestrateur Python (TM-001).
+
+Schedule unique qui déclenche ``OrchestratorCronWorkflow`` : un seul appel HTTP
+vers ``POST /orchestrator/run``. Aucune logique de sélection de contrats côté
+Temporal — tout est porté par l'API Python (PY-005/006).
+
+Sous-commandes : ``create`` / ``pause`` / ``resume`` / ``delete`` / ``status``
+(mêmes conventions que ``manage_exchange_profile_schedule.py``).
+
+Paramètres via env (surchargés par les options CLI) :
+    - ``ORCHESTRATOR_RUN_URL`` (défaut ``http://python-orchestrator:8099/orchestrator/run``)
+    - ``ORCHESTRATOR_DASHBOARD_ID``
+    - ``ORCHESTRATOR_SCHEDULE_ID`` / ``ORCHESTRATOR_WORKFLOW_ID``
+    - ``ORCHESTRATOR_CRON`` (défaut ``*/1 * * * *``)
+
+Overlap : ``BUFFER_ONE`` (un seul tick bufferisé si le précédent déborde).
+"""
+
+import argparse
+import asyncio
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+TEMPORAL_ADDRESS = os.getenv("TEMPORAL_ADDRESS", "temporal:7233")
+TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default")
+TASK_QUEUE = os.getenv("TASK_QUEUE_NAME", "cron_symfony_mtf_workers")
+TIME_ZONE = os.getenv("TZ", "UTC")
+
+WORKFLOW_TYPE = "OrchestratorCronWorkflow"
+
+DEFAULT_URL = os.getenv(
+    "ORCHESTRATOR_RUN_URL", "http://python-orchestrator:8099/orchestrator/run"
+)
+DEFAULT_CRON = os.getenv("ORCHESTRATOR_CRON", "*/1 * * * *")
+DEFAULT_DASHBOARD_ID = os.getenv("ORCHESTRATOR_DASHBOARD_ID")
+DEFAULT_SCHEDULE_ID = os.getenv("ORCHESTRATOR_SCHEDULE_ID", "cron-orchestrator-run-1m")
+DEFAULT_WORKFLOW_ID = os.getenv("ORCHESTRATOR_WORKFLOW_ID", "cron-orchestrator-run-runner")
+
+
+@dataclass(frozen=True)
+class ScheduleConfig:
+    command: str
+    url: str
+    dashboard_id: Optional[str]
+    cron: str
+    schedule_id: str
+    workflow_id: str
+    dry_run_schedule: bool
+
+
+def build_workflow_config(
+    *,
+    url: str,
+    dashboard_id: Optional[str],
+    schedule_id: str,
+) -> Dict[str, Any]:
+    """Construit la config passée au ``OrchestratorCronWorkflow``.
+
+    C'est l'unique argument du workflow : il s'en sert pour bâtir le minimal
+    ``RunRequest`` et appeler ``/orchestrator/run``. Aucune logique métier ici.
+    Le ``schedule_id`` est propagé pour tracer l'origine du tick côté API Python.
+    """
+    config: Dict[str, Any] = {"url": url, "schedule_id": schedule_id}
+    if dashboard_id is not None:
+        config["dashboard_id"] = dashboard_id
+    return config
+
+
+def resolve_schedule_config(args: argparse.Namespace) -> ScheduleConfig:
+    return ScheduleConfig(
+        command=args.command,
+        url=getattr(args, "url", None) or DEFAULT_URL,
+        dashboard_id=getattr(args, "dashboard_id", None) or DEFAULT_DASHBOARD_ID,
+        cron=getattr(args, "cron", None) or DEFAULT_CRON,
+        schedule_id=getattr(args, "schedule_id", None) or DEFAULT_SCHEDULE_ID,
+        workflow_id=getattr(args, "workflow_id", None) or DEFAULT_WORKFLOW_ID,
+        dry_run_schedule=getattr(args, "dry_run_schedule", False),
+    )
+
+
+async def get_client():
+    from temporalio.client import Client
+
+    return await Client.connect(TEMPORAL_ADDRESS, namespace=TEMPORAL_NAMESPACE)
+
+
+def temporal_schedule_classes():
+    from temporalio.api.enums.v1 import ScheduleOverlapPolicy
+
+    try:
+        from temporalio.client import (
+            Schedule,
+            ScheduleActionStartWorkflow,
+            SchedulePolicy,
+            ScheduleSpec,
+        )
+    except ImportError:  # pragma: no cover - compatibility with older Temporal SDKs
+        from temporalio.client.schedule import (  # type: ignore[attr-defined]
+            Schedule,
+            ScheduleActionStartWorkflow,
+            SchedulePolicy,
+            ScheduleSpec,
+        )
+
+    try:
+        overlap = ScheduleOverlapPolicy.BUFFER_ONE
+    except AttributeError:  # pragma: no cover - compatibility with older Temporal SDKs
+        overlap = ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE
+
+    return Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap
+
+
+async def create_schedule(client: Any, config: ScheduleConfig) -> None:
+    workflow_config = build_workflow_config(
+        url=config.url,
+        dashboard_id=config.dashboard_id,
+        schedule_id=config.schedule_id,
+    )
+
+    if config.dry_run_schedule:
+        print(
+            "[DRY-RUN] would create schedule "
+            f"{config.schedule_id} (workflow_id='{config.workflow_id}', cron='{config.cron}', "
+            f"tz='{TIME_ZONE}', config={workflow_config})"
+        )
+        return
+
+    Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap = (
+        temporal_schedule_classes()
+    )
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_TYPE,
+            args=[workflow_config],
+            id=config.workflow_id,
+            task_queue=TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(
+            cron_expressions=[config.cron],
+            time_zone_name=TIME_ZONE,
+        ),
+        policy=SchedulePolicy(overlap=overlap),
+    )
+
+    try:
+        await client.create_schedule(config.schedule_id, schedule)
+    except Exception as exc:
+        from temporalio.client import ScheduleAlreadyRunningError
+
+        if isinstance(exc, ScheduleAlreadyRunningError):
+            print(
+                f"schedule '{config.schedule_id}' already exists."
+                " Use 'status' to inspect or 'delete' before recreating."
+            )
+            return
+        raise
+
+    print(
+        f"created schedule '{config.schedule_id}' -> cron='{config.cron}' -> config={workflow_config}"
+    )
+
+
+async def pause_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.pause("manual pause")
+    print(f"schedule '{config.schedule_id}' paused")
+
+
+async def resume_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.unpause()
+    print(f"schedule '{config.schedule_id}' resumed")
+
+
+async def delete_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.delete()
+    print(f"schedule '{config.schedule_id}' deleted")
+
+
+async def describe_schedule(handle: Any) -> None:
+    description = await handle.describe()
+    print("schedule status:")
+    print(description)
+
+
+async def async_main(args: argparse.Namespace) -> None:
+    config = resolve_schedule_config(args)
+
+    if config.command == "create":
+        client = None if config.dry_run_schedule else await get_client()
+        await create_schedule(client, config)
+        return
+
+    client = await get_client()
+    handle = client.get_schedule_handle(config.schedule_id)
+    if config.command == "pause":
+        await pause_schedule(handle, config)
+    elif config.command == "resume":
+        await resume_schedule(handle, config)
+    elif config.command == "delete":
+        await delete_schedule(handle, config)
+    elif config.command == "status":
+        await describe_schedule(handle)
+
+
+def add_common_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--url", help="Orchestrator run URL (default ORCHESTRATOR_RUN_URL)")
+    parser.add_argument(
+        "--dashboard-id", help="Dashboard id forwarded in the RunRequest (default ORCHESTRATOR_DASHBOARD_ID)"
+    )
+    parser.add_argument("--cron", help="Cron expression (default ORCHESTRATOR_CRON)")
+    parser.add_argument("--schedule-id", help="Schedule id (default ORCHESTRATOR_SCHEDULE_ID)")
+    parser.add_argument("--workflow-id", help="Workflow id (default ORCHESTRATOR_WORKFLOW_ID)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Manage the target Temporal cron schedule for the Python orchestrator (/orchestrator/run)"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create_cmd = sub.add_parser("create", help="Create the schedule")
+    add_common_options(create_cmd)
+    # ``--dry-run`` ne crée rien : il prévisualise le schedule cible. (Il n'y a
+    # pas de dry_run de payload ici — le dry_run par set est décidé côté API
+    # Python.) ``--dry-run-schedule`` est conservé comme alias rétro-compatible.
+    create_cmd.add_argument(
+        "--dry-run",
+        "--dry-run-schedule",
+        dest="dry_run_schedule",
+        action="store_true",
+        help="Preview the target schedule without creating it",
+    )
+
+    for command in ("status", "pause", "resume", "delete"):
+        cmd = sub.add_parser(command, help=f"{command.capitalize()} the schedule")
+        add_common_options(cmd)
+        cmd.set_defaults(dry_run_schedule=False)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    asyncio.run(async_main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
@@ -112,7 +112,33 @@ def temporal_schedule_classes():
     return Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap
 
 
+def assert_dashboard_configured(config: ScheduleConfig) -> Optional[str]:
+    """Garde-fou ``create`` : un dashboard est requis pour un schedule utile.
+
+    ``/orchestrator/run`` résout un ``dashboard_id`` absent en ``no_sets``
+    immédiat (cf. ``python-orchestrator/app/routers/orchestrator.py``) : un
+    schedule créé sans dashboard tournerait indéfiniment sans exécuter aucun set.
+    On échoue donc vite à la création réelle. En prévisualisation
+    (``--dry-run``), on n'échoue pas mais on retourne le message d'avertissement.
+    """
+    if config.dashboard_id is not None:
+        return None
+    message = (
+        "no dashboard configured: pass --dashboard-id or set ORCHESTRATOR_DASHBOARD_ID. "
+        "/orchestrator/run resolves a missing dashboard to no_sets, so the schedule "
+        "would tick forever without executing any set."
+    )
+    if not config.dry_run_schedule:
+        raise SystemExit(f"refusing to create schedule: {message}")
+    return message
+
+
 async def create_schedule(client: Any, config: ScheduleConfig) -> None:
+    # Fail fast : pas de dashboard => schedule inutile (no_sets en boucle).
+    warning = assert_dashboard_configured(config)
+    if warning is not None:
+        print(f"WARNING: {warning}")
+
     workflow_config = build_workflow_config(
         url=config.url,
         dashboard_id=config.dashboard_id,
@@ -187,6 +213,10 @@ async def async_main(args: argparse.Namespace) -> None:
     config = resolve_schedule_config(args)
 
     if config.command == "create":
+        # Fail fast AVANT toute connexion Temporal : un create sans dashboard est
+        # refusé (sinon la connexion réseau échouerait avant d'atteindre le
+        # garde-fou). En dry-run, l'avertissement est émis par create_schedule.
+        assert_dashboard_configured(config)
         client = None if config.dry_run_schedule else await get_client()
         await create_schedule(client, config)
         return

--- a/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py
@@ -112,20 +112,43 @@ def temporal_schedule_classes():
     return Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, overlap
 
 
-def assert_dashboard_configured(config: ScheduleConfig) -> Optional[str]:
-    """Garde-fou ``create`` : un dashboard est requis pour un schedule utile.
+def dashboard_is_valid(dashboard_id: Optional[str]) -> bool:
+    """Indique si ``dashboard_id`` résoudra un dashboard côté orchestrateur.
 
-    ``/orchestrator/run`` résout un ``dashboard_id`` absent en ``no_sets``
-    immédiat (cf. ``python-orchestrator/app/routers/orchestrator.py``) : un
-    schedule créé sans dashboard tournerait indéfiniment sans exécuter aucun set.
-    On échoue donc vite à la création réelle. En prévisualisation
-    (``--dry-run``), on n'échoue pas mais on retourne le message d'avertissement.
+    ``/orchestrator/run`` fait ``int(dashboard_id)`` et retombe sur ``None``
+    (=> ``no_sets``) pour une valeur absente, blanche ou non numérique
+    (cf. ``_resolve_dashboard_id`` dans
+    ``python-orchestrator/app/routers/orchestrator.py``). On applique la même
+    règle ici pour ne pas créer un schedule qui tournerait à vide.
     """
-    if config.dashboard_id is not None:
+    if dashboard_id is None:
+        return False
+    stripped = str(dashboard_id).strip()
+    if not stripped:
+        return False
+    try:
+        int(stripped)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def assert_dashboard_configured(config: ScheduleConfig) -> Optional[str]:
+    """Garde-fou ``create`` : un dashboard numérique valide est requis.
+
+    ``/orchestrator/run`` résout un ``dashboard_id`` absent / blanc / non
+    numérique en ``no_sets`` immédiat (cf.
+    ``python-orchestrator/app/routers/orchestrator.py``) : un schedule créé
+    ainsi tournerait indéfiniment sans exécuter aucun set. On échoue donc vite à
+    la création réelle. En prévisualisation (``--dry-run``), on n'échoue pas mais
+    on retourne le message d'avertissement.
+    """
+    if dashboard_is_valid(config.dashboard_id):
         return None
     message = (
-        "no dashboard configured: pass --dashboard-id or set ORCHESTRATOR_DASHBOARD_ID. "
-        "/orchestrator/run resolves a missing dashboard to no_sets, so the schedule "
+        f"no valid dashboard configured (got {config.dashboard_id!r}): pass a numeric "
+        "--dashboard-id or set a numeric ORCHESTRATOR_DASHBOARD_ID. /orchestrator/run "
+        "resolves a missing/blank/non-numeric dashboard to no_sets, so the schedule "
         "would tick forever without executing any set."
     )
     if not config.dry_run_schedule:

--- a/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
@@ -13,7 +13,9 @@ from scripts.manage_orchestrator_schedule import (
     build_parser,
     build_workflow_config,
     create_schedule,
+    pause_schedule,
     resolve_schedule_config,
+    resume_schedule,
 )
 
 
@@ -240,6 +242,38 @@ def test_dry_run_preview_without_dashboard_warns_but_previews(monkeypatch, capsy
     assert "WARNING: no valid dashboard configured" in output
     # La prévisualisation est tout de même affichée (rien n'est créé).
     assert "[DRY-RUN] would create schedule cron-orchestrator-run-1m" in output
+
+
+def test_pause_passes_note_as_keyword():
+    # ScheduleHandle.pause(note=...) est keyword-only : un appel positionnel
+    # lèverait TypeError. Le fake ci-dessous reproduit cette contrainte.
+    class _KwOnlyHandle:
+        def __init__(self):
+            self.calls = []
+
+        async def pause(self, *, note=None):
+            self.calls.append(("pause", note))
+
+        async def unpause(self, *, note=None):
+            self.calls.append(("unpause", note))
+
+    config = ScheduleConfig(
+        command="pause",
+        url=DEFAULT_URL,
+        dashboard_id="7",
+        cron="*/1 * * * *",
+        schedule_id="cron-orchestrator-run-1m",
+        workflow_id="cron-orchestrator-run-runner",
+        dry_run_schedule=False,
+    )
+
+    handle = _KwOnlyHandle()
+    asyncio.run(pause_schedule(handle, config))
+    assert handle.calls == [("pause", "manual pause")]
+
+    # resume ne passe pas de note positionnelle non plus.
+    asyncio.run(resume_schedule(handle, config))
+    assert handle.calls[-1] == ("unpause", None)
 
 
 def test_create_schedule_handles_already_running(monkeypatch, capsys):

--- a/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
@@ -2,6 +2,8 @@
 
 import asyncio
 
+import pytest
+
 import scripts.manage_orchestrator_schedule as schedule_manager
 from scripts.manage_orchestrator_schedule import (
     DEFAULT_URL,
@@ -180,6 +182,40 @@ def test_create_schedule_passes_single_workflow_config_arg(monkeypatch):
     ]
 
 
+def test_create_without_dashboard_fails_fast(monkeypatch):
+    # Un schedule sans dashboard tournerait en no_sets indéfiniment : refus.
+    def fail_schedule_classes():
+        raise AssertionError("must not build Temporal classes when dashboard is missing")
+
+    monkeypatch.setattr(schedule_manager, "temporal_schedule_classes", fail_schedule_classes)
+
+    config = ScheduleConfig(
+        command="create",
+        url=DEFAULT_URL,
+        dashboard_id=None,
+        cron="*/1 * * * *",
+        schedule_id="cron-orchestrator-run-1m",
+        workflow_id="cron-orchestrator-run-runner",
+        dry_run_schedule=False,
+    )
+
+    with pytest.raises(SystemExit, match="no dashboard configured"):
+        asyncio.run(create_schedule(object(), config))
+
+
+def test_dry_run_preview_without_dashboard_warns_but_previews(monkeypatch, capsys):
+    monkeypatch.setattr(schedule_manager, "DEFAULT_DASHBOARD_ID", None)
+    parser = build_parser()
+    args = parser.parse_args(["create", "--dry-run"])
+
+    asyncio.run(async_main(args))
+
+    output = capsys.readouterr().out
+    assert "WARNING: no dashboard configured" in output
+    # La prévisualisation est tout de même affichée (rien n'est créé).
+    assert "[DRY-RUN] would create schedule cron-orchestrator-run-1m" in output
+
+
 def test_create_schedule_handles_already_running(monkeypatch, capsys):
     class DummyScheduleClass:
         def __init__(self, *args, **kwargs):
@@ -212,7 +248,7 @@ def test_create_schedule_handles_already_running(monkeypatch, capsys):
     config = ScheduleConfig(
         command="create",
         url=DEFAULT_URL,
-        dashboard_id=None,
+        dashboard_id="7",
         cron="*/1 * * * *",
         schedule_id="cron-orchestrator-run-1m",
         workflow_id="cron-orchestrator-run-runner",

--- a/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
@@ -199,8 +199,34 @@ def test_create_without_dashboard_fails_fast(monkeypatch):
         dry_run_schedule=False,
     )
 
-    with pytest.raises(SystemExit, match="no dashboard configured"):
+    with pytest.raises(SystemExit, match="no valid dashboard configured"):
         asyncio.run(create_schedule(object(), config))
+
+
+def test_dashboard_is_valid_rejects_blank_and_non_numeric():
+    assert schedule_manager.dashboard_is_valid("7") is True
+    assert schedule_manager.dashboard_is_valid(" 7 ") is True
+    assert schedule_manager.dashboard_is_valid(None) is False
+    assert schedule_manager.dashboard_is_valid("") is False
+    assert schedule_manager.dashboard_is_valid("   ") is False
+    assert schedule_manager.dashboard_is_valid("abc") is False
+
+
+def test_create_with_blank_or_non_numeric_dashboard_fails_fast():
+    def make_config(dashboard_id):
+        return ScheduleConfig(
+            command="create",
+            url=DEFAULT_URL,
+            dashboard_id=dashboard_id,
+            cron="*/1 * * * *",
+            schedule_id="cron-orchestrator-run-1m",
+            workflow_id="cron-orchestrator-run-runner",
+            dry_run_schedule=False,
+        )
+
+    for bad in ("", "   ", "abc"):
+        with pytest.raises(SystemExit, match="no valid dashboard configured"):
+            asyncio.run(create_schedule(object(), make_config(bad)))
 
 
 def test_dry_run_preview_without_dashboard_warns_but_previews(monkeypatch, capsys):
@@ -211,7 +237,7 @@ def test_dry_run_preview_without_dashboard_warns_but_previews(monkeypatch, capsy
     asyncio.run(async_main(args))
 
     output = capsys.readouterr().out
-    assert "WARNING: no dashboard configured" in output
+    assert "WARNING: no valid dashboard configured" in output
     # La prévisualisation est tout de même affichée (rien n'est créé).
     assert "[DRY-RUN] would create schedule cron-orchestrator-run-1m" in output
 

--- a/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_orchestrator_schedule.py
@@ -1,0 +1,225 @@
+"""Tests du gestionnaire de schedule cron cible vers l'orchestrateur (TM-001)."""
+
+import asyncio
+
+import scripts.manage_orchestrator_schedule as schedule_manager
+from scripts.manage_orchestrator_schedule import (
+    DEFAULT_URL,
+    WORKFLOW_TYPE,
+    ScheduleConfig,
+    async_main,
+    build_parser,
+    build_workflow_config,
+    create_schedule,
+    resolve_schedule_config,
+)
+
+
+def test_build_workflow_config_includes_url_schedule_and_dashboard():
+    config = build_workflow_config(
+        url="http://python-orchestrator:8099/orchestrator/run",
+        dashboard_id="7",
+        schedule_id="cron-orchestrator-run-1m",
+    )
+
+    assert config == {
+        "url": "http://python-orchestrator:8099/orchestrator/run",
+        "schedule_id": "cron-orchestrator-run-1m",
+        "dashboard_id": "7",
+    }
+
+
+def test_build_workflow_config_omits_absent_dashboard():
+    config = build_workflow_config(
+        url=DEFAULT_URL,
+        dashboard_id=None,
+        schedule_id="cron-orchestrator-run-1m",
+    )
+
+    assert "dashboard_id" not in config
+    assert config["url"] == DEFAULT_URL
+
+
+def test_workflow_type_targets_orchestrator_cron():
+    # Sécurité : le schedule cible le workflow cron orchestrateur, pas le legacy MTF.
+    assert WORKFLOW_TYPE == "OrchestratorCronWorkflow"
+
+
+def test_default_url_targets_orchestrator_run_endpoint():
+    assert DEFAULT_URL.endswith("/orchestrator/run")
+
+
+def test_resolve_schedule_config_uses_defaults(monkeypatch):
+    # Pas d'env override : on doit retomber sur les valeurs par défaut.
+    monkeypatch.setattr(schedule_manager, "DEFAULT_DASHBOARD_ID", None)
+    parser = build_parser()
+    args = parser.parse_args(["create"])
+    config = resolve_schedule_config(args)
+
+    assert config.url == DEFAULT_URL
+    assert config.cron == "*/1 * * * *"
+    assert config.schedule_id == "cron-orchestrator-run-1m"
+    assert config.workflow_id == "cron-orchestrator-run-runner"
+    assert config.dashboard_id is None
+    assert config.dry_run_schedule is False
+
+
+def test_resolve_schedule_config_honors_cli_overrides():
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "create",
+            "--url",
+            "http://custom:9000/orchestrator/run",
+            "--dashboard-id",
+            "12",
+            "--cron",
+            "*/5 * * * *",
+            "--schedule-id",
+            "cron-orchestrator-run-5m",
+            "--workflow-id",
+            "my-runner",
+            "--dry-run-schedule",
+        ]
+    )
+    config = resolve_schedule_config(args)
+
+    assert config.url == "http://custom:9000/orchestrator/run"
+    assert config.dashboard_id == "12"
+    assert config.cron == "*/5 * * * *"
+    assert config.schedule_id == "cron-orchestrator-run-5m"
+    assert config.workflow_id == "my-runner"
+    assert config.dry_run_schedule is True
+
+
+def test_status_command_resolves_without_create_options():
+    parser = build_parser()
+    args = parser.parse_args(["status", "--schedule-id", "cron-orchestrator-run-1m"])
+    config = resolve_schedule_config(args)
+
+    assert config.command == "status"
+    assert config.schedule_id == "cron-orchestrator-run-1m"
+
+
+def test_create_dry_run_schedule_preview_skips_temporal(monkeypatch, capsys):
+    async def fail_get_client():
+        raise AssertionError("dry-run schedule preview must not connect to Temporal")
+
+    def fail_schedule_classes():
+        raise AssertionError("dry-run schedule preview must not build Temporal schedule classes")
+
+    monkeypatch.setattr(schedule_manager, "get_client", fail_get_client)
+    monkeypatch.setattr(schedule_manager, "temporal_schedule_classes", fail_schedule_classes)
+
+    parser = build_parser()
+    args = parser.parse_args(
+        ["create", "--dashboard-id", "7", "--dry-run-schedule"]
+    )
+
+    asyncio.run(async_main(args))
+
+    output = capsys.readouterr().out
+    assert "[DRY-RUN] would create schedule cron-orchestrator-run-1m" in output
+    assert "/orchestrator/run" in output
+    assert "'dashboard_id': '7'" in output
+    assert "*/1 * * * *" in output
+
+
+def test_create_schedule_passes_single_workflow_config_arg(monkeypatch):
+    class DummyScheduleClass:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class CapturingClient:
+        def __init__(self):
+            self.created = []
+
+        async def create_schedule(self, schedule_id, schedule):
+            self.created.append((schedule_id, schedule))
+
+    captured = {}
+
+    def capturing_action(workflow_type, *, args, id, task_queue):
+        captured["workflow_type"] = workflow_type
+        captured["args"] = args
+        captured["id"] = id
+        captured["task_queue"] = task_queue
+        return DummyScheduleClass()
+
+    monkeypatch.setattr(
+        schedule_manager,
+        "temporal_schedule_classes",
+        lambda: (
+            DummyScheduleClass,
+            capturing_action,
+            DummyScheduleClass,
+            DummyScheduleClass,
+            "buffer_one",
+        ),
+    )
+
+    config = ScheduleConfig(
+        command="create",
+        url=DEFAULT_URL,
+        dashboard_id="7",
+        cron="*/1 * * * *",
+        schedule_id="cron-orchestrator-run-1m",
+        workflow_id="cron-orchestrator-run-runner",
+        dry_run_schedule=False,
+    )
+    client = CapturingClient()
+
+    asyncio.run(create_schedule(client, config))
+
+    assert client.created[0][0] == "cron-orchestrator-run-1m"
+    assert captured["workflow_type"] == "OrchestratorCronWorkflow"
+    # Un seul argument workflow : la config (pas une liste de jobs comme le legacy).
+    assert captured["args"] == [
+        {"url": DEFAULT_URL, "schedule_id": "cron-orchestrator-run-1m", "dashboard_id": "7"}
+    ]
+
+
+def test_create_schedule_handles_already_running(monkeypatch, capsys):
+    class DummyScheduleClass:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    # Reproduit ScheduleAlreadyRunningError sans dépendre du SDK réel.
+    import temporalio.client as temporal_client
+
+    class FakeAlreadyRunning(Exception):
+        pass
+
+    monkeypatch.setattr(temporal_client, "ScheduleAlreadyRunningError", FakeAlreadyRunning)
+
+    class AlreadyRunningClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise FakeAlreadyRunning("exists")
+
+    monkeypatch.setattr(
+        schedule_manager,
+        "temporal_schedule_classes",
+        lambda: (
+            DummyScheduleClass,
+            lambda *a, **k: DummyScheduleClass(),
+            DummyScheduleClass,
+            DummyScheduleClass,
+            "buffer_one",
+        ),
+    )
+
+    config = ScheduleConfig(
+        command="create",
+        url=DEFAULT_URL,
+        dashboard_id=None,
+        cron="*/1 * * * *",
+        schedule_id="cron-orchestrator-run-1m",
+        workflow_id="cron-orchestrator-run-runner",
+        dry_run_schedule=False,
+    )
+
+    asyncio.run(create_schedule(AlreadyRunningClient(), config))
+
+    output = capsys.readouterr().out
+    assert "already exists" in output

--- a/cron_symfony_mtf_workers/tests/test_orchestrator_workflow.py
+++ b/cron_symfony_mtf_workers/tests/test_orchestrator_workflow.py
@@ -39,6 +39,11 @@ class _FakeResponse:
         self.text = text if text is not None else json.dumps(payload)
         self._raise_json = raise_json
 
+    @property
+    def is_success(self):
+        # Aligné sur httpx.Response.is_success (2xx).
+        return 200 <= self.status_code < 300
+
     def json(self):
         if self._raise_json:
             raise json.JSONDecodeError("invalid", self.text or "", 0)
@@ -143,6 +148,44 @@ def test_activity_network_error_returns_explicit_dict(monkeypatch):
     assert result["status"] == "error"
     assert "boom" in result["error"]
     assert result["summary"] == {"total_calls": 0, "success": 0, "failed": 0}
+
+
+def test_activity_http_error_with_json_body_returns_explicit_dict(monkeypatch):
+    # FastAPI renvoie un JSON {"detail": ...} avec un statut non-2xx (404/422/…).
+    # Ce n'est pas un RunResponse : il doit être normalisé en ok=false, pas
+    # propagé verbatim (sinon TM-002 ne distinguerait pas l'échec HTTP d'un run).
+    _patch_async_client(
+        monkeypatch,
+        response=_FakeResponse({"detail": "Not Found"}, status_code=404),
+    )
+
+    result = asyncio.run(orchestrator_run(DEFAULT_ORCHESTRATOR_URL, None))
+
+    assert result["ok"] is False
+    assert result["status"] == "error"
+    assert "404" in result["error"]
+    assert "Not Found" in result["error"]
+    assert result["summary"] == {"total_calls": 0, "success": 0, "failed": 0}
+    # Le corps brut n'est PAS propagé tel quel.
+    assert "detail" not in result
+
+
+def test_activity_ok_false_with_http_200_is_propagated(monkeypatch):
+    # ok=false avec HTTP 200 (no_sets / failed) reste un RunResponse valide :
+    # il doit être propagé tel quel (pas transformé en erreur HTTP).
+    run_response = {
+        "ok": False,
+        "run_id": "run_x",
+        "status": "no_sets",
+        "summary": {"total_calls": 0, "success": 0, "failed": 0},
+    }
+    _patch_async_client(
+        monkeypatch, response=_FakeResponse(run_response, status_code=200)
+    )
+
+    result = asyncio.run(orchestrator_run(DEFAULT_ORCHESTRATOR_URL, None))
+
+    assert result == run_response
 
 
 def test_activity_non_json_body_returns_explicit_dict(monkeypatch):

--- a/cron_symfony_mtf_workers/tests/test_orchestrator_workflow.py
+++ b/cron_symfony_mtf_workers/tests/test_orchestrator_workflow.py
@@ -1,0 +1,274 @@
+"""Tests du cron Temporal cible vers l'orchestrateur Python (TM-001).
+
+Couvre :
+- l'activity ``orchestrator_run`` (POST httpx, retour RunResponse tel quel,
+  chemins d'erreur réseau / non-JSON) ;
+- le workflow ``OrchestratorCronWorkflow`` : avec l'activity mockée renvoyant
+  ``ok=true`` / ``ok=false``, on vérifie qu'il PROPAGE le résultat sans le
+  modifier (l'échec sur ok=false est TM-002, hors scope ici), et qu'il bâtit un
+  RunRequest minimal avec un ``tick_timestamp`` dérivé de ``workflow.now()``.
+
+Le serveur de test Temporal n'étant pas téléchargeable dans cet environnement,
+le workflow est exercé en patchant les primitives ``workflow.now`` /
+``workflow.execute_activity`` / ``workflow.logger`` (pas de serveur requis), à la
+manière d'un test unitaire — cohérent avec le pattern ``asyncio.run`` du repo.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+import activities.orchestrator_http as orchestrator_http
+import workflows.orchestrator_cron as orchestrator_cron
+from activities.orchestrator_http import orchestrator_run
+from workflows.orchestrator_cron import (
+    DEFAULT_ORCHESTRATOR_URL,
+    OrchestratorCronWorkflow,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes httpx pour l'activity
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200, text=None, raise_json=False):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text if text is not None else json.dumps(payload)
+        self._raise_json = raise_json
+
+    def json(self):
+        if self._raise_json:
+            raise json.JSONDecodeError("invalid", self.text or "", 0)
+        return self._payload
+
+
+class _FakeClient:
+    """AsyncClient minimal capturant l'appel POST."""
+
+    def __init__(self, *, response=None, exc=None, capture=None):
+        self._response = response
+        self._exc = exc
+        self._capture = capture if capture is not None else {}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        return False
+
+    async def post(self, url, json=None):
+        self._capture["url"] = url
+        self._capture["json"] = json
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+def _patch_async_client(monkeypatch, *, response=None, exc=None):
+    capture = {}
+
+    def _factory(*_args, **_kwargs):
+        return _FakeClient(response=response, exc=exc, capture=capture)
+
+    monkeypatch.setattr(orchestrator_http.httpx, "AsyncClient", _factory)
+    return capture
+
+
+# ---------------------------------------------------------------------------
+# Activity : orchestrator_run
+# ---------------------------------------------------------------------------
+
+
+def test_activity_returns_run_response_verbatim(monkeypatch):
+    run_response = {
+        "ok": True,
+        "run_id": "run_42",
+        "status": "success",
+        "summary": {"total_calls": 3, "success": 3, "failed": 0},
+    }
+    capture = _patch_async_client(monkeypatch, response=_FakeResponse(run_response))
+
+    result = asyncio.run(
+        orchestrator_run(
+            "http://python-orchestrator:8099/orchestrator/run",
+            {"dashboard_id": "7", "schedule_id": "sched-1"},
+        )
+    )
+
+    # Le RunResponse est remonté tel quel (aucune reconstruction métier).
+    assert result == run_response
+    assert capture["url"] == "http://python-orchestrator:8099/orchestrator/run"
+    assert capture["json"] == {"dashboard_id": "7", "schedule_id": "sched-1"}
+
+
+def test_activity_propagates_ok_false_without_raising(monkeypatch):
+    # TM-001 : ok=false n'est PAS transformé en exception (c'est TM-002).
+    run_response = {
+        "ok": False,
+        "run_id": "run_99",
+        "status": "no_sets",
+        "summary": {"total_calls": 0, "success": 0, "failed": 0},
+    }
+    _patch_async_client(monkeypatch, response=_FakeResponse(run_response))
+
+    result = asyncio.run(orchestrator_run(DEFAULT_ORCHESTRATOR_URL, None))
+
+    assert result == run_response
+
+
+def test_activity_none_request_posts_empty_body(monkeypatch):
+    capture = _patch_async_client(
+        monkeypatch,
+        response=_FakeResponse(
+            {"ok": True, "run_id": "r", "status": "success", "summary": {}}
+        ),
+    )
+
+    asyncio.run(orchestrator_run(DEFAULT_ORCHESTRATOR_URL, None))
+
+    assert capture["json"] == {}
+
+
+def test_activity_network_error_returns_explicit_dict(monkeypatch):
+    import httpx
+
+    _patch_async_client(monkeypatch, exc=httpx.ConnectError("boom"))
+
+    result = asyncio.run(orchestrator_run(DEFAULT_ORCHESTRATOR_URL, {"dashboard_id": "1"}))
+
+    assert result["ok"] is False
+    assert result["status"] == "error"
+    assert "boom" in result["error"]
+    assert result["summary"] == {"total_calls": 0, "success": 0, "failed": 0}
+
+
+def test_activity_non_json_body_returns_explicit_dict(monkeypatch):
+    _patch_async_client(
+        monkeypatch,
+        response=_FakeResponse(None, status_code=502, text="<html>bad gateway</html>", raise_json=True),
+    )
+
+    result = asyncio.run(orchestrator_run(DEFAULT_ORCHESTRATOR_URL, None))
+
+    assert result["ok"] is False
+    assert result["status"] == "error"
+    assert "502" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Workflow : OrchestratorCronWorkflow (primitives patchées, sans serveur)
+# ---------------------------------------------------------------------------
+
+
+class _DummyLogger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+    def error(self, *_args, **_kwargs):
+        pass
+
+
+def _run_workflow(monkeypatch, *, config, activity_result):
+    """Exécute le workflow en patchant les primitives Temporal.
+
+    Renvoie ``(result, captured_activity_args)``.
+    """
+    fixed_now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+    captured = {}
+
+    async def _fake_execute_activity(name, *, args, start_to_close_timeout):
+        captured["name"] = name
+        captured["args"] = args
+        captured["timeout"] = start_to_close_timeout
+        return activity_result
+
+    monkeypatch.setattr(orchestrator_cron.workflow, "now", lambda: fixed_now)
+    monkeypatch.setattr(orchestrator_cron.workflow, "execute_activity", _fake_execute_activity)
+    monkeypatch.setattr(orchestrator_cron.workflow, "logger", _DummyLogger())
+
+    wf = OrchestratorCronWorkflow()
+    result = asyncio.run(wf.run(config))
+    return result, captured, fixed_now
+
+
+def test_workflow_propagates_ok_true_result(monkeypatch):
+    activity_result = {
+        "ok": True,
+        "run_id": "run_ok",
+        "status": "success",
+        "summary": {"total_calls": 2, "success": 2, "failed": 0},
+    }
+
+    result, captured, fixed_now = _run_workflow(
+        monkeypatch,
+        config={"dashboard_id": "7", "schedule_id": "sched-1"},
+        activity_result=activity_result,
+    )
+
+    # Le workflow propage le RunResponse tel quel.
+    assert result == activity_result
+    # Une seule activity, la cible orchestrateur.
+    assert captured["name"] == "orchestrator_run"
+    url, request = captured["args"]
+    assert url == DEFAULT_ORCHESTRATOR_URL
+    # RunRequest minimal : tick_timestamp dérivé de workflow.now() (déterminisme).
+    assert request["tick_timestamp"] == fixed_now.isoformat()
+    assert request["dashboard_id"] == "7"
+    assert request["schedule_id"] == "sched-1"
+
+
+def test_workflow_propagates_ok_false_without_raising(monkeypatch):
+    # TM-001 : ok=false est propagé, PAS converti en échec (TM-002).
+    activity_result = {
+        "ok": False,
+        "run_id": "run_ko",
+        "status": "failed",
+        "summary": {"total_calls": 1, "success": 0, "failed": 1},
+    }
+
+    result, _captured, _now = _run_workflow(
+        monkeypatch,
+        config={"dashboard_id": "7"},
+        activity_result=activity_result,
+    )
+
+    assert result == activity_result
+
+
+def test_workflow_uses_custom_url_and_forwards_optional_fields(monkeypatch):
+    activity_result = {"ok": True, "run_id": "r", "status": "success", "summary": {}}
+
+    _result, captured, _now = _run_workflow(
+        monkeypatch,
+        config={
+            "url": "http://custom:9000/orchestrator/run",
+            "dashboard_id": "3",
+            "schedule_id": "s",
+            "idempotency_key": "key-1",
+            "dry_run": True,
+        },
+        activity_result=activity_result,
+    )
+
+    url, request = captured["args"]
+    assert url == "http://custom:9000/orchestrator/run"
+    assert request["idempotency_key"] == "key-1"
+    assert request["dry_run"] is True
+
+
+def test_workflow_with_none_config_builds_minimal_request(monkeypatch):
+    activity_result = {"ok": True, "run_id": "r", "status": "success", "summary": {}}
+
+    _result, captured, fixed_now = _run_workflow(
+        monkeypatch,
+        config=None,
+        activity_result=activity_result,
+    )
+
+    url, request = captured["args"]
+    assert url == DEFAULT_ORCHESTRATOR_URL
+    # Aucun dashboard/schedule fourni : seul le tick_timestamp est présent.
+    assert request == {"tick_timestamp": fixed_now.isoformat()}

--- a/cron_symfony_mtf_workers/worker.py
+++ b/cron_symfony_mtf_workers/worker.py
@@ -8,7 +8,9 @@ from temporalio.client import Client
 from temporalio.worker import Worker
 
 from activities.mtf_http import mtf_api_call
+from activities.orchestrator_http import orchestrator_run
 from workflows.mtf_workers import CronSymfonyMtfWorkersWorkflow
+from workflows.orchestrator_cron import OrchestratorCronWorkflow
 
 
 TEMPORAL_ADDRESS = os.getenv("TEMPORAL_ADDRESS", "temporal:7233")
@@ -38,8 +40,10 @@ async def main() -> None:
     worker = Worker(
         client,
         task_queue=TASK_QUEUE,
-        workflows=[CronSymfonyMtfWorkersWorkflow],
-        activities=[mtf_api_call],
+        # Legacy (transition, CLEAN-001) + cron cible orchestrateur (TM-001),
+        # enregistrés côte à côte sur la même task queue.
+        workflows=[CronSymfonyMtfWorkersWorkflow, OrchestratorCronWorkflow],
+        activities=[mtf_api_call, orchestrator_run],
     )
     await worker.run()
 

--- a/cron_symfony_mtf_workers/workflows/orchestrator_cron.py
+++ b/cron_symfony_mtf_workers/workflows/orchestrator_cron.py
@@ -1,0 +1,96 @@
+"""Workflow cron minimal vers l'orchestrateur Python (TM-001).
+
+``OrchestratorCronWorkflow`` est un déclencheur cron supervisé basique : il
+exécute l'unique activity ``orchestrator_run`` (un seul appel HTTP vers
+``POST /orchestrator/run``), journalise ``run_id`` + ``summary`` et retourne le
+``RunResponse`` tel quel.
+
+Il NE reconstruit AUCUNE logique métier : pas de sélection de contrats, pas de
+jobs multiples, pas d'agrégation. Tout cela reste côté API Python (PY-005/006).
+
+Déterminisme Temporal : aucune I/O ni ``datetime.now()`` dans le workflow. Le
+``tick_timestamp`` transmis dans le ``RunRequest`` est dérivé via
+``workflow.now()`` (horloge déterministe Temporal), pas ``datetime`` direct.
+
+Hors-scope TM-001 : ne PAS lever d'exception sur ``ok=false`` (c'est TM-002).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Dict, Optional
+
+from temporalio import workflow
+
+# URL réseau interne par défaut de l'orchestrateur (container python_orchestrator,
+# port 8099, profile compose ``orchestrator``). Surchargeable via la config du
+# schedule (clé ``url``).
+DEFAULT_ORCHESTRATOR_URL = "http://python-orchestrator:8099/orchestrator/run"
+
+
+@workflow.defn(name="OrchestratorCronWorkflow")
+class OrchestratorCronWorkflow:
+    @workflow.run
+    async def run(self, config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Exécute l'unique activity orchestrator et retourne son ``RunResponse``.
+
+        Args:
+            config: Config du tick (transmise par le schedule). Clés :
+                - ``url`` : URL de l'orchestrateur (défaut
+                  ``DEFAULT_ORCHESTRATOR_URL``) ;
+                - ``dashboard_id`` : dashboard d'origine (RunRequest) ;
+                - ``schedule_id`` : schedule Temporal d'origine (RunRequest) ;
+                - ``idempotency_key`` : clé d'idempotence explicite (optionnel) ;
+                - ``dry_run`` : forçage dry-run demandé par l'appelant (optionnel) ;
+                - ``timeout_minutes`` : timeout de l'activity (défaut 15).
+
+        Returns:
+            Le ``RunResponse`` retourné par l'activity (``{ok, run_id, status,
+            summary}``), propagé tel quel.
+        """
+        config = config or {}
+        url = config.get("url") or DEFAULT_ORCHESTRATOR_URL
+
+        # Construit le RunRequest minimal. Le tick_timestamp est dérivé de
+        # l'horloge déterministe Temporal (workflow.now()), jamais de
+        # datetime.now() — sinon le workflow ne serait pas rejouable.
+        request: Dict[str, Any] = {
+            "tick_timestamp": workflow.now().isoformat(),
+        }
+        if config.get("dashboard_id") is not None:
+            request["dashboard_id"] = config["dashboard_id"]
+        if config.get("schedule_id") is not None:
+            request["schedule_id"] = config["schedule_id"]
+        # Idempotence triviale (TM-001) : on transmet la clé seulement si
+        # fournie. La vraie idempotence est SAFE-002.
+        if config.get("idempotency_key") is not None:
+            request["idempotency_key"] = config["idempotency_key"]
+        if config.get("dry_run") is not None:
+            request["dry_run"] = config["dry_run"]
+
+        timeout_minutes = int(config.get("timeout_minutes", 15))
+
+        workflow.logger.info(
+            "[OrchestratorCron] calling %s with request=%s (timeout=%d min)",
+            url,
+            request,
+            timeout_minutes,
+        )
+
+        result: Dict[str, Any] = await workflow.execute_activity(
+            "orchestrator_run",
+            args=[url, request],
+            start_to_close_timeout=timedelta(minutes=timeout_minutes),
+        )
+
+        # Journalise run_id + summary (le JSON complet reste côté API Python).
+        # On ne lève pas sur ok=false ici (TM-002) : on propage le RunResponse.
+        workflow.logger.info(
+            "[OrchestratorCron] ✅ ok=%s run_id=%s status=%s summary=%s",
+            result.get("ok"),
+            result.get("run_id"),
+            result.get("status"),
+            result.get("summary"),
+        )
+
+        return result

--- a/docs/handbook/technical/temporal.md
+++ b/docs/handbook/technical/temporal.md
@@ -150,7 +150,46 @@ Le JSON complet et les détails par set restent dans l'API Python et dans la bas
 | `scripts/manage_contract_sync_schedule.py` | actif | Sync quotidienne des contrats via `/api/mtf/sync-contracts`. |
 | `scripts/manage_cleanup_schedule.py` | actif | Jobs de cleanup. |
 
-Le prochain chemin cible documenté est un schedule unique vers l'orchestrateur Python. Les scripts legacy restent disponibles tant que la transition n'est pas terminée.
+Le chemin cible documenté est un schedule unique vers l'orchestrateur Python. Les scripts legacy restent disponibles tant que la transition n'est pas terminée.
+
+## Schedule cible (orchestrateur)
+
+TM-001 livre le déclencheur cron minimal vers l'orchestrateur Python. Un schedule unique démarre `OrchestratorCronWorkflow`, qui exécute l'unique activity `orchestrator_run` : un seul `POST /orchestrator/run`. Aucune sélection de contrats côté Temporal — la sélection des sets, la concurrence, l'agrégation et la conservation du JSON sont portées par l'API Python (PY-005/PY-006).
+
+| Script | Statut | Usage |
+| --- | --- | --- |
+| `scripts/manage_orchestrator_schedule.py` | cible | Schedule cron unique vers `POST /orchestrator/run` (`OrchestratorCronWorkflow`). |
+
+Composants (à côté du legacy, task queue inchangée `cron_symfony_mtf_workers`) :
+
+- `activities/orchestrator_http.py` (`orchestrator_run`) : POST httpx du `RunRequest` minimal (`dashboard_id`, `schedule_id`, `tick_timestamp`) et retour du `RunResponse` tel quel. En cas d'erreur réseau / corps non JSON, un dict explicite `ok=false` est renvoyé (jamais d'exception).
+- `workflows/orchestrator_cron.py` (`OrchestratorCronWorkflow`) : exécute l'unique activity, journalise `run_id` + `summary`, et propage le résultat. Le `tick_timestamp` est dérivé de `workflow.now()` (déterminisme : aucune I/O ni `datetime.now()` dans le workflow).
+
+Sous-commandes (mêmes conventions que `manage_exchange_profile_schedule.py`) : `create` / `pause` / `resume` / `delete` / `status`. Overlap `BUFFER_ONE`.
+
+Paramètres via env (surchargés par les options CLI `--url`, `--dashboard-id`, `--cron`, `--schedule-id`, `--workflow-id`) :
+
+| Variable | Défaut |
+| --- | --- |
+| `ORCHESTRATOR_RUN_URL` | `http://python-orchestrator:8099/orchestrator/run` |
+| `ORCHESTRATOR_DASHBOARD_ID` | _(aucun)_ |
+| `ORCHESTRATOR_SCHEDULE_ID` | `cron-orchestrator-run-1m` |
+| `ORCHESTRATOR_WORKFLOW_ID` | `cron-orchestrator-run-runner` |
+| `ORCHESTRATOR_CRON` | `*/1 * * * *` |
+
+```bash
+# Prévisualiser le schedule cible sans rien créer
+python scripts/manage_orchestrator_schedule.py create --dry-run --dashboard-id 7
+
+# Créer / piloter le schedule
+python scripts/manage_orchestrator_schedule.py create --dashboard-id 7
+python scripts/manage_orchestrator_schedule.py status
+python scripts/manage_orchestrator_schedule.py pause
+python scripts/manage_orchestrator_schedule.py resume
+python scripts/manage_orchestrator_schedule.py delete
+```
+
+> `ok=false` n'est pas un succès Temporal : l'activity remonte le `RunResponse` complet pour que **TM-002** lève l'erreur côté workflow. TM-001 ne lève pas sur `ok=false`.
 
 ## Garde-fous live
 
@@ -183,6 +222,8 @@ Depuis `cron_symfony_mtf_workers/` :
 pytest
 pytest tests/test_response_formatter.py
 pytest tests/test_manage_exchange_profile_schedule.py
+pytest tests/test_orchestrator_workflow.py
+pytest tests/test_manage_orchestrator_schedule.py
 ```
 
 Après création de l'orchestrateur Python, les tests attendus devront aussi couvrir :


### PR DESCRIPTION
Add the target Temporal cron path toward the Python orchestrator without
duplicating any business logic.

- activities/orchestrator_http.py (orchestrator_run): POST the minimal
  RunRequest to POST /orchestrator/run and return the RunResponse verbatim,
  reusing the httpx pattern of mtf_http.py (timeout, exception -> explicit
  dict). Does NOT raise on ok=false (that is TM-002).
- workflows/orchestrator_cron.py (OrchestratorCronWorkflow): execute the
  single activity, log run_id + summary, propagate the result. tick_timestamp
  is derived from workflow.now() (no I/O / datetime.now() in the workflow).
- tests: activity (ok=true/false, network + non-JSON error paths) and
  workflow (propagates ok=true/false, builds a minimal deterministic
  RunRequest).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XXD9ycUmrQM8VKbPLdqkXX