### PR TITLE
OBS-002: Métriques d'exécution par set (python-orchestrator)

### DIFF
--- a/docs/handbook/technical/exchange-schedule-policy.md
+++ b/docs/handbook/technical/exchange-schedule-policy.md
@@ -111,7 +111,9 @@ Avant d'autoriser une cadence 1m pour un dashboard ou un set, il faut valider :
 - idempotence ;
 - lock cross-profile ;
 - audit complet (la piste d'audit structurée minimale est livrée par OBS-001 ;
-  les métriques par set restent à venir, cf. OBS-002) ;
+  les **métriques d'exécution par set** sont livrées par OBS-002 — registre
+  in-process exposé en JSON via `GET /metrics`, cf. §*Métriques d'exécution
+  par set (OBS-002)* de `python-orchestrator.md`) ;
 - dry-run stable ;
 - absence de double soumission ;
 - SL attaché immédiatement ;

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -628,6 +628,44 @@ changer le comportement métier**.
   `logging`). Locks SAFE-001, idempotence SAFE-002 et garde-fous live SAFE-003
   restent intacts ; réponses HTTP inchangées.
 
+### Métriques d'exécution par set (OBS-002)
+
+OBS-001 fournit un **flux d'événements** et un **historique DB**, mais aucune
+**couche quantitative** prête à grapher/alerter. OBS-002 ajoute un **registre
+de métriques in-process** (`app/services/run_metrics.py`), alimenté aux **mêmes
+points d'instrumentation** qu'OBS-001 (`set_dispatched` / `set_result` /
+`set_skipped` / `snapshot_fetch` / `run_finished`) — pas de duplication de schéma,
+pas de redéfinition de cause métier.
+
+- **Sink** : **endpoint JSON dérivé** du registre — `GET /metrics`
+  (`app/routers/metrics.py`). Aucune migration, aucune écriture DB, aucune I/O
+  bloquante pendant les ~900 s d'appels Symfony ; le pattern transaction courte
+  du runner est inchangé.
+- **Métriques** :
+  - compteurs de **runs** par `status` (débit, par status terminal y compris
+    `no_sets`) ;
+  - compteurs de **sets** : `dispatched`, `results` (ok=true/false +
+    `business_status`), `skipped` (par `code` stable) ;
+  - compteurs de **snapshots** (`snapshot_fetch` ok / indisponible) ;
+  - **histogramme** de durée de dispatch (`set_result.duration_ms`, bornes ms
+    cumulées « le » + `+Inf` + somme).
+- **Labels** (cardinalité bornée, décision produit OBS-002) : `exchange`,
+  `market_type`, `mtf_profile` (+ `code` de skip, `business_status`, `status` de
+  run). **Ni `set_id` ni `dashboard_id`** (qui feraient exploser le nombre de
+  séries). Les `code`/`status` réutilisent les valeurs **stables** OBS-001/SAFE-003.
+- **Activation** : `ORCHESTRATION_METRICS_ENABLED` (défaut **ON**, validé au
+  démarrage comme `ORCHESTRATION_LIVE_ENABLED` — lève sur valeur invalide). À OFF,
+  les `observe_*` deviennent des no-op et `GET /metrics` renvoie un snapshot vide.
+- **Cohérence** : sur un run nominal (sans skip ni reprise), `sets.dispatched`
+  réconcilie avec `summary.total_calls` et `sets.results` (ok=true/false) avec
+  `summary.success` / `summary.failed`. Les skips réconcilient avec les `code`
+  audités.
+- **Fail-safe** : une erreur de métrique (état corrompu, sérialisation) est
+  absorbée (`try/except` interne) et ne fait **jamais** échouer ni ralentir un
+  run. **Aucun changement de comportement** : dispatch, décisions live/lock/
+  idempotence, réponses HTTP et forme de `last_json`/`RunSet` inchangés ; OBS-001
+  et SAFE-001/002/003 intacts.
+
 ## Garde-fous fonctionnels
 
 Avant tout run :
@@ -697,6 +735,7 @@ Avant tout run :
 | SAFE-002 ✅ | Idempotence des runs et des sets | Livré : statut non terminal `running` + claim précoce (`runs.expires_at` = TTL de claim, transaction courte) ; court-circuit selon l'état du run existant — replay (terminal success), reprise des sets non réussis (terminal non-ok), réplique en vol (`running` non périmé), reclaim (`running` périmé). Réutilise `record_run`/savepoints et le calcul de TTL SAFE-001. Migration `0003_run_claim_expires_at`. Ne réactive pas le live. |
 | SAFE-003 ✅ | Centraliser et durcir les garde-fous live | Livré : module unique `app/services/live_guard.py` (`assess_live -> LiveDecision`) consommé par `assert_set_persistable`, `assert_live_allowed` et le runner `_dispatch_set` (plus de logique live dupliquée schemas ↔ runner). Hiérarchie fail-closed : bannissements permanents OKX/Hyperliquid (jamais relâchés) > interrupteur `ORCHESTRATION_LIVE_ENABLED` (défaut OFF) > allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > snapshot d'état ouvert présent. `reason`/`code` stables par cause. Persistance ↔ runtime cohérents. **Le live reste désactivé par défaut** : aucune réactivation effective, seule l'activation devient possible/auditable/testée. Pas de migration. |
 | OBS-001 ✅ | Audit des runs d'orchestration | Livré : couche d'audit structurée, fail-safe et corrélée par `run_id` (`app/services/run_audit.py`, `emit`) sur le logger `orchestrator.audit`, format **JSON line** sur stdout (`app/logging_config.py`), niveau piloté par `ORCHESTRATION_LOG_LEVEL` (défaut INFO, validé au démarrage). Points d'audit : `run_started`, `run_short_circuit` (replay/in_flight/resume/reclaim), `snapshot_fetch`, `set_skipped` (codes live_guard / locked / conflicting_live / open_state_unavailable), `set_dispatched`, `set_result`, `run_finished`. `code`/`reason` identiques à `RunSet.error` (source unique SAFE-003). Trace-id `X-Run-Id` propagé à Symfony. **Aucun changement de comportement** (SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
+| OBS-002 ✅ | Métriques d'exécution par set | Livré : registre de métriques in-process (`app/services/run_metrics.py`) branché aux **mêmes points** qu'OBS-001 (`set_dispatched`/`set_result`/`set_skipped`/`snapshot_fetch`/`run_finished`). Compteurs (runs par status ; sets dispatched/results ok+`business_status`/skipped par `code` ; snapshots ok/indispo) + **histogramme** de durée de dispatch (`set_result.duration_ms`, bornes « le »). Sink = **endpoint JSON dérivé** `GET /metrics` (`app/routers/metrics.py`), aucune migration ni écriture DB. Labels **faible cardinalité** (`exchange`/`market_type`/`mtf_profile` + `code`/`business_status`/`status`), ni `set_id` ni `dashboard_id`. Activation `ORCHESTRATION_METRICS_ENABLED` (défaut ON, validé au démarrage). Réconcilie avec `summary`. **Fail-safe**, **aucun changement de comportement** (OBS-001 et SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -70,6 +70,7 @@ Hors-scope (PR suivantes) :
 | `GET` | `/runs` | Liste les runs (`?dashboard_id=&limit=&offset=`) (PY-006). |
 | `GET` | `/runs/{run_id}` | Dernier JSON global d'un run + détail par set (PY-006). |
 | `GET` | `/runs/{run_id}/sets/{set_id}` | Dernier JSON d'un set (payload + réponse brute) (PY-006). |
+| `GET` | `/metrics` | Métriques d'exécution agrégées (compteurs + histogramme de durée), JSON dérivé du registre (OBS-002). |
 | `GET` | `/docs` | Swagger UI (OpenAPI). |
 
 ### Gestion des dashboards et sets (PY-002)
@@ -283,6 +284,7 @@ un service `postgres:15`.
 | `ORCHESTRATION_LIVE_ENABLED` | `false` | **Interrupteur d'activation live** (SAFE-003), défaut **OFF**. OFF ⇒ tout set `dry_run=false` est skippé fail-closed (comportement d'avant SAFE-003). Accepte `true/false`, `1/0`, `yes/no`, `on/off` ; toute autre valeur lève au démarrage. **Ne jamais livrer à `true` sans readiness runtime.** |
 | `ORCHESTRATION_LIVE_EXCHANGES` | *(vide)* | Allow-list CSV des exchanges autorisés live **quand l'interrupteur est ON** (SAFE-003). Normalisée en minuscules, dédupliquée ; chaque entrée doit être un exchange connu (sinon lève au démarrage). En pratique au plus `bitmart` (+ `fake` en simulation). OKX/Hyperliquid restent interdits **même listés** (bannissement permanent). |
 | `ORCHESTRATION_LOG_LEVEL` | `INFO` | **Niveau du log d'audit des runs** (OBS-001) sur le logger `orchestrator.audit`. Accepte `DEBUG/INFO/WARNING/ERROR/CRITICAL` (insensible à la casse) ; toute autre valeur lève au démarrage (comme `ORCHESTRATION_LOCK_TTL_SECONDS`). Cf. *Observabilité / Audit (OBS-001)*. |
+| `ORCHESTRATION_METRICS_ENABLED` | `true` | **Collecte des métriques d'exécution par set** (OBS-002), défaut **ON**. Accepte `true/false`, `1/0`, `yes/no`, `on/off` ; toute autre valeur lève au démarrage. À OFF, les compteurs/histogramme ne sont plus alimentés et `GET /metrics` renvoie un snapshot vide. Cf. *Métriques d'exécution (OBS-002)*. |
 
 Une valeur non entière, non booléenne, hors borne, un niveau de log inconnu ou un
 exchange inconnu lève une erreur explicite au démarrage (pas de repli silencieux
@@ -326,6 +328,56 @@ Symfony au run d'orchestration.
 interne et ne fait aucune I/O bloquante hors `logging` stdlib. **Aucun changement
 de comportement métier** : pas de nouvelle décision, locks SAFE-001 / idempotence
 SAFE-002 / garde-fous live SAFE-003 intacts, réponses HTTP inchangées.
+
+## Métriques d'exécution (OBS-002)
+
+OBS-001 donne un **flux d'événements** ; OBS-002 ajoute la **couche quantitative**
+prête à grapher/alerter. Un **registre de métriques in-process**
+(`app/services/run_metrics.py`) est alimenté aux **mêmes points** que l'audit
+(`set_dispatched` / `set_result` / `set_skipped` / `snapshot_fetch` /
+`run_finished`) et exposé en **JSON dérivé** via `GET /metrics`
+(`app/routers/metrics.py`) — aucune migration, aucune écriture DB.
+
+| Métrique | Type | Labels |
+| --- | --- | --- |
+| `runs` | compteur | `status` (y compris `no_sets`) |
+| `sets.dispatched` | compteur | `exchange`, `market_type`, `mtf_profile` |
+| `sets.results` | compteur | `exchange`, `market_type`, `mtf_profile`, `ok`, `business_status` |
+| `sets.skipped` | compteur | `code` (stable OBS-001/SAFE-003), `exchange`, `market_type`, `mtf_profile` |
+| `snapshots` | compteur | `exchange`, `market_type`, `ok` |
+| `dispatch_duration_ms` | histogramme | `exchange`, `market_type`, `mtf_profile` (bornes ms cumulées « le » + `+Inf` + somme) |
+
+**Cardinalité bornée** (décision produit OBS-002) : ni `set_id` ni `dashboard_id`
+en labels. **Réconciliation** : sur un run nominal (sans skip ni reprise),
+`sets.dispatched` = `summary.total_calls`, `sets.results` (ok=true/false) =
+`summary.success`/`summary.failed`.
+
+Exemple :
+
+```bash
+curl -s http://localhost:8099/metrics | jq .
+```
+
+```json
+{
+  "enabled": true,
+  "runs": [{"status": "success", "value": 12}],
+  "sets": {
+    "dispatched": [{"exchange": "bitmart", "market_type": "perpetual", "mtf_profile": "scalper_micro", "value": 34}],
+    "results": [{"exchange": "bitmart", "market_type": "perpetual", "mtf_profile": "scalper_micro", "ok": "true", "business_status": "success", "value": 31}],
+    "skipped": [{"code": "locked", "exchange": "bitmart", "market_type": "perpetual", "mtf_profile": "scalper_micro", "value": 2}]
+  },
+  "snapshots": [{"exchange": "bitmart", "market_type": "perpetual", "ok": "true", "value": 12}],
+  "dispatch_duration_ms": {"buckets": [100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, 300000, 600000, 900000],
+    "series": [{"exchange": "bitmart", "market_type": "perpetual", "mtf_profile": "scalper_micro", "count": 31, "sum_ms": 26102, "buckets": {"100": 0, "250": 4, "500": 18, "...": "...", "+Inf": 31}}]}
+}
+```
+
+**Fail-safe** : une erreur de métrique (état corrompu, sérialisation) est absorbée
+(`try/except` interne) et ne fait jamais échouer ni ralentir un run. Désactivable
+via `ORCHESTRATION_METRICS_ENABLED=false`. **Aucun changement de comportement** :
+dispatch, décisions live/lock/idempotence, réponses HTTP et forme de
+`last_json`/`RunSet` inchangés ; OBS-001 et SAFE-001/002/003 intacts.
 
 ## Persistance (DB-001)
 

--- a/python-orchestrator/app/main.py
+++ b/python-orchestrator/app/main.py
@@ -11,13 +11,19 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
 from app.logging_config import configure_audit_logging
-from app.routers import dashboards, health, orchestrator, runs
+from app.routers import dashboards, health, metrics, orchestrator, runs
+from app.services import run_metrics
 from app.settings import get_settings
 
 # Audit des runs (OBS-001) : on branche le logger JSON line `orchestrator.audit`
 # au démarrage, au niveau piloté par `ORCHESTRATION_LOG_LEVEL` (défaut INFO,
 # validé par `settings`). Idempotent (un seul handler), pas de double émission.
 configure_audit_logging(get_settings().log_level)
+
+# Métriques d'exécution (OBS-002) : registre in-process activé selon
+# `ORCHESTRATION_METRICS_ENABLED` (défaut ON, validé par `settings`). À OFF, les
+# `observe_*` deviennent des no-op et `GET /metrics` renvoie un snapshot vide.
+run_metrics.configure(enabled=get_settings().metrics_enabled)
 
 app = FastAPI(
     title="TradingV3 — Python Orchestrator",
@@ -45,3 +51,4 @@ app.include_router(health.router)
 app.include_router(orchestrator.router)
 app.include_router(dashboards.router)
 app.include_router(runs.router)
+app.include_router(metrics.router)

--- a/python-orchestrator/app/routers/metrics.py
+++ b/python-orchestrator/app/routers/metrics.py
@@ -1,0 +1,35 @@
+"""Exposition des métriques d'exécution des runs d'orchestration (OBS-002).
+
+Sink retenu (décision produit OBS-002) : un **endpoint JSON dérivé** du registre
+in-process (``app/services/run_metrics.py``), alimenté aux mêmes points
+d'instrumentation qu'OBS-001. Aucune migration, aucune écriture DB, aucune I/O
+bloquante : l'endpoint sérialise simplement le snapshot courant des compteurs et
+de l'histogramme de durée de dispatch.
+
+Lecture seule, fail-safe : un échec de sérialisation du registre ne lève pas (le
+snapshot retombe sur ``{"enabled": false, "error": …}``). Cardinalité bornée :
+labels limités à ``exchange`` / ``market_type`` / ``mtf_profile`` (+ ``code`` de
+skip, ``business_status``, ``status`` de run) — ni ``set_id`` ni ``dashboard_id``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from app.services import run_metrics
+
+router = APIRouter(tags=["metrics"])
+
+
+@router.get("/metrics")
+def get_metrics() -> Dict[str, Any]:
+    """Snapshot JSON des métriques agrégées d'exécution par set (OBS-002).
+
+    Compteurs : runs par ``status`` ; sets ``dispatched`` / ``results``
+    (ok/échec + ``business_status``) / ``skipped`` (par ``code``) ; ``snapshots``
+    (ok/indispo). Histogramme : durée de dispatch (``set_result.duration_ms``,
+    bornes ms cumulées « le » + ``+Inf``).
+    """
+    return run_metrics.snapshot()

--- a/python-orchestrator/app/routers/orchestrator.py
+++ b/python-orchestrator/app/routers/orchestrator.py
@@ -41,7 +41,7 @@ from app.schemas import (
     RunStatus,
     RunSummary,
 )
-from app.services import run_audit
+from app.services import run_audit, run_metrics
 from app.services.live_guard import (
     OPEN_STATE_UNAVAILABLE,
     OPEN_STATE_UNAVAILABLE_REASON,
@@ -192,6 +192,9 @@ def _no_sets_response(run_id: str) -> RunResponse:
         success=0,
         failed=0,
     )
+    # OBS-002 : un run sans set compte comme un run terminé `no_sets` (débit de
+    # runs par status), sans aucun compteur de set/dispatch.
+    run_metrics.observe_run_finished(status="no_sets", total_calls=0, success=0, failed=0)
     return RunResponse(
         ok=False,
         run_id=run_id,
@@ -583,6 +586,21 @@ def _conflicting_live_set_ids(mtf_sets: List[Any], force_dry_run: bool) -> set:
     return conflicting
 
 
+def _set_labels(a_set: Any) -> Dict[str, str]:
+    """Labels de métriques d'un set (OBS-002), cardinalité bornée.
+
+    Limité à ``exchange`` / ``market_type`` / ``mtf_profile`` (valeurs d'enum
+    résolues, normalisées en chaîne) — décision produit OBS-002 : ni ``set_id``
+    ni ``dashboard_id`` (qui feraient exploser le nombre de séries). Mêmes valeurs
+    que celles versées dans l'audit/Symfony, donc réconciliables.
+    """
+    return {
+        "exchange": str(getattr(a_set.exchange, "value", a_set.exchange)),
+        "market_type": str(getattr(a_set.market_type, "value", a_set.market_type)),
+        "mtf_profile": str(getattr(a_set.mtf_profile, "value", a_set.mtf_profile)),
+    }
+
+
 def _now() -> datetime:
     """Horloge de l'orchestrateur (UTC, déterministe).
 
@@ -663,6 +681,9 @@ async def _collect_snapshots(
                 market_type=market_type,
                 ok=True,
             )
+            run_metrics.observe_snapshot_fetch(
+                exchange=exchange, market_type=market_type, ok=True
+            )
         except OpenStateUnavailableError:
             # Pas de snapshot fiable pour ce couple : on ne met rien en cache.
             run_audit.emit(
@@ -673,6 +694,9 @@ async def _collect_snapshots(
                 market_type=market_type,
                 ok=False,
                 code=OPEN_STATE_UNAVAILABLE,
+            )
+            run_metrics.observe_snapshot_fetch(
+                exchange=exchange, market_type=market_type, ok=False
             )
             continue
     return snapshots
@@ -935,6 +959,9 @@ async def run_orchestrator(
                     set_id=a_set.set_id,
                     code=_SKIP_CODE_CONFLICTING_LIVE,
                 )
+                run_metrics.observe_set_skipped(
+                    code=_SKIP_CODE_CONFLICTING_LIVE, **_set_labels(a_set)
+                )
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -953,6 +980,9 @@ async def run_orchestrator(
                     level="warning",
                     set_id=a_set.set_id,
                     code=_SKIP_CODE_LOCKED,
+                )
+                run_metrics.observe_set_skipped(
+                    code=_SKIP_CODE_LOCKED, **_set_labels(a_set)
                 )
                 return {
                     "set_id": a_set.set_id,
@@ -1006,6 +1036,9 @@ async def run_orchestrator(
                     set_id=a_set.set_id,
                     code=decision.code,
                 )
+                run_metrics.observe_set_skipped(
+                    code=decision.code, **_set_labels(a_set)
+                )
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -1025,6 +1058,9 @@ async def run_orchestrator(
                     level="warning",
                     set_id=a_set.set_id,
                     code=OPEN_STATE_UNAVAILABLE,
+                )
+                run_metrics.observe_set_skipped(
+                    code=OPEN_STATE_UNAVAILABLE, **_set_labels(a_set)
                 )
                 return {
                     "set_id": a_set.set_id,
@@ -1048,6 +1084,9 @@ async def run_orchestrator(
                     set_id=a_set.set_id,
                     code=_SKIP_CODE_NOT_MATERIALIZED,
                 )
+                run_metrics.observe_set_skipped(
+                    code=_SKIP_CODE_NOT_MATERIALIZED, **_set_labels(a_set)
+                )
                 return {
                     "set_id": a_set.set_id,
                     "ok": False,
@@ -1066,6 +1105,7 @@ async def run_orchestrator(
                     set_id=a_set.set_id,
                     dry_run=effective_dry_run,
                 )
+                run_metrics.observe_set_dispatched(**_set_labels(a_set))
                 start = time.monotonic()
                 try:
                     result = await run_persisted_set(
@@ -1095,6 +1135,12 @@ async def run_orchestrator(
                     ok=bool(result.get("ok")),
                     business_status=result.get("business_status"),
                     duration_ms=result.get("duration_ms"),
+                )
+                run_metrics.observe_set_result(
+                    ok=bool(result.get("ok")),
+                    business_status=result.get("business_status"),
+                    duration_ms=result.get("duration_ms"),
+                    **_set_labels(a_set),
                 )
                 return result
 
@@ -1131,6 +1177,16 @@ async def run_orchestrator(
     run_audit.emit(
         run_audit.RUN_FINISHED,
         run_id=run_id,
+        status=status,
+        total_calls=summary.total_calls,
+        success=summary.success,
+        failed=summary.failed,
+    )
+    # OBS-002 : débit de runs par status. Les compteurs par set (dispatched /
+    # results / skipped) ont déjà été observés au fil du run ; sur un run nominal
+    # (sans skip ni reprise) `sets_dispatched` réconcilie avec `summary.total_calls`
+    # et `sets_result` (ok=true/false) avec `summary.success`/`summary.failed`.
+    run_metrics.observe_run_finished(
         status=status,
         total_calls=summary.total_calls,
         success=summary.success,

--- a/python-orchestrator/app/services/run_metrics.py
+++ b/python-orchestrator/app/services/run_metrics.py
@@ -1,0 +1,315 @@
+"""Métriques d'exécution agrégées des runs d'orchestration (OBS-002).
+
+OBS-001 a posé un **flux d'événements** (audit JSON line corrélé par ``run_id``)
+et un **historique DB** (``runs`` / ``run_sets``). Il manquait la couche
+**quantitative** : compteurs et distribution de durées, prêts à grapher/alerter
+(taux de skip par cause, succès par exchange/profil, débit de runs, lenteur de
+dispatch) sans agréger des logs ou requêter la base à la main.
+
+Ce module expose un **registre in-process** alimenté aux **mêmes points
+d'instrumentation** que ``run_audit`` (``set_dispatched`` / ``set_result`` /
+``set_skipped`` / ``snapshot_fetch`` / ``run_finished``). Il ne redéfinit aucune
+cause métier : il réutilise les ``code``/``status`` STABLES d'OBS-001 / SAFE-003
+comme labels. Le sink (décision produit OBS-002) est un **endpoint JSON dérivé**
+du registre (``GET /metrics``, cf. ``app/routers/metrics.py``) : aucune migration,
+aucune écriture DB, aucune dépendance supplémentaire.
+
+Invariants :
+
+- **Fail-safe** : une erreur de métrique (clé non hashable, état corrompu) ne
+  fait JAMAIS échouer ni ralentir un run. Chaque ``observe_*`` est encapsulé dans
+  un ``try/except`` interne et ne lève jamais.
+- **Cardinalité bornée** (décision produit OBS-002) : labels limités à
+  ``exchange`` / ``market_type`` / ``mtf_profile`` (+ ``code`` de skip,
+  ``business_status``, ``status`` de run). Ni ``set_id`` ni ``dashboard_id`` (qui
+  feraient exploser le nombre de séries).
+- **Cohérence** : les compteurs complètent l'audit et l'historique ; sur un run
+  nominal (sans skip ni reprise), ``sets_dispatched`` réconcilie avec
+  ``summary.total_calls`` et ``sets_result`` (ok=true / false) avec
+  ``summary.success`` / ``summary.failed``.
+
+Le module est désactivable via ``configure(enabled=False)`` (piloté par
+``ORCHESTRATION_METRICS_ENABLED`` au démarrage) : les ``observe_*`` deviennent
+alors des no-op et le snapshot reste vide.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
+# Bornes (ms) de l'histogramme de durée de dispatch (``set_result.duration_ms``).
+# La durée mesure tout l'appel Symfony (jusqu'à ``_HTTP_TIMEOUT`` = 900 s), donc
+# les bornes montent jusqu'à 900 000 ms. Convention Prometheus « le » (cumulatif) :
+# chaque borne compte les observations <= borne ; ``+Inf`` = total.
+DISPATCH_DURATION_BUCKETS_MS: Tuple[int, ...] = (
+    100,
+    250,
+    500,
+    1000,
+    2500,
+    5000,
+    10000,
+    30000,
+    60000,
+    120000,
+    300000,
+    600000,
+    900000,
+)
+
+# Valeur de repli pour un label absent/None (ex. ``business_status`` non renvoyé
+# par Symfony sur erreur HTTP) — on ne laisse jamais ``None`` polluer une clé.
+_UNKNOWN = "unknown"
+
+
+def _label(value: Any) -> str:
+    """Normalise une valeur de label en chaîne stable (None → ``unknown``)."""
+    if value is None:
+        return _UNKNOWN
+    return str(value)
+
+
+class _Registry:
+    """Registre in-process thread-safe des métriques d'exécution.
+
+    Les ``observe_*`` sont appelés depuis la boucle asyncio du runner ; le snapshot
+    JSON est lu depuis le threadpool FastAPI (endpoint sync). Un ``Lock`` protège
+    donc l'état partagé. Les compteurs sont des ``dict`` indexés par tuple de
+    valeurs de labels ; l'histogramme stocke, par tuple de labels, le total, la
+    somme et les compteurs cumulés par borne.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._enabled = True
+        self._reset_locked()
+
+    def _reset_locked(self) -> None:
+        self._runs: Dict[Tuple[str, ...], int] = {}            # (status,)
+        self._dispatched: Dict[Tuple[str, ...], int] = {}      # (exchange, market_type, mtf_profile)
+        self._results: Dict[Tuple[str, ...], int] = {}         # (exchange, market_type, mtf_profile, ok, business_status)
+        self._skipped: Dict[Tuple[str, ...], int] = {}         # (code, exchange, market_type, mtf_profile)
+        self._snapshots: Dict[Tuple[str, ...], int] = {}       # (exchange, market_type, ok)
+        # (exchange, market_type, mtf_profile) -> {"count", "sum", "le": [..]}
+        self._duration: Dict[Tuple[str, ...], Dict[str, Any]] = {}
+
+    # --- configuration ------------------------------------------------------
+
+    def configure(self, *, enabled: bool) -> None:
+        with self._lock:
+            self._enabled = enabled
+
+    def reset(self) -> None:
+        """Remet le registre à zéro (tests) sans toucher au flag ``enabled``."""
+        with self._lock:
+            self._reset_locked()
+
+    # --- observations (fail-safe via les wrappers module) -------------------
+
+    def inc_run(self, status: Any) -> None:
+        with self._lock:
+            if not self._enabled:
+                return
+            key = (_label(status),)
+            self._runs[key] = self._runs.get(key, 0) + 1
+
+    def inc_dispatched(self, exchange: Any, market_type: Any, mtf_profile: Any) -> None:
+        with self._lock:
+            if not self._enabled:
+                return
+            key = (_label(exchange), _label(market_type), _label(mtf_profile))
+            self._dispatched[key] = self._dispatched.get(key, 0) + 1
+
+    def inc_result(
+        self,
+        exchange: Any,
+        market_type: Any,
+        mtf_profile: Any,
+        ok: bool,
+        business_status: Any,
+        duration_ms: Optional[int],
+    ) -> None:
+        with self._lock:
+            if not self._enabled:
+                return
+            key = (
+                _label(exchange),
+                _label(market_type),
+                _label(mtf_profile),
+                "true" if ok else "false",
+                _label(business_status),
+            )
+            self._results[key] = self._results.get(key, 0) + 1
+            if duration_ms is not None:
+                self._observe_duration_locked(exchange, market_type, mtf_profile, duration_ms)
+
+    def _observe_duration_locked(
+        self, exchange: Any, market_type: Any, mtf_profile: Any, duration_ms: int
+    ) -> None:
+        key = (_label(exchange), _label(market_type), _label(mtf_profile))
+        data = self._duration.get(key)
+        if data is None:
+            data = {"count": 0, "sum": 0, "le": [0] * len(DISPATCH_DURATION_BUCKETS_MS)}
+            self._duration[key] = data
+        data["count"] += 1
+        data["sum"] += int(duration_ms)
+        for i, bound in enumerate(DISPATCH_DURATION_BUCKETS_MS):
+            if duration_ms <= bound:
+                data["le"][i] += 1
+
+    def inc_skipped(
+        self, code: Any, exchange: Any, market_type: Any, mtf_profile: Any
+    ) -> None:
+        with self._lock:
+            if not self._enabled:
+                return
+            key = (_label(code), _label(exchange), _label(market_type), _label(mtf_profile))
+            self._skipped[key] = self._skipped.get(key, 0) + 1
+
+    def inc_snapshot(self, exchange: Any, market_type: Any, ok: bool) -> None:
+        with self._lock:
+            if not self._enabled:
+                return
+            key = (_label(exchange), _label(market_type), "true" if ok else "false")
+            self._snapshots[key] = self._snapshots.get(key, 0) + 1
+
+    # --- exposition ---------------------------------------------------------
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Sérialise le registre en dict JSON déterministe (trié)."""
+        with self._lock:
+            return {
+                "enabled": self._enabled,
+                "runs": _series(self._runs, ("status",)),
+                "sets": {
+                    "dispatched": _series(
+                        self._dispatched, ("exchange", "market_type", "mtf_profile")
+                    ),
+                    "results": _series(
+                        self._results,
+                        ("exchange", "market_type", "mtf_profile", "ok", "business_status"),
+                    ),
+                    "skipped": _series(
+                        self._skipped, ("code", "exchange", "market_type", "mtf_profile")
+                    ),
+                },
+                "snapshots": _series(self._snapshots, ("exchange", "market_type", "ok")),
+                "dispatch_duration_ms": {
+                    "buckets": list(DISPATCH_DURATION_BUCKETS_MS),
+                    "series": _hist_series(
+                        self._duration, ("exchange", "market_type", "mtf_profile")
+                    ),
+                },
+            }
+
+
+def _series(counter: Dict[Tuple[str, ...], int], label_names: Tuple[str, ...]) -> List[Dict[str, Any]]:
+    """Sérialise un compteur indexé par tuple en liste triée de séries labellées."""
+    out: List[Dict[str, Any]] = []
+    for key in sorted(counter):
+        entry: Dict[str, Any] = dict(zip(label_names, key))
+        entry["value"] = counter[key]
+        out.append(entry)
+    return out
+
+
+def _hist_series(
+    hist: Dict[Tuple[str, ...], Dict[str, Any]], label_names: Tuple[str, ...]
+) -> List[Dict[str, Any]]:
+    """Sérialise l'histogramme : bornes cumulées « le » + ``+Inf`` (= count) + somme."""
+    out: List[Dict[str, Any]] = []
+    for key in sorted(hist):
+        data = hist[key]
+        entry: Dict[str, Any] = dict(zip(label_names, key))
+        buckets = {str(bound): data["le"][i] for i, bound in enumerate(DISPATCH_DURATION_BUCKETS_MS)}
+        buckets["+Inf"] = data["count"]
+        entry["count"] = data["count"]
+        entry["sum_ms"] = data["sum"]
+        entry["buckets"] = buckets
+        out.append(entry)
+    return out
+
+
+# Singleton module : un seul registre partagé par le runner et l'endpoint.
+_REGISTRY = _Registry()
+
+
+def configure(*, enabled: bool) -> None:
+    """Active/désactive le registre au démarrage (``ORCHESTRATION_METRICS_ENABLED``)."""
+    _REGISTRY.configure(enabled=enabled)
+
+
+def reset() -> None:
+    """Remet le registre à zéro (tests)."""
+    _REGISTRY.reset()
+
+
+def snapshot() -> Dict[str, Any]:
+    """Snapshot JSON déterministe du registre (consommé par ``GET /metrics``)."""
+    try:
+        return _REGISTRY.snapshot()
+    except Exception:  # noqa: BLE001 - fail-safe : l'exposition ne casse jamais.
+        return {"enabled": False, "error": "metrics snapshot failed"}
+
+
+# --- API d'observation, alignée 1:1 sur les points d'audit OBS-001 ----------
+#
+# Chaque fonction est fail-safe : une erreur interne (clé non hashable, état
+# corrompu) est absorbée et ne fait jamais échouer ni ralentir un run.
+
+
+def observe_run_finished(*, status: Any, total_calls: int, success: int, failed: int) -> None:
+    """Compteur de runs par ``status`` (point ``run_finished``).
+
+    ``total_calls`` / ``success`` / ``failed`` ne sont pas re-comptés ici (ils
+    découlent des observations par set : ``sets_dispatched`` / ``sets_result``) ;
+    ils restent dans la signature pour rappeler la réconciliation avec ``summary``.
+    """
+    try:
+        _REGISTRY.inc_run(status)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def observe_set_dispatched(*, exchange: Any, market_type: Any, mtf_profile: Any) -> None:
+    """Compteur de sets effectivement dispatchés (point ``set_dispatched``)."""
+    try:
+        _REGISTRY.inc_dispatched(exchange, market_type, mtf_profile)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def observe_set_result(
+    *,
+    exchange: Any,
+    market_type: Any,
+    mtf_profile: Any,
+    ok: bool,
+    business_status: Any,
+    duration_ms: Optional[int],
+) -> None:
+    """Compteur de résultats (ok/échec + ``business_status``) et histogramme de durée
+    (point ``set_result``)."""
+    try:
+        _REGISTRY.inc_result(exchange, market_type, mtf_profile, bool(ok), business_status, duration_ms)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def observe_set_skipped(
+    *, code: Any, exchange: Any, market_type: Any, mtf_profile: Any
+) -> None:
+    """Compteur de skips par ``code`` STABLE (OBS-001/SAFE-003) (point ``set_skipped``)."""
+    try:
+        _REGISTRY.inc_skipped(code, exchange, market_type, mtf_profile)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def observe_snapshot_fetch(*, exchange: Any, market_type: Any, ok: bool) -> None:
+    """Compteur de fetch d'état ouvert (ok/indispo) (point ``snapshot_fetch``)."""
+    try:
+        _REGISTRY.inc_snapshot(exchange, market_type, bool(ok))
+    except Exception:  # noqa: BLE001
+        pass

--- a/python-orchestrator/app/settings.py
+++ b/python-orchestrator/app/settings.py
@@ -161,6 +161,13 @@ class Settings:
     # ``ORCHESTRATION_LOG_LEVEL`` (défaut INFO). Validé au démarrage : une valeur
     # inconnue lève (pas de repli silencieux). Cf. ``app/logging_config.py``.
     log_level: str = "INFO"
+    # Collecte des métriques d'exécution par set (OBS-002), pilotée par
+    # ``ORCHESTRATION_METRICS_ENABLED`` (défaut **ON**). Validé au démarrage
+    # (jeu fermé true/false…, comme ``ORCHESTRATION_LIVE_ENABLED``) : une valeur
+    # invalide lève plutôt qu'un repli silencieux. À OFF, les ``observe_*`` du
+    # registre deviennent des no-op et ``GET /metrics`` renvoie un snapshot vide.
+    # Cf. ``app/services/run_metrics.py``.
+    metrics_enabled: bool = True
     # Origines autorisées par CORS pour les appels navigateur du cockpit (UI-001).
     # Défauts = front servi par CRA (:3000) ou nginx (:8082). Surchargeable via
     # CORS_ALLOW_ORIGINS (CSV) ; ``"*"`` autorise toute origine.
@@ -202,6 +209,7 @@ class Settings:
             live_enabled=_bool_env("ORCHESTRATION_LIVE_ENABLED", cls.live_enabled),
             live_exchanges=_live_exchanges_env("ORCHESTRATION_LIVE_EXCHANGES", cls.live_exchanges),
             log_level=_log_level_env("ORCHESTRATION_LOG_LEVEL", cls.log_level),
+            metrics_enabled=_bool_env("ORCHESTRATION_METRICS_ENABLED", cls.metrics_enabled),
             cors_allow_origins=_csv_env("CORS_ALLOW_ORIGINS", cls.cors_allow_origins),
         )
 

--- a/python-orchestrator/tests/test_run_metrics.py
+++ b/python-orchestrator/tests/test_run_metrics.py
@@ -1,0 +1,308 @@
+"""Tests des métriques d'exécution par set (OBS-002).
+
+Couvre :
+- le **registre in-process** ``run_metrics`` : incréments des compteurs, histogramme
+  de durée de dispatch, normalisation des labels, désactivation, **fail-safe** ;
+- le **branchement** sur les points d'instrumentation OBS-001 via
+  ``POST /orchestrator/run`` : un run nominal incrémente runs/sets et observe la
+  durée ; un set skippé incrémente le bon compteur de skip sans dispatch ; un
+  replay/in-flight n'incrémente aucun dispatch ; réconciliation avec ``summary`` ;
+  une erreur interne de métrique ne fait jamais échouer un run ;
+- l'**endpoint** ``GET /metrics`` (sink JSON dérivé du registre).
+
+Les tests lisent le registre via ``run_metrics.snapshot()`` (et non un format
+brut), conformément à la consigne OBS-002.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta, timezone
+from typing import Any, Dict, List
+
+import pytest
+from sqlalchemy import select
+
+from app.db.models import Run
+from app.routers import orchestrator as orch
+from app.services import run_metrics
+
+# Réutilise les helpers de seed/mocks du test du runner (DB SQLite + faux httpx).
+from tests.test_orchestrator_run import (
+    _FakeAsyncClient,
+    _install_fake_client,
+    _mtf_posts,
+    _seed_dashboard,
+    _seed_set,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isole chaque test : registre vide et activé avant, réinitialisé après."""
+    run_metrics.configure(enabled=True)
+    run_metrics.reset()
+    yield
+    run_metrics.configure(enabled=True)
+    run_metrics.reset()
+
+
+def _sum_values(series: List[Dict[str, Any]]) -> int:
+    return sum(entry["value"] for entry in series)
+
+
+def _find(series: List[Dict[str, Any]], **labels: Any) -> Dict[str, Any]:
+    for entry in series:
+        if all(entry.get(k) == v for k, v in labels.items()):
+            return entry
+    raise AssertionError(f"no series matching {labels} in {series}")
+
+
+# ===========================================================================
+# Registre in-process (unitaire)
+# ===========================================================================
+
+
+def test_counters_increment_and_snapshot_shape():
+    run_metrics.observe_run_finished(status="success", total_calls=2, success=2, failed=0)
+    run_metrics.observe_set_dispatched(
+        exchange="bitmart", market_type="perpetual", mtf_profile="scalper_micro"
+    )
+    run_metrics.observe_set_result(
+        exchange="bitmart",
+        market_type="perpetual",
+        mtf_profile="scalper_micro",
+        ok=True,
+        business_status="success",
+        duration_ms=120,
+    )
+    run_metrics.observe_set_skipped(
+        code="locked", exchange="bitmart", market_type="perpetual", mtf_profile="scalper_micro"
+    )
+    run_metrics.observe_snapshot_fetch(exchange="bitmart", market_type="perpetual", ok=True)
+
+    snap = run_metrics.snapshot()
+    assert snap["enabled"] is True
+    assert set(snap.keys()) == {"enabled", "runs", "sets", "snapshots", "dispatch_duration_ms"}
+    assert _find(snap["runs"], status="success")["value"] == 1
+    assert _find(snap["sets"]["dispatched"], mtf_profile="scalper_micro")["value"] == 1
+    assert _find(snap["sets"]["results"], ok="true", business_status="success")["value"] == 1
+    assert _find(snap["sets"]["skipped"], code="locked")["value"] == 1
+    assert _find(snap["snapshots"], exchange="bitmart", ok="true")["value"] == 1
+
+
+def test_set_result_records_duration_histogram_with_le_buckets():
+    run_metrics.observe_set_result(
+        exchange="bitmart",
+        market_type="perpetual",
+        mtf_profile="scalper_micro",
+        ok=True,
+        business_status="success",
+        duration_ms=300,
+    )
+    hist = run_metrics.snapshot()["dispatch_duration_ms"]
+    assert hist["buckets"] == list(run_metrics.DISPATCH_DURATION_BUCKETS_MS)
+    series = hist["series"]
+    assert len(series) == 1
+    entry = series[0]
+    assert entry["count"] == 1
+    assert entry["sum_ms"] == 300
+    # Convention « le » cumulée : 300 ms tombe dans les bornes >= 500.
+    assert entry["buckets"]["100"] == 0
+    assert entry["buckets"]["250"] == 0
+    assert entry["buckets"]["500"] == 1
+    assert entry["buckets"]["+Inf"] == 1
+
+
+def test_missing_business_status_label_normalized_to_unknown():
+    run_metrics.observe_set_result(
+        exchange="bitmart",
+        market_type="perpetual",
+        mtf_profile="scalper_micro",
+        ok=False,
+        business_status=None,
+        duration_ms=None,
+    )
+    results = run_metrics.snapshot()["sets"]["results"]
+    assert _find(results, ok="false")["business_status"] == "unknown"
+
+
+def test_disabled_registry_is_noop():
+    run_metrics.configure(enabled=False)
+    run_metrics.observe_set_dispatched(
+        exchange="bitmart", market_type="perpetual", mtf_profile="scalper_micro"
+    )
+    run_metrics.observe_run_finished(status="success", total_calls=1, success=1, failed=0)
+    snap = run_metrics.snapshot()
+    assert snap["enabled"] is False
+    assert snap["runs"] == []
+    assert snap["sets"]["dispatched"] == []
+
+
+def test_observe_is_failsafe_when_registry_explodes(monkeypatch):
+    # Une erreur interne (état corrompu) est absorbée : l'observation ne lève jamais.
+    def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(run_metrics._REGISTRY, "inc_dispatched", _boom)
+    # Ne doit pas propager.
+    run_metrics.observe_set_dispatched(
+        exchange="bitmart", market_type="perpetual", mtf_profile="scalper_micro"
+    )
+
+
+# ===========================================================================
+# Branchement sur les points OBS-001 (intégration runner)
+# ===========================================================================
+
+
+def test_nominal_run_increments_and_reconciles_with_summary(orchestrator_env, monkeypatch):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _seed_set(session, dash.id, "b", symbols=("ETHUSDT",))
+    _seed_set(session, dash.id, "c", symbols=("XRPUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+    assert body["summary"] == {"total_calls": 3, "success": 3, "failed": 0}
+
+    snap = run_metrics.snapshot()
+    # Run terminé compté par status.
+    assert _find(snap["runs"], status="success")["value"] == 1
+    # Réconciliation avec summary (run nominal : aucun skip ni reprise).
+    assert _sum_values(snap["sets"]["dispatched"]) == body["summary"]["total_calls"]
+    ok_results = [r for r in snap["sets"]["results"] if r["ok"] == "true"]
+    failed_results = [r for r in snap["sets"]["results"] if r["ok"] == "false"]
+    assert _sum_values(ok_results) == body["summary"]["success"]
+    assert _sum_values(failed_results) == body["summary"]["failed"]
+    # Durée de dispatch observée pour chaque set dispatché.
+    hist_count = sum(s["count"] for s in snap["dispatch_duration_ms"]["series"])
+    assert hist_count == 3
+
+
+def test_skipped_live_off_increments_skip_code_without_dispatch(orchestrator_env, monkeypatch):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    # Interrupteur live OFF (défaut) : un set live est skippé fail-closed.
+    _seed_set(session, dash.id, "live", exchange="bitmart", dry_run=False, symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)})
+
+    snap = run_metrics.snapshot()
+    assert _find(snap["sets"]["skipped"], code="live_not_enabled")["value"] == 1
+    # Aucun dispatch ni résultat pour un set skippé.
+    assert snap["sets"]["dispatched"] == []
+    assert snap["sets"]["results"] == []
+
+
+def test_locked_and_not_materialized_skips_use_stable_codes(orchestrator_env, monkeypatch):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    # `not_materialized` : set valide mais sans symbole concret (aucun POST).
+    _seed_set(session, dash.id, "empty", exchange="bitmart", symbols=())
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)})
+
+    snap = run_metrics.snapshot()
+    assert _find(snap["sets"]["skipped"], code="not_materialized")["value"] == 1
+    assert snap["sets"]["dispatched"] == []
+
+
+def test_replay_does_not_increment_dispatch_counters(orchestrator_env, monkeypatch):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    payload = {"dashboard_id": str(dash.id), "idempotency_key": "mrk1"}
+    first = client.post("/orchestrator/run", json=payload).json()
+    assert first["ok"] is True
+
+    # Deuxième appel = REPLAY (aucun dispatch). On repart d'un registre propre pour
+    # n'observer que ce que le replay incrémente (rien).
+    run_metrics.reset()
+    second = client.post("/orchestrator/run", json=payload).json()
+    assert second["run_id"] == first["run_id"]
+    assert len(_mtf_posts(fake)) == 1  # pas de POST supplémentaire
+
+    snap = run_metrics.snapshot()
+    assert snap["sets"]["dispatched"] == []
+    assert snap["sets"]["results"] == []
+    assert snap["runs"] == []  # replay émet run_short_circuit, pas run_finished
+
+
+def test_in_flight_does_not_increment_dispatch_counters(orchestrator_env, monkeypatch):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+
+    now = orch._now()
+    # Un run concurrent est déjà EN VOL (claim running non périmé) sous la même clé.
+    session.add(
+        Run(
+            run_id="run_mik",
+            idempotency_key="mik",
+            ok=False,
+            status="running",
+            total_calls=0,
+            success_count=0,
+            failed_count=0,
+            started_at=now,
+            expires_at=now + timedelta(seconds=3600),
+        )
+    )
+    session.commit()
+    fake = _FakeAsyncClient()
+    _install_fake_client(monkeypatch, fake)
+
+    run_metrics.reset()
+    body = client.post(
+        "/orchestrator/run", json={"dashboard_id": str(dash.id), "idempotency_key": "mik"}
+    ).json()
+    assert body["status"] == "running"
+    assert _mtf_posts(fake) == []
+
+    snap = run_metrics.snapshot()
+    assert snap["sets"]["dispatched"] == []
+    assert snap["runs"] == []
+
+
+def test_metric_internal_error_does_not_fail_run(orchestrator_env, monkeypatch):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+
+    # Une erreur interne de métrique (registre cassé) ne doit jamais casser un run.
+    def _boom(*_a, **_k):
+        raise RuntimeError("metric boom")
+
+    monkeypatch.setattr(run_metrics._REGISTRY, "inc_dispatched", _boom)
+
+    body = client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)}).json()
+    # Le run se termine normalement (comportement métier inchangé).
+    assert body["ok"] is True
+    assert body["summary"] == {"total_calls": 1, "success": 1, "failed": 0}
+
+
+# ===========================================================================
+# Endpoint /metrics (sink JSON)
+# ===========================================================================
+
+
+def test_metrics_endpoint_exposes_snapshot(orchestrator_env, monkeypatch):
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_set(session, dash.id, "a", symbols=("BTCUSDT",))
+    _install_fake_client(monkeypatch, _FakeAsyncClient())
+    client.post("/orchestrator/run", json={"dashboard_id": str(dash.id)})
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data.keys()) == {"enabled", "runs", "sets", "snapshots", "dispatch_duration_ms"}
+    assert _find(data["runs"], status="success")["value"] == 1
+    assert _sum_values(data["sets"]["dispatched"]) == 1

--- a/python-orchestrator/tests/test_settings.py
+++ b/python-orchestrator/tests/test_settings.py
@@ -142,3 +142,28 @@ def test_log_level_invalid_raises_at_startup(monkeypatch):
     monkeypatch.setenv("ORCHESTRATION_LOG_LEVEL", "verbose")
     with pytest.raises(SettingsError):
         Settings.from_env()
+
+
+# --- Collecte des métriques d'exécution (OBS-002) ---------------------------
+
+
+def test_metrics_enabled_on_by_default(monkeypatch):
+    monkeypatch.delenv("ORCHESTRATION_METRICS_ENABLED", raising=False)
+    assert Settings.from_env().metrics_enabled is True
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("true", True), ("1", True), ("on", True), ("false", False), ("0", False), ("off", False)],
+)
+def test_metrics_enabled_parsing(monkeypatch, raw, expected):
+    monkeypatch.setenv("ORCHESTRATION_METRICS_ENABLED", raw)
+    assert Settings.from_env().metrics_enabled is expected
+
+
+def test_metrics_enabled_invalid_raises_at_startup(monkeypatch):
+    # Comme les autres interrupteurs : une valeur invalide lève au démarrage plutôt
+    # qu'un repli silencieux.
+    monkeypatch.setenv("ORCHESTRATION_METRICS_ENABLED", "sometimes")
+    with pytest.raises(SettingsError):
+        Settings.from_env()


### PR DESCRIPTION
## Contexte

OBS-001 a posé un **flux d'audit** (JSON line corrélé par `run_id`) et un **historique DB** (`runs`/`run_sets`), mais aucune **couche quantitative** prête à grapher/alerter. OBS-002 ajoute les **métriques d'exécution par set**, fail-safe, **sans changer le comportement métier**.

## Scope

- **Registre in-process** `app/services/run_metrics.py`, branché aux **mêmes points** qu'OBS-001 (`set_dispatched` / `set_result` / `set_skipped` / `snapshot_fetch` / `run_finished`) — pas de duplication de schéma, codes/status stables réutilisés comme labels.
- **Métriques** : compteurs de runs (par `status`), de sets (`dispatched` / `results` ok+`business_status` / `skipped` par `code`), de snapshots (ok/indispo) + **histogramme** de durée de dispatch (`set_result.duration_ms`, bornes « le »).
- **Sink** (décision produit) : **endpoint JSON dérivé** `GET /metrics` (`app/routers/metrics.py`) — aucune migration, aucune écriture DB, aucune I/O bloquante pendant les ~900 s d'appels Symfony.
- **Labels faible cardinalité** : `exchange` / `market_type` / `mtf_profile` (+ `code` / `business_status` / `status`). **Ni `set_id` ni `dashboard_id`.**
- **Activation** : `ORCHESTRATION_METRICS_ENABLED` (défaut **ON**), validé au démarrage comme `ORCHESTRATION_LIVE_ENABLED`.
- **Fail-safe** : une erreur de métrique ne fait jamais échouer ni ralentir un run (`try/except` interne).
- Doc : sous-section *Métriques d'exécution par set (OBS-002)* du handbook + ligne plan OBS-002 ✅ ; README (endpoint, variable d'env, exemple) ; readiness dans `exchange-schedule-policy.md`.

## Hors-scope

- Lien avec `position_trade_analysis` (OBS-003).
- Garde-fous live (SAFE-003), locks (SAFE-001), idempotence (SAFE-002), audit OBS-001 au-delà du branchement.
- Front/cockpit, contrat `RunRequest`/`RunResponse`, endpoint Symfony, schedule Temporal, stratégie YAML.

## Vérifications

`cd python-orchestrator && pytest` → **321 passed, 3 skipped** (smoke PostgreSQL). Nouveaux tests :
- un run nominal incrémente runs/sets et observe la durée de dispatch ;
- un set skippé (live OFF / locked / not_materialized…) incrémente le compteur de skip avec le bon `code`, **sans** dispatch ;
- un replay / in-flight n'incrémente **aucun** compteur de dispatch ;
- les compteurs **réconcilient** avec `summary` (total_calls/success/failed) ;
- une **erreur interne** de métrique ne fait pas échouer le run (fail-safe) ;
- `ORCHESTRATION_METRICS_ENABLED` invalide ⇒ lève au démarrage ;
- `GET /metrics` expose le snapshot.

**Revue** : aucune décision métier modifiée, réponses HTTP inchangées, forme `last_json`/`RunSet` inchangée, OBS-001 et SAFE-001/002/003 intacts. Pas de migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N15Am7ddCghMEgVWXwLFkL)_