### PR TITLE
SAFE-002: add run statuses + claim TTL column/migration

### DIFF
--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -501,16 +501,19 @@ d'idempotence** existe (`idempotency_key`, ou `dashboard_id` + `tick_timestamp` 
 (comme les locks SAFE-001, jamais maintenue pendant les ~900s) — on pose/résout la
 ligne `Run` via `claim_run` (variante *compare-and-set* de `record_run`, savepoint
 anti-course réutilisé) avec `status="running"`, `started_at`, et
-`expires_at = now + TTL de claim`. `claim_run` ne remplace une ligne existante que
-si elle **n'est pas** un claim actif. Deux courses sont neutralisées : (1) **INSERT
-concurrent** (la ligne n'existait pas — les deux requêtes ont vu une absence au
-pré-check) → savepoint + violation d'unicité, le perdant relit le gagnant ; (2)
-**UPDATE concurrent** (reprise/reclaim d'une ligne déjà présente) → le read-modify-
-write se fait **sous `SELECT … FOR UPDATE`** (+ `populate_existing` pour ré-évaluer
-le claim sur l'état frais), donc deux reprises d'une même ligne périmée ne peuvent
-pas toutes deux la ré-écrire : la seconde bloque, relit le claim désormais actif et
-s'efface. Dans les deux cas le perdant **réplique l'état en vol sans dispatcher**
-plutôt que d'écraser la ligne partagée et de re-soumettre du travail. Le **TTL de claim réutilise
+`expires_at = now + TTL de claim`. `claim_run` **classe** la ligne
+existante sous verrou et ne la remplace que si elle est réellement reprenable
+(terminal non-ok → reprise ; claim périmé → reclaim). Deux courses sont neutralisées
+sur l'état le plus frais possible : (1) **INSERT concurrent** (la ligne n'existait pas
+— les deux requêtes ont vu une absence au pré-check) → savepoint + violation
+d'unicité, le perdant relit le gagnant ; (2) **UPDATE concurrent** (ligne déjà
+présente) → le read-modify-write se fait **sous `SELECT … FOR UPDATE`** (+
+`populate_existing` pour reclasser sur l'état frais). Le perdant **cède** alors selon
+l'état committé par le gagnant : **replay** si le gagnant a déjà **finalisé en succès**
+(on ne ré-écrit pas la ligne réussie et on ne ré-exécute pas), **réplique in-flight**
+si un run est encore en vol — au lieu d'écraser la ligne partagée et de re-soumettre
+du travail. Cette classification sous verrou est la même que celle du pré-check, mais
+ré-évaluée sur l'état frais. Le **TTL de claim réutilise
 le calcul SAFE-001** du pire temps de paroi du run
 (`ceil(n_sets / max_concurrency)` × timeout Symfony + marge `ORCHESTRATION_LOCK_TTL_SECONDS`) :
 aucune variable d'environnement dédiée. Le `now` est lu via `orch._now`

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -502,10 +502,15 @@ d'idempotence** existe (`idempotency_key`, ou `dashboard_id` + `tick_timestamp` 
 ligne `Run` via `claim_run` (variante *compare-and-set* de `record_run`, savepoint
 anti-course réutilisé) avec `status="running"`, `started_at`, et
 `expires_at = now + TTL de claim`. `claim_run` ne remplace une ligne existante que
-si elle **n'est pas** un claim actif : si un run concurrent a committé son claim
-**entre le pré-check et le seed** (course TOCTOU : les deux requêtes avaient vu une
-absence de ligne), le perdant **réplique l'état en vol sans dispatcher** plutôt que
-d'écraser la ligne partagée et de re-soumettre du travail. Le **TTL de claim réutilise
+si elle **n'est pas** un claim actif. Deux courses sont neutralisées : (1) **INSERT
+concurrent** (la ligne n'existait pas — les deux requêtes ont vu une absence au
+pré-check) → savepoint + violation d'unicité, le perdant relit le gagnant ; (2)
+**UPDATE concurrent** (reprise/reclaim d'une ligne déjà présente) → le read-modify-
+write se fait **sous `SELECT … FOR UPDATE`** (+ `populate_existing` pour ré-évaluer
+le claim sur l'état frais), donc deux reprises d'une même ligne périmée ne peuvent
+pas toutes deux la ré-écrire : la seconde bloque, relit le claim désormais actif et
+s'efface. Dans les deux cas le perdant **réplique l'état en vol sans dispatcher**
+plutôt que d'écraser la ligne partagée et de re-soumettre du travail. Le **TTL de claim réutilise
 le calcul SAFE-001** du pire temps de paroi du run
 (`ceil(n_sets / max_concurrency)` × timeout Symfony + marge `ORCHESTRATION_LOCK_TTL_SECONDS`) :
 aucune variable d'environnement dédiée. Le `now` est lu via `orch._now`

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -498,13 +498,24 @@ d'idempotence** existe (`idempotency_key`, ou `dashboard_id` + `tick_timestamp` 
 | `no_sets` | — | Aucun set à exécuter ; **jamais persisté** (inchangé). |
 
 **Claim précoce** : avant le dispatch — dans une **transaction courte committée**
-(comme les locks SAFE-001, jamais maintenue pendant les ~900s) — on insère/résout la
-ligne `Run` via le `record_run` existant (savepoint anti-course réutilisé) avec
-`status="running"`, `started_at`, et `expires_at = now + TTL de claim`. Le **TTL de
-claim réutilise le calcul SAFE-001** du pire temps de paroi du run
+(comme les locks SAFE-001, jamais maintenue pendant les ~900s) — on pose/résout la
+ligne `Run` via `claim_run` (variante *compare-and-set* de `record_run`, savepoint
+anti-course réutilisé) avec `status="running"`, `started_at`, et
+`expires_at = now + TTL de claim`. `claim_run` ne remplace une ligne existante que
+si elle **n'est pas** un claim actif : si un run concurrent a committé son claim
+**entre le pré-check et le seed** (course TOCTOU : les deux requêtes avaient vu une
+absence de ligne), le perdant **réplique l'état en vol sans dispatcher** plutôt que
+d'écraser la ligne partagée et de re-soumettre du travail. Le **TTL de claim réutilise
+le calcul SAFE-001** du pire temps de paroi du run
 (`ceil(n_sets / max_concurrency)` × timeout Symfony + marge `ORCHESTRATION_LOCK_TTL_SECONDS`) :
 aucune variable d'environnement dédiée. Le `now` est lu via `orch._now`
 (`datetime.now(timezone.utc)`, injectable en test), partagé avec le TTL des locks.
+
+Le **replay** (terminal success) et la **réplique in-flight** (run en vol) sont
+résolus **avant le gating `no_sets`** : ils ne nécessitent ni dashboard ni sets, donc
+un retry après désactivation/suppression du dashboard (ou avec la seule clé) rejoue
+quand même le succès persisté. La **reprise** et le **reclaim**, qui re-exécutent,
+restent gated par la disponibilité des sets.
 
 **Court-circuit selon l'état du run existant** (résolu par `run_id` puis
 `idempotency_key`) :

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -432,7 +432,7 @@ Doctrine de Symfony (qui n'introspecte que `public`).
 | --- | --- |
 | `dashboards` | Configurations d'orchestration (nom, statut actif). |
 | `orchestration_sets` | Sets prêts à exécuter (miroir d'`OrchestratorSet`, dont `sync_tables`, `symbols`, `contracts_limit`, et le `payload` préparé). |
-| `runs` | Runs déclenchés (`run_id`, statut, compteurs, idempotency_key) + **dernier JSON global** (`last_json`). |
+| `runs` | Runs déclenchés (`run_id`, statut, compteurs, idempotency_key, `expires_at` = TTL du claim « en vol ») + **dernier JSON global** (`last_json`). |
 | `run_sets` | Détail par set d'un run (payload envoyé, réponse Symfony, statut, erreur, durée) + **dernier JSON par set** (`response_json`). |
 | `orchestration_locks` | Locks d'orchestration par `(mtf_profile, exchange, market_type, symbol)` sérialisant deux runs concurrents (**SAFE-001**). |
 
@@ -479,8 +479,56 @@ complet) ne pose aucun lock : il n'est de toute façon pas dispatché
 (`run_persisted_set` exige une sélection matérialisée). Le `now` est lu via
 `datetime.now(timezone.utc)` (aucune contrainte Temporal ici) et injectable en test.
 
-> Hors-scope SAFE-001 : l'idempotence des runs (`runs.idempotency_key`, **SAFE-002**)
-> n'est pas modifiée.
+### Statuts de run et idempotence à l'exécution (SAFE-002)
+
+SAFE-001 sérialise les dispatches concurrents **au grain symbole**, mais ne fournit
+pas la sémantique de replay/reprise **au grain run**. SAFE-002 rend
+`POST /orchestrator/run` idempotent **à l'exécution** lorsqu'un **ancrage
+d'idempotence** existe (`idempotency_key`, ou `dashboard_id` + `tick_timestamp` →
+`run_id` stable). Un `run_id` aléatoire (aucun contexte) reste non idempotent.
+
+**Statuts de run** (centralisés dans `app/schemas.py`) :
+
+| Statut | Terminal ? | Sens |
+| --- | --- | --- |
+| `running` | non | **Claim « en vol »** posé au démarrage du run (avant le dispatch). |
+| `success` | oui | Tous les sets exécutés réussis (`ok=true`). |
+| `partial_failure` | oui | Au moins un succès et au moins un échec. |
+| `failed` | oui | Aucun set réussi. |
+| `no_sets` | — | Aucun set à exécuter ; **jamais persisté** (inchangé). |
+
+**Claim précoce** : avant le dispatch — dans une **transaction courte committée**
+(comme les locks SAFE-001, jamais maintenue pendant les ~900s) — on insère/résout la
+ligne `Run` via le `record_run` existant (savepoint anti-course réutilisé) avec
+`status="running"`, `started_at`, et `expires_at = now + TTL de claim`. Le **TTL de
+claim réutilise le calcul SAFE-001** du pire temps de paroi du run
+(`ceil(n_sets / max_concurrency)` × timeout Symfony + marge `ORCHESTRATION_LOCK_TTL_SECONDS`) :
+aucune variable d'environnement dédiée. Le `now` est lu via `orch._now`
+(`datetime.now(timezone.utc)`, injectable en test), partagé avec le TTL des locks.
+
+**Court-circuit selon l'état du run existant** (résolu par `run_id` puis
+`idempotency_key`) :
+
+| État existant | Action |
+| --- | --- |
+| terminal `success` (`ok=true`) | **Replay** : `summary`/`run_id` reconstruits depuis `last_json`, **aucun ré-appel Symfony**. |
+| terminal non-ok (`failed`/`partial_failure`) | **Reprise** : ré-exécution des seuls sets **sans** `RunSet.ok=true` ; les RunSet réussis sont conservés et fusionnés au `summary`/`last_json` recomposés. |
+| `running` **non périmé** | Un autre run est **en vol** : pas de dispatch, réponse de réplique (`ok=false`, `status="running"`, summary courant). |
+| `running` **périmé** (TTL dépassé, process tué) | **Reclaim** + ré-exécution comme un nouveau run. |
+
+**Finalisation** : à la fin, le statut terminal résolu (`_resolve_status`) +
+`finished_at` sont écrits via le `_persist_run` existant. Le claim initial et la
+finalisation portent **le même `run_id`** (on réutilise le `run_id` réellement
+persisté renvoyé par `record_run`, y compris quand un run existant est résolu par
+`idempotency_key` sous un `run_id` legacy distinct du dérivé).
+
+**Périmètre** : SAFE-002 **ne réactive pas le live** (tout set `dry_run=false` reste
+skippé par le runner) et **ne modifie pas** les locks SAFE-001 au-delà de la
+coordination claim ↔ locks (même transaction courte, même `now`, même TTL).
+
+> Migration : `0003_run_claim_expires_at` ajoute la colonne nullable
+> `orchestration.runs.expires_at` (TTL de claim), dans le schéma dédié
+> (aucun impact `public`/Doctrine).
 
 **PY-002** câble la couche DB dans une API REST de **configuration** des dashboards et des
 sets (CRUD), sous le préfixe `/dashboards` :
@@ -521,6 +569,14 @@ Avant tout run :
   (`locked: <key> held by run <id>`). Appliqué à **tous** les sets `mtf_run` (le live
   reste désactivé) ; TTL anti-deadlock + purge des locks expirés au démarrage. Cf.
   *Locks d'orchestration (SAFE-001)*. ;
+- **idempotence runs/sets** (SAFE-002, livré) : lorsqu'un ancrage existe (`run_id`
+  stable), un run rejoué ne ré-exécute pas le travail. Un **claim** `running` (TTL)
+  est posé avant le dispatch (transaction courte) ; un run existant terminal réussi
+  est **rejoué** (replay, aucun ré-appel Symfony), un terminal non-ok est **repris**
+  (seuls les sets non réussis sont re-dispatchés, les `RunSet.ok=true` conservés), un
+  `running` non périmé renvoie l'**état en vol** (`ok=false`, `status="running"`, pas
+  de dispatch), un `running` périmé est **reclaim**. Le live reste désactivé. Cf.
+  *Statuts de run et idempotence à l'exécution (SAFE-002)*. ;
 - ne lancer aucun set live tant que la readiness live n'est pas livrée (tout set
   `dry_run=false` est skippé par le runner, en miroir de `assert_set_persistable`) ;
 - ne pas autoriser OKX live (garde permanente, conservée après readiness) ;
@@ -549,6 +605,7 @@ Avant tout run :
 | PY-005 ✅ | Exécuter les sets persistés + persister les runs | Livré : `/orchestrator/run` lit les sets actifs du dashboard depuis la base, exécute chaque set via son `payload` persisté (+ snapshot runtime + override `dry_run`), et persiste le run (`Run.last_json` global + un `RunSet` par set avec `payload_sent`/`response_json`/`duration_ms`). `no_sets` reste `ok=false`. Garde-fou live défense-en-profondeur au run : OKX/Hyperliquid live (ligne ORM écrite hors API) sont fail-closed avant tout dispatch. |
 | PY-006 ✅ | Exposer l'historique des runs en lecture | Livré : endpoints `GET` en lecture seule du dernier JSON global et par set (`/runs`, `/runs/{run_id}`, `/runs/{run_id}/sets/{set_id}`, `/dashboards/{id}/runs`, `/dashboards/{id}/runs/latest`) ; vue allégée paginée pour les listes, détail complet `last_json` + sets. |
 | SAFE-001 ✅ | Locks d'orchestration par symbole et profil | Livré : table `orchestration_locks` (clé `lock_key` UNIQUE), acquisition tout-ou-rien par set avant dispatch (transaction courte, reclaim des locks expirés, skip fail-closed `locked: …`), libération en fin de set, purge des expirés au démarrage. Prérequis readiness live ; ne réactive pas le live. |
+| SAFE-002 ✅ | Idempotence des runs et des sets | Livré : statut non terminal `running` + claim précoce (`runs.expires_at` = TTL de claim, transaction courte) ; court-circuit selon l'état du run existant — replay (terminal success), reprise des sets non réussis (terminal non-ok), réplique en vol (`running` non périmé), reclaim (`running` périmé). Réutilise `record_run`/savepoints et le calcul de TTL SAFE-001. Migration `0003_run_claim_expires_at`. Ne réactive pas le live. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -143,9 +143,36 @@ Réponse :
 }
 ```
 
-`status` ∈ `success | partial_failure | failed | no_sets`. **Aucun set actif**
-renvoie `status="no_sets"` et `ok=false` : ce n'est pas un succès Temporal
-(le workflow/activity devra échouer, cf. TM-002).
+`status` ∈ `success | partial_failure | failed | no_sets | running`. **Aucun set
+actif** renvoie `status="no_sets"` et `ok=false` : ce n'est pas un succès Temporal
+(le workflow/activity devra échouer, cf. TM-002). `status="running"` est renvoyé
+(avec `ok=false`) quand un run idempotent identique est **déjà en vol** (cf.
+*Idempotence runs/sets (SAFE-002)*).
+
+### Idempotence runs/sets (SAFE-002)
+
+Quand un **ancrage d'idempotence** existe (`idempotency_key`, ou `dashboard_id` +
+`tick_timestamp` → `run_id` stable), `POST /orchestrator/run` est idempotent **à
+l'exécution** : un run rejoué ne relance pas les appels Symfony.
+
+- **Claim précoce** : avant le dispatch (transaction courte committée, jamais tenue
+  pendant les ~900s), la ligne `Run` est posée en `status="running"` avec
+  `started_at` et `expires_at` (**TTL de claim**).
+- **Court-circuit** selon l'état du run existant (résolu par `run_id` puis
+  `idempotency_key`) :
+  - terminal `success` → **replay** : `run_id`/`summary` reconstruits depuis
+    `last_json`, aucun ré-appel Symfony ;
+  - terminal `failed`/`partial_failure` → **reprise** : seuls les sets sans
+    `RunSet.ok=true` sont re-dispatchés ; les RunSet réussis sont conservés ;
+  - `running` non périmé → **en vol** : pas de dispatch, réponse `ok=false`,
+    `status="running"` ;
+  - `running` périmé (TTL, process tué) → **reclaim** + ré-exécution.
+- Un `run_id` **aléatoire** (aucun contexte) reste **non idempotent** (inchangé) ;
+  `no_sets` reste **non persisté**.
+- Le **live reste désactivé** (tout set `dry_run=false` est skippé) et les locks
+  SAFE-001 sont inchangés. Le **TTL de claim réutilise** le calcul SAFE-001 (pire
+  temps de paroi du run + marge `ORCHESTRATION_LOCK_TTL_SECONDS`) : **pas de nouvelle
+  variable d'environnement**.
 
 ### Historique des runs en lecture (PY-006)
 
@@ -249,7 +276,7 @@ un service `postgres:15`.
 | `MAX_CONCURRENCY` | `2` | Concurrence globale bornée, ≥ 1 (PY-002+). |
 | `DATABASE_URL` | `postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app` | URL SQLAlchemy de la base orchestration (DB-001). |
 | `ORCHESTRATION_DB_SCHEMA` | `orchestration` | Schéma PostgreSQL dédié (DB-001). Identifiant SQL simple validé (`^[A-Za-z_][A-Za-z0-9_]*$`). |
-| `ORCHESTRATION_LOCK_TTL_SECONDS` | `1800` | Marge (s) anti-deadlock des locks d'orchestration par `(profil, symbole)` (SAFE-001), ≥ 1. Le TTL effectif = pire temps de paroi du run (vagues `max_concurrency` × timeout Symfony) + cette marge, pour qu'un set en file n'expire pas avant son dispatch. |
+| `ORCHESTRATION_LOCK_TTL_SECONDS` | `1800` | Marge (s) anti-deadlock des locks d'orchestration par `(profil, symbole)` (SAFE-001), ≥ 1. Le TTL effectif = pire temps de paroi du run (vagues `max_concurrency` × timeout Symfony) + cette marge, pour qu'un set en file n'expire pas avant son dispatch. **Borne aussi le TTL de claim de run** (SAFE-002, même calcul) : pas de variable dédiée. |
 
 Une valeur non entière ou hors borne lève une erreur explicite au démarrage
 (pas de repli silencieux sur le défaut).
@@ -268,7 +295,7 @@ Tables (`app/db/models.py`) :
 | --- | --- |
 | `dashboards` | Configurations d'orchestration (nom, statut). |
 | `orchestration_sets` | Sets prêts à exécuter (miroir d'`OrchestratorSet` + `payload` préparé). |
-| `runs` | Runs déclenchés + **dernier JSON global** (`last_json`). |
+| `runs` | Runs déclenchés + **dernier JSON global** (`last_json`). Statut `running` (claim « en vol ») et `expires_at` (TTL de claim) ajoutés par **SAFE-002**. |
 | `run_sets` | Résultat par set + **dernier JSON par set** (`response_json`). |
 | `orchestration_locks` | Locks par `(mtf_profile, exchange, market_type, symbol)` sérialisant deux runs concurrents (**SAFE-001**). |
 
@@ -294,10 +321,12 @@ cron) ne peuvent donc pas traiter le même couple `(profil, symbole)` en même t
 - **Libération** dans le `finally` de chaque set (succès/échec/exception).
 - Appliqué à **tous** les sets `mtf_run` (inoffensif en dry-run) ; **le live reste
   désactivé** (SAFE-001 ne relâche pas le skip « live execution not yet enabled »).
-  L'`idempotency_key` des runs (SAFE-002) n'est pas modifié.
+  L'idempotence **à l'exécution** des runs/sets est livrée par **SAFE-002** (cf.
+  *Idempotence runs/sets (SAFE-002)* plus haut).
 
 La migration Alembic `0002_orchestration_locks` crée la table ; elle s'applique via
-`alembic upgrade head` (cf. *Migrations*).
+`alembic upgrade head` (cf. *Migrations*). La migration `0003_run_claim_expires_at`
+ajoute la colonne `runs.expires_at` (TTL du claim « en vol », **SAFE-002**).
 
 ### Migrations
 

--- a/python-orchestrator/alembic/versions/0003_run_claim_expires_at.py
+++ b/python-orchestrator/alembic/versions/0003_run_claim_expires_at.py
@@ -1,0 +1,39 @@
+"""run claim TTL column (SAFE-002)
+
+Revision ID: 0003_run_claim_expires_at
+Revises: 0002_orchestration_locks
+Create Date: 2026-06-21
+
+Ajoute la colonne ``orchestration.runs.expires_at`` : le TTL du claim « en vol »
+(statut ``running``) posé au démarrage d'un run idempotent. Passé cette date, un
+run resté ``running`` (process tué avant la finalisation) est reclaimable par un
+nouveau déclenchement partageant le même ancrage d'idempotence. Reste dans le
+schéma dédié ``orchestration`` (aucun impact sur ``public``/Doctrine).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.base import SCHEMA
+
+# revision identifiers, used by Alembic.
+revision: str = "0003_run_claim_expires_at"
+down_revision: Union[str, None] = "0002_orchestration_locks"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA_KW = {"schema": SCHEMA} if SCHEMA else {}
+
+
+def upgrade() -> None:
+    op.add_column(
+        "runs",
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        **SCHEMA_KW,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "expires_at", **SCHEMA_KW)

--- a/python-orchestrator/app/db/models.py
+++ b/python-orchestrator/app/db/models.py
@@ -137,6 +137,11 @@ class Run(Base):
     failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default="0")
     started_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    # TTL du claim « en vol » (SAFE-002). Renseigné au démarrage du run (statut
+    # ``running``) : passé cette date, un run resté ``running`` (process tué avant la
+    # finalisation) est reclaimable par un nouveau déclenchement partageant le même
+    # ancrage d'idempotence. Nul/ignoré sur un run terminal (le statut prime).
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     # Dernier JSON global du run.
     last_json: Mapped[Optional[dict]] = mapped_column(JSONVariant, nullable=True)
     created_at: Mapped[datetime] = mapped_column(

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -259,58 +259,62 @@ def _lock_run(session: Session, run_id: str) -> Optional[Run]:
     ).first()
 
 
-def _claim_locked(session: Session, run_id: str, run: Run, is_active_claim) -> Tuple[Run, bool]:
+def _claim_locked(session: Session, run_id: str, run: Run, classify) -> Tuple[Run, Optional[str]]:
     """Tranche le claim sur une ligne existante, **sous verrou ligne** (atomique).
 
-    Verrouille la ligne puis ré-évalue ``is_active_claim`` sur l'état frais : si un
-    run concurrent a posé un claim actif entre-temps, on s'efface (``claimed=False``)
-    au lieu d'écraser ; sinon on reprend la ligne (terminal/claim périmé → nouveau
-    claim). La ligne peut avoir disparu entre la résolution et le verrou (suppression,
-    non attendue en prod) : on retombe alors sur une insertion fraîche.
+    Verrouille la ligne puis demande à l'appelant de la **classer** sur l'état frais :
+    ``classify(locked)`` renvoie une *raison de céder* (chaîne opaque, ex. ``"replay"``
+    quand la ligne est un succès terminal, ``"in_flight"`` quand un run concurrent est
+    en vol) ou ``None`` pour **reprendre** la ligne (terminal non-ok / claim périmé →
+    nouveau claim). Quand on cède, la ligne **n'est pas écrasée** : on la retourne
+    telle quelle pour que l'appelant rejoue/réplique. La ligne peut avoir disparu entre
+    la résolution et le verrou (suppression, non attendue en prod) : insertion fraîche.
     """
     locked = _lock_run(session, run_id)
     if locked is None:
         with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
             session.add(run)
             session.flush()
-        return run, True
-    if is_active_claim(locked):
-        return locked, False  # un run concurrent détient un claim actif : on s'efface
-    return _update_existing_run(session, locked, run), True
+        return run, None
+    reason = classify(locked)
+    if reason is not None:
+        return locked, reason  # on cède (replay/in-flight) sans écraser la ligne
+    return _update_existing_run(session, locked, run), None
 
 
-def claim_run(session: Session, run: Run, *, is_active_claim) -> Tuple[Run, bool]:
-    """Pose un claim de run de façon atomique. Retourne ``(run_persisté, claimed)``.
+def claim_run(session: Session, run: Run, *, classify) -> Tuple[Run, Optional[str]]:
+    """Pose un claim de run de façon atomique. Retourne ``(run, yield_reason)``.
 
     Variante « compare-and-set » de ``record_run`` dédiée au **claim « en vol »**
-    (SAFE-002). ``claimed=False`` signale que le claim n'a **pas** été obtenu parce
-    qu'un run concurrent détient déjà un claim **actif** (``is_active_claim`` vrai) :
-    l'appelant doit alors répliquer l'état en vol **sans** dispatcher, au lieu
-    d'écraser la ligne partagée et de re-soumettre du travail.
+    (SAFE-002). ``yield_reason`` est ``None`` quand le claim est obtenu (la ligne a été
+    créée ou reprise vers le nouveau claim) ; sinon c'est la chaîne renvoyée par
+    ``classify`` (ex. ``"replay"``/``"in_flight"``) et la ligne existante est retournée
+    **sans modification** pour que l'appelant rejoue le succès persisté ou réplique
+    l'état en vol — au lieu d'écraser la ligne partagée et de re-soumettre du travail.
 
-    ``is_active_claim(existing)`` est fourni par l'appelant (il connaît la sémantique
-    des statuts et du TTL) : vrai ssi la ligne existante est un claim non terminal
-    **non périmé** d'un autre run en vol. Un run terminal (replay/reprise) ou un claim
-    périmé (reclaim) n'est PAS actif → la ligne est reprise par le nouveau claim.
+    ``classify(existing)`` est fourni par l'appelant (il connaît la sémantique des
+    statuts/TTL) : il **doit** céder (raison non ``None``) sur un succès terminal
+    (→ replay) et sur un claim non périmé d'un autre run (→ in-flight), et renvoyer
+    ``None`` pour les états repris (terminal non-ok, claim périmé).
 
-    Deux courses sont neutralisées :
+    Deux courses sont neutralisées **sous l'état le plus frais possible** :
 
     - **INSERT concurrent** (la ligne n'existait pas encore) : savepoint + rattrapage
       de la violation d'unicité comme ``record_run`` ; le perdant relit le gagnant ;
-    - **UPDATE concurrent** (la ligne existe déjà — reprise/reclaim) : le read-modify-
-      write se fait **sous ``SELECT ... FOR UPDATE``** (``_claim_locked``), donc deux
-      reprises d'une même ligne périmée ne peuvent pas toutes deux la ré-écrire : le
-      second bloque, relit le claim désormais actif et s'efface (``claimed=False``).
+    - **UPDATE concurrent** (la ligne existe déjà) : le read-modify-write se fait **sous
+      ``SELECT ... FOR UPDATE``** (``_claim_locked``) — le perdant bloque, relit l'état
+      committé par le gagnant (claim actif **ou succès finalisé**) et cède au lieu de
+      l'écraser.
     """
     existing = _resolve_existing_run(session, run)
     if existing is not None:
-        return _claim_locked(session, existing.run_id, run, is_active_claim)
+        return _claim_locked(session, existing.run_id, run, classify)
 
     try:
         with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
             session.add(run)
             session.flush()
-        return run, True
+        return run, None
     except IntegrityError:
         # Un writer concurrent a inséré la même clé/PK entre le lookup et le flush.
         if run in session:
@@ -319,8 +323,8 @@ def claim_run(session: Session, run: Run, *, is_active_claim) -> Tuple[Run, bool
         if existing is None:
             raise  # conflit sur une autre contrainte : ne pas masquer
         # La ligne gagnante existe : on tranche sous verrou (le gagnant a pu, depuis,
-        # finir et être repris ; on ré-évalue sur l'état frais et verrouillé).
-        return _claim_locked(session, existing.run_id, run, is_active_claim)
+        # finir — succès terminal — ou être encore en vol ; on classe l'état frais).
+        return _claim_locked(session, existing.run_id, run, classify)
 
 
 def _resolve_existing_run_set(session: Session, run_set: RunSet) -> Optional[RunSet]:

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -20,7 +20,8 @@ from app.db.models import Dashboard, OrchestrationLock, OrchestrationSet, Run, R
 # Colonnes mutables recopiées lors d'un upsert (la PK et created_at sont exclus).
 _RUN_UPDATABLE = (
     "dashboard_id", "ok", "status", "idempotency_key", "total_calls",
-    "success_count", "failed_count", "started_at", "finished_at", "last_json",
+    "success_count", "failed_count", "started_at", "finished_at", "expires_at",
+    "last_json",
 )
 _RUN_SET_UPDATABLE = (
     "set_ref_id", "payload_sent", "response_json", "ok", "error", "duration_ms",
@@ -177,12 +178,26 @@ def get_run_by_idempotency_key(session: Session, idempotency_key: str) -> Option
     return session.scalar(select(Run).where(Run.idempotency_key == idempotency_key))
 
 
+def resolve_run(
+    session: Session, run_id: str, idempotency_key: Optional[str] = None
+) -> Optional[Run]:
+    """Résout un run existant par ``run_id`` puis, à défaut, par ``idempotency_key``.
+
+    Surface publique du court-circuit d'idempotence (SAFE-002) : le runner inspecte
+    l'état du run existant (terminal success → replay, terminal non-ok → reprise,
+    ``running`` non périmé → en vol) **avant** de poser le claim. Même résolution
+    que ``_resolve_existing_run`` (utilisé par ``record_run``), donc le claim posé
+    ensuite via ``record_run`` retombe sur exactement la même ligne.
+    """
+    existing = session.get(Run, run_id)
+    if existing is None and idempotency_key:
+        existing = get_run_by_idempotency_key(session, idempotency_key)
+    return existing
+
+
 def _resolve_existing_run(session: Session, run: Run) -> Optional[Run]:
     """Cherche le run existant par ``run_id`` puis, à défaut, par ``idempotency_key``."""
-    existing = session.get(Run, run.run_id)
-    if existing is None and run.idempotency_key:
-        existing = get_run_by_idempotency_key(session, run.idempotency_key)
-    return existing
+    return resolve_run(session, run.run_id, run.idempotency_key)
 
 
 def _update_existing_run(session: Session, existing: Run, run: Run) -> Run:

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -240,6 +240,45 @@ def record_run(session: Session, run: Run) -> Run:
         return _update_existing_run(session, existing, run)
 
 
+def _lock_run(session: Session, run_id: str) -> Optional[Run]:
+    """Verrouille la ligne ``runs`` (``SELECT ... FOR UPDATE``) et rafraîchit l'instance.
+
+    Sur PostgreSQL, le verrou ligne sérialise le read-modify-write du claim : un
+    claimer concurrent **bloque** ici jusqu'au commit du gagnant, puis relit l'état
+    à jour. ``populate_existing`` force le rafraîchissement des attributs (statut,
+    ``expires_at``) à partir de la lecture verrouillée, sinon l'``identity map``
+    renverrait les valeurs périmées du premier read et l'évaluation du claim actif se
+    ferait sur des données obsolètes. Sur SQLite, ``FOR UPDATE`` est ignoré (accès
+    sérialisé par le verrou base) : aucun impact sur les tests.
+    """
+    return session.scalars(
+        select(Run)
+        .where(Run.run_id == run_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).first()
+
+
+def _claim_locked(session: Session, run_id: str, run: Run, is_active_claim) -> Tuple[Run, bool]:
+    """Tranche le claim sur une ligne existante, **sous verrou ligne** (atomique).
+
+    Verrouille la ligne puis ré-évalue ``is_active_claim`` sur l'état frais : si un
+    run concurrent a posé un claim actif entre-temps, on s'efface (``claimed=False``)
+    au lieu d'écraser ; sinon on reprend la ligne (terminal/claim périmé → nouveau
+    claim). La ligne peut avoir disparu entre la résolution et le verrou (suppression,
+    non attendue en prod) : on retombe alors sur une insertion fraîche.
+    """
+    locked = _lock_run(session, run_id)
+    if locked is None:
+        with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
+            session.add(run)
+            session.flush()
+        return run, True
+    if is_active_claim(locked):
+        return locked, False  # un run concurrent détient un claim actif : on s'efface
+    return _update_existing_run(session, locked, run), True
+
+
 def claim_run(session: Session, run: Run, *, is_active_claim) -> Tuple[Run, bool]:
     """Pose un claim de run de façon atomique. Retourne ``(run_persisté, claimed)``.
 
@@ -247,24 +286,25 @@ def claim_run(session: Session, run: Run, *, is_active_claim) -> Tuple[Run, bool
     (SAFE-002). ``claimed=False`` signale que le claim n'a **pas** été obtenu parce
     qu'un run concurrent détient déjà un claim **actif** (``is_active_claim`` vrai) :
     l'appelant doit alors répliquer l'état en vol **sans** dispatcher, au lieu
-    d'écraser la ligne partagée et de re-soumettre du travail (course perdue entre le
-    pré-check ``resolve_run`` et le seed).
+    d'écraser la ligne partagée et de re-soumettre du travail.
 
     ``is_active_claim(existing)`` est fourni par l'appelant (il connaît la sémantique
     des statuts et du TTL) : vrai ssi la ligne existante est un claim non terminal
     **non périmé** d'un autre run en vol. Un run terminal (replay/reprise) ou un claim
-    périmé (reclaim) n'est PAS actif → la ligne est mise à jour vers le nouveau claim.
+    périmé (reclaim) n'est PAS actif → la ligne est reprise par le nouveau claim.
 
-    Même protection anti-course que ``record_run`` (savepoint + rattrapage de la
-    violation d'unicité) : si un writer concurrent insère la même clé entre le lookup
-    et le flush, on relit le gagnant et on tranche via ``is_active_claim`` plutôt que
-    de propager l'erreur ou d'écraser un claim actif.
+    Deux courses sont neutralisées :
+
+    - **INSERT concurrent** (la ligne n'existait pas encore) : savepoint + rattrapage
+      de la violation d'unicité comme ``record_run`` ; le perdant relit le gagnant ;
+    - **UPDATE concurrent** (la ligne existe déjà — reprise/reclaim) : le read-modify-
+      write se fait **sous ``SELECT ... FOR UPDATE``** (``_claim_locked``), donc deux
+      reprises d'une même ligne périmée ne peuvent pas toutes deux la ré-écrire : le
+      second bloque, relit le claim désormais actif et s'efface (``claimed=False``).
     """
     existing = _resolve_existing_run(session, run)
     if existing is not None:
-        if is_active_claim(existing):
-            return existing, False  # course perdue : un run concurrent est en vol
-        return _update_existing_run(session, existing, run), True
+        return _claim_locked(session, existing.run_id, run, is_active_claim)
 
     try:
         with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
@@ -278,9 +318,9 @@ def claim_run(session: Session, run: Run, *, is_active_claim) -> Tuple[Run, bool
         existing = _resolve_existing_run(session, run)
         if existing is None:
             raise  # conflit sur une autre contrainte : ne pas masquer
-        if is_active_claim(existing):
-            return existing, False  # le gagnant détient un claim actif : on s'efface
-        return _update_existing_run(session, existing, run), True
+        # La ligne gagnante existe : on tranche sous verrou (le gagnant a pu, depuis,
+        # finir et être repris ; on ré-évalue sur l'état frais et verrouillé).
+        return _claim_locked(session, existing.run_id, run, is_active_claim)
 
 
 def _resolve_existing_run_set(session: Session, run_set: RunSet) -> Optional[RunSet]:

--- a/python-orchestrator/app/db/repositories.py
+++ b/python-orchestrator/app/db/repositories.py
@@ -240,6 +240,49 @@ def record_run(session: Session, run: Run) -> Run:
         return _update_existing_run(session, existing, run)
 
 
+def claim_run(session: Session, run: Run, *, is_active_claim) -> Tuple[Run, bool]:
+    """Pose un claim de run de façon atomique. Retourne ``(run_persisté, claimed)``.
+
+    Variante « compare-and-set » de ``record_run`` dédiée au **claim « en vol »**
+    (SAFE-002). ``claimed=False`` signale que le claim n'a **pas** été obtenu parce
+    qu'un run concurrent détient déjà un claim **actif** (``is_active_claim`` vrai) :
+    l'appelant doit alors répliquer l'état en vol **sans** dispatcher, au lieu
+    d'écraser la ligne partagée et de re-soumettre du travail (course perdue entre le
+    pré-check ``resolve_run`` et le seed).
+
+    ``is_active_claim(existing)`` est fourni par l'appelant (il connaît la sémantique
+    des statuts et du TTL) : vrai ssi la ligne existante est un claim non terminal
+    **non périmé** d'un autre run en vol. Un run terminal (replay/reprise) ou un claim
+    périmé (reclaim) n'est PAS actif → la ligne est mise à jour vers le nouveau claim.
+
+    Même protection anti-course que ``record_run`` (savepoint + rattrapage de la
+    violation d'unicité) : si un writer concurrent insère la même clé entre le lookup
+    et le flush, on relit le gagnant et on tranche via ``is_active_claim`` plutôt que
+    de propager l'erreur ou d'écraser un claim actif.
+    """
+    existing = _resolve_existing_run(session, run)
+    if existing is not None:
+        if is_active_claim(existing):
+            return existing, False  # course perdue : un run concurrent est en vol
+        return _update_existing_run(session, existing, run), True
+
+    try:
+        with session.begin_nested():  # SAVEPOINT : isole l'échec d'insertion
+            session.add(run)
+            session.flush()
+        return run, True
+    except IntegrityError:
+        # Un writer concurrent a inséré la même clé/PK entre le lookup et le flush.
+        if run in session:
+            session.expunge(run)
+        existing = _resolve_existing_run(session, run)
+        if existing is None:
+            raise  # conflit sur une autre contrainte : ne pas masquer
+        if is_active_claim(existing):
+            return existing, False  # le gagnant détient un claim actif : on s'efface
+        return _update_existing_run(session, existing, run), True
+
+
 def _resolve_existing_run_set(session: Session, run_set: RunSet) -> Optional[RunSet]:
     return session.scalar(
         select(RunSet).where(

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -35,6 +35,8 @@ from app.db.models import OrchestrationLock, OrchestrationSet, Run, RunSet
 from app.schemas import (
     Action,
     LIVE_FORBIDDEN_EXCHANGES,
+    RUN_STATUS_RUNNING,
+    TERMINAL_RUN_STATUSES,
     RunRequest,
     RunResponse,
     RunStatus,
@@ -104,6 +106,41 @@ def _resolve_run_id(request: Optional[RunRequest]) -> str:
     if len(run_id) > _MAX_PERSISTED_LEN or not _SAFE_RUN_ID.match(run_id):
         run_id = "run_" + hashlib.sha256(run_id.encode()).hexdigest()
     return run_id
+
+
+def _has_idempotency_anchor(request: Optional[RunRequest]) -> bool:
+    """Indique si un ancrage d'idempotence existe (→ ``run_id`` stable, claim posé).
+
+    Miroir exact de ``_resolve_run_id`` : avec un ``idempotency_key`` non blanc, ou
+    ``dashboard_id`` + ``tick_timestamp``, le ``run_id`` est dérivé de façon stable
+    et SAFE-002 s'applique (claim, replay, reprise, in-flight). Sinon le ``run_id``
+    est aléatoire et reste non idempotent (comportement inchangé).
+    """
+    if request is None:
+        return False
+    if request.idempotency_key and request.idempotency_key.strip():
+        return True
+    if request.dashboard_id and request.tick_timestamp:
+        return True
+    return False
+
+
+def _normalized_idempotency_key(request: Optional[RunRequest]) -> Optional[str]:
+    """Clé d'idempotence normalisée pour la colonne UNIQUE ``runs.idempotency_key``.
+
+    - clé absente/vide/blanche → ``None`` (traitée comme absente, cf. ``_resolve_run_id``) ;
+    - clé > 255 → hash déterministe borné (ne pas faire échouer l'INSERT/UPDATE).
+
+    Source **unique** partagée par le claim précoce (SAFE-002) et ``_persist_run`` :
+    le claim et la finalisation portent ainsi exactement la même clé, donc
+    ``record_run`` retombe sur la même ligne.
+    """
+    key = request.idempotency_key if request is not None else None
+    if key is not None and not key.strip():
+        key = None
+    if key is not None and len(key) > _MAX_PERSISTED_LEN:
+        key = "sha256:" + hashlib.sha256(key.encode()).hexdigest()
+    return key
 
 
 def _resolve_status(success: int, failed: int) -> RunStatus:
@@ -211,17 +248,10 @@ def _persist_run(
     doc). ``record_run``/``record_run_set`` sont des upserts idempotents ; le
     commit est géré ici (la dépendance ``get_session`` ne committe pas).
     """
-    idempotency_key = request.idempotency_key if request is not None else None
-    # Une clé vide/blanche est traitée comme absente par `_resolve_run_id` (run_id
-    # aléatoire) : il faut la normaliser en None ici aussi, sinon on persiste ""
-    # dans la colonne UNIQUE `runs.idempotency_key` et un second run à clé vide (avec
-    # un run_id différent) violerait la contrainte d'unicité au commit.
-    if idempotency_key is not None and not idempotency_key.strip():
-        idempotency_key = None
-    # Borne la colonne unique `runs.idempotency_key` (String(255)) pour ne pas
-    # faire échouer la persistance après coup ; hash déterministe au-delà.
-    if idempotency_key is not None and len(idempotency_key) > _MAX_PERSISTED_LEN:
-        idempotency_key = "sha256:" + hashlib.sha256(idempotency_key.encode()).hexdigest()
+    # Clé normalisée (blanche → None, > 255 → hash borné) : source unique partagée
+    # avec le claim précoce (SAFE-002), pour que claim et finalisation portent la
+    # même clé et que `record_run` retombe sur la même ligne.
+    idempotency_key = _normalized_idempotency_key(request)
     last_json = {
         "run_id": run_id,
         "dashboard_id": dashboard_id,
@@ -310,6 +340,143 @@ def _persist_run(
 
     session.commit()
     return run_id
+
+
+def _claim_expired(run: Run, now: datetime) -> bool:
+    """Indique si le claim « en vol » d'un run ``running`` est périmé (TTL dépassé).
+
+    Un ``expires_at`` absent (run ``running`` legacy sans TTL de claim) est traité
+    comme périmé → reclaimable. Le round-trip SQLite peut renvoyer un datetime naïf :
+    on normalise le fuseau en UTC avant comparaison (comme les locks SAFE-001).
+    """
+    expires_at = run.expires_at
+    if expires_at is None:
+        return True
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at <= now
+
+
+def _replay_response(run: Run) -> RunResponse:
+    """Réponse de **replay** d'un run terminal réussi (SAFE-002).
+
+    Reconstruit le contrat depuis le run persisté (``last_json`` + colonnes) sans
+    ré-exécuter ni ré-appeler Symfony. ``summary`` est relu depuis ``last_json`` (les
+    colonnes de compteurs servent de repli si le JSON est absent/tronqué).
+    """
+    last_json = run.last_json if isinstance(run.last_json, dict) else {}
+    summary = last_json.get("summary") if isinstance(last_json.get("summary"), dict) else {}
+    return RunResponse(
+        ok=bool(run.ok),
+        run_id=run.run_id,
+        status=run.status,
+        summary=RunSummary(
+            total_calls=summary.get("total_calls", run.total_calls),
+            success=summary.get("success", run.success_count),
+            failed=summary.get("failed", run.failed_count),
+        ),
+    )
+
+
+def _in_flight_response(run: Run) -> RunResponse:
+    """Réponse de **réplique** d'un run ``running`` non périmé (un autre run est en vol).
+
+    Décision produit (SAFE-002) : ``ok=false`` (jamais un succès Temporal) + statut
+    non terminal ``running`` ; aucun dispatch, aucun appel Symfony. ``summary``
+    réplique l'état courant (compteurs à 0 tant que la finalisation n'a pas eu lieu).
+    """
+    return RunResponse(
+        ok=False,
+        run_id=run.run_id,
+        status=RUN_STATUS_RUNNING,
+        summary=RunSummary(
+            total_calls=run.total_calls,
+            success=run.success_count,
+            failed=run.failed_count,
+        ),
+    )
+
+
+def _preserved_results(run: Run, run_sets: List[Any]) -> Dict[str, Dict[str, Any]]:
+    """Résultats des sets DÉJÀ réussis d'un run à reprendre (SAFE-002, reprise).
+
+    Pour chaque ``RunSet.ok=true``, reconstruit le dict de résultat attendu par le
+    runner/``_persist_run`` à partir des colonnes persistées (``response_json`` →
+    ``body``, ``payload_sent``, ``duration_ms``). Le ``status``/``business_status``
+    (non stockés en colonne) sont relus depuis le détail ``last_json`` de la
+    tentative précédente quand il est disponible. Ces sets ne sont PAS re-dispatchés :
+    leur résultat conservé est fusionné aux sets re-exécutés pour recomposer le
+    summary et le ``last_json`` final.
+    """
+    detail_by_set: Dict[str, Dict[str, Any]] = {}
+    last_json = run.last_json if isinstance(run.last_json, dict) else {}
+    sets_detail = last_json.get("sets")
+    if isinstance(sets_detail, list):
+        for detail in sets_detail:
+            if isinstance(detail, dict) and detail.get("set_id") is not None:
+                detail_by_set[detail["set_id"]] = detail
+    preserved: Dict[str, Dict[str, Any]] = {}
+    for run_set in run_sets:
+        if not run_set.ok:
+            continue
+        detail = detail_by_set.get(run_set.set_id, {})
+        preserved[run_set.set_id] = {
+            "set_id": run_set.set_id,
+            "ok": True,
+            "status": detail.get("status"),
+            "business_status": detail.get("business_status"),
+            "body": run_set.response_json,
+            "payload_sent": run_set.payload_sent,
+            "duration_ms": (
+                run_set.duration_ms
+                if run_set.duration_ms is not None
+                else detail.get("duration_ms")
+            ),
+        }
+    return preserved
+
+
+def _seed_claim(
+    session: Session,
+    *,
+    run_id: str,
+    dashboard_id: int,
+    idempotency_key: Optional[str],
+    now: datetime,
+    ttl_seconds: int,
+) -> str:
+    """Pose/reprend le claim « en vol » d'un run (SAFE-002), retourne le run_id persisté.
+
+    Transaction courte (committée par l'appelant AVANT les appels Symfony, jamais
+    maintenue pendant les ~900s, comme les locks SAFE-001) : insère/résout la ligne
+    ``Run`` via le ``record_run`` existant (statut ``running``, ``started_at``,
+    ``expires_at`` = ``now`` + TTL de claim), réutilisant son savepoint anti-course.
+
+    ``record_run`` peut résoudre un run existant (par ``idempotency_key``) dont le
+    ``run_id`` diffère du dérivé : on retourne le run_id réellement persisté afin que
+    claim, locks et finalisation portent le même identifiant (cf. logique
+    ``_persist_run``). On neutralise une FK ``dashboard_id`` périmée (dashboard
+    supprimé entre-temps) comme ``_persist_run``, pour ne pas faire échouer l'INSERT.
+    """
+    dashboard_ref = (
+        dashboard_id if repositories.get_dashboard(session, dashboard_id) is not None else None
+    )
+    persisted = repositories.record_run(
+        session,
+        Run(
+            run_id=run_id,
+            dashboard_id=dashboard_ref,
+            ok=False,
+            status=RUN_STATUS_RUNNING,
+            idempotency_key=idempotency_key,
+            total_calls=0,
+            success_count=0,
+            failed_count=0,
+            started_at=now,
+            expires_at=now + timedelta(seconds=ttl_seconds),
+        ),
+    )
+    return persisted.run_id
 
 
 def _symbols_overlap(a: Any, b: Any) -> bool:
@@ -471,6 +638,49 @@ async def run_orchestrator(
     # trade live ; on les rejette avant dispatch.
     conflicting_live_ids = _conflicting_live_set_ids(mtf_sets, force_dry_run)
 
+    # Horloge unique du run (injectable en test via `orch._now`) : partagée par le
+    # claim d'idempotence (SAFE-002), le TTL de claim ET le TTL des locks (SAFE-001).
+    now = _now()
+    # TTL effectif : un set peut rester en file derrière le sémaphore (`max_concurrency`)
+    # bien après l'acquisition de son lock. Si son `expires_at` tombait avant son
+    # dispatch, un run concurrent pourrait le purger/reclaim et dispatcher le MÊME
+    # (profil, exchange, market, symbole) — l'exclusion mutuelle SAFE-001 serait défaite.
+    # On dimensionne donc le TTL pour couvrir le pire temps de paroi du run (chaque vague
+    # de `max_concurrency` sets peut durer jusqu'au timeout Symfony) + la marge configurée.
+    # Le même TTL borne le claim de run « en vol » (SAFE-002) : un run resté `running`
+    # au-delà (process tué avant la finalisation) est reclaimable.
+    concurrency = max(1, settings.max_concurrency)
+    waves = math.ceil(len(mtf_sets) / concurrency)
+    effective_ttl_seconds = int(waves * _HTTP_TIMEOUT) + settings.lock_ttl_seconds
+
+    # SAFE-002 : idempotence à l'EXÉCUTION, uniquement lorsqu'un ancrage existe (run_id
+    # stable). Un run_id aléatoire (aucun contexte) reste non idempotent (inchangé). On
+    # inspecte le run existant (résolu par run_id puis idempotency_key) AVANT tout
+    # dispatch/écriture, donc un court-circuit (replay/in-flight) ne fait que des
+    # lectures : la session est simplement fermée par `get_session` (rien à committer).
+    preserved_results: Dict[str, Dict[str, Any]] = {}
+    has_anchor = _has_idempotency_anchor(request)
+    idempotency_key = _normalized_idempotency_key(request)
+    if has_anchor:
+        existing = repositories.resolve_run(session, run_id, idempotency_key)
+        if existing is not None:
+            if existing.status in TERMINAL_RUN_STATUSES and existing.ok:
+                # Terminal success → REPLAY : aucun ré-appel Symfony, on renvoie le
+                # summary/run_id reconstruits depuis le run persisté.
+                return _replay_response(existing)
+            if existing.status == RUN_STATUS_RUNNING and not _claim_expired(existing, now):
+                # `running` non périmé → un autre run est EN VOL : on ne dispatche pas
+                # (réponse de réplique de l'état courant, ok=false + statut running).
+                return _in_flight_response(existing)
+            if existing.status in TERMINAL_RUN_STATUSES and not existing.ok:
+                # Terminal non-ok (failed/partial) → REPRISE : on conserve les RunSet
+                # déjà réussis et on ne re-dispatchera que les sets restants.
+                preserved_results = _preserved_results(
+                    existing, list(repositories.list_run_sets(session, existing.run_id))
+                )
+            # `running` périmé (TTL, process tué) → reclaim : ré-exécution comme un
+            # nouveau run (aucun résultat conservé).
+
     # SAFE-001 : sérialisation per-(profil, symbole) ENTRE runs/process via des locks
     # DB. Le garde intra-run (`conflicting_live_ids`) ne couvre qu'un seul batch ; deux
     # runs concurrents (overlap du cron Temporal, ou front + cron) ne se voient pas
@@ -478,30 +688,36 @@ async def run_orchestrator(
     # (clé UNIQUE = mutex) AVANT le dispatch, dans la transaction de lecture courte
     # qui sera committée juste après (jamais maintenue pendant les ~900s d'appels
     # Symfony). Politique : appliqué à TOUS les sets `mtf_run` (inoffensif en dry-run,
-    # le live restant désactivé), sauf ceux déjà rejetés par le garde intra-run.
-    # Acquisition « tout ou rien » par set ; un set dont un symbole est déjà verrouillé
-    # par un run actif est skippé fail-closed (cohérent avec les autres skips du runner).
-    lock_now = _now()
+    # le live restant désactivé), sauf ceux déjà rejetés par le garde intra-run ou déjà
+    # réussis (reprise SAFE-002). Acquisition « tout ou rien » par set ; un set dont un
+    # symbole est déjà verrouillé par un run actif est skippé fail-closed.
+    lock_now = now
     # Balayage des locks expirés au démarrage : libère les fuites d'un process tué
     # avant son `finally` de libération (anti-deadlock via TTL).
     repositories.purge_expired_locks(session, lock_now)
-    # TTL effectif : tous les locks d'un run partagent ce `lock_now`, mais un set
-    # peut rester en file derrière le sémaphore (`max_concurrency`) bien après
-    # l'acquisition. Si son `expires_at` tombait avant son dispatch, un run concurrent
-    # pourrait le purger/reclaim et dispatcher le MÊME (profil, exchange, market, symbole)
-    # — l'exclusion mutuelle SAFE-001 serait défaite. On dimensionne donc le TTL pour
-    # couvrir le pire temps de paroi du run (chaque vague de `max_concurrency` sets peut
-    # durer jusqu'au timeout Symfony) + la marge anti-deadlock configurée : aucun lock en
-    # file n'expire avant la fin de son set, tout en gardant une expiration finie en cas
-    # de crash. (Le `finally` libère de toute façon chaque lock dès la fin de son set.)
-    concurrency = max(1, settings.max_concurrency)
-    waves = math.ceil(len(mtf_sets) / concurrency)
-    effective_ttl_seconds = int(waves * _HTTP_TIMEOUT) + settings.lock_ttl_seconds
+
+    # Claim précoce (SAFE-002) : pose/reprend la ligne Run (statut `running`,
+    # started_at, expires_at) AVANT le dispatch, dans cette même transaction courte
+    # committée juste après. `record_run` peut résoudre un run existant sous un run_id
+    # distinct (legacy par idempotency_key) : on réutilise le run_id réellement persisté
+    # pour les locks ET la finalisation (claim et finalisation portent le même run_id).
+    if has_anchor:
+        run_id = _seed_claim(
+            session,
+            run_id=run_id,
+            dashboard_id=dashboard_id,
+            idempotency_key=idempotency_key,
+            now=now,
+            ttl_seconds=effective_ttl_seconds,
+        )
+
     locked_out: Dict[str, str] = {}
     set_lock_keys: Dict[str, List[str]] = {}
     for a_set in mtf_sets:
         if a_set.set_id in conflicting_live_ids:
             continue  # déjà rejeté, jamais dispatché : rien à verrouiller
+        if a_set.set_id in preserved_results:
+            continue  # reprise SAFE-002 : set déjà réussi, pas de re-dispatch à sérialiser
         locks = _lock_specs_for_set(a_set, run_id, lock_now, effective_ttl_seconds)
         if not locks:
             continue  # univers complet / aucun symbole concret : rien à sérialiser
@@ -533,6 +749,11 @@ async def run_orchestrator(
         semaphore = asyncio.Semaphore(max(1, settings.max_concurrency))
 
         async def _execute(a_set: Any) -> Dict[str, Any]:
+            # Reprise SAFE-002 : un set déjà réussi lors d'une tentative précédente du
+            # même run n'est PAS re-dispatché (aucun appel Symfony, aucun lock posé) ;
+            # son résultat conservé est fusionné au summary/last_json recomposés.
+            if a_set.set_id in preserved_results:
+                return preserved_results[a_set.set_id]
             if a_set.set_id in conflicting_live_ids:
                 return {
                     "set_id": a_set.set_id,

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -444,20 +444,23 @@ def _seed_claim(
     idempotency_key: Optional[str],
     now: datetime,
     ttl_seconds: int,
-) -> tuple[str, Run, bool]:
+) -> tuple[str, Run, Optional[str]]:
     """Pose/reprend le claim « en vol » d'un run (SAFE-002).
 
-    Retourne ``(run_id_persisté, run, claimed)``. ``claimed=False`` signale qu'un run
-    concurrent détient déjà un claim **actif** (course perdue entre le pré-check et le
-    seed) : l'appelant doit alors répliquer l'état en vol sans dispatcher (sinon il
-    écraserait la ligne partagée et re-soumettrait du travail).
+    Retourne ``(run_id_persisté, run, yield_reason)``. ``yield_reason`` vaut ``None``
+    quand le claim est obtenu (création ou reprise). Sinon, un run concurrent a changé
+    l'état **entre le pré-check et le seed** (course TOCTOU) et l'appelant doit céder
+    sans dispatcher ni écraser la ligne partagée :
+
+    - ``"replay"`` : le gagnant a déjà **finalisé en succès** → on rejoue le succès ;
+    - ``"in_flight"`` : un run concurrent est **en vol** (claim non périmé) → réplique.
 
     Transaction courte (committée par l'appelant AVANT les appels Symfony, jamais
     maintenue pendant les ~900s, comme les locks SAFE-001) : pose la ligne ``Run``
     via ``claim_run`` (statut ``running``, ``started_at``, ``expires_at`` = ``now`` +
-    TTL de claim), réutilisant le savepoint anti-course de ``record_run``. Le claim ne
-    remplace une ligne existante que si elle n'est **pas** un claim actif (terminal →
-    reprise/replay déjà traités en amont ; claim périmé → reclaim).
+    TTL de claim) **sous verrou ligne** (savepoint anti-course + ``FOR UPDATE``). Le
+    claim ne remplace une ligne existante que si ``classify`` ne demande PAS de céder
+    (terminal non-ok → reprise ; claim périmé → reclaim).
 
     ``claim_run`` peut résoudre un run existant (par ``idempotency_key``) dont le
     ``run_id`` diffère du dérivé : on retourne le run_id réellement persisté afin que
@@ -468,7 +471,17 @@ def _seed_claim(
     dashboard_ref = (
         dashboard_id if repositories.get_dashboard(session, dashboard_id) is not None else None
     )
-    persisted, claimed = repositories.claim_run(
+
+    def _classify(existing: Run) -> Optional[str]:
+        # Mêmes court-circuits que le pré-check, mais ré-évalués sur l'état FRAIS et
+        # VERROUILLÉ (le gagnant d'une course a pu, depuis, finaliser ou rester en vol).
+        if existing.status in TERMINAL_RUN_STATUSES and existing.ok:
+            return "replay"  # succès finalisé → rejouer (ne PAS écraser/ré-exécuter)
+        if existing.status == RUN_STATUS_RUNNING and not _claim_expired(existing, now):
+            return "in_flight"  # un autre run est en vol → répliquer
+        return None  # terminal non-ok / claim périmé → reprise/reclaim
+
+    persisted, yield_reason = repositories.claim_run(
         session,
         Run(
             run_id=run_id,
@@ -482,12 +495,9 @@ def _seed_claim(
             started_at=now,
             expires_at=now + timedelta(seconds=ttl_seconds),
         ),
-        # Un claim est « actif » (course perdue) ssi la ligne existante est `running`
-        # ET non périmée : exactement le cas in-flight du pré-check, mais observé au
-        # moment du seed (un run concurrent a committé son claim entre-temps).
-        is_active_claim=lambda r: r.status == RUN_STATUS_RUNNING and not _claim_expired(r, now),
+        classify=_classify,
     )
-    return persisted.run_id, persisted, claimed
+    return persisted.run_id, persisted, yield_reason
 
 
 def _symbols_overlap(a: Any, b: Any) -> bool:
@@ -725,7 +735,7 @@ async def run_orchestrator(
     # distinct (legacy par idempotency_key) : on réutilise le run_id réellement persisté
     # pour les locks ET la finalisation (claim et finalisation portent le même run_id).
     if has_anchor:
-        run_id, claim_row, claimed = _seed_claim(
+        run_id, claim_row, yield_reason = _seed_claim(
             session,
             run_id=run_id,
             dashboard_id=dashboard_id,
@@ -733,12 +743,16 @@ async def run_orchestrator(
             now=now,
             ttl_seconds=effective_ttl_seconds,
         )
-        if not claimed:
-            # Course perdue : un run concurrent a committé son claim ENTRE le pré-check
-            # et le seed (les deux requêtes avaient vu une absence de ligne). On réplique
-            # l'état en vol SANS dispatcher ni écrire — sinon on écraserait la ligne
-            # partagée (statut/run_sets) et on re-soumettrait du travail. Rien n'a été
-            # committé ici (la purge non committée sera annulée à la fermeture de session).
+        if yield_reason is not None:
+            # Course perdue : un run concurrent a changé l'état ENTRE le pré-check et le
+            # seed (les deux requêtes avaient vu une absence de ligne, ou le gagnant a
+            # finalisé depuis). On cède SANS dispatcher ni écrire — sinon on écraserait
+            # la ligne partagée (statut/run_sets) et on re-soumettrait du travail. Rien
+            # n'a été committé ici (la purge non committée sera annulée à la fermeture de
+            # session). `replay` rejoue le succès finalisé par le gagnant ; `in_flight`
+            # réplique l'état d'un run encore en vol.
+            if yield_reason == "replay":
+                return _replay_response(claim_row)
             return _in_flight_response(claim_row)
 
     locked_out: Dict[str, str] = {}

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -444,15 +444,22 @@ def _seed_claim(
     idempotency_key: Optional[str],
     now: datetime,
     ttl_seconds: int,
-) -> str:
-    """Pose/reprend le claim « en vol » d'un run (SAFE-002), retourne le run_id persisté.
+) -> tuple[str, Run, bool]:
+    """Pose/reprend le claim « en vol » d'un run (SAFE-002).
+
+    Retourne ``(run_id_persisté, run, claimed)``. ``claimed=False`` signale qu'un run
+    concurrent détient déjà un claim **actif** (course perdue entre le pré-check et le
+    seed) : l'appelant doit alors répliquer l'état en vol sans dispatcher (sinon il
+    écraserait la ligne partagée et re-soumettrait du travail).
 
     Transaction courte (committée par l'appelant AVANT les appels Symfony, jamais
-    maintenue pendant les ~900s, comme les locks SAFE-001) : insère/résout la ligne
-    ``Run`` via le ``record_run`` existant (statut ``running``, ``started_at``,
-    ``expires_at`` = ``now`` + TTL de claim), réutilisant son savepoint anti-course.
+    maintenue pendant les ~900s, comme les locks SAFE-001) : pose la ligne ``Run``
+    via ``claim_run`` (statut ``running``, ``started_at``, ``expires_at`` = ``now`` +
+    TTL de claim), réutilisant le savepoint anti-course de ``record_run``. Le claim ne
+    remplace une ligne existante que si elle n'est **pas** un claim actif (terminal →
+    reprise/replay déjà traités en amont ; claim périmé → reclaim).
 
-    ``record_run`` peut résoudre un run existant (par ``idempotency_key``) dont le
+    ``claim_run`` peut résoudre un run existant (par ``idempotency_key``) dont le
     ``run_id`` diffère du dérivé : on retourne le run_id réellement persisté afin que
     claim, locks et finalisation portent le même identifiant (cf. logique
     ``_persist_run``). On neutralise une FK ``dashboard_id`` périmée (dashboard
@@ -461,7 +468,7 @@ def _seed_claim(
     dashboard_ref = (
         dashboard_id if repositories.get_dashboard(session, dashboard_id) is not None else None
     )
-    persisted = repositories.record_run(
+    persisted, claimed = repositories.claim_run(
         session,
         Run(
             run_id=run_id,
@@ -475,8 +482,12 @@ def _seed_claim(
             started_at=now,
             expires_at=now + timedelta(seconds=ttl_seconds),
         ),
+        # Un claim est « actif » (course perdue) ssi la ligne existante est `running`
+        # ET non périmée : exactement le cas in-flight du pré-check, mais observé au
+        # moment du seed (un run concurrent a committé son claim entre-temps).
+        is_active_claim=lambda r: r.status == RUN_STATUS_RUNNING and not _claim_expired(r, now),
     )
-    return persisted.run_id
+    return persisted.run_id, persisted, claimed
 
 
 def _symbols_overlap(a: Any, b: Any) -> bool:
@@ -605,6 +616,32 @@ async def run_orchestrator(
     settings = get_settings()
     run_id = _resolve_run_id(request)
 
+    # Horloge unique du run (injectable en test via `orch._now`) : partagée par le
+    # claim d'idempotence (SAFE-002), le TTL de claim ET le TTL des locks (SAFE-001).
+    now = _now()
+
+    # SAFE-002 : pré-résolution de l'éventuel run ancré (run_id stable). Les
+    # court-circuits qui NE ré-exécutent PAS — replay (terminal success) et réplique
+    # in-flight (run en vol) — sont traités ICI, AVANT le gating `no_sets` : ils ne
+    # nécessitent ni dashboard ni sets, donc un retry après désactivation/suppression
+    # du dashboard (ou avec la seule clé) doit quand même rejouer le succès persisté
+    # plutôt que renvoyer `no_sets`. La reprise/reclaim, qui re-exécutent, restent
+    # gated par la disponibilité des sets (plus bas).
+    has_anchor = _has_idempotency_anchor(request)
+    idempotency_key = _normalized_idempotency_key(request)
+    existing_run = (
+        repositories.resolve_run(session, run_id, idempotency_key) if has_anchor else None
+    )
+    if existing_run is not None:
+        if existing_run.status in TERMINAL_RUN_STATUSES and existing_run.ok:
+            # Terminal success → REPLAY : summary/run_id reconstruits depuis le run
+            # persisté, aucun ré-appel Symfony, indépendant de l'état du dashboard.
+            return _replay_response(existing_run)
+        if existing_run.status == RUN_STATUS_RUNNING and not _claim_expired(existing_run, now):
+            # `running` non périmé → un autre run est EN VOL : réplique de l'état
+            # courant (ok=false + statut running), aucun dispatch.
+            return _in_flight_response(existing_run)
+
     # Source des sets : la base, scopée par dashboard. Pas de dashboard / aucun
     # set actif => no_sets (aucun appel, aucune persistance).
     dashboard_id = _resolve_dashboard_id(request)
@@ -638,9 +675,6 @@ async def run_orchestrator(
     # trade live ; on les rejette avant dispatch.
     conflicting_live_ids = _conflicting_live_set_ids(mtf_sets, force_dry_run)
 
-    # Horloge unique du run (injectable en test via `orch._now`) : partagée par le
-    # claim d'idempotence (SAFE-002), le TTL de claim ET le TTL des locks (SAFE-001).
-    now = _now()
     # TTL effectif : un set peut rester en file derrière le sémaphore (`max_concurrency`)
     # bien après l'acquisition de son lock. Si son `expires_at` tombait avant son
     # dispatch, un run concurrent pourrait le purger/reclaim et dispatcher le MÊME
@@ -653,33 +687,22 @@ async def run_orchestrator(
     waves = math.ceil(len(mtf_sets) / concurrency)
     effective_ttl_seconds = int(waves * _HTTP_TIMEOUT) + settings.lock_ttl_seconds
 
-    # SAFE-002 : idempotence à l'EXÉCUTION, uniquement lorsqu'un ancrage existe (run_id
-    # stable). Un run_id aléatoire (aucun contexte) reste non idempotent (inchangé). On
-    # inspecte le run existant (résolu par run_id puis idempotency_key) AVANT tout
-    # dispatch/écriture, donc un court-circuit (replay/in-flight) ne fait que des
-    # lectures : la session est simplement fermée par `get_session` (rien à committer).
+    # SAFE-002 (suite) : les court-circuits qui RE-EXÉCUTENT — donc nécessitent des
+    # sets — sont décidés ici, après le gating `no_sets`. `existing_run` a été résolu
+    # en amont (le replay/in-flight ont déjà court-circuité). Reste :
+    #  - terminal non-ok (failed/partial) → REPRISE : on conserve les RunSet déjà
+    #    réussis et on ne re-dispatchera que les sets restants ;
+    #  - `running` périmé (TTL, process tué) → reclaim : ré-exécution comme un nouveau
+    #    run (aucun résultat conservé).
     preserved_results: Dict[str, Dict[str, Any]] = {}
-    has_anchor = _has_idempotency_anchor(request)
-    idempotency_key = _normalized_idempotency_key(request)
-    if has_anchor:
-        existing = repositories.resolve_run(session, run_id, idempotency_key)
-        if existing is not None:
-            if existing.status in TERMINAL_RUN_STATUSES and existing.ok:
-                # Terminal success → REPLAY : aucun ré-appel Symfony, on renvoie le
-                # summary/run_id reconstruits depuis le run persisté.
-                return _replay_response(existing)
-            if existing.status == RUN_STATUS_RUNNING and not _claim_expired(existing, now):
-                # `running` non périmé → un autre run est EN VOL : on ne dispatche pas
-                # (réponse de réplique de l'état courant, ok=false + statut running).
-                return _in_flight_response(existing)
-            if existing.status in TERMINAL_RUN_STATUSES and not existing.ok:
-                # Terminal non-ok (failed/partial) → REPRISE : on conserve les RunSet
-                # déjà réussis et on ne re-dispatchera que les sets restants.
-                preserved_results = _preserved_results(
-                    existing, list(repositories.list_run_sets(session, existing.run_id))
-                )
-            # `running` périmé (TTL, process tué) → reclaim : ré-exécution comme un
-            # nouveau run (aucun résultat conservé).
+    if (
+        existing_run is not None
+        and existing_run.status in TERMINAL_RUN_STATUSES
+        and not existing_run.ok
+    ):
+        preserved_results = _preserved_results(
+            existing_run, list(repositories.list_run_sets(session, existing_run.run_id))
+        )
 
     # SAFE-001 : sérialisation per-(profil, symbole) ENTRE runs/process via des locks
     # DB. Le garde intra-run (`conflicting_live_ids`) ne couvre qu'un seul batch ; deux
@@ -698,11 +721,11 @@ async def run_orchestrator(
 
     # Claim précoce (SAFE-002) : pose/reprend la ligne Run (statut `running`,
     # started_at, expires_at) AVANT le dispatch, dans cette même transaction courte
-    # committée juste après. `record_run` peut résoudre un run existant sous un run_id
+    # committée juste après. `claim_run` peut résoudre un run existant sous un run_id
     # distinct (legacy par idempotency_key) : on réutilise le run_id réellement persisté
     # pour les locks ET la finalisation (claim et finalisation portent le même run_id).
     if has_anchor:
-        run_id = _seed_claim(
+        run_id, claim_row, claimed = _seed_claim(
             session,
             run_id=run_id,
             dashboard_id=dashboard_id,
@@ -710,6 +733,13 @@ async def run_orchestrator(
             now=now,
             ttl_seconds=effective_ttl_seconds,
         )
+        if not claimed:
+            # Course perdue : un run concurrent a committé son claim ENTRE le pré-check
+            # et le seed (les deux requêtes avaient vu une absence de ligne). On réplique
+            # l'état en vol SANS dispatcher ni écrire — sinon on écraserait la ligne
+            # partagée (statut/run_sets) et on re-soumettrait du travail. Rien n'a été
+            # committé ici (la purge non committée sera annulée à la fermeture de session).
+            return _in_flight_response(claim_row)
 
     locked_out: Dict[str, str] = {}
     set_lock_keys: Dict[str, List[str]] = {}

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -60,7 +60,23 @@ class Action(str, Enum):
 # dédiée n'a pas été validée (cf. exchange-schedule-policy.md).
 LIVE_FORBIDDEN_EXCHANGES = frozenset({Exchange.OKX, Exchange.HYPERLIQUID})
 
-RunStatus = Literal["success", "partial_failure", "failed", "no_sets"]
+# Statuts de run centralisés (SAFE-002). ``running`` est un statut **non terminal**
+# (claim « en vol » posé au démarrage du run) ; ``no_sets`` n'est jamais persisté.
+# Les statuts terminaux sont dérivés par ``_resolve_status`` à la finalisation.
+RUN_STATUS_SUCCESS = "success"
+RUN_STATUS_PARTIAL_FAILURE = "partial_failure"
+RUN_STATUS_FAILED = "failed"
+RUN_STATUS_NO_SETS = "no_sets"
+RUN_STATUS_RUNNING = "running"
+
+# Statuts terminaux d'un run réellement exécuté (au moins un set). Sert au
+# court-circuit d'idempotence (SAFE-002) : un run terminal success est rejoué
+# (replay), un terminal non-ok est repris (reprise des sets non réussis).
+TERMINAL_RUN_STATUSES = frozenset(
+    {RUN_STATUS_SUCCESS, RUN_STATUS_PARTIAL_FAILURE, RUN_STATUS_FAILED}
+)
+
+RunStatus = Literal["success", "partial_failure", "failed", "no_sets", "running"]
 
 
 def assert_live_allowed(exchange: Exchange, dry_run: bool) -> None:

--- a/python-orchestrator/tests/test_db_models.py
+++ b/python-orchestrator/tests/test_db_models.py
@@ -74,11 +74,13 @@ def test_runs_columns_and_dashboard_fk_set_null():
     expected = {
         "run_id", "dashboard_id", "ok", "status", "idempotency_key",
         "total_calls", "success_count", "failed_count", "started_at",
-        "finished_at", "last_json", "created_at",
+        "finished_at", "expires_at", "last_json", "created_at",
     }
     assert expected <= set(table.columns.keys())
     assert table.c.run_id.primary_key
     assert table.c.dashboard_id.nullable is True
+    # TTL du claim « en vol » (SAFE-002) : nullable (nul/ignoré sur un run terminal).
+    assert table.c.expires_at.nullable is True
 
     fk = next(iter(table.c.dashboard_id.foreign_keys))
     assert fk.ondelete == "SET NULL"

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -189,44 +189,44 @@ def test_record_run_insert_race_falls_back_to_existing(db_session, monkeypatch):
     assert db_session.query(Run).count() == 1   # pas de doublon créé
 
 
-def test_claim_run_creates_then_blocks_active_then_reclaims(db_session):
-    """claim_run (SAFE-002) : crée, refuse un claim actif, reprend un claim inactif."""
-    inactive = lambda _r: False  # noqa: E731
-    active = lambda _r: True  # noqa: E731
+def test_claim_run_creates_then_yields_active_then_reclaims(db_session):
+    """claim_run (SAFE-002) : crée, cède sur un claim actif, reprend un claim inactif."""
+    none = lambda _r: None  # noqa: E731
+    in_flight = lambda _r: "in_flight"  # noqa: E731
 
-    # 1) Aucune ligne → création (claimed=True).
-    run, claimed = repo.claim_run(
+    # 1) Aucune ligne → création (claim obtenu, yield_reason=None).
+    run, reason = repo.claim_run(
         db_session, Run(run_id="c1", idempotency_key="k1", ok=False, status="running"),
-        is_active_claim=inactive,
+        classify=none,
     )
     db_session.commit()
-    assert claimed is True and run.run_id == "c1"
+    assert reason is None and run.run_id == "c1"
 
-    # 2) Ligne considérée ACTIVE → course perdue (claimed=False), aucun écrasement.
-    _, claimed2 = repo.claim_run(
+    # 2) Ligne classée à céder (in_flight) → on s'efface, aucun écrasement.
+    _, reason2 = repo.claim_run(
         db_session,
         Run(run_id="c1", idempotency_key="k1", ok=False, status="running", total_calls=7),
-        is_active_claim=active,
+        classify=in_flight,
     )
-    assert claimed2 is False
-    assert repo.get_run(db_session, "c1").total_calls == 0  # ligne active intacte
+    assert reason2 == "in_flight"
+    assert repo.get_run(db_session, "c1").total_calls == 0  # ligne intacte
 
-    # 3) Ligne considérée INACTIVE (terminal/périmé) → reprise (claimed=True, mise à jour).
-    _, claimed3 = repo.claim_run(
+    # 3) Ligne non cédée (terminal/périmé) → reprise (yield_reason=None, mise à jour).
+    _, reason3 = repo.claim_run(
         db_session,
         Run(run_id="c1", idempotency_key="k1", ok=False, status="running", total_calls=9),
-        is_active_claim=inactive,
+        classify=none,
     )
     db_session.commit()
-    assert claimed3 is True
+    assert reason3 is None
     assert repo.get_run(db_session, "c1").total_calls == 9
 
 
-def test_claim_run_reclaim_rereads_fresh_state_under_lock(db_session):
-    """P1 (atomicité reclaim) : le read-modify-write se fait sous ``FOR UPDATE`` +
-    ``populate_existing``, donc claim_run ré-évalue le claim sur l'état FRAIS, pas sur
+def test_claim_run_rereads_fresh_state_under_lock(db_session):
+    """P1 (atomicité) : le read-modify-write se fait sous ``FOR UPDATE`` +
+    ``populate_existing``, donc ``classify`` est ré-évalué sur l'état FRAIS, pas sur
     une copie périmée de l'identity map. Une ligne devenue active entre-temps fait
-    s'effacer la reprise (claimed=False) au lieu d'écraser le gagnant."""
+    céder la reprise (yield_reason='in_flight') au lieu d'écraser le gagnant."""
     from datetime import datetime, timedelta, timezone
 
     from sqlalchemy import text
@@ -248,20 +248,47 @@ def test_claim_run_reclaim_rereads_fresh_state_under_lock(db_session):
         {"e": now + timedelta(hours=1)},
     )
 
-    def is_active(r):
-        if r.status != "running" or r.expires_at is None:
-            return False
-        exp = r.expires_at if r.expires_at.tzinfo else r.expires_at.replace(tzinfo=timezone.utc)
-        return exp > now
+    def classify(r):
+        if r.status == "running" and r.expires_at is not None:
+            exp = r.expires_at if r.expires_at.tzinfo else r.expires_at.replace(tzinfo=timezone.utc)
+            if exp > now:
+                return "in_flight"
+        return None
 
-    _, claimed = repo.claim_run(
+    _, reason = repo.claim_run(
         db_session,
         Run(run_id="r", idempotency_key="k", ok=False, status="running",
             expires_at=now + timedelta(seconds=10)),
-        is_active_claim=is_active,
+        classify=classify,
     )
-    # populate_existing a relu l'expiry FUTURE → claim actif → on s'efface.
-    assert claimed is False
+    # populate_existing a relu l'expiry FUTURE → classify cède → on n'écrase pas.
+    assert reason == "in_flight"
+
+
+def test_claim_run_yields_terminal_success_for_replay(db_session):
+    """P1 (race winner finalise en succès) : si la ligne verrouillée est un succès
+    terminal, claim_run cède ('replay') sans l'écraser — le perdant rejouera au lieu
+    de ré-exécuter."""
+    db_session.add(
+        Run(run_id="s", idempotency_key="ks", ok=True, status="success",
+            total_calls=2, success_count=2, last_json={"ok": True})
+    )
+    db_session.commit()
+
+    def classify(r):
+        if r.status in ("success", "partial_failure", "failed") and r.ok:
+            return "replay"
+        return None
+
+    run, reason = repo.claim_run(
+        db_session,
+        Run(run_id="s", idempotency_key="ks", ok=False, status="running"),
+        classify=classify,
+    )
+    assert reason == "replay"
+    # La ligne de succès n'a PAS été écrasée vers running.
+    assert run.status == "success" and run.ok is True
+    assert repo.get_run(db_session, "s").status == "success"
 
 
 def test_record_run_set_upsert_same_run_set(db_session):

--- a/python-orchestrator/tests/test_db_repositories.py
+++ b/python-orchestrator/tests/test_db_repositories.py
@@ -189,6 +189,81 @@ def test_record_run_insert_race_falls_back_to_existing(db_session, monkeypatch):
     assert db_session.query(Run).count() == 1   # pas de doublon créé
 
 
+def test_claim_run_creates_then_blocks_active_then_reclaims(db_session):
+    """claim_run (SAFE-002) : crée, refuse un claim actif, reprend un claim inactif."""
+    inactive = lambda _r: False  # noqa: E731
+    active = lambda _r: True  # noqa: E731
+
+    # 1) Aucune ligne → création (claimed=True).
+    run, claimed = repo.claim_run(
+        db_session, Run(run_id="c1", idempotency_key="k1", ok=False, status="running"),
+        is_active_claim=inactive,
+    )
+    db_session.commit()
+    assert claimed is True and run.run_id == "c1"
+
+    # 2) Ligne considérée ACTIVE → course perdue (claimed=False), aucun écrasement.
+    _, claimed2 = repo.claim_run(
+        db_session,
+        Run(run_id="c1", idempotency_key="k1", ok=False, status="running", total_calls=7),
+        is_active_claim=active,
+    )
+    assert claimed2 is False
+    assert repo.get_run(db_session, "c1").total_calls == 0  # ligne active intacte
+
+    # 3) Ligne considérée INACTIVE (terminal/périmé) → reprise (claimed=True, mise à jour).
+    _, claimed3 = repo.claim_run(
+        db_session,
+        Run(run_id="c1", idempotency_key="k1", ok=False, status="running", total_calls=9),
+        is_active_claim=inactive,
+    )
+    db_session.commit()
+    assert claimed3 is True
+    assert repo.get_run(db_session, "c1").total_calls == 9
+
+
+def test_claim_run_reclaim_rereads_fresh_state_under_lock(db_session):
+    """P1 (atomicité reclaim) : le read-modify-write se fait sous ``FOR UPDATE`` +
+    ``populate_existing``, donc claim_run ré-évalue le claim sur l'état FRAIS, pas sur
+    une copie périmée de l'identity map. Une ligne devenue active entre-temps fait
+    s'effacer la reprise (claimed=False) au lieu d'écraser le gagnant."""
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import text
+
+    now = datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+    # Ligne running PÉRIMÉE, puis chargée dans la session (identity map = périmé).
+    db_session.add(
+        Run(run_id="r", idempotency_key="k", ok=False, status="running",
+            expires_at=now - timedelta(seconds=1))
+    )
+    db_session.commit()
+    stale = repo.get_run(db_session, "r")  # instance périmée en identity map
+    assert stale is not None
+
+    # Un gagnant concurrent rend la ligne ACTIVE (expiry future), écrit hors ORM pour
+    # que l'identity map reste périmée tant qu'on ne relit pas sous verrou.
+    db_session.execute(
+        text("UPDATE orchestration.runs SET expires_at = :e WHERE run_id = 'r'"),
+        {"e": now + timedelta(hours=1)},
+    )
+
+    def is_active(r):
+        if r.status != "running" or r.expires_at is None:
+            return False
+        exp = r.expires_at if r.expires_at.tzinfo else r.expires_at.replace(tzinfo=timezone.utc)
+        return exp > now
+
+    _, claimed = repo.claim_run(
+        db_session,
+        Run(run_id="r", idempotency_key="k", ok=False, status="running",
+            expires_at=now + timedelta(seconds=10)),
+        is_active_claim=is_active,
+    )
+    # populate_existing a relu l'expiry FUTURE → claim actif → on s'efface.
+    assert claimed is False
+
+
 def test_record_run_set_upsert_same_run_set(db_session):
     """Deux appels sur le même (run_id, set_id) mettent à jour le dernier résultat."""
     repo.record_run(db_session, Run(run_id="run_u", status="success", ok=True))

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1574,3 +1574,49 @@ def test_concurrent_claim_loser_returns_in_flight_without_dispatch(orchestrator_
     session.expire_all()
     winner = session.get(Run, "run_rk9")
     assert winner.status == "running"
+
+
+def test_concurrent_claim_loser_replays_when_winner_finalized_success(orchestrator_env, monkeypatch):
+    # P1 : si le gagnant a déjà FINALISÉ EN SUCCÈS au moment où le perdant pose son
+    # claim (pré-check manqué), le perdant doit REJOUER ce succès — pas écraser la
+    # ligne réussie ni ré-exécuter les sets.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+
+    # Le gagnant a déjà finalisé en succès (run terminal réussi persisté).
+    session.add(
+        Run(
+            run_id="run_rk10", idempotency_key="rk10", ok=True, status="success",
+            total_calls=1, success_count=1, failed_count=0,
+            last_json={"run_id": "run_rk10", "ok": True, "status": "success",
+                       "summary": {"total_calls": 1, "success": 1, "failed": 0}},
+        )
+    )
+    session.commit()
+
+    # Course : le pré-check rate la ligne ; le seed (claim_run) la voit (succès terminal).
+    real_resolve = orch.repositories.resolve_run
+    calls = {"n": 0}
+
+    def _racing_resolve(session_, run_id_, key=None):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else real_resolve(session_, run_id_, key)
+
+    monkeypatch.setattr(orch.repositories, "resolve_run", _racing_resolve)
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "idempotency_key": "rk10"}
+    ).json()
+
+    # Replay : succès renvoyé, run_id conservé, AUCUN dispatch.
+    assert body["ok"] is True
+    assert body["status"] == "success"
+    assert body["run_id"] == "run_rk10"
+    assert body["summary"] == {"total_calls": 1, "success": 1, "failed": 0}
+    assert _mtf_posts(fake) == []
+    # La ligne de succès du gagnant est intacte (non écrasée vers running).
+    session.expire_all()
+    assert session.get(Run, "run_rk10").status == "success"

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1524,61 +1524,6 @@ def test_terminal_success_replays_even_when_dashboard_disabled(orchestrator_env,
     assert len(_mtf_posts(fake)) == 1
 
 
-def test_claim_run_cas_reports_active_vs_reclaimable():
-    # P1 (unité) : claim_run renvoie claimed=False quand un claim ACTIF existe déjà
-    # (course perdue), claimed=True sinon (création, ou reprise d'un terminal/claim
-    # périmé), sans écraser le claim actif.
-    from app.db import repositories as repo
-    from app.db.models import Base  # noqa: F401
-    from sqlalchemy import create_engine, event
-    from sqlalchemy.orm import sessionmaker
-    from sqlalchemy.pool import StaticPool
-
-    engine = create_engine("sqlite://", future=True, connect_args={"check_same_thread": False}, poolclass=StaticPool)
-
-    @event.listens_for(engine, "connect")
-    def _prep(conn, _r):  # noqa: ANN001
-        cur = conn.cursor()
-        cur.execute("PRAGMA foreign_keys=ON")
-        cur.execute("ATTACH DATABASE ':memory:' AS orchestration")
-        cur.close()
-
-    from app.db.base import Base as B
-    B.metadata.create_all(engine)
-    session = sessionmaker(bind=engine, expire_on_commit=False)()
-
-    def _new(run_id="run_x", key="kx"):
-        return Run(run_id=run_id, idempotency_key=key, ok=False, status="running")
-
-    # Claim actif déjà détenu => course perdue (claimed=False), inchangé.
-    active = lambda r: True  # noqa: E731
-    inactive = lambda r: False  # noqa: E731
-
-    # 1) Aucune ligne => création (claimed=True).
-    run, claimed = repo.claim_run(session, _new(), is_active_claim=inactive)
-    session.commit()
-    assert claimed is True and run.run_id == "run_x"
-
-    # 2) Ligne existante considérée ACTIVE => course perdue, pas d'écrasement.
-    run2, claimed2 = repo.claim_run(
-        session, Run(run_id="run_x", idempotency_key="kx", ok=False, status="running", total_calls=7),
-        is_active_claim=active,
-    )
-    assert claimed2 is False
-    assert run2.run_id == "run_x"
-    assert run2.total_calls != 7  # la ligne active n'a pas été écrasée
-
-    # 3) Ligne existante considérée INACTIVE (terminal/périmé) => reprise (claimed=True).
-    run3, claimed3 = repo.claim_run(
-        session, Run(run_id="run_x", idempotency_key="kx", ok=False, status="running", total_calls=9),
-        is_active_claim=inactive,
-    )
-    session.commit()
-    assert claimed3 is True
-    session.close()
-    engine.dispose()
-
-
 def test_concurrent_claim_loser_returns_in_flight_without_dispatch(orchestrator_env, monkeypatch):
     # P1 (intégration) : si un run concurrent pose son claim ENTRE le pré-check et le
     # seed (pré-check qui ne voit pas encore la ligne), le perdant réplique l'état en

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1494,3 +1494,138 @@ def test_claim_reuses_legacy_run_id_resolved_by_idempotency_key(orchestrator_env
     assert legacy.status == "success"
     run_sets = session.scalars(select(RunSet).where(RunSet.run_id == "run_legacy")).all()
     assert {rs.set_id for rs in run_sets} == {"a"}
+
+
+def test_terminal_success_replays_even_when_dashboard_disabled(orchestrator_env, monkeypatch):
+    # P2 : un run terminal réussi doit être REPLAYÉ même si le dashboard a depuis été
+    # désactivé/supprimé — le replay ne nécessite ni dashboard ni sets. Sinon le retry
+    # renverrait `no_sets` au lieu du succès persisté promis par SAFE-002.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    payload = {"dashboard_id": str(dash.id), "idempotency_key": "rk8"}
+    first = client.post("/orchestrator/run", json=payload).json()
+    assert first["ok"] is True and first["status"] == "success"
+    assert len(_mtf_posts(fake)) == 1
+
+    # Le dashboard est désactivé APRÈS le succès.
+    dash.enabled = False
+    session.commit()
+
+    second = client.post("/orchestrator/run", json=payload).json()
+    # Replay (pas de `no_sets`), aucun dispatch supplémentaire.
+    assert second["status"] == "success"
+    assert second["ok"] is True
+    assert second["run_id"] == first["run_id"] == "run_rk8"
+    assert second["summary"] == first["summary"]
+    assert len(_mtf_posts(fake)) == 1
+
+
+def test_claim_run_cas_reports_active_vs_reclaimable():
+    # P1 (unité) : claim_run renvoie claimed=False quand un claim ACTIF existe déjà
+    # (course perdue), claimed=True sinon (création, ou reprise d'un terminal/claim
+    # périmé), sans écraser le claim actif.
+    from app.db import repositories as repo
+    from app.db.models import Base  # noqa: F401
+    from sqlalchemy import create_engine, event
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    engine = create_engine("sqlite://", future=True, connect_args={"check_same_thread": False}, poolclass=StaticPool)
+
+    @event.listens_for(engine, "connect")
+    def _prep(conn, _r):  # noqa: ANN001
+        cur = conn.cursor()
+        cur.execute("PRAGMA foreign_keys=ON")
+        cur.execute("ATTACH DATABASE ':memory:' AS orchestration")
+        cur.close()
+
+    from app.db.base import Base as B
+    B.metadata.create_all(engine)
+    session = sessionmaker(bind=engine, expire_on_commit=False)()
+
+    def _new(run_id="run_x", key="kx"):
+        return Run(run_id=run_id, idempotency_key=key, ok=False, status="running")
+
+    # Claim actif déjà détenu => course perdue (claimed=False), inchangé.
+    active = lambda r: True  # noqa: E731
+    inactive = lambda r: False  # noqa: E731
+
+    # 1) Aucune ligne => création (claimed=True).
+    run, claimed = repo.claim_run(session, _new(), is_active_claim=inactive)
+    session.commit()
+    assert claimed is True and run.run_id == "run_x"
+
+    # 2) Ligne existante considérée ACTIVE => course perdue, pas d'écrasement.
+    run2, claimed2 = repo.claim_run(
+        session, Run(run_id="run_x", idempotency_key="kx", ok=False, status="running", total_calls=7),
+        is_active_claim=active,
+    )
+    assert claimed2 is False
+    assert run2.run_id == "run_x"
+    assert run2.total_calls != 7  # la ligne active n'a pas été écrasée
+
+    # 3) Ligne existante considérée INACTIVE (terminal/périmé) => reprise (claimed=True).
+    run3, claimed3 = repo.claim_run(
+        session, Run(run_id="run_x", idempotency_key="kx", ok=False, status="running", total_calls=9),
+        is_active_claim=inactive,
+    )
+    session.commit()
+    assert claimed3 is True
+    session.close()
+    engine.dispose()
+
+
+def test_concurrent_claim_loser_returns_in_flight_without_dispatch(orchestrator_env, monkeypatch):
+    # P1 (intégration) : si un run concurrent pose son claim ENTRE le pré-check et le
+    # seed (pré-check qui ne voit pas encore la ligne), le perdant réplique l'état en
+    # vol SANS dispatcher ni écraser la ligne partagée.
+    from datetime import datetime, timedelta, timezone
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+
+    now = datetime.now(timezone.utc)
+    # Le « gagnant » a déjà posé un claim running non périmé.
+    session.add(
+        Run(
+            run_id="run_rk9", idempotency_key="rk9", ok=False, status="running",
+            total_calls=0, success_count=0, failed_count=0,
+            started_at=now, expires_at=now + timedelta(seconds=3600),
+        )
+    )
+    session.commit()
+
+    # On simule la course TOCTOU : le PRÉ-CHECK `resolve_run` (1er appel) ne voit PAS
+    # la ligne, mais le seed (`claim_run` → `_resolve_existing_run`, appels suivants)
+    # la voit — comme si le gagnant avait committé entre les deux.
+    real_resolve = orch.repositories.resolve_run
+    calls = {"n": 0}
+
+    def _racing_resolve(session_, run_id_, key=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return real_resolve(session_, run_id_, key)
+
+    monkeypatch.setattr(orch.repositories, "resolve_run", _racing_resolve)
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "idempotency_key": "rk9"}
+    ).json()
+
+    assert body["ok"] is False
+    assert body["status"] == "running"
+    assert body["run_id"] == "run_rk9"
+    # Le perdant n'a rien dispatché.
+    assert _mtf_posts(fake) == []
+    # La ligne partagée du gagnant est intacte (toujours running, non écrasée).
+    session.expire_all()
+    winner = session.get(Run, "run_rk9")
+    assert winner.status == "running"

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1213,3 +1213,284 @@ def test_lock_uses_injected_clock_for_expiry(orchestrator_env, monkeypatch):
     assert body["ok"] is True
     mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
     assert len(mtf_posts) == 1
+
+
+# --------------------------------------------------------------------------
+# SAFE-002 — idempotence à l'exécution (claim, replay, reprise, in-flight)
+# --------------------------------------------------------------------------
+
+
+class _PerSymbolClient(_FakeAsyncClient):
+    """Faux client dont ``/api/mtf/run`` échoue pour les symboles de ``fail_symbols``.
+
+    Permet de produire un run partiellement échoué (un set ok, un set ko) puis, en
+    vidant ``fail_symbols``, de simuler un re-trigger où le set restant réussit.
+    """
+
+    def __init__(self, *, fail_symbols=(), **kw):
+        super().__init__(**kw)
+        self.fail_symbols = set(fail_symbols)
+
+    async def post(self, url: str, json: Dict[str, Any] | None = None) -> _FakeResponse:
+        self.post_calls.append({"url": url, "json": json or {}})
+        symbols = (json or {}).get("symbols") or []
+        if url.endswith("/api/mtf/run") and symbols and symbols[0] in self.fail_symbols:
+            return _FakeResponse(200, {"status": "partial_success", "data": {"errors": ["boom"]}})
+        return _FakeResponse(200, {"status": "success"})
+
+
+def _mtf_posts(fake) -> List[Dict[str, Any]]:
+    return [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+
+
+def test_has_idempotency_anchor_branches():
+    from app.schemas import RunRequest
+
+    assert orch._has_idempotency_anchor(None) is False
+    assert orch._has_idempotency_anchor(RunRequest()) is False
+    # Clé blanche => pas d'ancrage (cohérent avec _resolve_run_id : run_id aléatoire).
+    assert orch._has_idempotency_anchor(RunRequest(idempotency_key="   ")) is False
+    assert orch._has_idempotency_anchor(RunRequest(idempotency_key="k")) is True
+    # dashboard_id seul (sans tick) => pas d'ancrage.
+    assert orch._has_idempotency_anchor(RunRequest(dashboard_id="1")) is False
+    assert (
+        orch._has_idempotency_anchor(
+            RunRequest(dashboard_id="1", tick_timestamp="2026-06-21T00:00:00Z")
+        )
+        is True
+    )
+
+
+def test_claim_expired_handles_missing_and_naive_expiry():
+    from datetime import datetime, timedelta, timezone
+
+    from app.db.models import Run
+
+    now = datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+    # Pas d'expires_at (run running legacy) => traité comme périmé (reclaimable).
+    assert orch._claim_expired(Run(run_id="r", status="running"), now) is True
+    # Expiry future => non périmé.
+    assert orch._claim_expired(
+        Run(run_id="r", status="running", expires_at=now + timedelta(seconds=10)), now
+    ) is False
+    # Expiry passée, fournie naïve (round-trip SQLite) => normalisée UTC, périmée.
+    assert orch._claim_expired(
+        Run(run_id="r", status="running", expires_at=(now - timedelta(seconds=1)).replace(tzinfo=None)),
+        now,
+    ) is True
+
+
+def test_terminal_success_replays_without_redispatch(orchestrator_env, monkeypatch):
+    # Deux runs même idempotency_key : le 1er réussit, le 2nd est un REPLAY (aucun
+    # POST /api/mtf/run supplémentaire, même run_id, même summary).
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _seed_set(session, dash.id, "b", symbols=("ETHUSDT",))
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    payload = {"dashboard_id": str(dash.id), "idempotency_key": "rk1"}
+    first = client.post("/orchestrator/run", json=payload).json()
+    assert first["ok"] is True
+    assert len(_mtf_posts(fake)) == 2
+
+    second = client.post("/orchestrator/run", json=payload).json()
+    # Aucun ré-appel Symfony : le compteur de POST reste à 2.
+    assert len(_mtf_posts(fake)) == 2
+    assert second["run_id"] == first["run_id"] == "run_rk1"
+    assert second["status"] == "success"
+    assert second["ok"] is True
+    assert second["summary"] == first["summary"]
+
+
+def test_partial_failure_resumes_only_failed_sets(orchestrator_env, monkeypatch):
+    # Run partiellement échoué puis re-trigger même clé : seuls les sets échoués sont
+    # re-dispatchés, les RunSet réussis sont conservés, le summary est recomposé.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _seed_set(session, dash.id, "b", symbols=("ETHUSDT",))
+    fake = _PerSymbolClient(fail_symbols={"ETHUSDT"})
+    _install_fake_client(monkeypatch, fake)
+
+    payload = {"dashboard_id": str(dash.id), "idempotency_key": "rk2"}
+    first = client.post("/orchestrator/run", json=payload).json()
+    assert first["status"] == "partial_failure"
+    assert first["summary"] == {"total_calls": 2, "success": 1, "failed": 1}
+    assert len(_mtf_posts(fake)) == 2
+
+    # Re-trigger même clé ; ETHUSDT réussit désormais.
+    fake.fail_symbols.clear()
+    second = client.post("/orchestrator/run", json=payload).json()
+    assert second["run_id"] == first["run_id"] == "run_rk2"
+    assert second["ok"] is True
+    assert second["status"] == "success"
+    assert second["summary"] == {"total_calls": 2, "success": 2, "failed": 0}
+
+    # Seul le set précédemment échoué (ETHUSDT) est re-dispatché.
+    second_posts = _mtf_posts(fake)[2:]
+    assert len(second_posts) == 1
+    assert second_posts[0]["json"]["symbols"] == ["ETHUSDT"]
+
+    # Persistance : les deux sets sont ok, "a" conservé (non re-dispatché), "b" mis à jour.
+    session.expire_all()
+    run_sets = session.scalars(select(RunSet).where(RunSet.run_id == "run_rk2")).all()
+    by = {rs.set_id: rs for rs in run_sets}
+    assert by["a"].ok is True
+    assert by["b"].ok is True
+    assert by["b"].error is None
+    run = session.get(Run, "run_rk2")
+    assert run.status == "success"
+    assert {d["set_id"]: d["ok"] for d in run.last_json["sets"]} == {"a": True, "b": True}
+
+
+def test_fresh_running_claim_blocks_second_trigger(orchestrator_env, monkeypatch):
+    # Un run `running` frais (ligne seedée, TTL non périmé) : un 2e trigger même clé
+    # ne dispatche pas (réplique de l'état, ok=false + statut running).
+    from datetime import datetime, timedelta, timezone
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    now = datetime.now(timezone.utc)
+    session.add(
+        Run(
+            run_id="run_rk3", idempotency_key="rk3", ok=False, status="running",
+            total_calls=0, success_count=0, failed_count=0,
+            started_at=now, expires_at=now + timedelta(seconds=3600),
+        )
+    )
+    session.commit()
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "idempotency_key": "rk3"}
+    ).json()
+
+    assert body["ok"] is False
+    assert body["status"] == "running"
+    assert body["run_id"] == "run_rk3"
+    # Aucun dispatch (ni open-state, ni mtf/run) : un autre run est en vol.
+    assert _mtf_posts(fake) == []
+    assert fake.get_calls == []
+
+
+def test_expired_running_claim_is_reclaimed(orchestrator_env, monkeypatch):
+    # Un run `running` périmé (TTL dépassé, process tué) est reclaim : ré-exécution
+    # comme un nouveau run, finalisé en terminal.
+    from datetime import datetime, timedelta, timezone
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    now = datetime.now(timezone.utc)
+    session.add(
+        Run(
+            run_id="run_rk4", idempotency_key="rk4", ok=False, status="running",
+            total_calls=0, success_count=0, failed_count=0,
+            started_at=now - timedelta(hours=2), expires_at=now - timedelta(seconds=1),
+        )
+    )
+    session.commit()
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "idempotency_key": "rk4"}
+    ).json()
+
+    assert body["ok"] is True
+    assert body["status"] == "success"
+    assert body["run_id"] == "run_rk4"
+    assert len(_mtf_posts(fake)) == 1
+
+    session.expire_all()
+    run = session.get(Run, "run_rk4")
+    assert run.status == "success"
+    assert run.finished_at is not None
+
+
+def test_random_run_id_is_not_idempotent(orchestrator_env, monkeypatch):
+    # run_id aléatoire (dashboard_id sans tick ni clé) : aucun claim, deux exécutions
+    # distinctes (idempotence non appliquée).
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    first = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+    second = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert first["run_id"] != second["run_id"]
+    # Les deux runs ont bien dispatché (aucun court-circuit d'idempotence).
+    assert len(_mtf_posts(fake)) == 2
+
+    session.expire_all()
+    # Aucune ligne `running` résiduelle : un run sans ancrage n'écrit pas de claim.
+    running = session.scalars(select(Run).where(Run.status == "running")).all()
+    assert running == []
+
+
+def test_claim_writes_running_row_with_ttl_during_dispatch(orchestrator_env, monkeypatch):
+    # Le claim précoce écrit une ligne `running` avec un `expires_at` = now + TTL de
+    # claim AVANT le dispatch (observé pendant l'appel Symfony, claim encore en vol).
+    from datetime import datetime, timedelta, timezone
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+
+    base = datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(orch, "_now", lambda: base)
+
+    captured: Dict[str, Any] = {}
+
+    class _CapturingClient(_FakeAsyncClient):
+        async def post(self, url, json=None):
+            row = session.scalars(select(Run).where(Run.run_id == "run_rk6")).first()
+            if row is not None:
+                captured["status"] = row.status
+                captured["expires_at"] = row.expires_at
+            return await super().post(url, json=json)
+
+    _install_fake_client(monkeypatch, _CapturingClient())
+
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "idempotency_key": "rk6"}
+    ).json()
+    assert body["ok"] is True
+
+    assert captured["status"] == "running"
+    exp = captured["expires_at"]
+    exp_utc = exp if exp.tzinfo else exp.replace(tzinfo=timezone.utc)
+    # 1 set, max_concurrency par défaut = 2 => 1 vague ; TTL = 1*900 + 1800 = 2700s.
+    assert exp_utc == base + timedelta(seconds=2700)
+
+
+def test_claim_reuses_legacy_run_id_resolved_by_idempotency_key(orchestrator_env, monkeypatch):
+    # Régression : si record_run résout un run existant (par idempotency_key) sous un
+    # run_id distinct du dérivé, le claim ET la finalisation doivent porter ce run_id-là.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    # Run terminal NON-ok pré-existant sous un run_id legacy (≠ "run_k1" dérivé).
+    session.add(Run(run_id="run_legacy", idempotency_key="k1", ok=False, status="failed"))
+    session.commit()
+
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "idempotency_key": "k1"}
+    ).json()
+
+    assert body["run_id"] == "run_legacy"
+    assert body["ok"] is True
+    session.expire_all()
+    assert session.get(Run, "run_k1") is None
+    legacy = session.get(Run, "run_legacy")
+    assert legacy.status == "success"
+    run_sets = session.scalars(select(RunSet).where(RunSet.run_id == "run_legacy")).all()
+    assert {rs.set_id for rs in run_sets} == {"a"}


### PR DESCRIPTION
Centralise run status constants in schemas (add non-terminal `running`,
`TERMINAL_RUN_STATUSES`). Add nullable `runs.expires_at` (claim TTL) to the
Run model and Alembic migration 0003 (orchestration schema only; no impact on
public/Doctrine). Add `repositories.resolve_run` (public run lookup by run_id
then idempotency_key) and include `expires_at` in the run upsert columns so
`record_run` carries the claim TTL.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BBmJU5Wd4DsQi6AY45dzQ8