### PR TITLE
SAFE-003: Centraliser et durcir les garde-fous live (OKX / Hyperliquid / Bitmart)

### DIFF
--- a/docs/handbook/technical/exchange-schedule-policy.md
+++ b/docs/handbook/technical/exchange-schedule-policy.md
@@ -32,6 +32,31 @@ Un déclenchement doit déclarer explicitement :
 | `live_forbidden` | Interdit en live. |
 | `live_candidate` | Potentiellement live plus tard, après PR dédiée. |
 
+## Couche unique de garde-fous live (orchestrateur)
+
+Côté `python-orchestrator`, la décision « ce set peut-il s'exécuter en live ? »
+est centralisée en **un seul module fail-closed**, `app/services/live_guard.py`
+(`assess_live(...) -> LiveDecision`). La persistance des sets
+(`assert_set_persistable`), les sets en mémoire (`assert_live_allowed`) et le
+runner (`_dispatch_set`) délèguent tous à cette source unique — il n'y a plus de
+politique live dupliquée. La décision distingue explicitement :
+
+- **interdictions permanentes** : OKX et Hyperliquid live restent interdits
+  **même interrupteur d'activation activé et même exchange allow-listé** (garde
+  jamais relâchée, normalisation casse/espaces incluse) ;
+- **verrou transitoire** : un interrupteur d'activation explicite
+  `ORCHESTRATION_LIVE_ENABLED` (défaut **OFF**) + une allow-list
+  `ORCHESTRATION_LIVE_EXCHANGES` (défaut **vide**, au plus `bitmart`, + `fake` en
+  simulation). Tant que l'interrupteur est OFF, **tout** set `dry_run=false` est
+  skippé fail-closed, comme avant ;
+- **prérequis runtime** : même live autorisé, un set n'est dispatché que si le
+  snapshot d'état ouvert est présent (sinon skip `open_state_unavailable`), et
+  l'override run-level `{"dry_run": true}` force toujours le dry (prééminence
+  sécurité).
+
+Le live reste **désactivé par défaut** dans la config livrée : l'interrupteur
+rend l'activation *possible, explicite, auditable et testée*, sans la réactiver.
+
 ## Politique par exchange
 
 | Exchange | Simulation | Dry-run | Live | Commentaire |

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -61,15 +61,33 @@ ce snapshot à chaque `POST /api/mtf/run` dans le champ `open_state_snapshot` av
 `sync_tables=false`. Côté Symfony, la présence du snapshot **court-circuite**
 totalement le fetch exchange (priorité : snapshot > `sync_tables=true` > filtre).
 
-**Fail-closed live (phase actuelle)** : tant que la readiness live n'est pas
-livrée, `assert_set_persistable` interdit la persistance de **tout** set live
-(`dry_run=false`, tous exchanges/environnements). Le runner DB-backed applique la
-même politique de bout en bout : **tout set effectivement live est skippé**
-(marqué en erreur, aucun `POST /api/mtf/run`), **même sur un exchange autorisé et
-même avec un snapshot disponible**, car la seule façon d'obtenir une ligne live
-est de contourner l'API. Seul un override run-level `dry_run=true` rend un set
-exécutable (en dry). Ce garde-fou sera relâché quand la readiness live
-(SAFE-001/SAFE-002, TM-001) sera livrée.
+**Couche unique de garde-fous live (SAFE-003)** : toute la politique « ce set
+peut-il s'exécuter en live ? » vit dans **un seul module** fail-closed,
+`app/services/live_guard.py`, exposant `assess_live(exchange, market_type,
+environment, dry_run, settings) -> LiveDecision`. La persistance
+(`assert_set_persistable`), les `OrchestratorSet` en mémoire
+(`assert_live_allowed`) et le runner (`_dispatch_set`) **délèguent** à cette
+source unique — plus de logique live dupliquée entre `schemas` et le runner. La
+décision suit une hiérarchie : (1) dry-run ⇒ autorisé ; (2) **bannissement
+permanent** OKX/Hyperliquid ⇒ refusé, *même interrupteur activé + exchange
+allow-listé* ; (3) **interrupteur** `ORCHESTRATION_LIVE_ENABLED` OFF (défaut) ⇒
+refusé ; (4) exchange hors **allow-list** `ORCHESTRATION_LIVE_EXCHANGES` (défaut
+vide) ⇒ refusé ; (5) sinon ⇒ autorisé. Chaque refus porte un `reason`/`code`
+stable (`live_forbidden_exchange`, `live_not_enabled`,
+`live_exchange_not_allowlisted`, `open_state_unavailable`) versé dans
+`RunSet.error` / `last_json`.
+
+**Le live reste désactivé par défaut** : la config livrée garde l'interrupteur
+OFF et l'allow-list vide, donc **tout set effectivement live est skippé** (marqué
+en erreur, aucun `POST /api/mtf/run`), **même sur un exchange autorisé et même
+avec un snapshot disponible** — comportement identique à avant SAFE-003. SAFE-003
+ne fait que rendre l'activation *possible, explicite, auditable et testée* (via
+l'interrupteur + l'allow-list + le snapshot d'état ouvert présent), sans la
+réactiver. Seul un override run-level `dry_run=true` rend un set exécutable (en
+dry), quel que soit l'état de l'interrupteur (prééminence sécurité). La
+persistance d'un set `dry_run=false` n'est autorisée que si `assess_live`
+l'autorise (mêmes gardes) : une ligne stockée ne peut jamais déclencher un live
+que le runner refuserait, et inversement.
 
 **Fail-closed live (post-readiness)** : si le fetch du snapshot échoue pour un
 couple, les sets **live** (`dry_run=false`) de ce couple sont marqués en erreur et
@@ -596,10 +614,21 @@ Avant tout run :
   `running` non périmé renvoie l'**état en vol** (`ok=false`, `status="running"`, pas
   de dispatch), un `running` périmé est **reclaim**. Le live reste désactivé. Cf.
   *Statuts de run et idempotence à l'exécution (SAFE-002)*. ;
-- ne lancer aucun set live tant que la readiness live n'est pas livrée (tout set
-  `dry_run=false` est skippé par le runner, en miroir de `assert_set_persistable`) ;
-- ne pas autoriser OKX live (garde permanente, conservée après readiness) ;
-- ne pas autoriser Hyperliquid live (garde permanente, conservée après readiness) ;
+- **couche unique de garde-fous live** (SAFE-003, livré) : `app/services/live_guard.py`
+  (`assess_live`) est la **source unique** consommée par la persistance
+  (`assert_set_persistable`), les `OrchestratorSet` en mémoire (`assert_live_allowed`)
+  et le runner (`_dispatch_set`). Hiérarchie fail-closed : bannissements permanents
+  OKX/Hyperliquid (jamais relâchés) > interrupteur `ORCHESTRATION_LIVE_ENABLED`
+  (défaut OFF) > allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > prérequis
+  runtime (snapshot d'état ouvert présent). **Le live reste désactivé par défaut**
+  (interrupteur OFF dans la config livrée) ; persistance ↔ runtime cohérents (une ligne
+  ne peut déclencher que ce que le runner exécuterait). Cf. *Couche unique de garde-fous
+  live (SAFE-003)* ;
+- ne lancer aucun set live tant que l'interrupteur n'est pas explicitement activé
+  (tout set `dry_run=false` skippé par le runner par défaut, en miroir de
+  `assert_set_persistable`) ;
+- ne pas autoriser OKX live (garde permanente, conservée même interrupteur activé) ;
+- ne pas autoriser Hyperliquid live (garde permanente, conservée même interrupteur activé) ;
 - garder `workers=1` côté Symfony au début ;
 - borner la concurrence globale ;
 - refuser les valeurs dangereuses de workers, concurrence ou nombre de contrats ;
@@ -625,6 +654,7 @@ Avant tout run :
 | PY-006 ✅ | Exposer l'historique des runs en lecture | Livré : endpoints `GET` en lecture seule du dernier JSON global et par set (`/runs`, `/runs/{run_id}`, `/runs/{run_id}/sets/{set_id}`, `/dashboards/{id}/runs`, `/dashboards/{id}/runs/latest`) ; vue allégée paginée pour les listes, détail complet `last_json` + sets. |
 | SAFE-001 ✅ | Locks d'orchestration par symbole et profil | Livré : table `orchestration_locks` (clé `lock_key` UNIQUE), acquisition tout-ou-rien par set avant dispatch (transaction courte, reclaim des locks expirés, skip fail-closed `locked: …`), libération en fin de set, purge des expirés au démarrage. Prérequis readiness live ; ne réactive pas le live. |
 | SAFE-002 ✅ | Idempotence des runs et des sets | Livré : statut non terminal `running` + claim précoce (`runs.expires_at` = TTL de claim, transaction courte) ; court-circuit selon l'état du run existant — replay (terminal success), reprise des sets non réussis (terminal non-ok), réplique en vol (`running` non périmé), reclaim (`running` périmé). Réutilise `record_run`/savepoints et le calcul de TTL SAFE-001. Migration `0003_run_claim_expires_at`. Ne réactive pas le live. |
+| SAFE-003 ✅ | Centraliser et durcir les garde-fous live | Livré : module unique `app/services/live_guard.py` (`assess_live -> LiveDecision`) consommé par `assert_set_persistable`, `assert_live_allowed` et le runner `_dispatch_set` (plus de logique live dupliquée schemas ↔ runner). Hiérarchie fail-closed : bannissements permanents OKX/Hyperliquid (jamais relâchés) > interrupteur `ORCHESTRATION_LIVE_ENABLED` (défaut OFF) > allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > snapshot d'état ouvert présent. `reason`/`code` stables par cause. Persistance ↔ runtime cohérents. **Le live reste désactivé par défaut** : aucune réactivation effective, seule l'activation devient possible/auditable/testée. Pas de migration. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -83,8 +83,11 @@ Garde-fous appliqués dès la création/mise à jour des sets (revalidés sur le
 `PATCH` partiels, l'état résultant étant fusionné avec la ligne persistée) :
 
 - `workers` borné à `MAX_WORKERS_PER_SET` (1 au début) → `422` au-delà ;
-- **aucun live persistable** : `dry_run=false` est refusé pour tous les
-  exchanges/environnements tant que la readiness live n'est pas livrée → `422` ;
+- **aucun live persistable par défaut** : `dry_run=false` est refusé tant que
+  l'interrupteur d'activation live est OFF (config livrée) → `422`. La décision
+  délègue à la couche unique `app/services/live_guard.py` (`assess_live`), mêmes
+  gardes que le runner — une ligne stockée ne peut déclencher que ce que le runner
+  exécuterait. Cf. *Garde-fous live (SAFE-003)* ;
 - **sélection exploitable obligatoire** : un set doit avoir `symbols` non vide
   **ou** `contracts_limit` renseigné (pas de set ambigu) → `422` ;
 - **`payload` non writable** : produit côté serveur (PY-004), exposé en lecture
@@ -277,9 +280,11 @@ un service `postgres:15`.
 | `DATABASE_URL` | `postgresql+psycopg://postgres:password@trading-app-db:5432/trading_app` | URL SQLAlchemy de la base orchestration (DB-001). |
 | `ORCHESTRATION_DB_SCHEMA` | `orchestration` | Schéma PostgreSQL dédié (DB-001). Identifiant SQL simple validé (`^[A-Za-z_][A-Za-z0-9_]*$`). |
 | `ORCHESTRATION_LOCK_TTL_SECONDS` | `1800` | Marge (s) anti-deadlock des locks d'orchestration par `(profil, symbole)` (SAFE-001), ≥ 1. Le TTL effectif = pire temps de paroi du run (vagues `max_concurrency` × timeout Symfony) + cette marge, pour qu'un set en file n'expire pas avant son dispatch. **Borne aussi le TTL de claim de run** (SAFE-002, même calcul) : pas de variable dédiée. |
+| `ORCHESTRATION_LIVE_ENABLED` | `false` | **Interrupteur d'activation live** (SAFE-003), défaut **OFF**. OFF ⇒ tout set `dry_run=false` est skippé fail-closed (comportement d'avant SAFE-003). Accepte `true/false`, `1/0`, `yes/no`, `on/off` ; toute autre valeur lève au démarrage. **Ne jamais livrer à `true` sans readiness runtime.** |
+| `ORCHESTRATION_LIVE_EXCHANGES` | *(vide)* | Allow-list CSV des exchanges autorisés live **quand l'interrupteur est ON** (SAFE-003). Normalisée en minuscules, dédupliquée ; chaque entrée doit être un exchange connu (sinon lève au démarrage). En pratique au plus `bitmart` (+ `fake` en simulation). OKX/Hyperliquid restent interdits **même listés** (bannissement permanent). |
 
-Une valeur non entière ou hors borne lève une erreur explicite au démarrage
-(pas de repli silencieux sur le défaut).
+Une valeur non entière, non booléenne, hors borne ou un exchange inconnu lève une
+erreur explicite au démarrage (pas de repli silencieux sur le défaut).
 
 ## Persistance (DB-001)
 
@@ -327,6 +332,33 @@ cron) ne peuvent donc pas traiter le même couple `(profil, symbole)` en même t
 La migration Alembic `0002_orchestration_locks` crée la table ; elle s'applique via
 `alembic upgrade head` (cf. *Migrations*). La migration `0003_run_claim_expires_at`
 ajoute la colonne `runs.expires_at` (TTL du claim « en vol », **SAFE-002**).
+
+### Garde-fous live (SAFE-003)
+
+Toute la politique « ce set peut-il s'exécuter en live ? » est centralisée dans
+**un seul module fail-closed**, `app/services/live_guard.py`, exposant
+`assess_live(exchange, market_type, environment, dry_run, settings) -> LiveDecision`.
+La persistance (`schemas.assert_set_persistable`), les sets en mémoire
+(`schemas.assert_live_allowed`) et le runner (`_dispatch_set`) **délèguent** tous à
+cette source unique : plus de logique live dupliquée entre `schemas` et le runner.
+
+Hiérarchie de décision (fail-closed, l'ordre est sécuritaire) :
+
+1. `dry_run` effectif ⇒ autorisé (l'override run-level `{"dry_run": true}` force
+   toujours le dry, quelle que soit la suite) ;
+2. **bannissement permanent** OKX/Hyperliquid ⇒ refusé, **même interrupteur ON et
+   même exchange allow-listé** (normalisation casse/espaces incluse) ;
+3. interrupteur `ORCHESTRATION_LIVE_ENABLED` **OFF** (défaut) ⇒ refusé
+   (`live_not_enabled`) — comportement identique à avant SAFE-003 ;
+4. exchange hors allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) ⇒ refusé
+   (`live_exchange_not_allowlisted`) ;
+5. sinon ⇒ autorisé, **mais** le runner exige encore le snapshot d'état ouvert
+   (sinon skip `open_state_unavailable`).
+
+Chaque refus porte un `reason`/`code` stable versé dans `RunSet.error` / `last_json`.
+**Le live reste désactivé par défaut** : la config livrée garde l'interrupteur OFF
+et l'allow-list vide. SAFE-003 rend l'activation *possible, explicite, auditable et
+testée*, sans la réactiver, et **n'ajoute aucune migration**.
 
 ### Migrations
 

--- a/python-orchestrator/app/routers/dashboards.py
+++ b/python-orchestrator/app/routers/dashboards.py
@@ -167,11 +167,17 @@ def update_set(
     effective_dry_run = updates.get("dry_run", a_set.dry_run)
     effective_symbols = updates.get("symbols", a_set.symbols)
     effective_limit = updates.get("contracts_limit", a_set.contracts_limit)
+    effective_exchange = updates.get("exchange", a_set.exchange)
+    effective_market_type = updates.get("market_type", a_set.market_type)
+    effective_environment = updates.get("environment", a_set.environment)
     try:
         assert_set_persistable(
             dry_run=effective_dry_run,
             symbols=effective_symbols,
             contracts_limit=effective_limit,
+            exchange=effective_exchange,
+            market_type=effective_market_type,
+            environment=effective_environment,
         )
     except ValueError as exc:
         # 422 littéral : la constante `status.HTTP_422_*` a été renommée selon
@@ -313,6 +319,9 @@ async def refresh_contracts(
                 dry_run=a_set.dry_run,
                 symbols=symbols,
                 contracts_limit=a_set.contracts_limit,
+                exchange=a_set.exchange,
+                market_type=a_set.market_type,
+                environment=a_set.environment,
             )
         except ValueError as exc:
             raise HTTPException(

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -34,7 +34,6 @@ from app.db.engine import get_session
 from app.db.models import OrchestrationLock, OrchestrationSet, Run, RunSet
 from app.schemas import (
     Action,
-    LIVE_FORBIDDEN_EXCHANGES,
     RUN_STATUS_RUNNING,
     TERMINAL_RUN_STATUSES,
     RunRequest,
@@ -42,6 +41,7 @@ from app.schemas import (
     RunStatus,
     RunSummary,
 )
+from app.services.live_guard import OPEN_STATE_UNAVAILABLE_REASON, assess_live
 from app.services.symfony_client import (
     OpenStateUnavailableError,
     SnapshotKey,
@@ -68,11 +68,6 @@ _MAX_PERSISTED_LEN = 255
 # restreint donc le `run_id` aux caractères sûrs d'un segment de chemin ; tout le
 # reste est haché (cf. `_resolve_run_id`).
 _SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9_.\-]+$")
-
-# Exchanges dont le live est interdit (OKX/Hyperliquid), en chaînes pour comparer
-# aux colonnes ORM. Le validateur de schéma bloque déjà toute persistance live ;
-# ce miroir sert de garde-fou défense-en-profondeur au moment du run.
-_LIVE_FORBIDDEN_EXCHANGES = frozenset(e.value for e in LIVE_FORBIDDEN_EXCHANGES)
 
 
 def _resolve_run_id(request: Optional[RunRequest]) -> str:
@@ -834,48 +829,42 @@ async def run_orchestrator(
 
         async def _dispatch_set(a_set: Any) -> Dict[str, Any]:
             snapshot = snapshots.get(snapshot_key(a_set))
+            # État live EFFECTIF (override run-level `{"dry_run": true}` déjà reflété) :
+            # le forçage ne peut que rendre un set plus sûr, jamais downgrader dry→live.
             effective_dry_run = a_set.dry_run or force_dry_run
-            exchange = getattr(a_set.exchange, "value", a_set.exchange)
-            # Garde live défense-en-profondeur : OKX/Hyperliquid live sont interdits.
-            # La persistance les bloque déjà (assert_set_persistable), mais une ligne
-            # ORM écrite hors API ne doit jamais déclencher un /api/mtf/run live ici.
-            # Un override run-level dry_run rend le set sûr (effective_dry_run=True).
-            # On normalise (casse/espaces) avant comparaison : une ligne hors API
-            # avec `OKX` ou ` hyperliquid ` doit fail-closer comme `okx`/`hyperliquid`.
-            normalized_exchange = exchange.strip().lower() if isinstance(exchange, str) else exchange
-            if effective_dry_run is False and normalized_exchange in _LIVE_FORBIDDEN_EXCHANGES:
+            # Couche UNIQUE de garde-fous live (SAFE-003) : toute la politique
+            # (bannissements permanents OKX/Hyperliquid, interrupteur d'activation,
+            # allow-list) vit dans `live_guard.assess_live`. Le runner DB-backed
+            # délègue ici exactement comme `assert_set_persistable` à la persistance :
+            # une ligne ORM écrite hors API ne peut jamais déclencher un /api/mtf/run
+            # live que la persistance refuserait. Par défaut (interrupteur OFF), tout
+            # set effectivement live est skippé fail-closed, comme avant SAFE-003.
+            decision = assess_live(
+                exchange=getattr(a_set.exchange, "value", a_set.exchange),
+                market_type=getattr(a_set.market_type, "value", a_set.market_type),
+                environment=getattr(a_set.environment, "value", a_set.environment),
+                dry_run=effective_dry_run,
+                settings=settings,
+            )
+            if not decision.allowed:
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
                     "status": None,
-                    "body": f"live forbidden for exchange '{exchange}': set skipped (fail-closed)",
+                    "body": decision.reason,
                     "payload_sent": None,
                     "duration_ms": None,
                 }
-            # Fail-closed live (phase actuelle) : tant que la readiness live n'est pas
-            # livrée, `assert_set_persistable` (app/schemas.py) interdit la persistance
-            # de TOUT set live (tous exchanges/environnements). Le runner DB-backed
-            # applique la même politique de bout en bout : une ligne ORM effectivement
-            # live — écrite hors API, même avec un snapshot disponible — ne doit jamais
-            # déclencher un /api/mtf/run live. L'override run-level dry_run reste le seul
-            # moyen de rendre un set exécutable (en dry). À relâcher quand la readiness
-            # live (SAFE-001/SAFE-002, TM-001) sera livrée.
-            if effective_dry_run is False:
+            # Prérequis runtime conservé : un set autorisé live mais sans snapshot
+            # d'état ouvert fiable n'est PAS dispatché (on ne trade pas à l'aveugle).
+            # `assess_live` ne peut pas l'évaluer (le snapshot n'existe pas à la
+            # persistance), donc ce garde fail-closed reste ici, après la décision.
+            if effective_dry_run is False and snapshot is None:
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
                     "status": None,
-                    "body": "live execution not yet enabled: live set skipped (fail-closed)",
-                    "payload_sent": None,
-                    "duration_ms": None,
-                }
-            # Fail-closed live : pas de snapshot fiable + set (effectivement) live => on n'exécute pas.
-            if snapshot is None and effective_dry_run is False:
-                return {
-                    "set_id": a_set.set_id,
-                    "ok": False,
-                    "status": None,
-                    "body": "open_state_snapshot unavailable: live set skipped (fail-closed)",
+                    "body": OPEN_STATE_UNAVAILABLE_REASON,
                     "payload_sent": None,
                     "duration_ms": None,
                 }

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -15,6 +15,11 @@ from typing import List, Literal, Optional, Tuple
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
 from app import __version__
+from app.services.live_guard import (
+    PERMANENT_LIVE_FORBIDDEN_EXCHANGES,
+    assess_live,
+    is_permanently_forbidden,
+)
 
 # Nombre maximum de workers Symfony autorisés par set. La cible impose
 # `workers=1` au début ; on relèvera cette borne dans une PR dédiée.
@@ -56,9 +61,14 @@ class Action(str, Enum):
     REPORTING = "reporting"
 
 
-# Exchanges verrouillés en dry-run uniquement tant qu'une PR de readiness live
-# dédiée n'a pas été validée (cf. exchange-schedule-policy.md).
-LIVE_FORBIDDEN_EXCHANGES = frozenset({Exchange.OKX, Exchange.HYPERLIQUID})
+# Exchanges interdits live **en permanence** (OKX/Hyperliquid, cf.
+# exchange-schedule-policy.md). Dérivé de la source **unique**
+# ``live_guard.PERMANENT_LIVE_FORBIDDEN_EXCHANGES`` (SAFE-003) : plus de liste
+# dupliquée entre schemas et runner. Conservé sous forme d'enums pour les usages
+# typés historiques.
+LIVE_FORBIDDEN_EXCHANGES = frozenset(
+    e for e in Exchange if e.value in PERMANENT_LIVE_FORBIDDEN_EXCHANGES
+)
 
 # Statuts de run centralisés (SAFE-002). ``running`` est un statut **non terminal**
 # (claim « en vol » posé au démarrage du run) ; ``no_sets`` n'est jamais persisté.
@@ -80,25 +90,38 @@ RunStatus = Literal["success", "partial_failure", "failed", "no_sets", "running"
 
 
 def assert_live_allowed(exchange: Exchange, dry_run: bool) -> None:
-    """Garde-fou live : interdit ``dry_run=false`` sur OKX/Hyperliquid.
+    """Garde-fou live des ``OrchestratorSet`` en mémoire : OKX/Hyperliquid interdits.
 
-    Utilisé par ``OrchestratorSet`` (sets simulés en mémoire, non persistés). La
-    configuration persistante (PY-002) applique une règle **plus stricte** via
-    ``assert_set_persistable``. Lève ``ValueError`` (mappé en 422 côté API).
+    Utilisé par ``OrchestratorSet`` (sets simulés en mémoire, non persistés). Délègue
+    la connaissance des exchanges bannis à ``live_guard.is_permanently_forbidden``
+    (source **unique** SAFE-003) : seuls les bannissements **permanents** s'appliquent
+    ici. Le verrou d'activation live (interrupteur + allow-list) est appliqué à la
+    persistance (``assert_set_persistable``) et au runtime (runner), pas sur l'objet
+    en mémoire. Lève ``ValueError`` (mappé en 422 côté API).
     """
-    if dry_run is False and exchange in LIVE_FORBIDDEN_EXCHANGES:
+    if dry_run is False and is_permanently_forbidden(exchange):
         raise ValueError(
             f"{exchange.value} live est interdit : dry_run doit rester true."
         )
 
 
-def assert_set_persistable(*, dry_run: bool, symbols: list, contracts_limit: Optional[int]) -> None:
+def assert_set_persistable(
+    *,
+    dry_run: bool,
+    symbols: list,
+    contracts_limit: Optional[int],
+    exchange: object,
+    market_type: object = None,
+    environment: object = None,
+) -> None:
     """Invariants d'un set **persisté** via l'API de configuration (PY-002).
 
-    1. Aucun live persistable tant que la readiness live n'est pas livrée : un
-       set stocké pourra être consommé tel quel par PY-005 sans nouvelle
-       validation humaine, donc on refuse tout ``dry_run=false`` (tous exchanges,
-       tous environnements) à ce stade.
+    1. Cohérence persistance ↔ runtime (SAFE-003) : un set ``dry_run=false`` n'est
+       persistable que si ``live_guard.assess_live`` l'autorise — **exactement** les
+       gardes appliquées par le runner au dispatch. Une ligne stockée ne peut donc
+       jamais déclencher un live que le runner refuserait (et inversement). Par
+       défaut (interrupteur OFF), tout ``dry_run=false`` reste refusé, comme avant
+       SAFE-003.
     2. Pas de set ambigu : il faut une sélection exploitable — soit ``symbols``
        non vide, soit ``contracts_limit`` renseigné — sinon PY-005 devrait
        deviner quoi exécuter.
@@ -106,10 +129,22 @@ def assert_set_persistable(*, dry_run: bool, symbols: list, contracts_limit: Opt
     Lève ``ValueError`` (mappé en 422 côté API).
     """
     if dry_run is False:
-        raise ValueError(
-            "persister un set live (dry_run=false) est interdit tant que la "
-            "readiness live n'est pas livrée : PY-002 ne stocke que des sets dry-run."
+        # Import différé de `get_settings` : la politique live lit l'environnement
+        # courant (interrupteur + allow-list) sans coupler le module au runtime.
+        from app.settings import get_settings
+
+        decision = assess_live(
+            exchange=exchange,
+            market_type=market_type,
+            environment=environment,
+            dry_run=False,
+            settings=get_settings(),
         )
+        if not decision.allowed:
+            raise ValueError(
+                decision.reason
+                or "live non autorisé pour la persistance (fail-closed)."
+            )
     # On normalise les symboles (trim + écarte les vides/blancs) comme le fait
     # `generate_set_payload` au dispatch : une sélection `symbols=[" "]` se réduit à
     # vide côté exécution (Symfony trim/filtre, ce qui vaudrait « tout l'univers »).
@@ -390,7 +425,12 @@ class SetCreate(BaseModel):
     @model_validator(mode="after")
     def _enforce_persistable_invariants(self) -> "SetCreate":
         assert_set_persistable(
-            dry_run=self.dry_run, symbols=self.symbols, contracts_limit=self.contracts_limit
+            dry_run=self.dry_run,
+            symbols=self.symbols,
+            contracts_limit=self.contracts_limit,
+            exchange=self.exchange,
+            market_type=self.market_type,
+            environment=self.environment,
         )
         return self
 

--- a/python-orchestrator/app/services/live_guard.py
+++ b/python-orchestrator/app/services/live_guard.py
@@ -1,0 +1,167 @@
+"""Couche **unique** de garde-fous live de l'orchestrateur (SAFE-003).
+
+Avant SAFE-003, la politique « ce set peut-il s'exécuter en live ? » était
+éparpillée et dupliquée entre ``app/schemas.py`` (persistance) et
+``app/routers/orchestrator.py`` (runner). Ce module centralise toute la décision
+en **un seul point fail-closed** :
+
+- bannissements **permanents** OKX/Hyperliquid (jamais relâchés, même
+  interrupteur activé) ;
+- interrupteur d'activation explicite ``ORCHESTRATION_LIVE_ENABLED`` (défaut
+  OFF) + allow-list ``ORCHESTRATION_LIVE_EXCHANGES`` (défaut vide), portés par
+  ``app/settings.py`` ;
+- prérequis runtime (snapshot d'état ouvert) laissés au runner, mais dont le
+  message canonique est défini ici pour rester stable dans l'historique.
+
+``schemas.assert_set_persistable``, ``schemas.assert_live_allowed`` et le runner
+``_dispatch_set`` **délèguent** ici : il n'existe plus de logique live dupliquée.
+Politique de référence : ``docs/handbook/technical/exchange-schedule-policy.md``.
+
+Invariant fondamental : **fail-closed**. Tout doute ⇒ pas de live. Aucune valeur
+par défaut n'active le live silencieusement (interrupteur OFF + allow-list vide).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - import de typage seul (évite tout cycle)
+    from app.settings import Settings
+
+
+# Exchanges dont le live est **interdit en permanence** (garde jamais relâchée,
+# même interrupteur activé + exchange allow-listé). Stockés en chaînes normalisées
+# (minuscules) : une ligne ORM écrite hors API avec ``OKX`` ou `` hyperliquid ``
+# doit fail-closer comme ``okx``/``hyperliquid``. Source **unique** : ``schemas``
+# en dérive son ``LIVE_FORBIDDEN_EXCHANGES`` (enums) et ``assert_live_allowed`` le
+# consomme via ``is_permanently_forbidden``.
+PERMANENT_LIVE_FORBIDDEN_EXCHANGES = frozenset({"okx", "hyperliquid"})
+
+
+# Codes de décision stables (``LiveDecision.code``) — réutilisés pour l'historique
+# ``RunSet.error`` / ``last_json`` et les assertions de test. Distincts par cause
+# pour une histoire de run exploitable.
+LIVE_OK = "live_ok"  # set live autorisé (interrupteur ON + allow-list + exchange OK)
+DRY_RUN = "dry_run"  # pas une requête live (dry-run) : autorisé trivialement
+LIVE_FORBIDDEN_EXCHANGE = "live_forbidden_exchange"  # OKX/Hyperliquid (permanent)
+LIVE_NOT_ENABLED = "live_not_enabled"  # interrupteur global OFF
+LIVE_EXCHANGE_NOT_ALLOWLISTED = "live_exchange_not_allowlisted"  # hors allow-list
+# Prérequis runtime appliqué côté runner (le snapshot n'existe pas à la
+# persistance) ; le message canonique vit ici pour rester stable.
+OPEN_STATE_UNAVAILABLE = "open_state_unavailable"
+
+# Message canonique du skip runtime « snapshot indisponible » (réutilisé par le
+# runner). Conservé tel quel pour la compatibilité de l'historique.
+OPEN_STATE_UNAVAILABLE_REASON = (
+    "open_state_snapshot unavailable: live set skipped (fail-closed)"
+)
+
+
+@dataclass(frozen=True)
+class LiveDecision:
+    """Décision **unique** « ce set peut-il s'exécuter en live ? ».
+
+    - ``allowed`` : True si l'exécution demandée est permise (dry-run trivialement
+      autorisé ; live autorisé seulement si toute la politique passe) ;
+    - ``reason`` : message stable explicitant un refus (``None`` si autorisé), versé
+      tel quel dans ``RunSet.error`` / ``last_json`` ;
+    - ``code`` : code machine stable de la cause (voir constantes ci-dessus).
+    """
+
+    allowed: bool
+    reason: Optional[str]
+    code: str
+
+
+def _normalize_exchange(exchange: object) -> str:
+    """Normalise un exchange (enum ou chaîne) en minuscules sans espaces.
+
+    Une ligne ORM écrite hors API peut porter une casse/des espaces non
+    normalisés (``OKX``, `` bitmart ``) : on aligne sur la forme canonique pour
+    que les comparaisons de politique soient fail-closed.
+    """
+    raw = getattr(exchange, "value", exchange)
+    return raw.strip().lower() if isinstance(raw, str) else str(raw)
+
+
+def is_permanently_forbidden(exchange: object) -> bool:
+    """Indique si l'exchange est interdit live **en permanence** (OKX/Hyperliquid).
+
+    Source unique consommée par ``schemas.assert_live_allowed`` (OrchestratorSet en
+    mémoire) ET par ``assess_live`` (persistance + runner) : aucune duplication de
+    la liste des exchanges bannis.
+    """
+    return _normalize_exchange(exchange) in PERMANENT_LIVE_FORBIDDEN_EXCHANGES
+
+
+def assess_live(
+    *,
+    exchange: object,
+    market_type: object = None,
+    environment: object = None,
+    dry_run: bool,
+    settings: "Settings",
+) -> LiveDecision:
+    """Décision **unique** et fail-closed d'autorisation live d'un set.
+
+    Hiérarchie des décisions (l'ordre est sécuritaire et ne doit pas changer) :
+
+    1. ``dry_run`` (état EFFECTIF, override run-level déjà appliqué par l'appelant)
+       ⇒ pas de live ⇒ autorisé (``DRY_RUN``).
+    2. Exchange **permanently forbidden** (OKX/Hyperliquid) ⇒ refusé, **même
+       interrupteur ON + exchange allow-listé** (``LIVE_FORBIDDEN_EXCHANGE``).
+       Vérifié AVANT l'interrupteur pour ne jamais être relâché.
+    3. Interrupteur global OFF (``ORCHESTRATION_LIVE_ENABLED=false``, défaut)
+       ⇒ refusé (``LIVE_NOT_ENABLED``) : comportement identique à aujourd'hui.
+    4. Exchange hors allow-list (``ORCHESTRATION_LIVE_EXCHANGES``, défaut vide)
+       ⇒ refusé (``LIVE_EXCHANGE_NOT_ALLOWLISTED``).
+    5. Sinon ⇒ autorisé (``LIVE_OK``).
+
+    Le prérequis runtime « snapshot d'état ouvert présent » N'est PAS évalué ici
+    (le snapshot n'existe pas à la persistance) : le runner l'applique en plus,
+    APRÈS une décision ``allowed=True``, via ``OPEN_STATE_UNAVAILABLE_REASON``.
+
+    ``market_type`` et ``environment`` sont acceptés (signature cible figée) mais
+    non encore branchés dans la politique : l'activation est portée par
+    l'interrupteur + l'allow-list (décision produit SAFE-003). Ils restent
+    disponibles pour un futur gate par environnement sans changer la signature.
+    """
+    # 1. Dry-run : aucune exécution live, autorisé trivialement (l'override
+    #    run-level `{"dry_run": true}` est déjà reflété dans `dry_run` par l'appelant).
+    if dry_run is not False:
+        return LiveDecision(allowed=True, reason=None, code=DRY_RUN)
+
+    raw_exchange = getattr(exchange, "value", exchange)
+    normalized = _normalize_exchange(exchange)
+
+    # 2. Bannissement permanent (OKX/Hyperliquid) : prééminent sur l'interrupteur.
+    #    Jamais relâché, même interrupteur ON + exchange dans l'allow-list.
+    if normalized in PERMANENT_LIVE_FORBIDDEN_EXCHANGES:
+        return LiveDecision(
+            allowed=False,
+            reason=f"live forbidden for exchange '{raw_exchange}': set skipped (fail-closed)",
+            code=LIVE_FORBIDDEN_EXCHANGE,
+        )
+
+    # 3. Interrupteur global : OFF par défaut ⇒ tout set live skippé (fail-closed),
+    #    message conservé/compatibilisé avec la phase pré-SAFE-003.
+    if not settings.live_enabled:
+        return LiveDecision(
+            allowed=False,
+            reason="live execution not yet enabled: live set skipped (fail-closed)",
+            code=LIVE_NOT_ENABLED,
+        )
+
+    # 4. Allow-list : même interrupteur ON, seuls les exchanges explicitement listés
+    #    (au plus `bitmart`, + `fake` en simulation) peuvent passer live.
+    if normalized not in settings.live_exchanges:
+        return LiveDecision(
+            allowed=False,
+            reason=f"live not allow-listed for exchange '{raw_exchange}': set skipped (fail-closed)",
+            code=LIVE_EXCHANGE_NOT_ALLOWLISTED,
+        )
+
+    # 5. Toutes les gardes de politique passent : live autorisé (le runner exige
+    #    encore le snapshot d'état ouvert avant de dispatcher réellement).
+    return LiveDecision(allowed=True, reason=None, code=LIVE_OK)

--- a/python-orchestrator/app/settings.py
+++ b/python-orchestrator/app/settings.py
@@ -41,6 +41,63 @@ def _csv_env(name: str, default: Tuple[str, ...]) -> Tuple[str, ...]:
     return tuple(item.strip() for item in raw.split(",") if item.strip())
 
 
+# Valeurs booléennes acceptées (cassse-insensible) pour les interrupteurs d'env.
+_TRUE_TOKENS = frozenset({"1", "true", "yes", "on"})
+_FALSE_TOKENS = frozenset({"0", "false", "no", "off"})
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    """Lit un booléen depuis l'environnement, ou lève si la valeur est invalide.
+
+    Fail-closed : on n'interprète qu'un jeu fermé de jetons (``true/false``,
+    ``1/0``, ``yes/no``, ``on/off``) ; toute autre valeur lève au démarrage plutôt
+    que d'activer/désactiver silencieusement un interrupteur de sécurité (live).
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    token = raw.strip().lower()
+    if token in _TRUE_TOKENS:
+        return True
+    if token in _FALSE_TOKENS:
+        return False
+    raise SettingsError(
+        f"Variable {name!r} invalide : {raw!r} (attendu true/false, 1/0, yes/no, on/off)."
+    )
+
+
+def _live_exchanges_env(name: str, default: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Allow-list live (CSV), normalisée en minuscules et validée au démarrage.
+
+    Chaque entrée doit être un exchange **connu** (valeur de ``schemas.Exchange``) ;
+    sinon on lève (``SettingsError``) plutôt que d'ignorer silencieusement une
+    coquille qui rendrait l'allow-list inopérante. La normalisation casse/espaces
+    s'aligne sur ``live_guard._normalize_exchange`` (``Bitmart`` ⇒ ``bitmart``).
+    Les bannissements permanents (OKX/Hyperliquid) ne sont PAS rejetés ici : ils
+    restent interdits par ``assess_live`` même listés (défense en profondeur).
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    # Import différé : évite tout couplage d'import au chargement du module settings.
+    from app.schemas import Exchange
+
+    known = {e.value for e in Exchange}
+    cleaned: list[str] = []
+    for item in raw.split(","):
+        token = item.strip().lower()
+        if not token:
+            continue
+        if token not in known:
+            raise SettingsError(
+                f"Variable {name!r} invalide : exchange inconnu {token!r} "
+                f"(connus : {sorted(known)})."
+            )
+        if token not in cleaned:
+            cleaned.append(token)
+    return tuple(cleaned)
+
+
 @dataclass(frozen=True)
 class Settings:
     """Paramètres runtime de l'API Python Orchestrator."""
@@ -66,6 +123,16 @@ class Settings:
     # n'expire jamais avant son dispatch ; passé ce délai, un lock dont le titulaire a
     # été tué avant la libération est reclaimable. Défaut 1800s.
     lock_ttl_seconds: int = 1800
+    # Interrupteur d'activation live (SAFE-003). Par défaut **OFF** : tout set
+    # `dry_run=false` est skippé fail-closed (comportement identique à avant
+    # SAFE-003). Tant qu'il reste OFF, aucun ordre live ne peut partir, quelle que
+    # soit l'allow-list. À ne JAMAIS livrer à True sans readiness runtime.
+    live_enabled: bool = False
+    # Allow-list des exchanges autorisés à passer live QUAND l'interrupteur est ON
+    # (défaut **vide** = aucun). OKX/Hyperliquid restent interdits même listés
+    # (bannissement permanent géré par `live_guard`). En pratique : au plus
+    # `bitmart` (+ `fake` en simulation).
+    live_exchanges: Tuple[str, ...] = ()
     # Origines autorisées par CORS pour les appels navigateur du cockpit (UI-001).
     # Défauts = front servi par CRA (:3000) ou nginx (:8082). Surchargeable via
     # CORS_ALLOW_ORIGINS (CSV) ; ``"*"`` autorise toute origine.
@@ -99,6 +166,8 @@ class Settings:
             database_url=os.getenv("DATABASE_URL", cls.database_url),
             db_schema=os.getenv("ORCHESTRATION_DB_SCHEMA", cls.db_schema),
             lock_ttl_seconds=_int_env("ORCHESTRATION_LOCK_TTL_SECONDS", cls.lock_ttl_seconds),
+            live_enabled=_bool_env("ORCHESTRATION_LIVE_ENABLED", cls.live_enabled),
+            live_exchanges=_live_exchanges_env("ORCHESTRATION_LIVE_EXCHANGES", cls.live_exchanges),
             cors_allow_origins=_csv_env("CORS_ALLOW_ORIGINS", cls.cors_allow_origins),
         )
 

--- a/python-orchestrator/tests/test_live_guard.py
+++ b/python-orchestrator/tests/test_live_guard.py
@@ -1,0 +1,112 @@
+"""Tests de la couche **unique** de garde-fous live (SAFE-003).
+
+``live_guard.assess_live`` est la source de vérité partagée par la persistance
+(``schemas.assert_set_persistable``) et le runner (``_dispatch_set``). On vérifie
+ici la hiérarchie fail-closed des décisions, indépendamment des couches qui la
+consomment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import pytest
+
+from app.services import live_guard
+from app.services.live_guard import (
+    DRY_RUN,
+    LIVE_EXCHANGE_NOT_ALLOWLISTED,
+    LIVE_FORBIDDEN_EXCHANGE,
+    LIVE_NOT_ENABLED,
+    LIVE_OK,
+    assess_live,
+    is_permanently_forbidden,
+)
+
+
+@dataclass(frozen=True)
+class _FakeSettings:
+    """Réplique minimale des attributs lus par ``assess_live``."""
+
+    live_enabled: bool = False
+    live_exchanges: Tuple[str, ...] = ()
+
+
+def _assess(exchange, *, dry_run, enabled=False, allow=()):
+    return assess_live(
+        exchange=exchange,
+        market_type="perpetual",
+        environment="mainnet",
+        dry_run=dry_run,
+        settings=_FakeSettings(live_enabled=enabled, live_exchanges=allow),
+    )
+
+
+# --- Dry-run : toujours autorisé -------------------------------------------
+
+
+def test_dry_run_is_always_allowed_even_for_forbidden_exchange():
+    decision = _assess("okx", dry_run=True)
+    assert decision.allowed is True
+    assert decision.code == DRY_RUN
+    assert decision.reason is None
+
+
+# --- Bannissements permanents (jamais relâchés) -----------------------------
+
+
+@pytest.mark.parametrize("exchange", ["okx", "hyperliquid", "OKX", " Hyperliquid "])
+def test_permanent_forbidden_even_with_switch_on_and_allowlisted(exchange):
+    # OKX/Hyperliquid restent interdits MÊME interrupteur ON + exchange allow-listé,
+    # et quelle que soit la casse/les espaces d'une ligne ORM hors API.
+    decision = _assess(exchange, dry_run=False, enabled=True, allow=("okx", "hyperliquid"))
+    assert decision.allowed is False
+    assert decision.code == LIVE_FORBIDDEN_EXCHANGE
+
+
+def test_is_permanently_forbidden_normalizes_case_and_spaces():
+    assert is_permanently_forbidden(" OKX ") is True
+    assert is_permanently_forbidden("hyperliquid") is True
+    assert is_permanently_forbidden("bitmart") is False
+    assert is_permanently_forbidden("fake") is False
+
+
+# --- Interrupteur OFF (défaut) ----------------------------------------------
+
+
+def test_switch_off_skips_any_live_set():
+    decision = _assess("bitmart", dry_run=False, enabled=False, allow=("bitmart",))
+    assert decision.allowed is False
+    assert decision.code == LIVE_NOT_ENABLED
+
+
+# --- Interrupteur ON --------------------------------------------------------
+
+
+def test_switch_on_but_exchange_not_allowlisted_is_refused():
+    decision = _assess("bitmart", dry_run=False, enabled=True, allow=())
+    assert decision.allowed is False
+    assert decision.code == LIVE_EXCHANGE_NOT_ALLOWLISTED
+
+
+def test_switch_on_and_allowlisted_is_allowed():
+    decision = _assess("bitmart", dry_run=False, enabled=True, allow=("bitmart",))
+    assert decision.allowed is True
+    assert decision.code == LIVE_OK
+    assert decision.reason is None
+
+
+def test_allowlist_match_is_case_insensitive_on_orm_value():
+    # Une ligne ORM hors API peut porter `Bitmart` ; l'allow-list normalisée matche.
+    decision = _assess(" Bitmart ", dry_run=False, enabled=True, allow=("bitmart",))
+    assert decision.allowed is True
+    assert decision.code == LIVE_OK
+
+
+def test_forbidden_takes_precedence_over_allowlist_membership():
+    # Même si OKX était (par erreur) dans l'allow-list, le bannissement permanent
+    # prime : la garde n'est jamais relâchée.
+    decision = _assess("okx", dry_run=False, enabled=True, allow=("okx", "bitmart"))
+    assert decision.code == LIVE_FORBIDDEN_EXCHANGE
+    assert decision.allowed is False

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -528,6 +528,119 @@ def test_live_forbidden_exchange_skipped_with_uppercase_name(orchestrator_env, m
     assert len(mtf_posts) == 0
 
 
+# --------------------------------------------------------------------------
+# SAFE-003 — interrupteur d'activation live (live_guard)
+# --------------------------------------------------------------------------
+
+
+def test_live_bitmart_dispatched_when_switch_on_with_snapshot(orchestrator_env, monkeypatch):
+    # Interrupteur ON + bitmart allow-listé + snapshot présent ⇒ le set live est
+    # réellement dispatché (POST /api/mtf/run avec dry_run=false).
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "bitmart")
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "live", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",))
+    snapshot = {"open_positions": [], "open_orders": []}
+    fake = _FakeAsyncClient(open_state=snapshot)
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is True
+    assert body["summary"] == {"total_calls": 1, "success": 1, "failed": 0}
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+    assert mtf_posts[0]["json"]["dry_run"] is False
+    assert mtf_posts[0]["json"]["open_state_snapshot"] == snapshot
+
+
+def test_live_skipped_when_switch_on_but_snapshot_absent(orchestrator_env, monkeypatch):
+    # Live autorisé (ON + allow-listé) mais snapshot indisponible ⇒ skip fail-closed
+    # `open_state_unavailable` : on ne trade pas à l'aveugle.
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "bitmart")
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "live", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient(open_state_status=503)
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is False
+    assert body["summary"] == {"total_calls": 1, "success": 0, "failed": 1}
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 0
+
+    session.expire_all()
+    run_set = session.scalars(select(RunSet).where(RunSet.set_id == "live")).one()
+    assert "open_state_snapshot unavailable" in run_set.error
+
+
+def test_live_okx_forbidden_even_when_switch_on_and_allowlisted(orchestrator_env, monkeypatch):
+    # Bannissement permanent : OKX live reste skippé même interrupteur ON + listé.
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "okx,bitmart")
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "okx_live", dry_run=False, exchange="okx", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient()  # snapshot dispo
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is False
+    assert body["summary"] == {"total_calls": 1, "success": 0, "failed": 1}
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 0
+    session.expire_all()
+    run_set = session.scalars(select(RunSet).where(RunSet.set_id == "okx_live")).one()
+    assert "live forbidden for exchange" in run_set.error
+
+
+def test_live_skipped_when_exchange_not_allowlisted(orchestrator_env, monkeypatch):
+    # Interrupteur ON mais bitmart hors allow-list ⇒ skip fail-closed.
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "fake")
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "live", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+
+    assert body["ok"] is False
+    assert body["summary"] == {"total_calls": 1, "success": 0, "failed": 1}
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 0
+    session.expire_all()
+    run_set = session.scalars(select(RunSet).where(RunSet.set_id == "live")).one()
+    assert "not allow-listed" in run_set.error
+
+
+def test_run_level_dry_run_override_forces_dry_even_when_switch_on(orchestrator_env, monkeypatch):
+    # Prééminence sécurité : {"dry_run": true} force le dry quel que soit l'état de
+    # l'interrupteur (même ON + allow-listé), et même sans snapshot.
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "bitmart")
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "live", dry_run=False, exchange="bitmart", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient(open_state_status=503)
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "dry_run": True}
+    ).json()
+
+    assert body["ok"] is True
+    mtf_posts = [c for c in fake.post_calls if c["url"].endswith("/api/mtf/run")]
+    assert len(mtf_posts) == 1
+    assert mtf_posts[0]["json"]["dry_run"] is True
+
+
 def test_disabled_dashboard_returns_no_sets(orchestrator_env, monkeypatch):
     # Le flag enabled du dashboard est un interrupteur de pause global : un
     # dashboard désactivé ne lance aucun set, même s'ils sont actifs.

--- a/python-orchestrator/tests/test_schemas.py
+++ b/python-orchestrator/tests/test_schemas.py
@@ -11,6 +11,7 @@ from app.schemas import (
     MtfProfile,
     OrchestratorSet,
     SetRead,
+    assert_set_persistable,
 )
 
 
@@ -32,6 +33,60 @@ def test_okx_dry_run_is_allowed():
 def test_bitmart_live_is_allowed():
     s = OrchestratorSet(set_id="x", exchange="bitmart", dry_run=False)
     assert s.dry_run is False
+
+
+# --- assert_set_persistable ⇆ assess_live (SAFE-003) ------------------------
+#
+# La persistance d'un set live n'est autorisée que si le runner l'exécuterait
+# (mêmes gardes via `live_guard.assess_live`). On vérifie ici la cohérence
+# persistance ↔ runtime en pilotant l'interrupteur d'activation par l'env.
+
+
+def _persist(exchange="bitmart", dry_run=False):
+    assert_set_persistable(
+        dry_run=dry_run,
+        symbols=["BTCUSDT"],
+        contracts_limit=None,
+        exchange=exchange,
+        market_type="perpetual",
+        environment="mainnet",
+    )
+
+
+def test_persist_live_refused_by_default(monkeypatch):
+    # Interrupteur OFF (config livrée) : aucun set live persistable, comme avant SAFE-003.
+    monkeypatch.delenv("ORCHESTRATION_LIVE_ENABLED", raising=False)
+    monkeypatch.delenv("ORCHESTRATION_LIVE_EXCHANGES", raising=False)
+    with pytest.raises(ValueError):
+        _persist(exchange="bitmart", dry_run=False)
+
+
+def test_persist_dry_run_allowed_by_default(monkeypatch):
+    monkeypatch.delenv("ORCHESTRATION_LIVE_ENABLED", raising=False)
+    monkeypatch.delenv("ORCHESTRATION_LIVE_EXCHANGES", raising=False)
+    _persist(exchange="bitmart", dry_run=True)  # ne lève pas
+
+
+def test_persist_live_allowed_when_switch_on_and_allowlisted(monkeypatch):
+    # Interrupteur ON + bitmart allow-listé ⇒ assess_live autorise ⇒ persistance OK.
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "bitmart")
+    _persist(exchange="bitmart", dry_run=False)  # ne lève pas
+
+
+def test_persist_live_okx_refused_even_when_switch_on(monkeypatch):
+    # Bannissement permanent : OKX live refusé même interrupteur ON + allow-listé.
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "okx,bitmart")
+    with pytest.raises(ValueError):
+        _persist(exchange="okx", dry_run=False)
+
+
+def test_persist_live_refused_when_exchange_not_allowlisted(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "true")
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "fake")
+    with pytest.raises(ValueError):
+        _persist(exchange="bitmart", dry_run=False)
 
 
 def test_unknown_exchange_is_rejected():

--- a/python-orchestrator/tests/test_settings.py
+++ b/python-orchestrator/tests/test_settings.py
@@ -61,3 +61,53 @@ def test_port_out_of_range_raises(monkeypatch):
     monkeypatch.setenv("ORCHESTRATOR_PORT", "70000")
     with pytest.raises(SettingsError):
         Settings.from_env()
+
+
+# --- Interrupteur d'activation live (SAFE-003) ------------------------------
+
+
+def test_live_switch_off_by_default(monkeypatch):
+    # La config livrée garde le live désactivé : interrupteur OFF + allow-list vide.
+    monkeypatch.delenv("ORCHESTRATION_LIVE_ENABLED", raising=False)
+    monkeypatch.delenv("ORCHESTRATION_LIVE_EXCHANGES", raising=False)
+    settings = Settings.from_env()
+    assert settings.live_enabled is False
+    assert settings.live_exchanges == ()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_live_enabled_parsing(monkeypatch, raw, expected):
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", raw)
+    assert Settings.from_env().live_enabled is expected
+
+
+def test_live_enabled_invalid_raises(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATION_LIVE_ENABLED", "maybe")
+    with pytest.raises(SettingsError):
+        Settings.from_env()
+
+
+def test_live_exchanges_parsed_normalized_and_deduped(monkeypatch):
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", " Bitmart , bitmart , FAKE ")
+    assert Settings.from_env().live_exchanges == ("bitmart", "fake")
+
+
+def test_live_exchanges_unknown_raises(monkeypatch):
+    # Une coquille (exchange inconnu) doit lever au démarrage plutôt que de rendre
+    # l'allow-list silencieusement inopérante (fail-closed explicite).
+    monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "bitmart,binance")
+    with pytest.raises(SettingsError):
+        Settings.from_env()


### PR DESCRIPTION
## Contexte

Les garde-fous live de l'orchestrateur Python étaient **éparpillés et dupliqués**
entre `app/schemas.py` (persistance) et `app/routers/orchestrator.py` (runner),
sans distinguer les **interdictions permanentes** (OKX/Hyperliquid) des **verrous
transitoires** (« live pas encore activé »), et sans interrupteur d'activation
explicite, audité et fail-closed.

## Objectif

Centraliser et durcir les garde-fous live en **une seule couche fail-closed**,
**sans réactiver le live par défaut**.

## Changements

- **Module unique** `app/services/live_guard.py` : `assess_live(exchange,
  market_type, environment, dry_run, settings) -> LiveDecision`, source de vérité
  partagée. Hiérarchie fail-closed : dry-run autorisé > **bannissement permanent**
  OKX/Hyperliquid (jamais relâché, même interrupteur ON + allow-listé) >
  interrupteur `ORCHESTRATION_LIVE_ENABLED` (défaut OFF) > allow-list
  `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > snapshot d'état ouvert présent
  (côté runner). `reason`/`code` stables par cause (`live_forbidden_exchange`,
  `live_not_enabled`, `live_exchange_not_allowlisted`, `open_state_unavailable`).
- **Délégation** : `assert_set_persistable`, `assert_live_allowed` et le runner
  `_dispatch_set` délèguent au module ; suppression du miroir forbidden dans le
  runner et de la logique live dupliquée.
- **Settings** : `ORCHESTRATION_LIVE_ENABLED` (bool, défaut `false`) et
  `ORCHESTRATION_LIVE_EXCHANGES` (CSV normalisé/validé, défaut vide), avec levée
  explicite au démarrage sur valeur invalide (comme `ORCHESTRATION_LOCK_TTL_SECONDS`).
- **Cohérence persistance ↔ runtime** : un set `dry_run=false` n'est persistable
  que si `assess_live` l'autorise — une ligne stockée ne peut déclencher que ce
  que le runner exécuterait.
- **Doc** : `exchange-schedule-policy.md`, `python-orchestrator.md` (SAFE-003 ✅),
  `README.md` (variables d'env, défaut OFF).

## Hors-scope

- SAFE-001 (locks) et SAFE-002 (idempotence) inchangés au-delà de la coordination.
- Readiness/credentials runtime réels, WebSocket privé, OBS-*/UI-*, contrat
  `RunRequest/RunResponse`, endpoint Symfony `/api/mtf/run`, schedule Temporal.
- Retrait de Bitmart legacy (CLEAN-*), YAML/EntryZone/levier/cadence.

## Vérifications

`cd python-orchestrator && pytest` OK (nouveaux tests inclus) :

- interrupteur OFF (défaut) ⇒ tout set `dry_run=false` skippé, comme avant ;
- OKX/Hyperliquid `dry_run=false` ⇒ refusés **même interrupteur ON + allow-listé** ;
- interrupteur ON + `bitmart` allow-listé + snapshot présent ⇒ live dispatché ;
- interrupteur ON + exchange **hors allow-list** ⇒ refusé ;
- live autorisé mais **snapshot absent** ⇒ skip `open_state_unavailable` ;
- override run-level `{"dry_run": true}` ⇒ force le dry quel que soit l'interrupteur ;
- persistance ↔ runtime cohérents ;
- **interrupteur OFF dans la config livrée** (test dédié) ; OKX/Hyperliquid jamais
  relâchés ; locks SAFE-001 et idempotence SAFE-002 intacts ; pas de migration.

**Aucune réactivation effective du live par défaut** : la PR rend l'activation
*possible, explicite, auditable et testée* — l'interrupteur reste OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCPmTBnSScgf3rRLdhAVe2)_