### PR TITLE
OBS-001: audit structuré des runs d'orchestration (python-orchestrator)

### DIFF
--- a/docs/handbook/technical/exchange-schedule-policy.md
+++ b/docs/handbook/technical/exchange-schedule-policy.md
@@ -110,7 +110,8 @@ Avant d'autoriser une cadence 1m pour un dashboard ou un set, il faut valider :
 - WebSocket privé stable ;
 - idempotence ;
 - lock cross-profile ;
-- audit complet ;
+- audit complet (la piste d'audit structurée minimale est livrée par OBS-001 ;
+  les métriques par set restent à venir, cf. OBS-002) ;
 - dry-run stable ;
 - absence de double soumission ;
 - SL attaché immédiatement ;
@@ -192,7 +193,10 @@ Avant tout nouveau set, vérifier :
 4. le profil est explicitement autorisé ;
 5. la cadence est justifiée ;
 6. les rate limits sont connus ;
-7. l'audit minimal est actif ;
+7. l'audit minimal est actif (**outillé depuis OBS-001** : piste structurée JSON
+   line corrélée par `run_id` sur le logger `orchestrator.audit`, émise au fil du
+   run par `POST /orchestrator/run` — cf. `docs/handbook/technical/python-orchestrator.md`,
+   §*Observabilité / Audit des runs (OBS-001)*) ;
 8. Fake/Paper fallback existe ;
 9. la PR reste atomique ;
 10. les invariants trading ne sont pas cassés.

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -593,6 +593,41 @@ est livrée par **PY-006** (`GET /runs`, `/runs/{run_id}`, `/runs/{run_id}/sets/
 `/dashboards/{id}/runs`, `/dashboards/{id}/runs/latest`). Les migrations s'appliquent via
 `alembic upgrade head` (voir `python-orchestrator/README.md`).
 
+## Observabilité / Audit des runs (OBS-001)
+
+Avant OBS-001, les décisions du runner (`POST /orchestrator/run`) n'étaient
+observables qu'**en base**, après coup (`runs.last_json`, `run_sets`) : aucun
+flux corrélé pour le diagnostic temps réel. OBS-001 ajoute une **couche d'audit
+structurée, fail-safe et corrélée par `run_id`**, émise au fil du cycle, **sans
+changer le comportement métier**.
+
+- **Sink** : logs structurés **JSON line** sur stdout (décision produit OBS-001),
+  via `logging` stdlib sur le logger nommé `orchestrator.audit`
+  (`app/services/run_audit.py` expose `emit(event, *, run_id, level, **fields)` ;
+  `app/logging_config.py` porte le `JsonLineFormatter` et la config idempotente).
+  Aucune migration ; container/aggregator-friendly.
+- **Niveau** : `ORCHESTRATION_LOG_LEVEL` (défaut `INFO`, validé au démarrage comme
+  `ORCHESTRATION_LOCK_TTL_SECONDS` — lève sur valeur invalide).
+- **Corrélation** : chaque ligne porte le `run_id` **réellement persisté** (résolu
+  par `_seed_claim`/`_persist_run`, qui peut différer du dérivé). Le `run_id` est
+  aussi propagé à Symfony en en-tête **`X-Run-Id`** sur `POST /api/mtf/run`.
+- **Événements** : `run_started` (run_id, dashboard_id, has_anchor) ;
+  `run_short_circuit` (`reason` = replay / in_flight / resume / reclaim) ;
+  `snapshot_fetch` (couple exchange/market_type, ok/indisponible) ;
+  `set_skipped` (`code` = live_not_enabled / live_forbidden_exchange /
+  live_exchange_not_allowlisted / open_state_unavailable / locked /
+  conflicting_live) ; `set_dispatched` ; `set_result` (ok, business_status,
+  duration_ms) ; `run_finished` (status, compteurs). **Un seul point d'émission
+  par cause.**
+- **Cohérence** : l'audit **complète** `last_json`/`RunSet` (flux temps réel), il
+  ne le remplace pas. Les `code`/`reason` audités sont **identiques** à ceux
+  versés dans `RunSet.error` (source unique SAFE-003) — l'audit ne redéfinit
+  aucune raison métier.
+- **Fail-safe** : une erreur d'audit (sérialisation, handler) ne fait **jamais**
+  échouer ni ralentir un run (`try/except` interne, pas d'I/O bloquante hors
+  `logging`). Locks SAFE-001, idempotence SAFE-002 et garde-fous live SAFE-003
+  restent intacts ; réponses HTTP inchangées.
+
 ## Garde-fous fonctionnels
 
 Avant tout run :
@@ -624,6 +659,12 @@ Avant tout run :
   (interrupteur OFF dans la config livrée) ; persistance ↔ runtime cohérents (une ligne
   ne peut déclencher que ce que le runner exécuterait). Cf. *Couche unique de garde-fous
   live (SAFE-003)* ;
+- **audit des runs** (OBS-001, livré) : piste structurée JSON line corrélée par
+  `run_id` sur le logger `orchestrator.audit`, émise au fil du cycle (started /
+  short-circuit / snapshot / skip / dispatch / result / finished). Fail-safe (ne
+  casse jamais un run), niveau via `ORCHESTRATION_LOG_LEVEL`, trace-id `X-Run-Id`
+  vers Symfony ; ne change aucun comportement métier. Cf. *Observabilité / Audit
+  des runs (OBS-001)* ;
 - ne lancer aucun set live tant que l'interrupteur n'est pas explicitement activé
   (tout set `dry_run=false` skippé par le runner par défaut, en miroir de
   `assert_set_persistable`) ;
@@ -655,6 +696,7 @@ Avant tout run :
 | SAFE-001 ✅ | Locks d'orchestration par symbole et profil | Livré : table `orchestration_locks` (clé `lock_key` UNIQUE), acquisition tout-ou-rien par set avant dispatch (transaction courte, reclaim des locks expirés, skip fail-closed `locked: …`), libération en fin de set, purge des expirés au démarrage. Prérequis readiness live ; ne réactive pas le live. |
 | SAFE-002 ✅ | Idempotence des runs et des sets | Livré : statut non terminal `running` + claim précoce (`runs.expires_at` = TTL de claim, transaction courte) ; court-circuit selon l'état du run existant — replay (terminal success), reprise des sets non réussis (terminal non-ok), réplique en vol (`running` non périmé), reclaim (`running` périmé). Réutilise `record_run`/savepoints et le calcul de TTL SAFE-001. Migration `0003_run_claim_expires_at`. Ne réactive pas le live. |
 | SAFE-003 ✅ | Centraliser et durcir les garde-fous live | Livré : module unique `app/services/live_guard.py` (`assess_live -> LiveDecision`) consommé par `assert_set_persistable`, `assert_live_allowed` et le runner `_dispatch_set` (plus de logique live dupliquée schemas ↔ runner). Hiérarchie fail-closed : bannissements permanents OKX/Hyperliquid (jamais relâchés) > interrupteur `ORCHESTRATION_LIVE_ENABLED` (défaut OFF) > allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > snapshot d'état ouvert présent. `reason`/`code` stables par cause. Persistance ↔ runtime cohérents. **Le live reste désactivé par défaut** : aucune réactivation effective, seule l'activation devient possible/auditable/testée. Pas de migration. |
+| OBS-001 ✅ | Audit des runs d'orchestration | Livré : couche d'audit structurée, fail-safe et corrélée par `run_id` (`app/services/run_audit.py`, `emit`) sur le logger `orchestrator.audit`, format **JSON line** sur stdout (`app/logging_config.py`), niveau piloté par `ORCHESTRATION_LOG_LEVEL` (défaut INFO, validé au démarrage). Points d'audit : `run_started`, `run_short_circuit` (replay/in_flight/resume/reclaim), `snapshot_fetch`, `set_skipped` (codes live_guard / locked / conflicting_live / open_state_unavailable), `set_dispatched`, `set_result`, `run_finished`. `code`/`reason` identiques à `RunSet.error` (source unique SAFE-003). Trace-id `X-Run-Id` propagé à Symfony. **Aucun changement de comportement** (SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -282,9 +282,50 @@ un service `postgres:15`.
 | `ORCHESTRATION_LOCK_TTL_SECONDS` | `1800` | Marge (s) anti-deadlock des locks d'orchestration par `(profil, symbole)` (SAFE-001), ≥ 1. Le TTL effectif = pire temps de paroi du run (vagues `max_concurrency` × timeout Symfony) + cette marge, pour qu'un set en file n'expire pas avant son dispatch. **Borne aussi le TTL de claim de run** (SAFE-002, même calcul) : pas de variable dédiée. |
 | `ORCHESTRATION_LIVE_ENABLED` | `false` | **Interrupteur d'activation live** (SAFE-003), défaut **OFF**. OFF ⇒ tout set `dry_run=false` est skippé fail-closed (comportement d'avant SAFE-003). Accepte `true/false`, `1/0`, `yes/no`, `on/off` ; toute autre valeur lève au démarrage. **Ne jamais livrer à `true` sans readiness runtime.** |
 | `ORCHESTRATION_LIVE_EXCHANGES` | *(vide)* | Allow-list CSV des exchanges autorisés live **quand l'interrupteur est ON** (SAFE-003). Normalisée en minuscules, dédupliquée ; chaque entrée doit être un exchange connu (sinon lève au démarrage). En pratique au plus `bitmart` (+ `fake` en simulation). OKX/Hyperliquid restent interdits **même listés** (bannissement permanent). |
+| `ORCHESTRATION_LOG_LEVEL` | `INFO` | **Niveau du log d'audit des runs** (OBS-001) sur le logger `orchestrator.audit`. Accepte `DEBUG/INFO/WARNING/ERROR/CRITICAL` (insensible à la casse) ; toute autre valeur lève au démarrage (comme `ORCHESTRATION_LOCK_TTL_SECONDS`). Cf. *Observabilité / Audit (OBS-001)*. |
 
-Une valeur non entière, non booléenne, hors borne ou un exchange inconnu lève une
-erreur explicite au démarrage (pas de repli silencieux sur le défaut).
+Une valeur non entière, non booléenne, hors borne, un niveau de log inconnu ou un
+exchange inconnu lève une erreur explicite au démarrage (pas de repli silencieux
+sur le défaut).
+
+## Observabilité / Audit (OBS-001)
+
+`POST /orchestrator/run` émet, **au fil du cycle**, une **piste d'audit
+structurée, fail-safe et corrélée par `run_id`** sur le logger nommé
+`orchestrator.audit`. Sink **logs JSON line sur stdout** (aucune migration,
+container/aggregator-friendly) ; le niveau est piloté par `ORCHESTRATION_LOG_LEVEL`
+(défaut `INFO`). L'audit **complète** l'historique DB (`runs.last_json` / `run_sets`,
+PY-005/PY-006) — il ne le remplace pas et n'en change pas le contenu ; les
+`code`/`reason` audités sont **identiques** à ceux versés dans `RunSet.error`
+(source unique SAFE-003).
+
+Événements (clé `event`) :
+
+| `event` | Émis quand | Champs notables |
+| --- | --- | --- |
+| `run_started` | entrée du run | `dashboard_id`, `has_anchor` |
+| `run_short_circuit` | court-circuit SAFE-002 | `reason` = `replay` / `in_flight` / `resume` / `reclaim` |
+| `snapshot_fetch` | fetch d'état ouvert 1×/(exchange, market_type) | `exchange`, `market_type`, `ok` (+ `code` si indisponible) |
+| `set_skipped` | set non dispatché (fail-closed) | `set_id`, `code` = `live_not_enabled` / `live_forbidden_exchange` / `live_exchange_not_allowlisted` / `open_state_unavailable` / `locked` / `conflicting_live` |
+| `set_dispatched` | appel Symfony effectif | `set_id`, `dry_run` |
+| `set_result` | issue de l'appel Symfony | `set_id`, `ok`, `business_status`, `duration_ms` |
+| `run_finished` | clôture (y compris `no_sets`) | `status`, `total_calls`, `success`, `failed` |
+
+Exemple de ligne (stdout) :
+
+```json
+{"timestamp": "2026-06-21T08:30:00.123456+00:00", "level": "INFO", "event": "set_result", "run_id": "run_dashA_20260617T083000Z", "set_id": "bitmart_regular_top", "ok": true, "business_status": "success", "duration_ms": 842}
+```
+
+**Corrélation Symfony (trace-id)** : le `run_id` réellement persisté est propagé
+en en-tête HTTP **`X-Run-Id`** sur `POST /api/mtf/run`, pour relier les logs
+Symfony au run d'orchestration.
+
+**Fail-safe** : une erreur d'audit (sérialisation, handler) ne fait jamais
+échouer ni ralentir un run — l'émission est encapsulée dans un `try/except`
+interne et ne fait aucune I/O bloquante hors `logging` stdlib. **Aucun changement
+de comportement métier** : pas de nouvelle décision, locks SAFE-001 / idempotence
+SAFE-002 / garde-fous live SAFE-003 intacts, réponses HTTP inchangées.
 
 ## Persistance (DB-001)
 

--- a/python-orchestrator/alembic/env.py
+++ b/python-orchestrator/alembic/env.py
@@ -21,7 +21,12 @@ from app.settings import get_settings
 config = context.config
 
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    # `disable_existing_loggers=False` : configurer le logging Alembic ne doit PAS
+    # désactiver les autres loggers déjà créés (notamment `orchestrator.audit`,
+    # OBS-001). Le défaut `True` poserait `disabled=True` sur tout logger absent
+    # de `alembic.ini` → l'audit serait silencieusement coupé après un
+    # `alembic upgrade` exécuté dans le même process (ex. smoke test PostgreSQL).
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 settings = get_settings()
 config.set_main_option("sqlalchemy.url", settings.database_url)

--- a/python-orchestrator/app/logging_config.py
+++ b/python-orchestrator/app/logging_config.py
@@ -1,0 +1,88 @@
+"""Configuration centralisée du logging d'audit (OBS-001).
+
+Branche, **au démarrage** (cf. ``app/main.py``), un handler ``stdout`` sur le
+logger ``orchestrator.audit`` avec un formatteur **JSON line déterministe** :
+
+    {"timestamp": "<ISO UTC>", "level": "INFO", "event": "run_started",
+     "run_id": "run_…", <champs métier plats>}
+
+Décisions produit OBS-001 (figées) :
+
+- **sink = logs structurés JSON sur stdout** (aucune migration, container /
+  aggregator-friendly) ;
+- **format = JSON line strict** (une clé ``event`` + champs plats).
+
+Le niveau est piloté par ``ORCHESTRATION_LOG_LEVEL`` (défaut ``INFO``, validé
+au démarrage par ``app/settings.py`` comme ``ORCHESTRATION_LOCK_TTL_SECONDS``).
+
+Idempotent : ``configure_audit_logging`` ne pose qu'**un seul** handler d'audit
+même appelée plusieurs fois (pas de double émission), et coupe la propagation
+vers le root pour ne pas dupliquer la ligne via les handlers uvicorn/applicatifs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+
+from app.services.run_audit import AUDIT_LOGGER_NAME
+
+# Marqueur posé sur notre handler pour garantir l'idempotence (un seul handler
+# d'audit, quel que soit le nombre d'appels à ``configure_audit_logging``).
+_AUDIT_HANDLER_FLAG = "_orchestrator_audit_handler"
+
+
+class JsonLineFormatter(logging.Formatter):
+    """Rend chaque ``LogRecord`` d'audit en **une ligne JSON déterministe**.
+
+    Ordre de clés stable : ``timestamp`` (ISO UTC), ``level``, puis le payload
+    d'audit (``event``, ``run_id``, champs métier) tel que construit par
+    ``run_audit.emit``. ``default=str`` garantit qu'un champ non nativement
+    sérialisable (ex. ``datetime``) ne fait jamais lever le rendu (fail-safe).
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        # `created` est un timestamp epoch ; on le rend en ISO 8601 UTC.
+        timestamp = datetime.fromtimestamp(record.created, timezone.utc).isoformat()
+        payload = {"timestamp": timestamp, "level": record.levelname}
+        audit = getattr(record, "audit", None)
+        if isinstance(audit, dict):
+            # `audit` contient déjà `event` + `run_id` + champs métier aplatis.
+            payload.update(audit)
+        else:
+            # Ligne non-audit éventuelle (ex. trace de garde interne) : on reste
+            # JSON line en repli sur le message brut.
+            payload["event"] = record.name
+            payload["message"] = record.getMessage()
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def configure_audit_logging(level: str = "INFO") -> logging.Logger:
+    """Configure (idempotemment) le logger d'audit ``orchestrator.audit``.
+
+    - pose un unique ``StreamHandler(stdout)`` muni du ``JsonLineFormatter`` ;
+    - règle le niveau sur ``level`` (déjà validé par ``settings``) ;
+    - coupe ``propagate`` (pas de double émission via le root/uvicorn).
+
+    Réappelée (rechargement, tests), elle ne duplique pas le handler.
+    """
+    logger = logging.getLogger(AUDIT_LOGGER_NAME)
+    logger.setLevel(level)
+    # Pas de double émission : la ligne ne remonte pas au root (qui peut porter
+    # ses propres handlers, ex. uvicorn) — notre handler dédié suffit.
+    logger.propagate = False
+
+    for handler in logger.handlers:
+        if getattr(handler, _AUDIT_HANDLER_FLAG, False):
+            # Handler déjà posé : on rafraîchit seulement le niveau effectif.
+            return logger
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonLineFormatter())
+    setattr(handler, _AUDIT_HANDLER_FLAG, True)
+    logger.addHandler(handler)
+    return logger

--- a/python-orchestrator/app/logging_config.py
+++ b/python-orchestrator/app/logging_config.py
@@ -72,6 +72,10 @@ def configure_audit_logging(level: str = "INFO") -> logging.Logger:
     """
     logger = logging.getLogger(AUDIT_LOGGER_NAME)
     logger.setLevel(level)
+    # Un `logging.config.fileConfig(...)` exécuté ailleurs (ex. Alembic) avec son
+    # défaut `disable_existing_loggers=True` désactiverait ce logger : on le
+    # réactive explicitement pour que l'audit reste émis quoi qu'il arrive.
+    logger.disabled = False
     # Pas de double émission : la ligne ne remonte pas au root (qui peut porter
     # ses propres handlers, ex. uvicorn) — notre handler dédié suffit.
     logger.propagate = False

--- a/python-orchestrator/app/main.py
+++ b/python-orchestrator/app/main.py
@@ -10,8 +10,14 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
+from app.logging_config import configure_audit_logging
 from app.routers import dashboards, health, orchestrator, runs
 from app.settings import get_settings
+
+# Audit des runs (OBS-001) : on branche le logger JSON line `orchestrator.audit`
+# au démarrage, au niveau piloté par `ORCHESTRATION_LOG_LEVEL` (défaut INFO,
+# validé par `settings`). Idempotent (un seul handler), pas de double émission.
+configure_audit_logging(get_settings().log_level)
 
 app = FastAPI(
     title="TradingV3 — Python Orchestrator",

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -41,7 +41,12 @@ from app.schemas import (
     RunStatus,
     RunSummary,
 )
-from app.services.live_guard import OPEN_STATE_UNAVAILABLE_REASON, assess_live
+from app.services import run_audit
+from app.services.live_guard import (
+    OPEN_STATE_UNAVAILABLE,
+    OPEN_STATE_UNAVAILABLE_REASON,
+    assess_live,
+)
 from app.services.symfony_client import (
     OpenStateUnavailableError,
     SnapshotKey,
@@ -68,6 +73,11 @@ _MAX_PERSISTED_LEN = 255
 # restreint donc le `run_id` aux caractères sûrs d'un segment de chemin ; tout le
 # reste est haché (cf. `_resolve_run_id`).
 _SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9_.\-]+$")
+
+# Codes de skip d'audit (OBS-001) propres au runner (les refus live portent leur
+# propre `code` via `live_guard.LiveDecision`). Stables, réutilisés tels quels.
+_SKIP_CODE_LOCKED = "locked"  # symbole déjà verrouillé par un run actif (SAFE-001)
+_SKIP_CODE_CONFLICTING_LIVE = "conflicting_live"  # sets live chevauchants intra-batch
 
 
 def _resolve_run_id(request: Optional[RunRequest]) -> str:
@@ -166,7 +176,20 @@ def _no_sets_response(run_id: str) -> RunResponse:
 
     Contrat conservé (cf. ``temporal.md``) : ``ok=false`` n'est pas un succès
     Temporal, donc un tick sans set ne valide pas le schedule.
+
+    OBS-001 : émet un ``run_finished`` corrélé (``status="no_sets"``, compteurs à
+    0) — point d'émission unique partagé par les quatre sorties ``no_sets`` du
+    runner (pas de dashboard, dashboard désactivé, aucun set actif, aucun set
+    ``mtf_run``), sans changer le contrat HTTP.
     """
+    run_audit.emit(
+        run_audit.RUN_FINISHED,
+        run_id=run_id,
+        status="no_sets",
+        total_calls=0,
+        success=0,
+        failed=0,
+    )
     return RunResponse(
         ok=False,
         run_id=run_id,
@@ -587,12 +610,17 @@ async def _collect_snapshots(
     client: httpx.AsyncClient,
     base_url: str,
     mtf_sets: List[Any],
+    *,
+    run_id: str,
 ) -> Dict[SnapshotKey, Dict[str, Any]]:
     """Récupère un snapshot d'état ouvert par couple ``(exchange, market_type)``.
 
     Un seul appel ``GET /api/exchange/open-state`` par couple distinct. Les
     couples dont le fetch échoue restent absents du cache (fail-closed géré par
     l'appelant pour les sets live).
+
+    OBS-001 : chaque couple émet un ``snapshot_fetch`` corrélé (``ok`` /
+    indisponible), pour rendre visible en flux le fetch 1×/(exchange, market_type).
     """
     keys = {snapshot_key(s) for s in mtf_sets}
     snapshots: Dict[SnapshotKey, Dict[str, Any]] = {}
@@ -601,8 +629,24 @@ async def _collect_snapshots(
             snapshots[(exchange, market_type)] = await fetch_open_state(
                 client, base_url, exchange, market_type
             )
+            run_audit.emit(
+                run_audit.SNAPSHOT_FETCH,
+                run_id=run_id,
+                exchange=exchange,
+                market_type=market_type,
+                ok=True,
+            )
         except OpenStateUnavailableError:
             # Pas de snapshot fiable pour ce couple : on ne met rien en cache.
+            run_audit.emit(
+                run_audit.SNAPSHOT_FETCH,
+                run_id=run_id,
+                level="warning",
+                exchange=exchange,
+                market_type=market_type,
+                ok=False,
+                code=OPEN_STATE_UNAVAILABLE,
+            )
             continue
     return snapshots
 
@@ -634,6 +678,17 @@ async def run_orchestrator(
     # gated par la disponibilité des sets (plus bas).
     has_anchor = _has_idempotency_anchor(request)
     idempotency_key = _normalized_idempotency_key(request)
+
+    # OBS-001 : point d'entrée d'audit. `run_id` est celui résolu ici ; un claim
+    # legacy (idempotency_key) pourra le réaligner plus bas — les événements
+    # suivants portent alors le run_id réellement persisté.
+    run_audit.emit(
+        run_audit.RUN_STARTED,
+        run_id=run_id,
+        dashboard_id=_resolve_dashboard_id(request),
+        has_anchor=has_anchor,
+    )
+
     existing_run = (
         repositories.resolve_run(session, run_id, idempotency_key) if has_anchor else None
     )
@@ -641,10 +696,22 @@ async def run_orchestrator(
         if existing_run.status in TERMINAL_RUN_STATUSES and existing_run.ok:
             # Terminal success → REPLAY : summary/run_id reconstruits depuis le run
             # persisté, aucun ré-appel Symfony, indépendant de l'état du dashboard.
+            run_audit.emit(
+                run_audit.RUN_SHORT_CIRCUIT,
+                run_id=existing_run.run_id,
+                level="warning",
+                reason="replay",
+            )
             return _replay_response(existing_run)
         if existing_run.status == RUN_STATUS_RUNNING and not _claim_expired(existing_run, now):
             # `running` non périmé → un autre run est EN VOL : réplique de l'état
             # courant (ok=false + statut running), aucun dispatch.
+            run_audit.emit(
+                run_audit.RUN_SHORT_CIRCUIT,
+                run_id=existing_run.run_id,
+                level="warning",
+                reason="in_flight",
+            )
             return _in_flight_response(existing_run)
 
     # Source des sets : la base, scopée par dashboard. Pas de dashboard / aucun
@@ -746,9 +813,38 @@ async def run_orchestrator(
             # n'a été committé ici (la purge non committée sera annulée à la fermeture de
             # session). `replay` rejoue le succès finalisé par le gagnant ; `in_flight`
             # réplique l'état d'un run encore en vol.
+            run_audit.emit(
+                run_audit.RUN_SHORT_CIRCUIT,
+                run_id=claim_row.run_id,
+                level="warning",
+                reason=yield_reason,
+            )
             if yield_reason == "replay":
                 return _replay_response(claim_row)
             return _in_flight_response(claim_row)
+
+    # OBS-001 : court-circuits SAFE-002 qui RE-EXÉCUTENT (le run_id est désormais
+    # celui réellement persisté par le claim). `resume` : reprise d'un terminal
+    # non-ok, les RunSet déjà réussis sont conservés et non re-dispatchés.
+    # `reclaim` : un `running` périmé (process tué) est repris comme un run neuf.
+    if preserved_results:
+        run_audit.emit(
+            run_audit.RUN_SHORT_CIRCUIT,
+            run_id=run_id,
+            reason="resume",
+            preserved_sets=len(preserved_results),
+        )
+    elif (
+        existing_run is not None
+        and existing_run.status == RUN_STATUS_RUNNING
+        and _claim_expired(existing_run, now)
+    ):
+        run_audit.emit(
+            run_audit.RUN_SHORT_CIRCUIT,
+            run_id=run_id,
+            level="warning",
+            reason="reclaim",
+        )
 
     locked_out: Dict[str, str] = {}
     set_lock_keys: Dict[str, List[str]] = {}
@@ -782,7 +878,9 @@ async def run_orchestrator(
 
     async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
         # 1) Un seul fetch d'état ouvert par couple (exchange, market_type).
-        snapshots = await _collect_snapshots(client, settings.symfony_base_url, mtf_sets)
+        snapshots = await _collect_snapshots(
+            client, settings.symfony_base_url, mtf_sets, run_id=run_id
+        )
 
         # 2) Exécution bornée des sets avec le snapshot en cache.
         semaphore = asyncio.Semaphore(max(1, settings.max_concurrency))
@@ -794,6 +892,13 @@ async def run_orchestrator(
             if a_set.set_id in preserved_results:
                 return preserved_results[a_set.set_id]
             if a_set.set_id in conflicting_live_ids:
+                run_audit.emit(
+                    run_audit.SET_SKIPPED,
+                    run_id=run_id,
+                    level="warning",
+                    set_id=a_set.set_id,
+                    code=_SKIP_CODE_CONFLICTING_LIVE,
+                )
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -806,6 +911,13 @@ async def run_orchestrator(
             # actif est skippé fail-closed (aucun lock acquis pour lui : rien à
             # libérer ici). Les autres sets du run continuent normalement.
             if a_set.set_id in locked_out:
+                run_audit.emit(
+                    run_audit.SET_SKIPPED,
+                    run_id=run_id,
+                    level="warning",
+                    set_id=a_set.set_id,
+                    code=_SKIP_CODE_LOCKED,
+                )
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -847,6 +959,17 @@ async def run_orchestrator(
                 settings=settings,
             )
             if not decision.allowed:
+                # OBS-001 : skip garde-fou live — on relaie le `code` STABLE déjà
+                # calculé par `live_guard` (live_not_enabled / live_forbidden_exchange
+                # / live_exchange_not_allowlisted), source unique partagée avec
+                # `RunSet.error`. L'audit ne redéfinit aucune raison.
+                run_audit.emit(
+                    run_audit.SET_SKIPPED,
+                    run_id=run_id,
+                    level="warning",
+                    set_id=a_set.set_id,
+                    code=decision.code,
+                )
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -860,6 +983,13 @@ async def run_orchestrator(
             # `assess_live` ne peut pas l'évaluer (le snapshot n'existe pas à la
             # persistance), donc ce garde fail-closed reste ici, après la décision.
             if effective_dry_run is False and snapshot is None:
+                run_audit.emit(
+                    run_audit.SET_SKIPPED,
+                    run_id=run_id,
+                    level="warning",
+                    set_id=a_set.set_id,
+                    code=OPEN_STATE_UNAVAILABLE,
+                )
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -869,10 +999,22 @@ async def run_orchestrator(
                     "duration_ms": None,
                 }
             async with semaphore:
+                # OBS-001 : le set franchit toutes les gardes → dispatch effectif.
+                run_audit.emit(
+                    run_audit.SET_DISPATCHED,
+                    run_id=run_id,
+                    set_id=a_set.set_id,
+                    dry_run=effective_dry_run,
+                )
                 start = time.monotonic()
                 try:
                     result = await run_persisted_set(
-                        client, settings.symfony_base_url, a_set, snapshot, effective_dry_run
+                        client,
+                        settings.symfony_base_url,
+                        a_set,
+                        snapshot,
+                        effective_dry_run,
+                        run_id=run_id,
                     )
                 except httpx.HTTPError as exc:  # noqa: BLE001
                     result = {
@@ -884,6 +1026,16 @@ async def run_orchestrator(
                     }
                 # Durée mesurée autour de l'appel Symfony (monotonic, en ms).
                 result["duration_ms"] = int((time.monotonic() - start) * 1000)
+                # OBS-001 : issue du dispatch (ok + statut métier + durée), corrélée.
+                run_audit.emit(
+                    run_audit.SET_RESULT,
+                    run_id=run_id,
+                    level="info" if result.get("ok") else "warning",
+                    set_id=a_set.set_id,
+                    ok=bool(result.get("ok")),
+                    business_status=result.get("business_status"),
+                    duration_ms=result.get("duration_ms"),
+                )
                 return result
 
         results = await asyncio.gather(*(_execute(s) for s in mtf_sets))
@@ -911,6 +1063,18 @@ async def run_orchestrator(
         finished_at=finished_at,
         mtf_sets=mtf_sets,
         results=results,
+    )
+
+    # OBS-001 : clôture du run, corrélée par le run_id RÉELLEMENT persisté (celui
+    # renvoyé par `_persist_run`, qui peut différer du dérivé en cas de retry
+    # legacy par idempotency_key). Compteurs identiques au `summary` HTTP.
+    run_audit.emit(
+        run_audit.RUN_FINISHED,
+        run_id=run_id,
+        status=status,
+        total_calls=summary.total_calls,
+        success=summary.success,
+        failed=summary.failed,
     )
 
     return RunResponse(ok=ok, run_id=run_id, status=status, summary=summary)

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -685,18 +685,6 @@ async def run_orchestrator(
         repositories.resolve_run(session, run_id, idempotency_key) if has_anchor else None
     )
 
-    # OBS-001 : point d'entrée d'audit, corrélé par le run_id RÉELLEMENT persisté.
-    # Un run ancré peut résoudre une ligne legacy (par `idempotency_key`) dont le
-    # `run_id` diffère du dérivé : on émet alors `run_started` sous cet id-là, pour
-    # que TOUS les événements du run (short_circuit / set_* / finished + X-Run-Id)
-    # partagent la même clé de corrélation.
-    run_audit.emit(
-        run_audit.RUN_STARTED,
-        run_id=existing_run.run_id if existing_run is not None else run_id,
-        dashboard_id=_resolve_dashboard_id(request),
-        has_anchor=has_anchor,
-    )
-
     if existing_run is not None:
         if existing_run.status in TERMINAL_RUN_STATUSES and existing_run.ok:
             # Terminal success → REPLAY : summary/run_id reconstruits depuis le run
@@ -827,6 +815,20 @@ async def run_orchestrator(
             if yield_reason == "replay":
                 return _replay_response(claim_row)
             return _in_flight_response(claim_row)
+
+    # OBS-001 : point d'entrée d'audit émis ICI — APRÈS que le claim a résolu le
+    # `run_id` réellement persisté (un run ancré peut le réécrire vers une ligne
+    # legacy résolue par `idempotency_key`, y compris sur la course SAFE-002 ratée
+    # au pré-check). Tous les événements du run (short_circuit resume/reclaim, set_*,
+    # finished) + l'en-tête X-Run-Id partagent donc la même clé de corrélation. Les
+    # sorties précoces (replay/in-flight, no_sets, cession de claim) n'exécutent rien
+    # et émettent leur propre événement terminal — pas de `run_started` orphelin.
+    run_audit.emit(
+        run_audit.RUN_STARTED,
+        run_id=run_id,
+        dashboard_id=dashboard_id,
+        has_anchor=has_anchor,
+    )
 
     # OBS-001 : court-circuits SAFE-002 qui RE-EXÉCUTENT (le run_id est désormais
     # celui réellement persisté par le claim). `resume` : reprise d'un terminal

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -50,6 +50,7 @@ from app.services.live_guard import (
 from app.services.symfony_client import (
     OpenStateUnavailableError,
     SnapshotKey,
+    effective_set_payload,
     fetch_open_state,
     run_persisted_set,
     snapshot_key,
@@ -78,6 +79,7 @@ _SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9_.\-]+$")
 # propre `code` via `live_guard.LiveDecision`). Stables, réutilisés tels quels.
 _SKIP_CODE_LOCKED = "locked"  # symbole déjà verrouillé par un run actif (SAFE-001)
 _SKIP_CODE_CONFLICTING_LIVE = "conflicting_live"  # sets live chevauchants intra-batch
+_SKIP_CODE_NOT_MATERIALIZED = "not_materialized"  # sélection non matérialisée (aucun POST)
 
 
 def _resolve_run_id(request: Optional[RunRequest]) -> str:
@@ -679,19 +681,22 @@ async def run_orchestrator(
     has_anchor = _has_idempotency_anchor(request)
     idempotency_key = _normalized_idempotency_key(request)
 
-    # OBS-001 : point d'entrée d'audit. `run_id` est celui résolu ici ; un claim
-    # legacy (idempotency_key) pourra le réaligner plus bas — les événements
-    # suivants portent alors le run_id réellement persisté.
+    existing_run = (
+        repositories.resolve_run(session, run_id, idempotency_key) if has_anchor else None
+    )
+
+    # OBS-001 : point d'entrée d'audit, corrélé par le run_id RÉELLEMENT persisté.
+    # Un run ancré peut résoudre une ligne legacy (par `idempotency_key`) dont le
+    # `run_id` diffère du dérivé : on émet alors `run_started` sous cet id-là, pour
+    # que TOUS les événements du run (short_circuit / set_* / finished + X-Run-Id)
+    # partagent la même clé de corrélation.
     run_audit.emit(
         run_audit.RUN_STARTED,
-        run_id=run_id,
+        run_id=existing_run.run_id if existing_run is not None else run_id,
         dashboard_id=_resolve_dashboard_id(request),
         has_anchor=has_anchor,
     )
 
-    existing_run = (
-        repositories.resolve_run(session, run_id, idempotency_key) if has_anchor else None
-    )
     if existing_run is not None:
         if existing_run.status in TERMINAL_RUN_STATUSES and existing_run.ok:
             # Terminal success → REPLAY : summary/run_id reconstruits depuis le run
@@ -998,8 +1003,32 @@ async def run_orchestrator(
                     "payload_sent": None,
                     "duration_ms": None,
                 }
+            # OBS-001 : un set dont la sélection n'est PAS matérialisée (symbols vide
+            # alors qu'il est valide par `contracts_limit`) ne déclenche AUCUN
+            # `POST /api/mtf/run` (`run_persisted_set` renvoie `payload_sent=None`).
+            # On ne doit donc pas auditer un `set_dispatched`/trace-id qui n'a pas eu
+            # lieu : c'est un skip fail-closed, audité comme tel. `effective_set_payload`
+            # est la fonction canonique partagée avec `run_persisted_set` (même verdict).
+            if effective_set_payload(a_set) is None:
+                run_audit.emit(
+                    run_audit.SET_SKIPPED,
+                    run_id=run_id,
+                    level="warning",
+                    set_id=a_set.set_id,
+                    code=_SKIP_CODE_NOT_MATERIALIZED,
+                )
+                return {
+                    "set_id": a_set.set_id,
+                    "ok": False,
+                    "status": None,
+                    "business_status": None,
+                    "body": "set payload not materialized (no concrete symbols)",
+                    "payload_sent": None,
+                    "duration_ms": None,
+                }
             async with semaphore:
-                # OBS-001 : le set franchit toutes les gardes → dispatch effectif.
+                # OBS-001 : le set franchit toutes les gardes ET sa sélection est
+                # matérialisée → dispatch Symfony effectif (POST réel + X-Run-Id).
                 run_audit.emit(
                     run_audit.SET_DISPATCHED,
                     run_id=run_id,

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -464,16 +464,25 @@ def _seed_claim(
     idempotency_key: Optional[str],
     now: datetime,
     ttl_seconds: int,
-) -> tuple[str, Run, Optional[str]]:
+) -> tuple[str, Run, Optional[str], Optional[str]]:
     """Pose/reprend le claim « en vol » d'un run (SAFE-002).
 
-    Retourne ``(run_id_persisté, run, yield_reason)``. ``yield_reason`` vaut ``None``
-    quand le claim est obtenu (création ou reprise). Sinon, un run concurrent a changé
-    l'état **entre le pré-check et le seed** (course TOCTOU) et l'appelant doit céder
-    sans dispatcher ni écraser la ligne partagée :
+    Retourne ``(run_id_persisté, run, yield_reason, claim_reason)``. ``yield_reason``
+    vaut ``None`` quand le claim est obtenu (création ou reprise). Sinon, un run
+    concurrent a changé l'état **entre le pré-check et le seed** (course TOCTOU) et
+    l'appelant doit céder sans dispatcher ni écraser la ligne partagée :
 
     - ``"replay"`` : le gagnant a déjà **finalisé en succès** → on rejoue le succès ;
     - ``"in_flight"`` : un run concurrent est **en vol** (claim non périmé) → réplique.
+
+    ``claim_reason`` (OBS-001, observation d'audit pure) qualifie le claim OBTENU
+    (``yield_reason is None``) d'après l'état PRÉ-claim **réellement classé** par
+    ``claim_run`` (la ligne fraîche verrouillée — pas le résultat du pré-check, qui
+    peut rater la ligne dans une course SAFE-002) :
+
+    - ``"reclaim"`` : reprise d'un ``running`` périmé (TTL dépassé, process tué) ;
+    - ``"resume"`` : reprise d'un terminal non-ok ;
+    - ``None`` : création d'une ligne neuve (aucune existante) ou cession (yield).
 
     Transaction courte (committée par l'appelant AVANT les appels Symfony, jamais
     maintenue pendant les ~900s, comme les locks SAFE-001) : pose la ligne ``Run``
@@ -492,6 +501,14 @@ def _seed_claim(
         dashboard_id if repositories.get_dashboard(session, dashboard_id) is not None else None
     )
 
+    # OBS-001 : capture la cause du claim OBTENU depuis l'état PRÉ-claim que
+    # `claim_run` classe réellement (la ligne fraîche verrouillée passée à
+    # `_classify`). C'est la seule source fiable : le pré-check `existing_run` peut
+    # rater la ligne dans une course SAFE-002, et `preserved_results` est vide pour
+    # une reprise « full-failure » (aucun RunSet réussi). `_classify` n'est invoqué
+    # que si une ligne existe ; un INSERT neuf laisse donc `claim_reason` à None.
+    observed: Dict[str, Optional[str]] = {"reason": None}
+
     def _classify(existing: Run) -> Optional[str]:
         # Mêmes court-circuits que le pré-check, mais ré-évalués sur l'état FRAIS et
         # VERROUILLÉ (le gagnant d'une course a pu, depuis, finaliser ou rester en vol).
@@ -499,6 +516,11 @@ def _seed_claim(
             return "replay"  # succès finalisé → rejouer (ne PAS écraser/ré-exécuter)
         if existing.status == RUN_STATUS_RUNNING and not _claim_expired(existing, now):
             return "in_flight"  # un autre run est en vol → répliquer
+        # Claim repris : on note la cause (audit) avant de céder la reprise au claim.
+        if existing.status == RUN_STATUS_RUNNING:
+            observed["reason"] = "reclaim"  # `running` périmé (TTL dépassé)
+        elif existing.status in TERMINAL_RUN_STATUSES:
+            observed["reason"] = "resume"  # terminal non-ok
         return None  # terminal non-ok / claim périmé → reprise/reclaim
 
     persisted, yield_reason = repositories.claim_run(
@@ -517,7 +539,10 @@ def _seed_claim(
         ),
         classify=_classify,
     )
-    return persisted.run_id, persisted, yield_reason
+    # Une cession (yield_reason non None) n'est pas une reprise : on n'expose alors
+    # aucune `claim_reason` (l'appelant émettra le short-circuit replay/in_flight).
+    claim_reason = observed["reason"] if yield_reason is None else None
+    return persisted.run_id, persisted, yield_reason, claim_reason
 
 
 def _symbols_overlap(a: Any, b: Any) -> bool:
@@ -769,16 +794,11 @@ async def run_orchestrator(
             existing_run, list(repositories.list_run_sets(session, existing_run.run_id))
         )
 
-    # OBS-001 : capture l'état « claim périmé » AVANT le claim. `_seed_claim` met à
-    # jour la MÊME instance ORM `existing_run` (reclaim → nouveau `expires_at` futur) :
-    # évalué après, `_claim_expired(existing_run, now)` serait toujours faux et le
-    # `run_short_circuit` reason="reclaim" ne serait jamais émis pour une reprise de
-    # claim périmé. On fige donc le verdict ici, sur l'état pré-claim.
-    reclaim_detected = (
-        existing_run is not None
-        and existing_run.status == RUN_STATUS_RUNNING
-        and _claim_expired(existing_run, now)
-    )
+    # OBS-001 : la cause d'un éventuel court-circuit SAFE-002 « reprise » (resume /
+    # reclaim) est déterminée par le claim lui-même (`_seed_claim` → `claim_reason`),
+    # depuis l'état PRÉ-claim réellement classé — fiable même quand le pré-check
+    # `existing_run` rate la ligne (course) ou quand aucun RunSet n'a été conservé.
+    claim_reason: Optional[str] = None
 
     # SAFE-001 : sérialisation per-(profil, symbole) ENTRE runs/process via des locks
     # DB. Le garde intra-run (`conflicting_live_ids`) ne couvre qu'un seul batch ; deux
@@ -801,7 +821,7 @@ async def run_orchestrator(
     # distinct (legacy par idempotency_key) : on réutilise le run_id réellement persisté
     # pour les locks ET la finalisation (claim et finalisation portent le même run_id).
     if has_anchor:
-        run_id, claim_row, yield_reason = _seed_claim(
+        run_id, claim_row, yield_reason, claim_reason = _seed_claim(
             session,
             run_id=run_id,
             dashboard_id=dashboard_id,
@@ -841,18 +861,20 @@ async def run_orchestrator(
         has_anchor=has_anchor,
     )
 
-    # OBS-001 : court-circuits SAFE-002 qui RE-EXÉCUTENT (le run_id est désormais
-    # celui réellement persisté par le claim). `resume` : reprise d'un terminal
-    # non-ok, les RunSet déjà réussis sont conservés et non re-dispatchés.
-    # `reclaim` : un `running` périmé (process tué) est repris comme un run neuf.
-    if preserved_results:
+    # OBS-001 : court-circuits SAFE-002 qui RE-EXÉCUTENT, fondés sur la cause réelle
+    # du claim (`claim_reason`), pas sur le pré-check ni sur `preserved_results` :
+    #  - `resume` : reprise d'un terminal non-ok — émis MÊME si aucun RunSet n'a été
+    #    conservé (reprise « full-failure » → `preserved_sets=0`) ;
+    #  - `reclaim` : reprise d'un `running` périmé (process tué), y compris quand le
+    #    pré-check a raté la ligne et que seul le claim l'a résolue (course SAFE-002).
+    if claim_reason == "resume":
         run_audit.emit(
             run_audit.RUN_SHORT_CIRCUIT,
             run_id=run_id,
             reason="resume",
             preserved_sets=len(preserved_results),
         )
-    elif reclaim_detected:
+    elif claim_reason == "reclaim":
         run_audit.emit(
             run_audit.RUN_SHORT_CIRCUIT,
             run_id=run_id,

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -769,6 +769,17 @@ async def run_orchestrator(
             existing_run, list(repositories.list_run_sets(session, existing_run.run_id))
         )
 
+    # OBS-001 : capture l'état « claim périmé » AVANT le claim. `_seed_claim` met à
+    # jour la MÊME instance ORM `existing_run` (reclaim → nouveau `expires_at` futur) :
+    # évalué après, `_claim_expired(existing_run, now)` serait toujours faux et le
+    # `run_short_circuit` reason="reclaim" ne serait jamais émis pour une reprise de
+    # claim périmé. On fige donc le verdict ici, sur l'état pré-claim.
+    reclaim_detected = (
+        existing_run is not None
+        and existing_run.status == RUN_STATUS_RUNNING
+        and _claim_expired(existing_run, now)
+    )
+
     # SAFE-001 : sérialisation per-(profil, symbole) ENTRE runs/process via des locks
     # DB. Le garde intra-run (`conflicting_live_ids`) ne couvre qu'un seul batch ; deux
     # runs concurrents (overlap du cron Temporal, ou front + cron) ne se voient pas
@@ -841,11 +852,7 @@ async def run_orchestrator(
             reason="resume",
             preserved_sets=len(preserved_results),
         )
-    elif (
-        existing_run is not None
-        and existing_run.status == RUN_STATUS_RUNNING
-        and _claim_expired(existing_run, now)
-    ):
+    elif reclaim_detected:
         run_audit.emit(
             run_audit.RUN_SHORT_CIRCUIT,
             run_id=run_id,

--- a/python-orchestrator/app/services/run_audit.py
+++ b/python-orchestrator/app/services/run_audit.py
@@ -1,0 +1,97 @@
+"""Audit structuré, fail-safe et corrélé des runs d'orchestration (OBS-001).
+
+Avant OBS-001, les décisions du runner (`POST /orchestrator/run`) — skips
+fail-closed, court-circuits d'idempotence (SAFE-002), pose/skip des locks
+(SAFE-001), garde-fous live (SAFE-003), échecs Symfony — n'étaient observables
+qu'**en base**, après coup (`runs.last_json`, `run_sets`). Aucun flux d'audit
+corrélé par `run_id` n'existait pour le diagnostic temps réel (logs conteneur /
+agrégation).
+
+Ce module expose un **point d'émission unique** :
+
+    emit(event, *, run_id, level="info", **fields)
+
+qui sérialise un événement structuré (une clé `event` + champs plats) sur le
+logger nommé ``orchestrator.audit``. Le rendu JSON line déterministe est porté
+par le formatteur (cf. ``app/logging_config.py``), branché au démarrage.
+
+Invariant fondamental : **fail-safe**. Une erreur d'audit (sérialisation,
+handler, logger mal configuré) ne doit JAMAIS faire échouer ni interrompre un
+run. Tout est encapsulé dans un ``try/except`` interne : ``emit`` ne lève jamais
+et ne fait aucune I/O bloquante hors ``logging`` stdlib.
+
+L'audit **complète** l'historique (`last_json`/`RunSet`) — il ne le remplace pas
+et n'en change pas le contenu. Les `reason`/`code` audités sont **identiques** à
+ceux versés dans `RunSet.error` (source unique SAFE-003 / runner) : ce module
+ne redéfinit aucune raison métier, il relaie celles déjà calculées.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+# Logger d'audit dédié. Nommé (pas le root) pour pouvoir le configurer/filtrer
+# indépendamment des logs applicatifs et éviter toute double émission.
+AUDIT_LOGGER_NAME = "orchestrator.audit"
+
+# Événements d'audit (noms stables, machine-readable). Un seul point d'émission
+# par cause — pas de duplication de schéma entre le runner et l'audit.
+RUN_STARTED = "run_started"
+RUN_SHORT_CIRCUIT = "run_short_circuit"
+SNAPSHOT_FETCH = "snapshot_fetch"
+SET_SKIPPED = "set_skipped"
+SET_DISPATCHED = "set_dispatched"
+SET_RESULT = "set_result"
+RUN_FINISHED = "run_finished"
+
+# Niveaux acceptés par ``emit`` (mappés sur ``logging``). Une valeur inconnue
+# retombe sur INFO (fail-safe : on n'échoue pas l'audit pour un niveau douteux).
+_LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+_logger = logging.getLogger(AUDIT_LOGGER_NAME)
+
+
+def emit(event: str, *, run_id: Any, level: str = "info", **fields: Any) -> None:
+    """Émet une ligne d'audit structurée corrélée par ``run_id`` (fail-safe).
+
+    - ``event`` : nom stable de l'événement (cf. constantes ci-dessus) ;
+    - ``run_id`` : clé de corrélation — le ``run_id`` **réellement persisté**
+      (résolu par ``_seed_claim``/``_persist_run``), passé par l'appelant ;
+    - ``level`` : niveau de log (``info`` par défaut ; ``warning`` pour les
+      skips/court-circuits) ;
+    - ``**fields`` : champs métier plats (ex. ``dashboard_id``, ``set_id``,
+      ``code``, ``duration_ms``), sérialisés tels quels.
+
+    Ne lève **jamais** : toute exception (champ non sérialisable au moment du
+    rendu, handler en échec, etc.) est absorbée. L'audit est un effet de bord
+    d'observabilité, jamais un chemin critique du run.
+    """
+    try:
+        levelno = _LEVELS.get(str(level).lower(), logging.INFO)
+        # Payload structuré : `event` + `run_id` + champs métier aplatis. Porté
+        # tel quel par le formatteur JSON line. On garde les champs métier DANS
+        # ce dict (et non dans `extra`) pour ne jamais entrer en collision avec
+        # un attribut réservé de ``LogRecord``.
+        payload = {"event": event, "run_id": run_id}
+        payload.update(fields)
+        # `event`/`run_id` sont aussi exposés comme attributs du record pour un
+        # accès direct en test (caplog) sans parser le JSON. Aucun n'est réservé.
+        _logger.log(
+            levelno,
+            event,
+            extra={"audit": payload, "event": event, "run_id": run_id},
+        )
+    except Exception:  # noqa: BLE001 - fail-safe : l'audit ne casse jamais un run.
+        # Dernier recours : on tente une trace minimale, elle-même protégée. On
+        # n'utilise pas `raise` : un run ne doit pas échouer à cause de l'audit.
+        try:  # pragma: no cover - chemin de garde extrême
+            _logger.exception("audit emit failed for event %r", event)
+        except Exception:  # pragma: no cover
+            pass

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -379,14 +379,24 @@ async def _dispatch_mtf_run(
     base_url: str,
     set_id: str,
     payload: Dict[str, Any],
+    *,
+    run_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """POST ``/api/mtf/run`` et normalise le résultat (succès métier + corps brut).
 
     Source unique de l'envoi : partagée entre ``run_mtf_set`` (set pydantic) et
     ``run_persisted_set`` (set ORM persisté) pour éviter toute dérive.
+
+    OBS-001 : quand un ``run_id`` est fourni, il est propagé en **en-tête de
+    corrélation** ``X-Run-Id`` sur l'appel Symfony (trace-id), pour relier les
+    logs Symfony au run d'orchestration. L'en-tête n'est ajouté que s'il est
+    présent (aucun changement de payload, contrat ``/api/mtf/run`` inchangé).
     """
     url = f"{base_url.rstrip('/')}/api/mtf/run"
-    response = await client.post(url, json=payload)
+    if run_id is not None:
+        response = await client.post(url, json=payload, headers={"X-Run-Id": run_id})
+    else:
+        response = await client.post(url, json=payload)
     try:
         body = response.json()
     except ValueError:
@@ -420,6 +430,8 @@ async def run_persisted_set(
     orm_set: Any,
     snapshot: Optional[Dict[str, Any]],
     dry_run: Optional[bool] = None,
+    *,
+    run_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Exécute un ``OrchestrationSet`` ORM persisté via ``POST /api/mtf/run`` (PY-005).
 
@@ -464,6 +476,6 @@ async def run_persisted_set(
         payload["dry_run"] = dry_run
     if snapshot is not None:
         payload["open_state_snapshot"] = snapshot
-    result = await _dispatch_mtf_run(client, base_url, orm_set.set_id, payload)
+    result = await _dispatch_mtf_run(client, base_url, orm_set.set_id, payload, run_id=run_id)
     result["payload_sent"] = payload
     return result

--- a/python-orchestrator/app/settings.py
+++ b/python-orchestrator/app/settings.py
@@ -45,6 +45,30 @@ def _csv_env(name: str, default: Tuple[str, ...]) -> Tuple[str, ...]:
 _TRUE_TOKENS = frozenset({"1", "true", "yes", "on"})
 _FALSE_TOKENS = frozenset({"0", "false", "no", "off"})
 
+# Niveaux de log d'audit acceptés (OBS-001), normalisés en MAJUSCULES — alignés
+# sur les noms standard de ``logging``.
+_VALID_LOG_LEVELS = frozenset({"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"})
+
+
+def _log_level_env(name: str, default: str) -> str:
+    """Lit un niveau de log depuis l'environnement, ou lève si invalide (OBS-001).
+
+    Normalisé en MAJUSCULES ; validé contre le jeu fermé des niveaux ``logging``
+    standard. Une valeur inconnue lève au démarrage (comme
+    ``ORCHESTRATION_LOCK_TTL_SECONDS``) plutôt que de retomber silencieusement
+    sur le défaut — pas de configuration d'observabilité ambiguë.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+    token = raw.strip().upper()
+    if token not in _VALID_LOG_LEVELS:
+        raise SettingsError(
+            f"Variable {name!r} invalide : {raw!r} "
+            f"(attendu {sorted(_VALID_LOG_LEVELS)})."
+        )
+    return token
+
 
 def _bool_env(name: str, default: bool) -> bool:
     """Lit un booléen depuis l'environnement, ou lève si la valeur est invalide.
@@ -133,6 +157,10 @@ class Settings:
     # (bannissement permanent géré par `live_guard`). En pratique : au plus
     # `bitmart` (+ `fake` en simulation).
     live_exchanges: Tuple[str, ...] = ()
+    # Niveau de log de l'audit des runs (OBS-001), piloté par
+    # ``ORCHESTRATION_LOG_LEVEL`` (défaut INFO). Validé au démarrage : une valeur
+    # inconnue lève (pas de repli silencieux). Cf. ``app/logging_config.py``.
+    log_level: str = "INFO"
     # Origines autorisées par CORS pour les appels navigateur du cockpit (UI-001).
     # Défauts = front servi par CRA (:3000) ou nginx (:8082). Surchargeable via
     # CORS_ALLOW_ORIGINS (CSV) ; ``"*"`` autorise toute origine.
@@ -156,6 +184,11 @@ class Settings:
             raise SettingsError(
                 f"ORCHESTRATION_LOCK_TTL_SECONDS doit être >= 1 (reçu {self.lock_ttl_seconds})."
             )
+        if self.log_level not in _VALID_LOG_LEVELS:
+            raise SettingsError(
+                f"ORCHESTRATION_LOG_LEVEL invalide : {self.log_level!r} "
+                f"(attendu {sorted(_VALID_LOG_LEVELS)})."
+            )
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -168,6 +201,7 @@ class Settings:
             lock_ttl_seconds=_int_env("ORCHESTRATION_LOCK_TTL_SECONDS", cls.lock_ttl_seconds),
             live_enabled=_bool_env("ORCHESTRATION_LIVE_ENABLED", cls.live_enabled),
             live_exchanges=_live_exchanges_env("ORCHESTRATION_LIVE_EXCHANGES", cls.live_exchanges),
+            log_level=_log_level_env("ORCHESTRATION_LOG_LEVEL", cls.log_level),
             cors_allow_origins=_csv_env("CORS_ALLOW_ORIGINS", cls.cors_allow_origins),
         )
 

--- a/python-orchestrator/tests/conftest.py
+++ b/python-orchestrator/tests/conftest.py
@@ -60,13 +60,18 @@ def audit_records():
     handler = _Recorder()
     handler.setLevel(logging.DEBUG)
     previous_level = logger.level
+    previous_disabled = logger.disabled
     logger.setLevel(logging.DEBUG)
+    # Un `fileConfig` exécuté par un test antérieur (ex. Alembic dans le smoke
+    # PostgreSQL) a pu désactiver ce logger : on le réactive pour capturer.
+    logger.disabled = False
     logger.addHandler(handler)
     try:
         yield records
     finally:
         logger.removeHandler(handler)
         logger.setLevel(previous_level)
+        logger.disabled = previous_disabled
 
 
 @pytest.fixture()

--- a/python-orchestrator/tests/conftest.py
+++ b/python-orchestrator/tests/conftest.py
@@ -38,6 +38,38 @@ def _attach_schema_and_fks(engine) -> None:
 
 
 @pytest.fixture()
+def audit_records():
+    """Capture les ``LogRecord`` d'audit ``orchestrator.audit`` (OBS-001).
+
+    Attache un handler de test **directement** au logger d'audit (sa propagation
+    est coupée en prod pour éviter la double émission, donc ``caplog`` — branché
+    sur le root — ne le verrait pas). Les tests lisent ``record.event`` /
+    ``record.run_id`` / ``record.audit`` plutôt que le format brut.
+    """
+    import logging
+
+    from app.services.run_audit import AUDIT_LOGGER_NAME
+
+    logger = logging.getLogger(AUDIT_LOGGER_NAME)
+    records: list = []
+
+    class _Recorder(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Recorder()
+    handler.setLevel(logging.DEBUG)
+    previous_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+
+@pytest.fixture()
 def db_session():
     """Session SQLite in-memory avec le schéma orchestration attaché."""
     from app.db.base import Base

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -2034,3 +2034,37 @@ def test_audit_run_started_after_claim_on_idempotency_race(
     run_ids = {r.run_id for r in audit_records}
     assert run_ids == {"run_legacy_race"}
     assert "run_krace" not in run_ids
+
+
+def test_audit_reclaim_emits_short_circuit(orchestrator_env, monkeypatch, audit_records):
+    # Un `running` périmé (TTL dépassé) repris doit émettre run_short_circuit
+    # reason="reclaim". Régression : le verdict d'expiration est figé AVANT le claim,
+    # car `_seed_claim` rafraîchit `expires_at` sur la même instance ORM.
+    from datetime import datetime, timedelta, timezone
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    now = datetime.now(timezone.utc)
+    session.add(
+        Run(
+            run_id="run_reclaim_obs", idempotency_key="reclobs", ok=False, status="running",
+            total_calls=0, success_count=0, failed_count=0,
+            started_at=now - timedelta(hours=2), expires_at=now - timedelta(seconds=1),
+        )
+    )
+    session.commit()
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "reclobs"},
+    ).json()
+
+    assert body["run_id"] == "run_reclaim_obs"
+    short = _by_event(audit_records, "run_short_circuit")
+    assert [s.audit["reason"] for s in short] == ["reclaim"]
+    assert short[0].run_id == "run_reclaim_obs"
+    # La reprise ré-exécute : run_started + dispatch + finished également présents.
+    assert _by_event(audit_records, "run_started")
+    assert _by_event(audit_records, "run_finished")

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1996,3 +1996,41 @@ def test_audit_not_materialized_set_emits_skip_without_dispatch(
     # Ni dispatch audité, ni POST réel.
     assert _by_event(audit_records, "set_dispatched") == []
     assert _mtf_posts(fake) == []
+
+
+def test_audit_run_started_after_claim_on_idempotency_race(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # Course SAFE-002 : le pré-check (resolve_run) RATE la ligne, mais le claim la
+    # résout par idempotency_key sous un run_id legacy distinct du dérivé. run_started
+    # étant émis APRÈS le claim, il porte le run_id persisté — pas d'orphelin sous le
+    # dérivé.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    session.add(Run(run_id="run_legacy_race", idempotency_key="krace", ok=False, status="failed"))
+    session.commit()
+
+    real_resolve = orch.repositories.resolve_run
+    calls = {"n": 0}
+
+    def _racing_resolve(session_, run_id_, key=None):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else real_resolve(session_, run_id_, key)
+
+    monkeypatch.setattr(orch.repositories, "resolve_run", _racing_resolve)
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "krace"},
+    ).json()
+
+    assert body["run_id"] == "run_legacy_race"
+    started = _by_event(audit_records, "run_started")
+    assert len(started) == 1
+    assert started[0].run_id == "run_legacy_race"
+    # Toute la piste est corrélée par le run_id persisté ; jamais sous le dérivé.
+    run_ids = {r.run_id for r in audit_records}
+    assert run_ids == {"run_legacy_race"}
+    assert "run_krace" not in run_ids

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -158,8 +158,15 @@ class _FakeAsyncClient:
         self.get_calls.append({"url": url, "params": params or {}})
         return _FakeResponse(self._open_state_status, self._open_state)
 
-    async def post(self, url: str, json: Dict[str, Any] | None = None) -> _FakeResponse:
-        self.post_calls.append({"url": url, "json": json or {}})
+    async def post(
+        self,
+        url: str,
+        json: Dict[str, Any] | None = None,
+        headers: Dict[str, Any] | None = None,
+    ) -> _FakeResponse:
+        # OBS-001 : on enregistre aussi les en-têtes pour vérifier la propagation
+        # du trace-id `X-Run-Id` sur `POST /api/mtf/run`.
+        self.post_calls.append({"url": url, "json": json or {}, "headers": headers or {}})
         return _FakeResponse(self._mtf_status, self._mtf_body)
 
 
@@ -1269,7 +1276,7 @@ def test_queued_lock_ttl_covers_worst_case_run(orchestrator_env, monkeypatch):
     captured: Dict[str, Any] = {}
 
     class _CapturingClient(_FakeAsyncClient):
-        async def post(self, url, json=None):
+        async def post(self, url, json=None, headers=None):
             symbols = (json or {}).get("symbols") or []
             if symbols:
                 row = session.scalars(
@@ -1277,7 +1284,7 @@ def test_queued_lock_ttl_covers_worst_case_run(orchestrator_env, monkeypatch):
                 ).first()
                 if row is not None:
                     captured[symbols[0]] = row.expires_at
-            return await super().post(url, json=json)
+            return await super().post(url, json=json, headers=headers)
 
     _install_fake_client(monkeypatch, _CapturingClient())
 
@@ -1344,8 +1351,13 @@ class _PerSymbolClient(_FakeAsyncClient):
         super().__init__(**kw)
         self.fail_symbols = set(fail_symbols)
 
-    async def post(self, url: str, json: Dict[str, Any] | None = None) -> _FakeResponse:
-        self.post_calls.append({"url": url, "json": json or {}})
+    async def post(
+        self,
+        url: str,
+        json: Dict[str, Any] | None = None,
+        headers: Dict[str, Any] | None = None,
+    ) -> _FakeResponse:
+        self.post_calls.append({"url": url, "json": json or {}, "headers": headers or {}})
         symbols = (json or {}).get("symbols") or []
         if url.endswith("/api/mtf/run") and symbols and symbols[0] in self.fail_symbols:
             return _FakeResponse(200, {"status": "partial_success", "data": {"errors": ["boom"]}})
@@ -1562,12 +1574,12 @@ def test_claim_writes_running_row_with_ttl_during_dispatch(orchestrator_env, mon
     captured: Dict[str, Any] = {}
 
     class _CapturingClient(_FakeAsyncClient):
-        async def post(self, url, json=None):
+        async def post(self, url, json=None, headers=None):
             row = session.scalars(select(Run).where(Run.run_id == "run_rk6")).first()
             if row is not None:
                 captured["status"] = row.status
                 captured["expires_at"] = row.expires_at
-            return await super().post(url, json=json)
+            return await super().post(url, json=json, headers=headers)
 
     _install_fake_client(monkeypatch, _CapturingClient())
 
@@ -1733,3 +1745,204 @@ def test_concurrent_claim_loser_replays_when_winner_finalized_success(orchestrat
     # La ligne de succès du gagnant est intacte (non écrasée vers running).
     session.expire_all()
     assert session.get(Run, "run_rk10").status == "success"
+
+
+# --------------------------------------------------------------------------
+# Audit des runs (OBS-001)
+# --------------------------------------------------------------------------
+
+
+def _events(records) -> List[str]:
+    """Liste ordonnée des noms d'événements d'audit capturés."""
+    return [r.event for r in records]
+
+
+def _by_event(records, event: str) -> List[Any]:
+    """Records d'audit d'un événement donné."""
+    return [r for r in records if r.event == event]
+
+
+def test_audit_nominal_run_emits_started_then_finished_correlated(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # Un run nominal émet run_started … run_finished, tous corrélés par le MÊME
+    # run_id (celui réellement persisté/renvoyé).
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "obs_nominal"},
+    ).json()
+    run_id = body["run_id"]
+
+    events = _events(audit_records)
+    assert events[0] == "run_started"
+    assert events[-1] == "run_finished"
+    # Tout est corrélé par le run_id persisté/renvoyé.
+    assert {r.run_id for r in audit_records} == {run_id}
+
+    finished = _by_event(audit_records, "run_finished")[0]
+    assert finished.audit["status"] == "success"
+    assert finished.audit["total_calls"] == 1
+    assert finished.audit["success"] == 1
+    assert finished.audit["failed"] == 0
+
+
+def test_audit_emits_set_dispatched_and_result(orchestrator_env, monkeypatch, audit_records):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "obs_disp"},
+    )
+
+    dispatched = _by_event(audit_records, "set_dispatched")
+    assert [r.audit["set_id"] for r in dispatched] == ["a"]
+    result = _by_event(audit_records, "set_result")
+    assert len(result) == 1
+    assert result[0].audit["set_id"] == "a"
+    assert result[0].audit["ok"] is True
+    assert result[0].audit["business_status"] == "success"
+    assert isinstance(result[0].audit["duration_ms"], int)
+    # snapshot_fetch émis pour le couple (exchange, market_type).
+    assert _by_event(audit_records, "snapshot_fetch")
+
+
+def test_audit_trace_id_propagated_to_symfony_header(orchestrator_env, monkeypatch):
+    # OBS-001 (décision produit : inclus) : le run_id est propagé en en-tête
+    # X-Run-Id sur POST /api/mtf/run.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "obs_trace"},
+    ).json()
+
+    posts = _mtf_posts(fake)
+    assert len(posts) == 1
+    assert posts[0]["headers"].get("X-Run-Id") == body["run_id"]
+
+
+def test_audit_live_off_emits_set_skipped_live_not_enabled(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # Interrupteur live OFF (défaut) : un set live est skippé fail-closed avec le
+    # code stable live_not_enabled (relayé depuis live_guard, pas redéfini).
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "live", exchange="bitmart", dry_run=False, symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)})
+
+    skipped = _by_event(audit_records, "set_skipped")
+    assert len(skipped) == 1
+    assert skipped[0].audit["set_id"] == "live"
+    assert skipped[0].audit["code"] == "live_not_enabled"
+    # Skip => aucun set_dispatched pour ce set.
+    assert _by_event(audit_records, "set_dispatched") == []
+
+
+def test_audit_okx_live_emits_set_skipped_forbidden_exchange(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # OKX live : bannissement permanent => code live_forbidden_exchange.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "okx", exchange="okx", dry_run=False, symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)})
+
+    skipped = _by_event(audit_records, "set_skipped")
+    assert len(skipped) == 1
+    assert skipped[0].audit["code"] == "live_forbidden_exchange"
+
+
+def test_audit_locked_set_emits_set_skipped_locked(orchestrator_env, monkeypatch, audit_records):
+    # Un couple (profil, symbole) déjà verrouillé par un autre run => set_skipped
+    # avec le motif locked.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "locked", exchange="bitmart", symbols=("BTCUSDT",))
+    _seed_lock(session, "run_other", "BTCUSDT")
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)})
+
+    skipped = _by_event(audit_records, "set_skipped")
+    assert len(skipped) == 1
+    assert skipped[0].audit["set_id"] == "locked"
+    assert skipped[0].audit["code"] == "locked"
+
+
+def test_audit_replay_emits_short_circuit_without_dispatch(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # Un replay SAFE-002 émet run_short_circuit et n'émet PAS set_dispatched.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    payload = {"dashboard_id": str(dash.id), "idempotency_key": "obs_replay"}
+    client.post("/orchestrator/run", json=payload)  # 1er run (succès persisté)
+    audit_records.clear()  # on n'observe que le 2e run (replay)
+
+    body = client.post("/orchestrator/run", json=payload).json()
+
+    short = _by_event(audit_records, "run_short_circuit")
+    assert len(short) == 1
+    assert short[0].audit["reason"] == "replay"
+    assert short[0].run_id == body["run_id"]
+    # Replay : aucun nouveau dispatch.
+    assert _by_event(audit_records, "set_dispatched") == []
+
+
+def test_audit_no_sets_emits_run_finished(orchestrator_env, monkeypatch, audit_records):
+    client, _session = orchestrator_env
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    client.post("/orchestrator/run")  # aucun dashboard => no_sets
+
+    finished = _by_event(audit_records, "run_finished")
+    assert len(finished) == 1
+    assert finished[0].audit["status"] == "no_sets"
+
+
+def test_audit_emit_failure_does_not_fail_run(orchestrator_env, monkeypatch):
+    # Fail-safe : une erreur interne d'audit (logger qui lève sur tout appel) ne
+    # doit JAMAIS faire échouer le run.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    class _BoomLogger:
+        def log(self, *_a, **_k):
+            raise RuntimeError("boom")
+
+        def exception(self, *_a, **_k):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(orch.run_audit, "_logger", _BoomLogger())
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "obs_failsafe"},
+    ).json()
+
+    # Le run aboutit normalement malgré l'audit en échec.
+    assert body["ok"] is True
+    assert body["status"] == "success"
+    assert body["summary"] == {"total_calls": 1, "success": 1, "failed": 0}

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -1946,3 +1946,53 @@ def test_audit_emit_failure_does_not_fail_run(orchestrator_env, monkeypatch):
     assert body["ok"] is True
     assert body["status"] == "success"
     assert body["summary"] == {"total_calls": 1, "success": 1, "failed": 0}
+
+
+def test_audit_run_started_uses_persisted_legacy_run_id(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # run_started doit porter le run_id RÉELLEMENT persisté : un run ancré qui
+    # résout une ligne legacy (par idempotency_key) sous un run_id distinct du
+    # dérivé doit voir TOUS ses événements corrélés par ce run_id-là.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    # Run terminal NON-ok legacy (≠ "run_legobs" dérivé) => reprise (ré-exécution).
+    session.add(Run(run_id="run_legacy_obs", idempotency_key="legobs", ok=False, status="failed"))
+    session.commit()
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "legobs"},
+    ).json()
+
+    assert body["run_id"] == "run_legacy_obs"
+    started = _by_event(audit_records, "run_started")
+    assert len(started) == 1
+    assert started[0].run_id == "run_legacy_obs"
+    # Toute la piste du run est corrélée par le run_id persisté (pas d'orphelin).
+    assert {r.run_id for r in audit_records} == {"run_legacy_obs"}
+
+
+def test_audit_not_materialized_set_emits_skip_without_dispatch(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # Un set valide mais à sélection NON matérialisée (symbols vide) ne déclenche
+    # aucun POST /api/mtf/run : on audite un set_skipped (not_materialized), jamais
+    # un set_dispatched/trace-id qui n'a pas eu lieu.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "nomat", symbols=())
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)})
+
+    skipped = _by_event(audit_records, "set_skipped")
+    assert len(skipped) == 1
+    assert skipped[0].audit["set_id"] == "nomat"
+    assert skipped[0].audit["code"] == "not_materialized"
+    # Ni dispatch audité, ni POST réel.
+    assert _by_event(audit_records, "set_dispatched") == []
+    assert _mtf_posts(fake) == []

--- a/python-orchestrator/tests/test_orchestrator_run.py
+++ b/python-orchestrator/tests/test_orchestrator_run.py
@@ -2068,3 +2068,70 @@ def test_audit_reclaim_emits_short_circuit(orchestrator_env, monkeypatch, audit_
     # La reprise ré-exécute : run_started + dispatch + finished également présents.
     assert _by_event(audit_records, "run_started")
     assert _by_event(audit_records, "run_finished")
+
+
+def test_audit_resume_emits_short_circuit_even_with_no_preserved_sets(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # Reprise « full-failure » : terminal non-ok SANS aucun RunSet réussi → preserved
+    # vide, mais c'est bien le chemin resume de SAFE-002. L'audit doit l'émettre
+    # (preserved_sets=0), pas le confondre avec un run neuf.
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    session.add(Run(run_id="run_resume_obs", idempotency_key="resobs", ok=False, status="failed"))
+    session.commit()
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "resobs"},
+    ).json()
+
+    assert body["run_id"] == "run_resume_obs"
+    short = _by_event(audit_records, "run_short_circuit")
+    assert [s.audit["reason"] for s in short] == ["resume"]
+    assert short[0].audit["preserved_sets"] == 0
+    assert short[0].run_id == "run_resume_obs"
+
+
+def test_audit_reclaim_emits_short_circuit_on_claim_race(
+    orchestrator_env, monkeypatch, audit_records
+):
+    # Course SAFE-002 : le pré-check rate la ligne `running` périmée, seul le claim la
+    # résout (et la reclaim). reason="reclaim" doit quand même être audité — le verdict
+    # vient du claim, pas du pré-check.
+    from datetime import datetime, timedelta, timezone
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    now = datetime.now(timezone.utc)
+    session.add(
+        Run(
+            run_id="run_reclaim_race", idempotency_key="rcrace", ok=False, status="running",
+            total_calls=0, success_count=0, failed_count=0,
+            started_at=now - timedelta(hours=2), expires_at=now - timedelta(seconds=1),
+        )
+    )
+    session.commit()
+
+    real_resolve = orch.repositories.resolve_run
+    calls = {"n": 0}
+
+    def _racing_resolve(session_, run_id_, key=None):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else real_resolve(session_, run_id_, key)
+
+    monkeypatch.setattr(orch.repositories, "resolve_run", _racing_resolve)
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    body = client.post(
+        "/orchestrator/run",
+        json={"dashboard_id": str(dash.id), "idempotency_key": "rcrace"},
+    ).json()
+
+    assert body["run_id"] == "run_reclaim_race"
+    short = _by_event(audit_records, "run_short_circuit")
+    assert [s.audit["reason"] for s in short] == ["reclaim"]
+    assert short[0].run_id == "run_reclaim_race"

--- a/python-orchestrator/tests/test_run_audit.py
+++ b/python-orchestrator/tests/test_run_audit.py
@@ -1,0 +1,149 @@
+"""Tests du module d'audit et de sa configuration logging (OBS-001).
+
+Couvre :
+- ``run_audit.emit`` : payload structuré, corrélation ``run_id``, **fail-safe** ;
+- ``JsonLineFormatter`` : rendu JSON line déterministe (timestamp ISO UTC) ;
+- ``configure_audit_logging`` : handler idempotent, pas de double émission.
+
+Les logs sont capturés via un handler de test attaché au logger d'audit (la
+``fixture audit_records``) plutôt qu'en dépendant du format brut.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from app import logging_config
+from app.logging_config import JsonLineFormatter, configure_audit_logging
+from app.services import run_audit
+from app.services.run_audit import AUDIT_LOGGER_NAME
+
+
+# --- emit : payload structuré + corrélation ---------------------------------
+
+
+def test_emit_builds_structured_correlated_payload(audit_records):
+    run_audit.emit(
+        run_audit.RUN_STARTED,
+        run_id="run_abc",
+        dashboard_id=7,
+        has_anchor=True,
+    )
+
+    assert len(audit_records) == 1
+    record = audit_records[0]
+    # Attributs directs (accès en test sans parser le JSON).
+    assert record.event == "run_started"
+    assert record.run_id == "run_abc"
+    # Payload complet (event + run_id + champs métier aplatis).
+    assert record.audit == {
+        "event": "run_started",
+        "run_id": "run_abc",
+        "dashboard_id": 7,
+        "has_anchor": True,
+    }
+
+
+def test_emit_maps_level(audit_records):
+    run_audit.emit(run_audit.SET_SKIPPED, run_id="r", level="warning", set_id="s", code="locked")
+    assert audit_records[0].levelno == logging.WARNING
+
+
+def test_emit_unknown_level_falls_back_to_info(audit_records):
+    run_audit.emit(run_audit.RUN_FINISHED, run_id="r", level="bogus", status="success")
+    assert audit_records[0].levelno == logging.INFO
+
+
+# --- emit : fail-safe (ne lève jamais) --------------------------------------
+
+
+def test_emit_never_raises_when_logger_explodes(monkeypatch):
+    # Une erreur interne d'audit (handler/logger en échec) ne doit pas propager :
+    # on remplace le logger interne par un objet qui lève sur tout appel.
+    class _BoomLogger:
+        def log(self, *_a, **_k):
+            raise RuntimeError("boom log")
+
+        def exception(self, *_a, **_k):
+            raise RuntimeError("boom exception")
+
+    monkeypatch.setattr(run_audit, "_logger", _BoomLogger())
+    # Aucune exception ne doit remonter (fail-safe).
+    run_audit.emit(run_audit.RUN_STARTED, run_id="r", dashboard_id=1)
+
+
+# --- JsonLineFormatter : JSON line déterministe -----------------------------
+
+
+def _make_audit_record(audit: dict, level: int = logging.INFO) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name=AUDIT_LOGGER_NAME,
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=audit.get("event", ""),
+        args=(),
+        exc_info=None,
+    )
+    record.audit = audit
+    return record
+
+
+def test_json_line_formatter_is_deterministic_json():
+    record = _make_audit_record(
+        {"event": "run_started", "run_id": "run_x", "dashboard_id": 5, "has_anchor": True}
+    )
+    line = JsonLineFormatter().format(record)
+    data = json.loads(line)  # ligne JSON valide
+
+    assert data["event"] == "run_started"
+    assert data["run_id"] == "run_x"
+    assert data["dashboard_id"] == 5
+    assert data["has_anchor"] is True
+    assert data["level"] == "INFO"
+    # Timestamp ISO UTC.
+    assert data["timestamp"].endswith("+00:00")
+
+
+def test_json_line_formatter_tolerates_non_serializable_field():
+    # default=str : un champ non nativement sérialisable ne fait jamais lever le
+    # rendu (fail-safe jusque dans le formatteur).
+    record = _make_audit_record({"event": "x", "run_id": "r", "obj": object()})
+    data = json.loads(JsonLineFormatter().format(record))
+    assert data["event"] == "x"
+    assert isinstance(data["obj"], str)
+
+
+def test_json_line_formatter_falls_back_for_non_audit_record():
+    record = logging.LogRecord(
+        name="some.logger",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    data = json.loads(JsonLineFormatter().format(record))
+    assert data["event"] == "some.logger"
+    assert data["message"] == "hello world"
+
+
+# --- configure_audit_logging : idempotent -----------------------------------
+
+
+def test_configure_audit_logging_is_idempotent():
+    logger = logging.getLogger(AUDIT_LOGGER_NAME)
+    # Plusieurs appels ne doivent poser qu'UN seul handler d'audit (pas de double
+    # émission), quel que soit l'état initial (main.py l'a déjà appelé à l'import).
+    configure_audit_logging("INFO")
+    configure_audit_logging("DEBUG")
+    audit_handlers = [
+        h
+        for h in logger.handlers
+        if getattr(h, logging_config._AUDIT_HANDLER_FLAG, False)
+    ]
+    assert len(audit_handlers) == 1
+    # Propagation coupée : pas de double émission via le root/uvicorn.
+    assert logger.propagate is False

--- a/python-orchestrator/tests/test_run_audit.py
+++ b/python-orchestrator/tests/test_run_audit.py
@@ -147,3 +147,14 @@ def test_configure_audit_logging_is_idempotent():
     assert len(audit_handlers) == 1
     # Propagation coupée : pas de double émission via le root/uvicorn.
     assert logger.propagate is False
+
+
+def test_configure_audit_logging_reenables_disabled_logger():
+    # Régression : un `logging.config.fileConfig(...)` exécuté ailleurs (ex. Alembic
+    # dans le smoke PostgreSQL) avec son défaut `disable_existing_loggers=True`
+    # poserait `disabled=True` sur le logger d'audit, coupant silencieusement
+    # l'émission. `configure_audit_logging` doit le réactiver.
+    logger = logging.getLogger(AUDIT_LOGGER_NAME)
+    logger.disabled = True
+    configure_audit_logging("INFO")
+    assert logger.disabled is False

--- a/python-orchestrator/tests/test_settings.py
+++ b/python-orchestrator/tests/test_settings.py
@@ -111,3 +111,34 @@ def test_live_exchanges_unknown_raises(monkeypatch):
     monkeypatch.setenv("ORCHESTRATION_LIVE_EXCHANGES", "bitmart,binance")
     with pytest.raises(SettingsError):
         Settings.from_env()
+
+
+# --- Niveau de log d'audit (OBS-001) ----------------------------------------
+
+
+def test_log_level_defaults_to_info(monkeypatch):
+    monkeypatch.delenv("ORCHESTRATION_LOG_LEVEL", raising=False)
+    assert Settings.from_env().log_level == "INFO"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("debug", "DEBUG"),
+        ("INFO", "INFO"),
+        (" warning ", "WARNING"),
+        ("Error", "ERROR"),
+        ("critical", "CRITICAL"),
+    ],
+)
+def test_log_level_parsed_and_normalized(monkeypatch, raw, expected):
+    monkeypatch.setenv("ORCHESTRATION_LOG_LEVEL", raw)
+    assert Settings.from_env().log_level == expected
+
+
+def test_log_level_invalid_raises_at_startup(monkeypatch):
+    # Une valeur invalide lève au démarrage (comme ORCHESTRATION_LOCK_TTL_SECONDS),
+    # pas de repli silencieux sur le défaut.
+    monkeypatch.setenv("ORCHESTRATION_LOG_LEVEL", "verbose")
+    with pytest.raises(SettingsError):
+        Settings.from_env()


### PR DESCRIPTION
## Contexte

`POST /orchestrator/run` exécutait déjà un cycle complet et persistait un historique exploitable (`runs.last_json`, `run_sets`), mais **n'émettait aucun log applicatif** : les décisions du runner (skips fail-closed, court-circuits d'idempotence SAFE-002, pose/skip des locks SAFE-001, garde-fous live SAFE-003, échecs Symfony) n'étaient observables qu'**en base, après coup**. Aucun flux corrélé par `run_id` n'existait pour le diagnostic temps réel.

OBS-001 ajoute une **couche d'audit structurée, fail-safe et corrélée par `run_id`**, émise au fil du cycle, **sans changer le comportement métier**.

## Décisions produit (figées via AskUserQuestion)

1. **Sink** : logs structurés **JSON line sur stdout** (aucune migration, container/aggregator-friendly).
2. **Trace-id Symfony** : **inclus** dans OBS-001 — propagation du `run_id` en en-tête `X-Run-Id` sur `POST /api/mtf/run`.
3. **Format** : **JSON line strict** (une clé `event` + champs plats).

## Scope

- `app/services/run_audit.py` : `emit(event, *, run_id, level="info", **fields)` — point d'émission unique, **fail-safe** (ne lève jamais), sur le logger `orchestrator.audit`.
- `app/logging_config.py` : `JsonLineFormatter` déterministe (timestamp ISO UTC, level, event, run_id, champs plats) + `configure_audit_logging` idempotent (un seul handler, propagation coupée → pas de double émission). Branché au démarrage dans `app/main.py`.
- `app/settings.py` : `ORCHESTRATION_LOG_LEVEL` (défaut `INFO`), validé au démarrage comme `ORCHESTRATION_LOCK_TTL_SECONDS` (lève sur valeur invalide).
- Instrumentation du runner (`run_orchestrator`/`_dispatch_set`/`_collect_snapshots`) : `run_started`, `run_short_circuit` (replay/in_flight/resume/reclaim), `snapshot_fetch`, `set_skipped` (codes relayés depuis `live_guard` / `locked` / `conflicting_live` / `open_state_unavailable`), `set_dispatched`, `set_result`, `run_finished`. Corrélé par le `run_id` réellement persisté.
- Propagation trace-id `X-Run-Id` à Symfony (`symfony_client`).
- Doc : handbook (§Observabilité/Audit + plan PR), README (var d'env + exemple de ligne), readiness gate « audit minimal actif » outillée.

## Hors-scope

- Métriques par set / compteurs agrégés (OBS-002), lien `position_trade_analysis` (OBS-003).
- Table d'audit DB persistée (sink retenu = logs).
- Modification des garde-fous live (SAFE-003), locks (SAFE-001), idempotence (SAFE-002) au-delà de l'ajout des points d'audit.
- Front/cockpit, contrat `RunRequest`/`RunResponse`, schedule Temporal, stratégie/EntryZone/levier/cadence.

## Vérifications

`cd python-orchestrator && pytest` → **294 passed, 3 skipped** (smoke PostgreSQL). Nouveaux tests :
- run nominal : `run_started … run_finished` corrélés par le même `run_id` ;
- set live (interrupteur OFF) → `set_skipped` code `live_not_enabled` ; OKX live → `live_forbidden_exchange` ; set verrouillé → motif `locked` ;
- replay (SAFE-002) → `run_short_circuit` **sans** `set_dispatched` ;
- erreur interne d'audit → le run aboutit quand même (**fail-safe**) ;
- `ORCHESTRATION_LOG_LEVEL` invalide ⇒ lève au démarrage ; défaut INFO ;
- trace-id `X-Run-Id` propagé sur `POST /api/mtf/run`.

**Revue** : aucune décision métier modifiée, réponses HTTP et `last_json`/`RunSet` inchangés, pas de transaction longue, SAFE-001/002/003 intacts.

Réf. issue : #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgFZBLouRGE3dFRETnxpUj)_