### PR TITLE
SAFE-001: orchestration_locks model + Alembic migration

### DIFF
--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -454,7 +454,7 @@ reste skippé par le runner).
 | `lock_key` (UNIQUE) | Clé canonique `{profile}\|{exchange}\|{market_type}\|{symbol}` — **c'est la contrainte d'unicité qui réalise l'exclusion mutuelle**. |
 | `mtf_profile`, `exchange`, `market_type`, `symbol` | Composantes dénormalisées (exchange/market_type normalisés comme Symfony, symbole en MAJUSCULES comme `_symbols_overlap`). |
 | `run_id` | Titulaire courant ; libère ses locks par `run_id` à la fin du set. |
-| `acquired_at`, `expires_at` (indexé) | `expires_at` = TTL anti-deadlock (`ORCHESTRATION_LOCK_TTL_SECONDS`, défaut 1800s). |
+| `acquired_at`, `expires_at` (indexé) | TTL anti-deadlock. `expires_at` = pire temps de paroi du run (`ceil(n_sets / max_concurrency)` × timeout Symfony) + marge `ORCHESTRATION_LOCK_TTL_SECONDS` (défaut 1800s), pour qu'un set resté en file n'expire jamais avant son dispatch. |
 
 **Acquisition** (avant le dispatch de chaque set, dans une transaction courte
 committée **avant** les appels Symfony — jamais maintenue pendant les ~900s) :

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -434,8 +434,53 @@ Doctrine de Symfony (qui n'introspecte que `public`).
 | `orchestration_sets` | Sets prêts à exécuter (miroir d'`OrchestratorSet`, dont `sync_tables`, `symbols`, `contracts_limit`, et le `payload` préparé). |
 | `runs` | Runs déclenchés (`run_id`, statut, compteurs, idempotency_key) + **dernier JSON global** (`last_json`). |
 | `run_sets` | Détail par set d'un run (payload envoyé, réponse Symfony, statut, erreur, durée) + **dernier JSON par set** (`response_json`). |
+| `orchestration_locks` | Locks d'orchestration par `(mtf_profile, exchange, market_type, symbol)` sérialisant deux runs concurrents (**SAFE-001**). |
 
 DB-001 ne livre que la couche schéma (modèles, migration, moteur/session, repositories).
+
+### Locks d'orchestration (SAFE-001)
+
+La table `orchestration_locks` empêche deux exécutions concurrentes (overlap du
+cron Temporal `BUFFER_ONE`, ou front + cron) de traiter le **même couple
+`(mtf_profile, exchange, market_type, symbol)`** en même temps. Le garde intra-run
+(`_conflicting_live_set_ids`) ne couvre qu'un seul batch ; sans lock partagé en
+base, l'activation future du live exposerait à des soumissions dupliquées sur un
+même instrument. SAFE-001 est un **prérequis** au relâchement de la readiness live
+(avec SAFE-002/SAFE-003) ; il **ne réactive pas le live** (tout set `dry_run=false`
+reste skippé par le runner).
+
+| Colonne | Rôle |
+| --- | --- |
+| `lock_key` (UNIQUE) | Clé canonique `{profile}\|{exchange}\|{market_type}\|{symbol}` — **c'est la contrainte d'unicité qui réalise l'exclusion mutuelle**. |
+| `mtf_profile`, `exchange`, `market_type`, `symbol` | Composantes dénormalisées (exchange/market_type normalisés comme Symfony, symbole en MAJUSCULES comme `_symbols_overlap`). |
+| `run_id` | Titulaire courant ; libère ses locks par `run_id` à la fin du set. |
+| `acquired_at`, `expires_at` (indexé) | `expires_at` = TTL anti-deadlock (`ORCHESTRATION_LOCK_TTL_SECONDS`, défaut 1800s). |
+
+**Acquisition** (avant le dispatch de chaque set, dans une transaction courte
+committée **avant** les appels Symfony — jamais maintenue pendant les ~900s) :
+pour chaque set on dérive un `lock_key` **par symbole** (symboles normalisés
+UPPERCASE), puis on insère sous `SAVEPOINT` (rattrapage `IntegrityError`,
+compatible SQLite/PostgreSQL). Un lock **expiré** (`expires_at <= now`, comparaison
+côté SQL) est *reclaim* (supprimé) avant l'insertion. L'acquisition est **tout ou
+rien** par set : si un symbole du set est déjà détenu par un run actif, les locks
+déjà pris pour ce set sont relâchés et le set est **skippé fail-closed**
+(`ok=false`, `body="locked: <key> held by run <id>"`), tandis que les autres sets
+du run continuent.
+
+**Libération** : dans le `finally` de chaque set (succès, échec métier ou
+exception), les locks détenus par ce `run_id` sont supprimés. Un **balayage des
+locks expirés au démarrage** du run (`purge_expired_locks`) évite les fuites si un
+process est tué avant son `finally`.
+
+**Périmètre** : le lock est posé pour **tous** les sets `mtf_run` (pas seulement
+les sets live) — l'infra est ainsi testable dès maintenant, la sérialisation
+per-symbole/profil étant inoffensive en dry-run. Un set à `symbols` vide (univers
+complet) ne pose aucun lock : il n'est de toute façon pas dispatché
+(`run_persisted_set` exige une sélection matérialisée). Le `now` est lu via
+`datetime.now(timezone.utc)` (aucune contrainte Temporal ici) et injectable en test.
+
+> Hors-scope SAFE-001 : l'idempotence des runs (`runs.idempotency_key`, **SAFE-002**)
+> n'est pas modifiée.
 
 **PY-002** câble la couche DB dans une API REST de **configuration** des dashboards et des
 sets (CRUD), sous le préfixe `/dashboards` :
@@ -468,6 +513,14 @@ est livrée par **PY-006** (`GET /runs`, `/runs/{run_id}`, `/runs/{run_id}/sets/
 Avant tout run :
 
 - ne jamais lancer deux sets live incompatibles sur le même symbole ;
+- **idempotence et lock par symbole** (SAFE-001, livré) : deux runs concurrents ne
+  peuvent pas traiter le même `(mtf_profile, exchange, market_type, symbol)` en même
+  temps. Un lock persistant (`orchestration_locks`, clé `lock_key` UNIQUE) est acquis
+  avant le dispatch de chaque set et libéré à sa fin (succès/échec/exception) ; un set
+  dont un symbole est déjà verrouillé par un run actif est skippé fail-closed
+  (`locked: <key> held by run <id>`). Appliqué à **tous** les sets `mtf_run` (le live
+  reste désactivé) ; TTL anti-deadlock + purge des locks expirés au démarrage. Cf.
+  *Locks d'orchestration (SAFE-001)*. ;
 - ne lancer aucun set live tant que la readiness live n'est pas livrée (tout set
   `dry_run=false` est skippé par le runner, en miroir de `assert_set_persistable`) ;
 - ne pas autoriser OKX live (garde permanente, conservée après readiness) ;
@@ -495,6 +548,7 @@ Avant tout run :
 | PY-004 ✅ | Générer le `payload` `/api/mtf/run` des sets | Livré : `payload` produit côté serveur (cœur partagé avec `build_mtf_payload`, `sync_tables`/`process_tp_sl=false`, sans snapshot) et régénéré à chaque create/update/refresh ; lecture seule via `SetRead`. |
 | PY-005 ✅ | Exécuter les sets persistés + persister les runs | Livré : `/orchestrator/run` lit les sets actifs du dashboard depuis la base, exécute chaque set via son `payload` persisté (+ snapshot runtime + override `dry_run`), et persiste le run (`Run.last_json` global + un `RunSet` par set avec `payload_sent`/`response_json`/`duration_ms`). `no_sets` reste `ok=false`. Garde-fou live défense-en-profondeur au run : OKX/Hyperliquid live (ligne ORM écrite hors API) sont fail-closed avant tout dispatch. |
 | PY-006 ✅ | Exposer l'historique des runs en lecture | Livré : endpoints `GET` en lecture seule du dernier JSON global et par set (`/runs`, `/runs/{run_id}`, `/runs/{run_id}/sets/{set_id}`, `/dashboards/{id}/runs`, `/dashboards/{id}/runs/latest`) ; vue allégée paginée pour les listes, détail complet `last_json` + sets. |
+| SAFE-001 ✅ | Locks d'orchestration par symbole et profil | Livré : table `orchestration_locks` (clé `lock_key` UNIQUE), acquisition tout-ou-rien par set avant dispatch (transaction courte, reclaim des locks expirés, skip fail-closed `locked: …`), libération en fin de set, purge des expirés au démarrage. Prérequis readiness live ; ne réactive pas le live. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -249,7 +249,7 @@ un service `postgres:15`.
 | `MAX_CONCURRENCY` | `2` | Concurrence globale bornée, ≥ 1 (PY-002+). |
 | `DATABASE_URL` | `postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app` | URL SQLAlchemy de la base orchestration (DB-001). |
 | `ORCHESTRATION_DB_SCHEMA` | `orchestration` | Schéma PostgreSQL dédié (DB-001). Identifiant SQL simple validé (`^[A-Za-z_][A-Za-z0-9_]*$`). |
-| `ORCHESTRATION_LOCK_TTL_SECONDS` | `1800` | TTL (s) des locks d'orchestration par `(profil, symbole)` (SAFE-001), ≥ 1. Borne haute anti-deadlock (doit couvrir la durée max d'un run). |
+| `ORCHESTRATION_LOCK_TTL_SECONDS` | `1800` | Marge (s) anti-deadlock des locks d'orchestration par `(profil, symbole)` (SAFE-001), ≥ 1. Le TTL effectif = pire temps de paroi du run (vagues `max_concurrency` × timeout Symfony) + cette marge, pour qu'un set en file n'expire pas avant son dispatch. |
 
 Une valeur non entière ou hors borne lève une erreur explicite au démarrage
 (pas de repli silencieux sur le défaut).
@@ -287,8 +287,10 @@ cron) ne peuvent donc pas traiter le même couple `(profil, symbole)` en même t
   avant** les appels Symfony (jamais maintenue pendant les ~900s). Un set dont un
   symbole est déjà verrouillé par un run actif est **skippé fail-closed**
   (`ok=false`, `locked: <key> held by run <id>`) ; les autres sets continuent.
-- **Reclaim des locks expirés** (TTL `ORCHESTRATION_LOCK_TTL_SECONDS`) + purge au
-  démarrage : pas de deadlock si un process est tué avant la libération.
+- **Reclaim des locks expirés** + purge au démarrage : pas de deadlock si un process
+  est tué avant la libération. Le TTL effectif couvre le pire temps de paroi du run
+  (vagues `max_concurrency` × timeout Symfony) + la marge `ORCHESTRATION_LOCK_TTL_SECONDS`,
+  donc un set resté en file derrière le sémaphore n'expire jamais avant son dispatch.
 - **Libération** dans le `finally` de chaque set (succès/échec/exception).
 - Appliqué à **tous** les sets `mtf_run` (inoffensif en dry-run) ; **le live reste
   désactivé** (SAFE-001 ne relâche pas le skip « live execution not yet enabled »).

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -249,6 +249,7 @@ un service `postgres:15`.
 | `MAX_CONCURRENCY` | `2` | Concurrence globale bornée, ≥ 1 (PY-002+). |
 | `DATABASE_URL` | `postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app` | URL SQLAlchemy de la base orchestration (DB-001). |
 | `ORCHESTRATION_DB_SCHEMA` | `orchestration` | Schéma PostgreSQL dédié (DB-001). Identifiant SQL simple validé (`^[A-Za-z_][A-Za-z0-9_]*$`). |
+| `ORCHESTRATION_LOCK_TTL_SECONDS` | `1800` | TTL (s) des locks d'orchestration par `(profil, symbole)` (SAFE-001), ≥ 1. Borne haute anti-deadlock (doit couvrir la durée max d'un run). |
 
 Une valeur non entière ou hors borne lève une erreur explicite au démarrage
 (pas de repli silencieux sur le défaut).
@@ -269,16 +270,39 @@ Tables (`app/db/models.py`) :
 | `orchestration_sets` | Sets prêts à exécuter (miroir d'`OrchestratorSet` + `payload` préparé). |
 | `runs` | Runs déclenchés + **dernier JSON global** (`last_json`). |
 | `run_sets` | Résultat par set + **dernier JSON par set** (`response_json`). |
+| `orchestration_locks` | Locks par `(mtf_profile, exchange, market_type, symbol)` sérialisant deux runs concurrents (**SAFE-001**). |
 
 La couche DB (`app/db/`) est **découplée** des routers/services : le câblage
 applicatif (CRUD, lecture des sets au run) est l'objet de **PY-002**.
+
+### Lock per-symbole/profil (SAFE-001)
+
+`POST /orchestrator/run` acquiert, **avant le dispatch de chaque set**, un lock
+persistant (`orchestration_locks`) par symbole — clé canonique
+`{profile}|{exchange}|{market_type}|{symbol}`, l'**unicité de `lock_key` réalisant
+l'exclusion mutuelle**. Deux runs concurrents (overlap du cron Temporal, ou front +
+cron) ne peuvent donc pas traiter le même couple `(profil, symbole)` en même temps.
+
+- **Acquisition tout ou rien par set**, dans une transaction **courte committée
+  avant** les appels Symfony (jamais maintenue pendant les ~900s). Un set dont un
+  symbole est déjà verrouillé par un run actif est **skippé fail-closed**
+  (`ok=false`, `locked: <key> held by run <id>`) ; les autres sets continuent.
+- **Reclaim des locks expirés** (TTL `ORCHESTRATION_LOCK_TTL_SECONDS`) + purge au
+  démarrage : pas de deadlock si un process est tué avant la libération.
+- **Libération** dans le `finally` de chaque set (succès/échec/exception).
+- Appliqué à **tous** les sets `mtf_run` (inoffensif en dry-run) ; **le live reste
+  désactivé** (SAFE-001 ne relâche pas le skip « live execution not yet enabled »).
+  L'`idempotency_key` des runs (SAFE-002) n'est pas modifié.
+
+La migration Alembic `0002_orchestration_locks` crée la table ; elle s'applique via
+`alembic upgrade head` (cf. *Migrations*).
 
 ### Migrations
 
 ```bash
 cd python-orchestrator
 export DATABASE_URL=postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app
-alembic upgrade head        # crée le schéma `orchestration` + les 4 tables
+alembic upgrade head        # crée le schéma `orchestration` + les 5 tables
 alembic downgrade base      # supprime les tables (laisse le schéma)
 alembic upgrade head --sql  # prévisualise le DDL sans l'appliquer
 ```

--- a/python-orchestrator/alembic/versions/0002_orchestration_locks.py
+++ b/python-orchestrator/alembic/versions/0002_orchestration_locks.py
@@ -1,0 +1,60 @@
+"""orchestration locks (SAFE-001)
+
+Revision ID: 0002_orchestration_locks
+Revises: 0001_orchestration
+Create Date: 2026-06-21
+
+Ajoute la table ``orchestration.orchestration_locks`` qui sérialise deux runs
+concurrents sur le même ``(mtf_profile, exchange, market_type, symbol)``.
+L'exclusion mutuelle est portée par la contrainte UNIQUE sur ``lock_key``. Reste
+dans le schéma dédié ``orchestration`` (aucun impact sur ``public``/Doctrine).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.base import SCHEMA
+
+# revision identifiers, used by Alembic.
+revision: str = "0002_orchestration_locks"
+down_revision: Union[str, None] = "0001_orchestration"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA_KW = {"schema": SCHEMA} if SCHEMA else {}
+
+
+def upgrade() -> None:
+    op.create_table(
+        "orchestration_locks",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("lock_key", sa.String(length=512), nullable=False),
+        sa.Column("mtf_profile", sa.String(length=32), nullable=False),
+        sa.Column("exchange", sa.String(length=32), nullable=False),
+        sa.Column("market_type", sa.String(length=32), nullable=False),
+        sa.Column("symbol", sa.String(length=64), nullable=False),
+        sa.Column("run_id", sa.String(length=255), nullable=False),
+        sa.Column("acquired_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id", name="pk_orchestration_locks"),
+        # Contrainte d'exclusion mutuelle : un seul titulaire par clé.
+        sa.UniqueConstraint("lock_key", name="uq_orchestration_locks_lock_key"),
+        **SCHEMA_KW,
+    )
+    op.create_index(
+        "ix_orchestration_locks_expires_at",
+        "orchestration_locks",
+        ["expires_at"],
+        **SCHEMA_KW,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_orchestration_locks_expires_at",
+        table_name="orchestration_locks",
+        **SCHEMA_KW,
+    )
+    op.drop_table("orchestration_locks", **SCHEMA_KW)

--- a/python-orchestrator/app/db/models.py
+++ b/python-orchestrator/app/db/models.py
@@ -1,11 +1,13 @@
-"""Modèles ORM des tables d'orchestration (DB-001).
+"""Modèles ORM des tables d'orchestration (DB-001, SAFE-001).
 
-Quatre tables alignées sur la cible documentée :
+Cinq tables alignées sur la cible documentée :
 
 - ``dashboards``           : configurations d'orchestration ;
 - ``orchestration_sets``   : sets prêts à exécuter (cf. ``OrchestratorSet``) ;
 - ``runs``                 : runs déclenchés + dernier JSON global ;
-- ``run_sets``             : résultat par set + dernier JSON par set.
+- ``run_sets``             : résultat par set + dernier JSON par set ;
+- ``orchestration_locks``  : locks d'orchestration par (profil, exchange,
+  market_type, symbole) sérialisant deux runs concurrents (SAFE-001).
 
 Les colonnes JSON utilisent ``JSONB`` sur PostgreSQL et retombent sur ``JSON``
 sur SQLite (tests). Aucun branchement avec les routers/services existants :
@@ -176,3 +178,49 @@ class RunSet(Base):
     )
 
     run: Mapped[Run] = relationship(back_populates="run_sets")
+
+
+class OrchestrationLock(Base):
+    """Lock d'orchestration par couple ``(profil, symbole)`` (SAFE-001).
+
+    Sérialise deux exécutions concurrentes (overlap du cron Temporal, ou front +
+    cron) qui cibleraient le même ``(mtf_profile, exchange, market_type, symbol)``.
+    Sans ce lock partagé en base, l'activation future du live exposerait à des
+    soumissions dupliquées : le garde intra-run (``_conflicting_live_set_ids``) ne
+    couvre qu'un seul batch, pas deux runs/process distincts.
+
+    L'exclusion mutuelle est réalisée par la **contrainte UNIQUE sur ``lock_key``** :
+    deux runs qui tentent d'insérer la même clé entrent en conflit ; seul le premier
+    l'obtient. Le lock est acquis avant le dispatch d'un set et libéré à sa fin
+    (succès comme échec). ``expires_at`` est un TTL anti-deadlock : un lock dont le
+    titulaire a été tué (process killé avant le ``finally`` de libération) est
+    *reclaim* par le run suivant une fois expiré.
+
+    NB : ce lock est posé pour **tous** les sets ``mtf_run`` (pas seulement les sets
+    live). La sérialisation per-symbole/profil est inoffensive en dry-run et rend
+    l'infra testable dès maintenant, alors que le live reste désactivé.
+    """
+
+    __tablename__ = "orchestration_locks"
+    __table_args__ = (
+        # La purge des locks expirés balaie ``expires_at`` : index dédié pour
+        # éviter un seq scan. Nom aligné sur la migration (anti-drift autogenerate).
+        Index("ix_orchestration_locks_expires_at", "expires_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigIntPK, primary_key=True, autoincrement=True)
+    # Clé canonique d'exclusion mutuelle : ``{profile}|{exchange}|{market_type}|{symbol}``
+    # (cf. ``repositories.build_lock_key``). UNIQUE => mutex partagé entre runs/process.
+    lock_key: Mapped[str] = mapped_column(String(512), nullable=False, unique=True)
+    # Composantes dénormalisées (lisibilité / requêtes ad hoc / purge ciblée).
+    mtf_profile: Mapped[str] = mapped_column(String(32), nullable=False)
+    exchange: Mapped[str] = mapped_column(String(32), nullable=False)
+    market_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Titulaire courant : libère ses locks par ``run_id`` à la fin du set.
+    run_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    acquired_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    # TTL anti-deadlock : passé cette date, le lock est reclaimable par un autre run.
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -8,13 +8,14 @@ test pour le schéma.
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from datetime import datetime
+from typing import Any, Mapping, Optional, Sequence, Tuple
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.db.models import Dashboard, OrchestrationSet, Run, RunSet
+from app.db.models import Dashboard, OrchestrationLock, OrchestrationSet, Run, RunSet
 
 # Colonnes mutables recopiées lors d'un upsert (la PK et created_at sont exclus).
 _RUN_UPDATABLE = (
@@ -316,3 +317,117 @@ def get_run_set(session: Session, run_id: str, set_id: str) -> Optional[RunSet]:
     return session.scalar(
         select(RunSet).where(RunSet.run_id == run_id, RunSet.set_id == set_id)
     )
+
+
+# ---------------------------------------------------------------------------
+# Locks d'orchestration (SAFE-001)
+#
+# Sérialise deux runs concurrents sur le même (mtf_profile, exchange,
+# market_type, symbol). L'exclusion mutuelle est portée par la contrainte
+# UNIQUE sur ``OrchestrationLock.lock_key`` ; un lock expiré (TTL dépassé) est
+# *reclaim* par le run suivant. Ces helpers ne committent pas : la transaction
+# (courte, posée AVANT les appels Symfony longs) est gérée par l'appelant.
+# ---------------------------------------------------------------------------
+
+
+def build_lock_key(mtf_profile: str, exchange: str, market_type: str, symbol: str) -> str:
+    """Clé canonique d'exclusion mutuelle d'un couple ``(profil, symbole)``.
+
+    Forme : ``{profile}|{exchange}|{market_type}|{symbol}``. Les composantes sont
+    supposées déjà normalisées par l'appelant (exchange/market_type comme Symfony,
+    symbole en MAJUSCULES comme ``_symbols_overlap``) ; on se contente d'un
+    ``strip()`` défensif pour que la clé soit stable. Le séparateur ``|`` n'apparaît
+    pas dans un identifiant d'exchange/symbole, donc la clé est sans ambiguïté.
+    """
+    parts = (mtf_profile, exchange, market_type, symbol)
+    return "|".join(p.strip() for p in parts)
+
+
+def purge_expired_locks(session: Session, now: datetime) -> int:
+    """Supprime tous les locks expirés (``expires_at <= now``).
+
+    Balayage de garde au démarrage d'un run : évite les fuites si un process
+    titulaire a été tué avant le ``finally`` de libération. Retourne le nombre de
+    lignes supprimées (best-effort selon le dialecte).
+    """
+    result = session.execute(
+        delete(OrchestrationLock).where(OrchestrationLock.expires_at <= now)
+    )
+    return result.rowcount or 0
+
+
+def _acquire_one_lock(session: Session, lock: OrchestrationLock, now: datetime) -> Optional[str]:
+    """Tente d'acquérir UN lock. Retourne ``None`` si acquis, sinon le ``run_id`` titulaire.
+
+    Reclaim d'abord un éventuel lock EXPIRÉ sur la même clé (titulaire mort/abandonné)
+    via un ``DELETE ... WHERE expires_at <= now`` : la comparaison du TTL est faite
+    **côté SQL** (le round-trip SQLite perd le fuseau, donc une comparaison Python
+    naïve/aware échouerait). On insère ensuite via un SAVEPOINT : une violation
+    d'unicité (lock encore actif, ou course concurrente entre la purge et le flush)
+    est rattrapée et on relit le titulaire gagnant plutôt que de propager l'erreur.
+    Compatible SQLite et PostgreSQL (pas d'``ON CONFLICT`` dialecte-spécifique).
+    """
+    # Libère la clé si un lock expiré la détient encore (no-op sinon). Le lock actif
+    # n'est PAS supprimé (expires_at > now) : son titulaire est préservé.
+    session.execute(
+        delete(OrchestrationLock).where(
+            OrchestrationLock.lock_key == lock.lock_key,
+            OrchestrationLock.expires_at <= now,
+        )
+    )
+    session.flush()
+
+    try:
+        with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
+            session.add(lock)
+            session.flush()
+    except IntegrityError:
+        # Clé encore détenue par un run actif (ou course concurrente) : fail-closed.
+        if lock in session:
+            session.expunge(lock)
+        existing = session.scalar(
+            select(OrchestrationLock).where(OrchestrationLock.lock_key == lock.lock_key)
+        )
+        if existing is None:
+            raise  # conflit sur une autre contrainte : ne pas masquer
+        return existing.run_id
+    return None
+
+
+def acquire_set_locks(
+    session: Session, locks: Sequence[OrchestrationLock], now: datetime
+) -> Optional[Tuple[str, str]]:
+    """Acquiert **tout ou rien** l'ensemble des locks d'un set.
+
+    Retourne ``None`` si tous les locks sont acquis. Si un lock est déjà détenu par
+    un run actif, libère ceux déjà pris pour ce set (aucun lock résiduel) et
+    retourne ``(lock_key, run_id_titulaire)`` du premier conflit.
+    """
+    acquired: list[OrchestrationLock] = []
+    for lock in locks:
+        holder = _acquire_one_lock(session, lock, now)
+        if holder is not None:
+            # Acquisition partielle annulée : on ne laisse aucun lock derrière soi.
+            for got in acquired:
+                session.delete(got)
+            if acquired:
+                session.flush()
+            return (lock.lock_key, holder)
+        acquired.append(lock)
+    return None
+
+
+def release_locks(
+    session: Session, *, run_id: str, lock_keys: Optional[Sequence[str]] = None
+) -> int:
+    """Libère les locks détenus par ``run_id`` (optionnellement restreints à ``lock_keys``).
+
+    Appelé dans le ``finally`` de chaque set (succès/échec/exception). Sans
+    ``lock_keys``, libère tous les locks du run. Retourne le nombre de lignes
+    supprimées (best-effort selon le dialecte).
+    """
+    stmt = delete(OrchestrationLock).where(OrchestrationLock.run_id == run_id)
+    if lock_keys is not None:
+        stmt = stmt.where(OrchestrationLock.lock_key.in_(list(lock_keys)))
+    result = session.execute(stmt)
+    return result.rowcount or 0

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import math
 import re
 import time
 import uuid
@@ -484,12 +485,24 @@ async def run_orchestrator(
     # Balayage des locks expirés au démarrage : libère les fuites d'un process tué
     # avant son `finally` de libération (anti-deadlock via TTL).
     repositories.purge_expired_locks(session, lock_now)
+    # TTL effectif : tous les locks d'un run partagent ce `lock_now`, mais un set
+    # peut rester en file derrière le sémaphore (`max_concurrency`) bien après
+    # l'acquisition. Si son `expires_at` tombait avant son dispatch, un run concurrent
+    # pourrait le purger/reclaim et dispatcher le MÊME (profil, exchange, market, symbole)
+    # — l'exclusion mutuelle SAFE-001 serait défaite. On dimensionne donc le TTL pour
+    # couvrir le pire temps de paroi du run (chaque vague de `max_concurrency` sets peut
+    # durer jusqu'au timeout Symfony) + la marge anti-deadlock configurée : aucun lock en
+    # file n'expire avant la fin de son set, tout en gardant une expiration finie en cas
+    # de crash. (Le `finally` libère de toute façon chaque lock dès la fin de son set.)
+    concurrency = max(1, settings.max_concurrency)
+    waves = math.ceil(len(mtf_sets) / concurrency)
+    effective_ttl_seconds = int(waves * _HTTP_TIMEOUT) + settings.lock_ttl_seconds
     locked_out: Dict[str, str] = {}
     set_lock_keys: Dict[str, List[str]] = {}
     for a_set in mtf_sets:
         if a_set.set_id in conflicting_live_ids:
             continue  # déjà rejeté, jamais dispatché : rien à verrouiller
-        locks = _lock_specs_for_set(a_set, run_id, lock_now, settings.lock_ttl_seconds)
+        locks = _lock_specs_for_set(a_set, run_id, lock_now, effective_ttl_seconds)
         if not locks:
             continue  # univers complet / aucun symbole concret : rien à sérialiser
         conflict = repositories.acquire_set_locks(session, locks, lock_now)

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -20,7 +20,7 @@ import hashlib
 import re
 import time
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Session
 
 from app.db import repositories
 from app.db.engine import get_session
-from app.db.models import OrchestrationSet, Run, RunSet
+from app.db.models import OrchestrationLock, OrchestrationSet, Run, RunSet
 from app.schemas import (
     Action,
     LIVE_FORBIDDEN_EXCHANGES,
@@ -349,6 +349,56 @@ def _conflicting_live_set_ids(mtf_sets: List[Any], force_dry_run: bool) -> set:
     return conflicting
 
 
+def _now() -> datetime:
+    """Horloge de l'orchestrateur (UTC, déterministe).
+
+    Aucune contrainte Temporal ici (contrairement au workflow) : on lit l'heure
+    système. Indirection dédiée pour pouvoir l'injecter dans les tests (monkeypatch
+    de ``orch._now``) sans figer ``datetime.now`` globalement.
+    """
+    return datetime.now(timezone.utc)
+
+
+def _lock_specs_for_set(
+    a_set: Any, run_id: str, now: datetime, ttl_seconds: int
+) -> List[OrchestrationLock]:
+    """Construit un ``OrchestrationLock`` par symbole concret d'un set (SAFE-001).
+
+    Symboles normalisés en MAJUSCULES (comme ``_symbols_overlap``) et dédupliqués ;
+    ``exchange``/``market_type`` normalisés comme Symfony (via ``snapshot_key``) ;
+    ``mtf_profile`` normalisé (casse/espaces). Un set sans symbole concret (univers
+    complet) ne produit AUCUN lock : il ne sera de toute façon pas dispatché
+    (``run_persisted_set`` exige une sélection matérialisée), donc il n'y a rien à
+    sérialiser per-symbole.
+    """
+    exchange, market_type = snapshot_key(a_set)
+    raw_profile = getattr(a_set.mtf_profile, "value", a_set.mtf_profile)
+    profile = raw_profile.strip().lower() if isinstance(raw_profile, str) else str(raw_profile)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    seen: set = set()
+    locks: List[OrchestrationLock] = []
+    for raw in a_set.symbols or []:
+        if not isinstance(raw, str):
+            continue
+        symbol = raw.strip().upper()
+        if not symbol or symbol in seen:
+            continue
+        seen.add(symbol)
+        locks.append(
+            OrchestrationLock(
+                lock_key=repositories.build_lock_key(profile, exchange, market_type, symbol),
+                mtf_profile=profile,
+                exchange=exchange,
+                market_type=market_type,
+                symbol=symbol,
+                run_id=run_id,
+                acquired_at=now,
+                expires_at=expires_at,
+            )
+        )
+    return locks
+
+
 async def _collect_snapshots(
     client: httpx.AsyncClient,
     base_url: str,
@@ -420,14 +470,45 @@ async def run_orchestrator(
     # trade live ; on les rejette avant dispatch.
     conflicting_live_ids = _conflicting_live_set_ids(mtf_sets, force_dry_run)
 
-    # Détache les sets et clôt la transaction de lecture AVANT les appels Symfony
-    # (jusqu'à 900s) : sinon la connexion PostgreSQL resterait « idle in
-    # transaction » pendant toute l'attente réseau (risque d'épuisement du pool /
-    # timeouts idle sous charge). Les colonnes déjà chargées restent lisibles sur
-    # les instances détachées (`expire_on_commit=False`, aucune relation lazy
-    # accédée pendant le run) ; `_persist_run` rouvre une transaction fraîche.
-    session.expunge_all()
+    # SAFE-001 : sérialisation per-(profil, symbole) ENTRE runs/process via des locks
+    # DB. Le garde intra-run (`conflicting_live_ids`) ne couvre qu'un seul batch ; deux
+    # runs concurrents (overlap du cron Temporal, ou front + cron) ne se voient pas
+    # sans lock partagé en base. On pose donc, pour chaque set, un lock par symbole
+    # (clé UNIQUE = mutex) AVANT le dispatch, dans la transaction de lecture courte
+    # qui sera committée juste après (jamais maintenue pendant les ~900s d'appels
+    # Symfony). Politique : appliqué à TOUS les sets `mtf_run` (inoffensif en dry-run,
+    # le live restant désactivé), sauf ceux déjà rejetés par le garde intra-run.
+    # Acquisition « tout ou rien » par set ; un set dont un symbole est déjà verrouillé
+    # par un run actif est skippé fail-closed (cohérent avec les autres skips du runner).
+    lock_now = _now()
+    # Balayage des locks expirés au démarrage : libère les fuites d'un process tué
+    # avant son `finally` de libération (anti-deadlock via TTL).
+    repositories.purge_expired_locks(session, lock_now)
+    locked_out: Dict[str, str] = {}
+    set_lock_keys: Dict[str, List[str]] = {}
+    for a_set in mtf_sets:
+        if a_set.set_id in conflicting_live_ids:
+            continue  # déjà rejeté, jamais dispatché : rien à verrouiller
+        locks = _lock_specs_for_set(a_set, run_id, lock_now, settings.lock_ttl_seconds)
+        if not locks:
+            continue  # univers complet / aucun symbole concret : rien à sérialiser
+        conflict = repositories.acquire_set_locks(session, locks, lock_now)
+        if conflict is not None:
+            key, holder = conflict
+            locked_out[a_set.set_id] = f"locked: {key} held by run {holder}"
+        else:
+            set_lock_keys[a_set.set_id] = [lock.lock_key for lock in locks]
+
+    # Persiste la purge + les locks acquis, PUIS détache les sets et clôt la
+    # transaction de lecture AVANT les appels Symfony (jusqu'à 900s) : sinon la
+    # connexion PostgreSQL resterait « idle in transaction » pendant toute l'attente
+    # réseau (risque d'épuisement du pool / timeouts idle sous charge). L'ordre
+    # commit→expunge importe : `expunge_all()` avant le commit jetterait les INSERT de
+    # locks en attente. Les colonnes déjà chargées restent lisibles sur les instances
+    # détachées (`expire_on_commit=False`, aucune relation lazy accédée pendant le
+    # run) ; `_persist_run` rouvre une transaction fraîche.
     session.commit()
+    session.expunge_all()
 
     started_at = datetime.now(timezone.utc)
 
@@ -448,6 +529,32 @@ async def run_orchestrator(
                     "payload_sent": None,
                     "duration_ms": None,
                 }
+            # SAFE-001 : un set dont un symbole est déjà verrouillé par un autre run
+            # actif est skippé fail-closed (aucun lock acquis pour lui : rien à
+            # libérer ici). Les autres sets du run continuent normalement.
+            if a_set.set_id in locked_out:
+                return {
+                    "set_id": a_set.set_id,
+                    "ok": False,
+                    "status": None,
+                    "body": locked_out[a_set.set_id],
+                    "payload_sent": None,
+                    "duration_ms": None,
+                }
+            try:
+                return await _dispatch_set(a_set)
+            finally:
+                # SAFE-001 : libération des locks de CE set, quoi qu'il arrive (succès,
+                # échec métier, skip fail-closed, exception). Le bloc delete+commit ne
+                # contient aucun `await` : il s'exécute atomiquement vis-à-vis des autres
+                # coroutines (ordonnancement coopératif), donc partager la session de
+                # requête entre les `_execute` concurrents est sûr.
+                lock_keys = set_lock_keys.get(a_set.set_id)
+                if lock_keys:
+                    repositories.release_locks(session, run_id=run_id, lock_keys=lock_keys)
+                    session.commit()
+
+        async def _dispatch_set(a_set: Any) -> Dict[str, Any]:
             snapshot = snapshots.get(snapshot_key(a_set))
             effective_dry_run = a_set.dry_run or force_dry_run
             exchange = getattr(a_set.exchange, "value", a_set.exchange)

--- a/python-orchestrator/app/settings.py
+++ b/python-orchestrator/app/settings.py
@@ -60,10 +60,11 @@ class Settings:
     )
     # Schéma PostgreSQL dédié aux tables d'orchestration.
     db_schema: str = "orchestration"
-    # TTL (s) des locks d'orchestration par (profil, symbole) (SAFE-001). Borne
-    # haute anti-deadlock : un lock dont le titulaire a été tué avant la libération
-    # est reclaimable au-delà. Doit couvrir la durée max d'un run (appels Symfony
-    # bornés à ~900s) avec marge ; défaut 1800s.
+    # Marge (s) anti-deadlock des locks d'orchestration par (profil, symbole)
+    # (SAFE-001). Le TTL effectif d'un lock = pire temps de paroi du run (vagues de
+    # `max_concurrency` * timeout Symfony) + cette marge, afin qu'un set resté en file
+    # n'expire jamais avant son dispatch ; passé ce délai, un lock dont le titulaire a
+    # été tué avant la libération est reclaimable. Défaut 1800s.
     lock_ttl_seconds: int = 1800
     # Origines autorisées par CORS pour les appels navigateur du cockpit (UI-001).
     # Défauts = front servi par CRA (:3000) ou nginx (:8082). Surchargeable via

--- a/python-orchestrator/app/settings.py
+++ b/python-orchestrator/app/settings.py
@@ -60,6 +60,11 @@ class Settings:
     )
     # Schéma PostgreSQL dédié aux tables d'orchestration.
     db_schema: str = "orchestration"
+    # TTL (s) des locks d'orchestration par (profil, symbole) (SAFE-001). Borne
+    # haute anti-deadlock : un lock dont le titulaire a été tué avant la libération
+    # est reclaimable au-delà. Doit couvrir la durée max d'un run (appels Symfony
+    # bornés à ~900s) avec marge ; défaut 1800s.
+    lock_ttl_seconds: int = 1800
     # Origines autorisées par CORS pour les appels navigateur du cockpit (UI-001).
     # Défauts = front servi par CRA (:3000) ou nginx (:8082). Surchargeable via
     # CORS_ALLOW_ORIGINS (CSV) ; ``"*"`` autorise toute origine.
@@ -79,6 +84,10 @@ class Settings:
             raise SettingsError("DATABASE_URL ne doit pas être vide.")
         if not self.db_schema.strip():
             raise SettingsError("ORCHESTRATION_DB_SCHEMA ne doit pas être vide.")
+        if self.lock_ttl_seconds < 1:
+            raise SettingsError(
+                f"ORCHESTRATION_LOCK_TTL_SECONDS doit être >= 1 (reçu {self.lock_ttl_seconds})."
+            )
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -88,6 +97,7 @@ class Settings:
             max_concurrency=_int_env("MAX_CONCURRENCY", cls.max_concurrency),
             database_url=os.getenv("DATABASE_URL", cls.database_url),
             db_schema=os.getenv("ORCHESTRATION_DB_SCHEMA", cls.db_schema),
+            lock_ttl_seconds=_int_env("ORCHESTRATION_LOCK_TTL_SECONDS", cls.lock_ttl_seconds),
             cors_allow_origins=_csv_env("CORS_ALLOW_ORIGINS", cls.cors_allow_origins),
         )
 

--- a/python-orchestrator/tests/test_db_models.py
+++ b/python-orchestrator/tests/test_db_models.py
@@ -20,9 +20,29 @@ def _table(name: str):
     raise AssertionError(f"table {name!r} absente des métadonnées")
 
 
-def test_four_tables_registered():
+def test_core_tables_registered():
     names = {t.name for t in Base.metadata.tables.values()}
-    assert {"dashboards", "orchestration_sets", "runs", "run_sets"} <= names
+    assert {
+        "dashboards", "orchestration_sets", "runs", "run_sets", "orchestration_locks",
+    } <= names
+
+
+def test_orchestration_locks_columns_and_unique_lock_key():
+    table = _table("orchestration_locks")
+    expected = {
+        "id", "lock_key", "mtf_profile", "exchange", "market_type",
+        "symbol", "run_id", "acquired_at", "expires_at",
+    }
+    assert expected <= set(table.columns.keys())
+
+    # L'exclusion mutuelle repose sur l'unicité de lock_key.
+    assert table.c.lock_key.unique is True
+    assert table.c.lock_key.nullable is False
+    assert table.c.expires_at.nullable is False
+
+    # Index dédié sur expires_at pour la purge.
+    index_names = {idx.name for idx in table.indexes}
+    assert "ix_orchestration_locks_expires_at" in index_names
 
 
 def test_orchestration_sets_columns_and_constraints():

--- a/python-orchestrator/tests/test_db_postgres_smoke.py
+++ b/python-orchestrator/tests/test_db_postgres_smoke.py
@@ -1,7 +1,7 @@
 """Smoke test PostgreSQL/Alembic du schéma orchestration (DB-001).
 
 Contrairement aux tests SQLite, ce test valide le **vrai contrat PostgreSQL** :
-cycle ``alembic upgrade head`` / ``downgrade base``, présence des 4 tables +
+cycle ``alembic upgrade head`` / ``downgrade base``, présence des 5 tables +
 ``alembic_version`` dans le schéma dédié, schéma ``public`` intact, et absence de
 drift entre les modèles ORM et la migration (``compare_metadata``).
 
@@ -26,7 +26,13 @@ pytestmark = pytest.mark.skipif(
 
 ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = "orchestration"
-EXPECTED_TABLES = {"dashboards", "orchestration_sets", "runs", "run_sets"}
+EXPECTED_TABLES = {
+    "dashboards",
+    "orchestration_sets",
+    "runs",
+    "run_sets",
+    "orchestration_locks",
+}
 
 
 def _alembic_config():

--- a/python-orchestrator/tests/test_orchestration_locks.py
+++ b/python-orchestrator/tests/test_orchestration_locks.py
@@ -1,0 +1,154 @@
+"""Tests de la couche locks d'orchestration (SAFE-001).
+
+Couvre les helpers ``app/db/repositories.py`` sur SQLite in-memory :
+
+- clé canonique d'exclusion mutuelle (``build_lock_key``) ;
+- acquisition atomique « tout ou rien » par set (``acquire_set_locks``) ;
+- reclaim d'un lock expiré (TTL dépassé) ;
+- libération par ``run_id`` (``release_locks``) et purge des expirés.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+
+from app.db import repositories as repo
+from app.db.models import OrchestrationLock
+
+
+def _lock(run_id: str, symbol: str, *, now: datetime, ttl: int = 1800,
+          profile: str = "regular", exchange: str = "bitmart",
+          market_type: str = "perpetual") -> OrchestrationLock:
+    return OrchestrationLock(
+        lock_key=repo.build_lock_key(profile, exchange, market_type, symbol),
+        mtf_profile=profile,
+        exchange=exchange,
+        market_type=market_type,
+        symbol=symbol,
+        run_id=run_id,
+        acquired_at=now,
+        expires_at=now + timedelta(seconds=ttl),
+    )
+
+
+def test_build_lock_key_is_canonical_and_stable():
+    key = repo.build_lock_key("regular", "bitmart", "perpetual", "BTCUSDT")
+    assert key == "regular|bitmart|perpetual|BTCUSDT"
+    # Déterministe : mêmes composantes => même clé.
+    assert key == repo.build_lock_key(" regular ", " bitmart ", " perpetual ", " BTCUSDT ")
+    # Le symbole/profil discriminent la clé (pas de collision).
+    assert key != repo.build_lock_key("scalper", "bitmart", "perpetual", "BTCUSDT")
+    assert key != repo.build_lock_key("regular", "bitmart", "perpetual", "ETHUSDT")
+
+
+def test_acquire_set_locks_success_then_present(db_session):
+    now = datetime.now(timezone.utc)
+    locks = [_lock("run1", "BTCUSDT", now=now), _lock("run1", "ETHUSDT", now=now)]
+
+    conflict = repo.acquire_set_locks(db_session, locks, now)
+    db_session.commit()
+
+    assert conflict is None
+    rows = db_session.scalars(select(OrchestrationLock)).all()
+    assert {r.symbol for r in rows} == {"BTCUSDT", "ETHUSDT"}
+    assert all(r.run_id == "run1" for r in rows)
+
+
+def test_acquire_set_locks_conflict_when_held_by_active_run(db_session):
+    now = datetime.now(timezone.utc)
+    # run1 détient BTCUSDT.
+    assert repo.acquire_set_locks(db_session, [_lock("run1", "BTCUSDT", now=now)], now) is None
+    db_session.commit()
+
+    # run2 tente BTCUSDT => conflit, lock_key + titulaire remontés.
+    conflict = repo.acquire_set_locks(db_session, [_lock("run2", "BTCUSDT", now=now)], now)
+    assert conflict is not None
+    key, holder = conflict
+    assert key == repo.build_lock_key("regular", "bitmart", "perpetual", "BTCUSDT")
+    assert holder == "run1"
+
+
+def test_acquire_set_locks_all_or_nothing_releases_partial(db_session):
+    now = datetime.now(timezone.utc)
+    # run1 détient ETHUSDT.
+    assert repo.acquire_set_locks(db_session, [_lock("run1", "ETHUSDT", now=now)], now) is None
+    db_session.commit()
+
+    # run2 veut [BTCUSDT, ETHUSDT] : BTCUSDT libre, ETHUSDT bloqué => tout ou rien.
+    conflict = repo.acquire_set_locks(
+        db_session,
+        [_lock("run2", "BTCUSDT", now=now), _lock("run2", "ETHUSDT", now=now)],
+        now,
+    )
+    db_session.commit()
+
+    assert conflict is not None
+    # Aucun lock résiduel de run2 (BTCUSDT pris puis relâché).
+    run2_rows = db_session.scalars(
+        select(OrchestrationLock).where(OrchestrationLock.run_id == "run2")
+    ).all()
+    assert run2_rows == []
+    # ETHUSDT reste à run1.
+    eth = db_session.scalar(
+        select(OrchestrationLock).where(OrchestrationLock.symbol == "ETHUSDT")
+    )
+    assert eth.run_id == "run1"
+
+
+def test_expired_lock_is_reclaimed(db_session):
+    now = datetime.now(timezone.utc)
+    # run1 détient un lock DÉJÀ expiré (acquis dans le passé).
+    past = now - timedelta(seconds=3600)
+    db_session.add(_lock("run1", "BTCUSDT", now=past, ttl=10))  # expires_at < now
+    db_session.commit()
+
+    # run2 acquiert : le lock expiré est reclaim, acquisition réussie.
+    conflict = repo.acquire_set_locks(db_session, [_lock("run2", "BTCUSDT", now=now)], now)
+    db_session.commit()
+
+    assert conflict is None
+    row = db_session.scalar(select(OrchestrationLock).where(OrchestrationLock.symbol == "BTCUSDT"))
+    assert row.run_id == "run2"
+
+
+def test_release_locks_by_run_id(db_session):
+    now = datetime.now(timezone.utc)
+    repo.acquire_set_locks(
+        db_session,
+        [_lock("run1", "BTCUSDT", now=now), _lock("run1", "ETHUSDT", now=now)],
+        now,
+    )
+    repo.acquire_set_locks(db_session, [_lock("run2", "XRPUSDT", now=now)], now)
+    db_session.commit()
+
+    # Libère uniquement BTCUSDT de run1 (restriction par lock_keys).
+    repo.release_locks(
+        db_session,
+        run_id="run1",
+        lock_keys=[repo.build_lock_key("regular", "bitmart", "perpetual", "BTCUSDT")],
+    )
+    db_session.commit()
+    remaining = {r.symbol for r in db_session.scalars(select(OrchestrationLock)).all()}
+    assert remaining == {"ETHUSDT", "XRPUSDT"}
+
+    # Libère tout le reste de run1.
+    repo.release_locks(db_session, run_id="run1")
+    db_session.commit()
+    remaining = {r.symbol for r in db_session.scalars(select(OrchestrationLock)).all()}
+    assert remaining == {"XRPUSDT"}  # XRPUSDT (run2) intact
+
+
+def test_purge_expired_locks(db_session):
+    now = datetime.now(timezone.utc)
+    db_session.add(_lock("dead", "BTCUSDT", now=now - timedelta(hours=2), ttl=10))  # expiré
+    db_session.add(_lock("alive", "ETHUSDT", now=now))  # actif
+    db_session.commit()
+
+    removed = repo.purge_expired_locks(db_session, now)
+    db_session.commit()
+
+    assert removed == 1
+    remaining = {r.symbol for r in db_session.scalars(select(OrchestrationLock)).all()}
+    assert remaining == {"ETHUSDT"}

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -946,3 +946,224 @@ def test_no_sets_run_is_not_persisted(orchestrator_env, monkeypatch):
 
     session.expire_all()
     assert session.get(Run, run_id) is None
+
+
+# --------------------------------------------------------------------------
+# SAFE-001 — locks d'orchestration par (profil, symbole)
+# --------------------------------------------------------------------------
+
+
+def _seed_lock(
+    session,
+    run_id: str,
+    symbol: str,
+    *,
+    profile: str = "regular",
+    exchange: str = "bitmart",
+    market_type: str = "perpetual",
+    ttl_seconds: int = 1800,
+    acquired_offset_seconds: int = 0,
+):
+    """Insère un ``OrchestrationLock`` détenu par ``run_id`` (simule un run concurrent).
+
+    ``acquired_offset_seconds`` décale ``acquired_at`` dans le passé ; combiné à
+    ``ttl_seconds`` il permet de produire un lock déjà expiré (TTL dépassé).
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from app.db import repositories as repo
+    from app.db.models import OrchestrationLock
+
+    acquired = datetime.now(timezone.utc) - timedelta(seconds=acquired_offset_seconds)
+    lock = OrchestrationLock(
+        lock_key=repo.build_lock_key(profile, exchange, market_type, symbol),
+        mtf_profile=profile,
+        exchange=exchange,
+        market_type=market_type,
+        symbol=symbol,
+        run_id=run_id,
+        acquired_at=acquired,
+        expires_at=acquired + timedelta(seconds=ttl_seconds),
+    )
+    session.add(lock)
+    session.commit()
+    return lock
+
+
+def _all_locks(session):
+    from app.db.models import OrchestrationLock
+
+    session.expire_all()
+    return session.scalars(select(OrchestrationLock)).all()
+
+
+def test_lock_acquired_then_released_after_successful_run(orchestrator_env, monkeypatch):
+    # Acquisition réussie -> set exécuté (POST mtf/run) -> lock libéré en fin de run.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", exchange="bitmart", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is True
+    assert body["summary"]["success"] == 1
+    # Le set a bien été dispatché.
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+    # Et plus aucun lock résiduel : libéré dans le finally du set.
+    assert _all_locks(session) == []
+
+
+def test_set_skipped_when_symbol_locked_by_other_run(orchestrator_env, monkeypatch):
+    # Un couple (profil, symbole) déjà verrouillé par un autre run actif => set skippé
+    # (ok=false, message "locked"), les AUTRES sets du run continuent.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "locked", exchange="bitmart", symbols=("BTCUSDT",))
+    _seed_set(session, dash.id, "free", exchange="bitmart", symbols=("ETHUSDT",))
+    # Run concurrent détenant déjà BTCUSDT (regular/bitmart/perpetual).
+    _seed_lock(session, "run_other", "BTCUSDT")
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["summary"]["total_calls"] == 2
+    assert body["summary"]["success"] == 1
+    assert body["summary"]["failed"] == 1
+
+    # Seul le set "free" (ETHUSDT) est dispatché ; "locked" est skippé sans POST.
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+
+    run_id = body["run_id"]
+    rs_locked = session.scalars(
+        select(RunSet).where(RunSet.run_id == run_id, RunSet.set_id == "locked")
+    ).one()
+    assert rs_locked.ok is False
+    assert rs_locked.error.startswith("locked: ")
+    assert "held by run run_other" in rs_locked.error
+
+    # Le lock du run concurrent reste intact ; aucun lock de ce run ne subsiste.
+    remaining = _all_locks(session)
+    assert {l.run_id for l in remaining} == {"run_other"}
+    assert {l.symbol for l in remaining} == {"BTCUSDT"}
+
+
+def test_expired_lock_is_reclaimed_and_set_runs(orchestrator_env, monkeypatch):
+    # Un lock expiré (TTL dépassé) ne bloque pas : il est reclaim, le set s'exécute.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", exchange="bitmart", symbols=("BTCUSDT",))
+    # Lock détenu par un run mort, acquis il y a 2h avec un TTL de 10s => expiré.
+    _seed_lock(session, "run_dead", "BTCUSDT", ttl_seconds=10, acquired_offset_seconds=7200)
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is True
+    assert body["summary"]["success"] == 1
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+    # Lock du run mort reclaim puis libéré : table vide en fin de run.
+    assert _all_locks(session) == []
+
+
+def test_partial_lock_leaves_no_residual_lock(orchestrator_env, monkeypatch):
+    # Acquisition « tout ou rien » : un set [BTCUSDT, ETHUSDT] dont ETHUSDT est déjà
+    # verrouillé est skippé, et NE laisse aucun lock résiduel sur BTCUSDT.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "multi", exchange="bitmart", symbols=("BTCUSDT", "ETHUSDT"))
+    _seed_lock(session, "run_other", "ETHUSDT")
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is False
+    assert body["summary"] == {"total_calls": 1, "success": 0, "failed": 1}
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 0
+
+    # Seul le lock concurrent ETHUSDT subsiste : pas de BTCUSDT résiduel.
+    remaining = _all_locks(session)
+    assert {(l.run_id, l.symbol) for l in remaining} == {("run_other", "ETHUSDT")}
+
+
+def test_lock_released_even_when_set_fails(orchestrator_env, monkeypatch):
+    # Libération garantie dans le finally même si le set échoue (erreur métier).
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", exchange="bitmart", symbols=("BTCUSDT",))
+    _install_fake_client(
+        monkeypatch,
+        _FakeAsyncClient(mtf_status=500, mtf_body={"status": "error", "message": "boom"}),
+    )
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is False
+    assert body["summary"]["failed"] == 1
+    # Échec métier => le lock est tout de même libéré (aucun lock résiduel).
+    assert _all_locks(session) == []
+
+
+def test_lock_released_even_on_dispatch_exception(orchestrator_env, monkeypatch):
+    # Libération garantie dans le finally même si le dispatch lève (HTTPError caught).
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", exchange="bitmart", symbols=("BTCUSDT",))
+
+    fake = _FakeAsyncClient()
+
+    async def _raise(*_a, **_k):
+        raise __import__("httpx").HTTPError("connection reset")
+
+    fake.post = _raise  # type: ignore[assignment]
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is False
+    assert body["summary"]["failed"] == 1
+    # Exception de dispatch => lock libéré quand même.
+    assert _all_locks(session) == []
+
+
+def test_lock_uses_injected_clock_for_expiry(orchestrator_env, monkeypatch):
+    # Le `now` de l'orchestrateur est injectable (orch._now) : un lock dont l'expiry
+    # est antérieur au `now` injecté est reclaim, postérieur il bloque.
+    from datetime import datetime, timedelta, timezone
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", exchange="bitmart", symbols=("BTCUSDT",))
+
+    base = datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+    # Lock qui expire 1s AVANT le now injecté => reclaimable.
+    from app.db import repositories as repo
+    from app.db.models import OrchestrationLock
+
+    session.add(
+        OrchestrationLock(
+            lock_key=repo.build_lock_key("regular", "bitmart", "perpetual", "BTCUSDT"),
+            mtf_profile="regular", exchange="bitmart", market_type="perpetual",
+            symbol="BTCUSDT", run_id="run_old",
+            acquired_at=base - timedelta(hours=1),
+            expires_at=base - timedelta(seconds=1),
+        )
+    )
+    session.commit()
+
+    monkeypatch.setattr(orch, "_now", lambda: base)
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+    assert body["ok"] is True
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1134,6 +1134,52 @@ def test_lock_released_even_on_dispatch_exception(orchestrator_env, monkeypatch)
     assert _all_locks(session) == []
 
 
+def test_queued_lock_ttl_covers_worst_case_run(orchestrator_env, monkeypatch):
+    # Régression (review #176) : le TTL d'un lock doit couvrir le PIRE temps de paroi
+    # du run (vagues de `max_concurrency` * timeout Symfony) + marge anti-deadlock,
+    # sinon un set resté en file derrière le sémaphore pourrait voir son lock expirer
+    # AVANT son dispatch et être reclaim par un run concurrent (exclusion défaite).
+    # On observe `expires_at` PENDANT le dispatch (lock encore détenu).
+    from datetime import datetime, timedelta, timezone
+
+    from app.db.models import OrchestrationLock
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", exchange="bitmart", symbols=("BTCUSDT",))
+    _seed_set(session, dash.id, "b", exchange="bitmart", symbols=("ETHUSDT",))
+    _seed_set(session, dash.id, "c", exchange="bitmart", symbols=("XRPUSDT",))
+
+    base = datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(orch, "_now", lambda: base)
+
+    captured: Dict[str, Any] = {}
+
+    class _CapturingClient(_FakeAsyncClient):
+        async def post(self, url, json=None):
+            symbols = (json or {}).get("symbols") or []
+            if symbols:
+                row = session.scalars(
+                    select(OrchestrationLock).where(OrchestrationLock.symbol == symbols[0])
+                ).first()
+                if row is not None:
+                    captured[symbols[0]] = row.expires_at
+            return await super().post(url, json=json)
+
+    _install_fake_client(monkeypatch, _CapturingClient())
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+    assert body["ok"] is True
+
+    # 3 sets, max_concurrency par défaut = 2 => 2 vagues ; TTL = 2*900 + 1800 = 3600s.
+    expected = base + timedelta(seconds=2 * 900 + 1800)
+    assert captured  # au moins un lock observé pendant le dispatch
+    for exp in captured.values():
+        # SQLite peut renvoyer un datetime naïf : on normalise le fuseau pour comparer.
+        exp_utc = exp if exp.tzinfo else exp.replace(tzinfo=timezone.utc)
+        assert exp_utc == expected
+
+
 def test_lock_uses_injected_clock_for_expiry(orchestrator_env, monkeypatch):
     # Le `now` de l'orchestrateur est injectable (orch._now) : un lock dont l'expiry
     # est antérieur au `now` injecté est reclaim, postérieur il bloque.

--- a/python-orchestrator/tests/test_settings.py
+++ b/python-orchestrator/tests/test_settings.py
@@ -9,11 +9,25 @@ def test_defaults(monkeypatch):
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.delenv("ORCHESTRATION_DB_SCHEMA", raising=False)
 
+    monkeypatch.delenv("ORCHESTRATION_LOCK_TTL_SECONDS", raising=False)
+
     settings = Settings.from_env()
     assert settings.max_concurrency == 2
     assert settings.port == 8099
     assert settings.database_url.startswith("postgresql+psycopg://")
     assert settings.db_schema == "orchestration"
+    assert settings.lock_ttl_seconds == 1800
+
+
+def test_lock_ttl_from_env(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATION_LOCK_TTL_SECONDS", "900")
+    assert Settings.from_env().lock_ttl_seconds == 900
+
+
+def test_lock_ttl_must_be_positive(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATION_LOCK_TTL_SECONDS", "0")
+    with pytest.raises(SettingsError):
+        Settings.from_env()
 
 
 def test_database_url_and_schema_from_env(monkeypatch):


### PR DESCRIPTION
Add the OrchestrationLock ORM model and migration 0002 creating the
orchestration.orchestration_locks table. The UNIQUE constraint on lock_key
realizes the per-(mtf_profile, exchange, market_type, symbol) mutual exclusion;
expires_at (indexed) is the anti-deadlock TTL. Stays in the dedicated
orchestration schema (no impact on public/Doctrine).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FuDGtgTzNDniG8Ypu1A1Aj