### PR TITLE
TM-002: fail OrchestratorCronWorkflow on ok=false

### DIFF
--- a/cron_symfony_mtf_workers/README.md
+++ b/cron_symfony_mtf_workers/README.md
@@ -74,12 +74,13 @@ Chaque schedule définit ses propres overrides via `job.payload`. Voir `models/m
 
 ## 4. Schedules disponibles
 
-### 4.0 Schedule cible — Orchestrateur Python (TM-001)
+### 4.0 Schedule cible — Orchestrateur Python (TM-001 / TM-002)
 
 - **Objectif** : déclencheur cron minimal vers l'orchestrateur Python. Un schedule unique démarre `OrchestratorCronWorkflow`, qui exécute l'unique activity `orchestrator_run` : un seul `POST /orchestrator/run`. **Aucune logique de sélection de contrats côté Temporal** — la sélection des sets, la concurrence, l'agrégation et la conservation du JSON sont portées par l'API Python (PY-005/PY-006).
 - **Fichier CLI** : `scripts/manage_orchestrator_schedule.py`.
 - **Statut** : cible. C'est le chemin à privilégier pour les nouveaux déploiements (les schedules MTF multi-jobs ci-dessous restent en transition, CLEAN-001).
 - **Composants** : `activities/orchestrator_http.py` (`orchestrator_run`) + `workflows/orchestrator_cron.py` (`OrchestratorCronWorkflow`), enregistrés à côté du legacy dans `worker.py` sur la même task queue `cron_symfony_mtf_workers`.
+- **Échec sur `ok=false` (TM-002)** : le workflow journalise `run_id` + `summary` puis, si le `RunResponse` a `ok=false` (`no_sets` / `failed` / `partial_failure` / `error`), lève une `ApplicationError` (`non_retryable=True`) pour que Temporal marque le tick en échec. Sur `ok=true`, le `RunResponse` est propagé inchangé. Le `non_retryable=True` évite un retry en boucle dans le même tick : le prochain tick cron est le « retry » naturel (overlap `BUFFER_ONE`). L'activity reste « return verbatim » (la levée vit uniquement dans le workflow).
 
 L'activity POST le `RunRequest` minimal et retourne le `RunResponse` tel quel :
 
@@ -115,7 +116,7 @@ python scripts/manage_orchestrator_schedule.py resume
 python scripts/manage_orchestrator_schedule.py delete
 ```
 
-> `ok=false` n'est pas un succès Temporal. TM-001 se contente de propager le `RunResponse` complet ; l'échec explicite du workflow sur `ok=false` est livré par **TM-002**.
+> `ok=false` n'est pas un succès Temporal. Le workflow propage le `RunResponse` complet sur `ok=true` et lève une `ApplicationError` non-retryable sur `ok=false` (implémenté par **TM-002**), après avoir journalisé `run_id` + `summary`.
 
 ### 4.1 Runtime Matrix Exchange/Profile
 

--- a/cron_symfony_mtf_workers/tests/test_orchestrator_workflow.py
+++ b/cron_symfony_mtf_workers/tests/test_orchestrator_workflow.py
@@ -4,9 +4,12 @@ Couvre :
 - l'activity ``orchestrator_run`` (POST httpx, retour RunResponse tel quel,
   chemins d'erreur réseau / non-JSON) ;
 - le workflow ``OrchestratorCronWorkflow`` : avec l'activity mockée renvoyant
-  ``ok=true`` / ``ok=false``, on vérifie qu'il PROPAGE le résultat sans le
-  modifier (l'échec sur ok=false est TM-002, hors scope ici), et qu'il bâtit un
-  RunRequest minimal avec un ``tick_timestamp`` dérivé de ``workflow.now()``.
+  ``ok=true``, on vérifie qu'il PROPAGE le résultat sans le modifier et qu'il
+  bâtit un RunRequest minimal avec un ``tick_timestamp`` dérivé de
+  ``workflow.now()`` ; avec ``ok=false`` (chaque statut : ``no_sets`` /
+  ``failed`` / ``partial_failure`` / ``error``), on vérifie qu'il lève une
+  ``ApplicationError`` non-retryable APRÈS avoir journalisé ``run_id`` +
+  ``summary`` (TM-002).
 
 Le serveur de test Temporal n'étant pas téléchargeable dans cet environnement,
 le workflow est exercé en patchant les primitives ``workflow.now`` /
@@ -17,6 +20,9 @@ manière d'un test unitaire — cohérent avec le pattern ``asyncio.run`` du rep
 import asyncio
 import json
 from datetime import datetime, timezone
+
+import pytest
+from temporalio.exceptions import ApplicationError
 
 import activities.orchestrator_http as orchestrator_http
 import workflows.orchestrator_cron as orchestrator_cron
@@ -206,21 +212,39 @@ def test_activity_non_json_body_returns_explicit_dict(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-class _DummyLogger:
-    def info(self, *_args, **_kwargs):
-        pass
+class _RecordingLogger:
+    """Logger capturant les messages formatés (pour vérifier le log AVANT levée)."""
 
-    def error(self, *_args, **_kwargs):
-        pass
+    def __init__(self):
+        self.infos = []
+        self.errors = []
+
+    def info(self, msg, *args, **_kwargs):
+        self.infos.append(msg % args if args else msg)
+
+    def error(self, msg, *args, **_kwargs):
+        self.errors.append(msg % args if args else msg)
 
 
 def _run_workflow(monkeypatch, *, config, activity_result):
     """Exécute le workflow en patchant les primitives Temporal.
 
-    Renvoie ``(result, captured_activity_args)``.
+    Renvoie ``(result, captured_activity_args, fixed_now)``.
+
+    Lève (propage) toute exception émise par le workflow — c'est ce que
+    vérifient les tests ok=false.
     """
+    result, captured, fixed_now, _logger = _run_workflow_with_logger(
+        monkeypatch, config=config, activity_result=activity_result
+    )
+    return result, captured, fixed_now
+
+
+def _run_workflow_with_logger(monkeypatch, *, config, activity_result):
+    """Variante exposant le logger enregistré (vérification log avant levée)."""
     fixed_now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
     captured = {}
+    logger = _RecordingLogger()
 
     async def _fake_execute_activity(name, *, args, start_to_close_timeout):
         captured["name"] = name
@@ -230,11 +254,11 @@ def _run_workflow(monkeypatch, *, config, activity_result):
 
     monkeypatch.setattr(orchestrator_cron.workflow, "now", lambda: fixed_now)
     monkeypatch.setattr(orchestrator_cron.workflow, "execute_activity", _fake_execute_activity)
-    monkeypatch.setattr(orchestrator_cron.workflow, "logger", _DummyLogger())
+    monkeypatch.setattr(orchestrator_cron.workflow, "logger", logger)
 
     wf = OrchestratorCronWorkflow()
     result = asyncio.run(wf.run(config))
-    return result, captured, fixed_now
+    return result, captured, fixed_now, logger
 
 
 def test_workflow_propagates_ok_true_result(monkeypatch):
@@ -263,22 +287,60 @@ def test_workflow_propagates_ok_true_result(monkeypatch):
     assert request["schedule_id"] == "sched-1"
 
 
-def test_workflow_propagates_ok_false_without_raising(monkeypatch):
-    # TM-001 : ok=false est propagé, PAS converti en échec (TM-002).
+@pytest.mark.parametrize("status", ["no_sets", "failed", "partial_failure", "error"])
+def test_workflow_raises_application_error_on_ok_false(monkeypatch, status):
+    # TM-002 : ok=false (quel que soit le statut) fait échouer le tick Temporal.
     activity_result = {
         "ok": False,
-        "run_id": "run_ko",
-        "status": "failed",
+        "run_id": f"run_ko_{status}",
+        "status": status,
         "summary": {"total_calls": 1, "success": 0, "failed": 1},
     }
 
-    result, _captured, _now = _run_workflow(
-        monkeypatch,
-        config={"dashboard_id": "7"},
-        activity_result=activity_result,
-    )
+    with pytest.raises(ApplicationError) as exc_info:
+        _run_workflow(
+            monkeypatch,
+            config={"dashboard_id": "7"},
+            activity_result=activity_result,
+        )
 
-    assert result == activity_result
+    err = exc_info.value
+    # Message exploitable : statut, run_id et summary y figurent.
+    assert status in str(err)
+    assert f"run_ko_{status}" in str(err)
+    assert "success" in str(err)  # le summary est inclus
+    # Pas de retry en boucle dans le même tick.
+    assert err.non_retryable is True
+
+
+def test_workflow_logs_run_id_and_summary_before_raising(monkeypatch):
+    # Le log run_id + summary DOIT précéder la levée (déterminisme + traçabilité).
+    activity_result = {
+        "ok": False,
+        "run_id": "run_logged",
+        "status": "partial_failure",
+        "summary": {"total_calls": 4, "success": 2, "failed": 2},
+    }
+
+    logger = _RecordingLogger()
+    fixed_now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    async def _fake_execute_activity(name, *, args, start_to_close_timeout):
+        return activity_result
+
+    monkeypatch.setattr(orchestrator_cron.workflow, "now", lambda: fixed_now)
+    monkeypatch.setattr(orchestrator_cron.workflow, "execute_activity", _fake_execute_activity)
+    monkeypatch.setattr(orchestrator_cron.workflow, "logger", logger)
+
+    wf = OrchestratorCronWorkflow()
+    with pytest.raises(ApplicationError):
+        asyncio.run(wf.run({"dashboard_id": "7"}))
+
+    # Le résumé du run a été journalisé avant que l'exception ne soit levée.
+    joined = "\n".join(logger.infos)
+    assert "run_logged" in joined
+    assert "partial_failure" in joined
+    assert "total_calls" in joined
 
 
 def test_workflow_uses_custom_url_and_forwards_optional_fields(monkeypatch):

--- a/cron_symfony_mtf_workers/workflows/orchestrator_cron.py
+++ b/cron_symfony_mtf_workers/workflows/orchestrator_cron.py
@@ -1,18 +1,24 @@
-"""Workflow cron minimal vers l'orchestrateur Python (TM-001).
+"""Workflow cron minimal vers l'orchestrateur Python (TM-001 / TM-002).
 
 ``OrchestratorCronWorkflow`` est un déclencheur cron supervisé basique : il
 exécute l'unique activity ``orchestrator_run`` (un seul appel HTTP vers
-``POST /orchestrator/run``), journalise ``run_id`` + ``summary`` et retourne le
-``RunResponse`` tel quel.
+``POST /orchestrator/run``), journalise ``run_id`` + ``summary``, puis :
+
+- sur ``ok=true`` → retourne le ``RunResponse`` tel quel ;
+- sur ``ok=false`` (``no_sets`` / ``failed`` / ``partial_failure`` / ``error``)
+  → lève une ``ApplicationError`` pour que Temporal marque le tick en échec
+  (TM-002). Sans cette levée, un échec métier ou un appel HTTP raté serait
+  affiché « réussi » dans la Schedule view.
 
 Il NE reconstruit AUCUNE logique métier : pas de sélection de contrats, pas de
 jobs multiples, pas d'agrégation. Tout cela reste côté API Python (PY-005/006).
+L'activity reste la source de vérité (« return verbatim ») : la levée vit
+uniquement ici, dans le workflow.
 
 Déterminisme Temporal : aucune I/O ni ``datetime.now()`` dans le workflow. Le
 ``tick_timestamp`` transmis dans le ``RunRequest`` est dérivé via
-``workflow.now()`` (horloge déterministe Temporal), pas ``datetime`` direct.
-
-Hors-scope TM-001 : ne PAS lever d'exception sur ``ok=false`` (c'est TM-002).
+``workflow.now()`` (horloge déterministe Temporal), pas ``datetime`` direct. Le
+log précède toujours la levée.
 """
 
 from __future__ import annotations
@@ -21,6 +27,7 @@ from datetime import timedelta
 from typing import Any, Dict, Optional
 
 from temporalio import workflow
+from temporalio.exceptions import ApplicationError
 
 # URL réseau interne par défaut de l'orchestrateur (container python_orchestrator,
 # port 8099, profile compose ``orchestrator``). Surchargeable via la config du
@@ -46,7 +53,14 @@ class OrchestratorCronWorkflow:
 
         Returns:
             Le ``RunResponse`` retourné par l'activity (``{ok, run_id, status,
-            summary}``), propagé tel quel.
+            summary}``), propagé tel quel lorsque ``ok=true``.
+
+        Raises:
+            ApplicationError: lorsque le ``RunResponse`` a ``ok=false`` (échec
+                métier ou appel HTTP raté normalisé par l'activity). Marquée
+                ``non_retryable`` : un tick ``ok=false`` ne doit pas être
+                re-tenté en boucle dans le même tick — le prochain tick cron est
+                le « retry » naturel (overlap ``BUFFER_ONE``).
         """
         config = config or {}
         url = config.get("url") or DEFAULT_ORCHESTRATOR_URL
@@ -84,13 +98,35 @@ class OrchestratorCronWorkflow:
         )
 
         # Journalise run_id + summary (le JSON complet reste côté API Python).
-        # On ne lève pas sur ok=false ici (TM-002) : on propage le RunResponse.
+        # Le log précède TOUJOURS la levée éventuelle (déterminisme + traçabilité
+        # du tick en échec).
+        ok = result.get("ok")
+        run_id = result.get("run_id")
+        status = result.get("status")
+        summary = result.get("summary")
         workflow.logger.info(
-            "[OrchestratorCron] ✅ ok=%s run_id=%s status=%s summary=%s",
-            result.get("ok"),
-            result.get("run_id"),
-            result.get("status"),
-            result.get("summary"),
+            "[OrchestratorCron] %s ok=%s run_id=%s status=%s summary=%s",
+            "✅" if ok else "❌",
+            ok,
+            run_id,
+            status,
+            summary,
         )
+
+        # TM-002 : un RunResponse ok=false (no_sets / failed / partial_failure /
+        # error) DOIT faire échouer le tick Temporal, sinon la Schedule view
+        # l'affiche « réussi » et les échecs passent inaperçus. On lève après le
+        # log, en réutilisant le RunResponse comme source de vérité (aucune
+        # logique métier reconstruite).
+        #
+        # non_retryable=True : pas de retry en boucle dans le même tick. Le
+        # prochain tick cron est le « retry » naturel (overlap BUFFER_ONE).
+        if not ok:
+            raise ApplicationError(
+                f"orchestrator run failed: ok=false status={status} "
+                f"run_id={run_id} summary={summary}",
+                type="OrchestratorRunFailed",
+                non_retryable=True,
+            )
 
         return result

--- a/docs/handbook/technical/temporal.md
+++ b/docs/handbook/technical/temporal.md
@@ -136,7 +136,7 @@ Retour minimal attendu :
 
 Contrat important : `ok=false` n'est pas un succès Temporal.
 
-L'activity ou le workflow minimal doit explicitement échouer lorsque l'orchestrateur retourne `ok=false`, par exemple en levant une erreur après avoir journalisé le `run_id` et le résumé. Il ne faut pas seulement retourner un JSON contenant `ok=false`, sinon Temporal affichera le tick comme réussi.
+Le workflow minimal échoue explicitement lorsque l'orchestrateur retourne `ok=false` (implémenté par **TM-002**) : après avoir journalisé le `run_id` et le résumé, `OrchestratorCronWorkflow` lève une `temporalio.exceptions.ApplicationError` (type `OrchestratorRunFailed`, message incluant `status`, `run_id` et `summary`). Il ne faut pas seulement retourner un JSON contenant `ok=false`, sinon Temporal afficherait le tick comme réussi. L'`ApplicationError` est `non_retryable=True` : un tick `ok=false` ne doit pas être re-tenté en boucle dans le même tick — le prochain tick cron est le « retry » naturel (overlap `BUFFER_ONE`). L'activity `orchestrator_run`, elle, reste inchangée : elle retourne le `RunResponse`/dict `ok=false` verbatim (source de vérité pour la persistance côté API Python) ; la levée vit uniquement dans le workflow.
 
 Le JSON complet et les détails par set restent dans l'API Python et dans la base d'orchestration.
 
@@ -162,8 +162,8 @@ TM-001 livre le déclencheur cron minimal vers l'orchestrateur Python. Un schedu
 
 Composants (à côté du legacy, task queue inchangée `cron_symfony_mtf_workers`) :
 
-- `activities/orchestrator_http.py` (`orchestrator_run`) : POST httpx du `RunRequest` minimal (`dashboard_id`, `schedule_id`, `tick_timestamp`) et retour du `RunResponse` tel quel. En cas d'erreur réseau / corps non JSON, un dict explicite `ok=false` est renvoyé (jamais d'exception).
-- `workflows/orchestrator_cron.py` (`OrchestratorCronWorkflow`) : exécute l'unique activity, journalise `run_id` + `summary`, et propage le résultat. Le `tick_timestamp` est dérivé de `workflow.now()` (déterminisme : aucune I/O ni `datetime.now()` dans le workflow).
+- `activities/orchestrator_http.py` (`orchestrator_run`) : POST httpx du `RunRequest` minimal (`dashboard_id`, `schedule_id`, `tick_timestamp`) et retour du `RunResponse` tel quel. En cas d'erreur réseau / corps non JSON, un dict explicite `ok=false` est renvoyé (jamais d'exception). Inchangée par TM-002 (« return verbatim »).
+- `workflows/orchestrator_cron.py` (`OrchestratorCronWorkflow`) : exécute l'unique activity, journalise `run_id` + `summary`, puis sur `ok=true` propage le résultat et sur `ok=false` lève une `ApplicationError` non-retryable (TM-002) pour marquer le tick en échec. Le `tick_timestamp` est dérivé de `workflow.now()` (déterminisme : aucune I/O ni `datetime.now()` dans le workflow ; le log précède toujours la levée).
 
 Sous-commandes (mêmes conventions que `manage_exchange_profile_schedule.py`) : `create` / `pause` / `resume` / `delete` / `status`. Overlap `BUFFER_ONE`.
 
@@ -189,7 +189,7 @@ python scripts/manage_orchestrator_schedule.py resume
 python scripts/manage_orchestrator_schedule.py delete
 ```
 
-> `ok=false` n'est pas un succès Temporal : l'activity remonte le `RunResponse` complet pour que **TM-002** lève l'erreur côté workflow. TM-001 ne lève pas sur `ok=false`.
+> `ok=false` n'est pas un succès Temporal : l'activity remonte le `RunResponse` complet et le workflow lève une `ApplicationError` non-retryable sur `ok=false` (implémenté par **TM-002**), après avoir journalisé `run_id` + `summary`.
 
 ## Garde-fous live
 


### PR DESCRIPTION
Le workflow journalise run_id + summary puis lève une ApplicationError
(non_retryable=True, type OrchestratorRunFailed) lorsque le RunResponse a
ok=false (no_sets / failed / partial_failure / error), pour que Temporal
marque le tick en échec. Sur ok=true, le RunResponse est propagé inchangé.

non_retryable=True évite un retry en boucle dans le même tick : le prochain
tick cron est le retry naturel (overlap BUFFER_ONE). Le log précède toujours
la levée (déterminisme, aucune I/O). L'activity reste inchangée (verbatim).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BBQ9TXWstUUZ4ypVUmWgxj