### PR TITLE
OBS-003: Relier les runs d'orchestration à position_trade_analysis

### DIFF
--- a/docs/handbook/functional/orchestration-dashboard.md
+++ b/docs/handbook/functional/orchestration-dashboard.md
@@ -169,12 +169,23 @@ Le cockpit ne doit pas :
 
 Les runs doivent ensuite pouvoir être rapprochés de :
 
-- `position_trade_analysis` ;
-- PnL net ;
-- MFE / MAE ;
-- durée de trade ;
+- `position_trade_analysis` ✅ (OBS-003) ;
+- PnL net ✅ (OBS-003 : `pnl_usdt` / `pnl_r`) ;
+- MFE / MAE ✅ (OBS-003 : moyens et médians) ;
+- durée de trade ✅ (OBS-003 : `holding_time_sec_avg`) ;
 - frais / spread / slippage ;
 - erreurs d'exécution ;
 - trades évités ou bloqués.
+
+Ce rapprochement est **disponible** depuis OBS-003 : `GET /runs/{run_id}/outcome`
+(orchestrateur) relie un run à ses trades via la vue Symfony
+`position_trade_analysis` (par `run_id`, en lecture seule, PnL non recalculé). Il
+expose le nombre de trades, le PnL net (USDT / R), le win-rate, les MFE/MAE moyens et
+médians et la durée de détention, avec ventilation par symbole. Le `run_id` est
+propagé à Symfony via l'en-tête `X-Run-Id` puis stocké sur les events (tronqué à 64
+des deux côtés pour la réconciliation). Fail-safe : un run sans trade ou une vue
+indisponible renvoie un agrégat vide explicite. Voir
+`docs/handbook/technical/python-orchestrator.md` (§ *Rapprochement runs ↔ trades
+(OBS-003)*).
 
 L'objectif reste la qualité des setups et l'expectancy nette, pas le nombre brut d'appels ou de trades.

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -666,6 +666,55 @@ pas de redéfinition de cause métier.
   idempotence, réponses HTTP et forme de `last_json`/`RunSet` inchangés ; OBS-001
   et SAFE-001/002/003 intacts.
 
+### Rapprochement runs ↔ trades (OBS-003)
+
+OBS-001/002 rendent visible l'**exécution** d'un run (audit + métriques), mais pas
+son **résultat de trading** : pour un `run_id` donné, impossible de répondre
+programmatiquement à « quels trades ont été ouverts/fermés, quel PnL net, quels
+MFE/MAE, quel win-rate ? ». OBS-003 ajoute la **couche OUTCOME** : une surface de
+**lecture seule** reliant un run d'orchestration (schéma `orchestration`) à ses
+trades résultants exposés par la vue Symfony `position_trade_analysis`, par `run_id`.
+
+- **Source** (décision produit) : un **nouvel endpoint Symfony** en lecture seule,
+  `GET /api/positions/analysis?run_id=…` (`PositionAnalysisApiController` →
+  `RunTradeOutcomeService` → vue `position_trade_analysis`), consommé par
+  l'orchestrateur en **HTTP** (`app/services/symfony_client.py:fetch_run_trade_outcome`).
+  L'orchestrateur n'est **pas couplé** au schéma interne Symfony : il parle à Symfony
+  comme pour tout le reste (snapshot, contrats, run). Le **PnL n'est jamais recalculé** :
+  Symfony agrège les valeurs déjà exposées par la vue.
+- **Surface orchestrateur** : `GET /runs/{run_id}/outcome` (`app/routers/runs.py`),
+  renvoie un agrégat **par run** + **ventilation par symbole** :
+  - `trade_count`, `closed_count`, `open_count`, `win_count`, `loss_count` ;
+  - `win_rate` (sur les trades **clôturés**, `null` si aucun) ;
+  - **PnL net** : `pnl_usdt` et `pnl_r` (sommes, jamais recalculées) ;
+  - `mfe_pct_avg` / `mfe_pct_median`, `mae_pct_avg` / `mae_pct_median` ;
+  - `holding_time_sec_avg` ;
+  - `by_symbol[]` : les mêmes agrégats par symbole.
+- **Réconciliation du `run_id`** (point dur, **vérifié et tranché**) : avant OBS-003,
+  Symfony **n'utilisait pas** l'en-tête `X-Run-Id` — `RunnerController` l'ignorait et
+  `MtfRunnerService` générait un `Uuid::uuid4()`, qui finissait sur
+  `trade_lifecycle_event.run_id` → la vue. Un join par `run_id` renvoyait donc **0
+  ligne**. OBS-003 **câble** `X-Run-Id` côté Symfony : `RunnerController` lit l'en-tête
+  et le propage au runner (`MtfRunnerRequestDto::runId`), utilisé comme `run_id` du run
+  (sinon fallback UUID, comportement CLI/appel direct inchangé). Comme
+  `trade_lifecycle_event.run_id` (== `position_trade_analysis.run_id`) est un
+  **VARCHAR(64)** alors que l'orchestration `runs.run_id` peut atteindre 255 (forme
+  hachée = 68), le run_id est **tronqué à 64** des deux côtés : le runner Symfony borne
+  l'en-tête avant de le stocker, et `GET /runs/{run_id}/outcome` interroge la vue avec
+  le même `run_id[:64]` (champ `reconciled_run_id` de la réponse). Règle unique, donc
+  les deux côtés utilisent strictement le même identifiant.
+- **Fail-safe** : un run inconnu, un run **sans trade** ou une **vue indisponible**
+  renvoient un agrégat **vide explicite** (`trade_count=0`, `by_symbol=[]`), jamais un
+  500 ni un blocage. Les drapeaux `run_found` (run connu côté orchestration) et
+  `source_available` (la vue Symfony a répondu) qualifient le résultat. Côté Symfony,
+  `RunTradeOutcomeService` enveloppe la lecture dans un `try/catch` (vue absente / erreur
+  SQL → `available=false`). Lecture seule, transaction courte, aucune écriture sur la vue.
+- **Aucun changement de comportement métier** : pas de dispatch, décisions
+  live/lock/idempotence inchangées, réponses HTTP de `/orchestrator/run` et forme de
+  `last_json`/`RunSet` inchangées, vue `position_trade_analysis` non modifiée. Seul
+  ajout : la consommation de `X-Run-Id` côté runner (identifiant de corrélation), sans
+  effet sur les décisions. Pas de migration.
+
 ## Garde-fous fonctionnels
 
 Avant tout run :
@@ -736,6 +785,7 @@ Avant tout run :
 | SAFE-003 ✅ | Centraliser et durcir les garde-fous live | Livré : module unique `app/services/live_guard.py` (`assess_live -> LiveDecision`) consommé par `assert_set_persistable`, `assert_live_allowed` et le runner `_dispatch_set` (plus de logique live dupliquée schemas ↔ runner). Hiérarchie fail-closed : bannissements permanents OKX/Hyperliquid (jamais relâchés) > interrupteur `ORCHESTRATION_LIVE_ENABLED` (défaut OFF) > allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > snapshot d'état ouvert présent. `reason`/`code` stables par cause. Persistance ↔ runtime cohérents. **Le live reste désactivé par défaut** : aucune réactivation effective, seule l'activation devient possible/auditable/testée. Pas de migration. |
 | OBS-001 ✅ | Audit des runs d'orchestration | Livré : couche d'audit structurée, fail-safe et corrélée par `run_id` (`app/services/run_audit.py`, `emit`) sur le logger `orchestrator.audit`, format **JSON line** sur stdout (`app/logging_config.py`), niveau piloté par `ORCHESTRATION_LOG_LEVEL` (défaut INFO, validé au démarrage). Points d'audit : `run_started`, `run_short_circuit` (replay/in_flight/resume/reclaim), `snapshot_fetch`, `set_skipped` (codes live_guard / locked / conflicting_live / open_state_unavailable), `set_dispatched`, `set_result`, `run_finished`. `code`/`reason` identiques à `RunSet.error` (source unique SAFE-003). Trace-id `X-Run-Id` propagé à Symfony. **Aucun changement de comportement** (SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
 | OBS-002 ✅ | Métriques d'exécution par set | Livré : registre de métriques in-process (`app/services/run_metrics.py`) branché aux **mêmes points** qu'OBS-001 (`set_dispatched`/`set_result`/`set_skipped`/`snapshot_fetch`/`run_finished`). Compteurs (runs par status ; sets dispatched/results ok+`business_status`/skipped par `code` ; snapshots ok/indispo) + **histogramme** de durée de dispatch (`set_result.duration_ms`, bornes « le »). Sink = **endpoint JSON dérivé** `GET /metrics` (`app/routers/metrics.py`), aucune migration ni écriture DB. Labels **faible cardinalité** (`exchange`/`market_type`/`mtf_profile` + `code`/`business_status`/`status`), ni `set_id` ni `dashboard_id`. Activation `ORCHESTRATION_METRICS_ENABLED` (défaut ON, validé au démarrage). Réconcilie avec `summary`. **Fail-safe**, **aucun changement de comportement** (OBS-001 et SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
+| OBS-003 ✅ | Relier les runs d'orchestration à `position_trade_analysis` | Livré : couche **OUTCOME** read-only reliant un run à ses trades par `run_id`. Source = nouvel endpoint Symfony `GET /api/positions/analysis?run_id=…` (`PositionAnalysisApiController` → `RunTradeOutcomeService` → vue `position_trade_analysis`, PnL jamais recalculé), consommé en HTTP (`symfony_client.fetch_run_trade_outcome`). Surface orchestrateur `GET /runs/{run_id}/outcome` : agrégat par run (count, `pnl_usdt`/`pnl_r`, win-rate, MFE/MAE moyens+médians, holding-time) + ventilation `by_symbol`. **Réconciliation `run_id`** : `X-Run-Id` désormais **consommé** par `RunnerController`/`MtfRunnerService` (avant : UUID, join vide), tronqué à 64 des deux côtés (`reconciled_run_id`) pour matcher `trade_lifecycle_event.run_id` VARCHAR(64). **Fail-safe** (run inconnu / sans trade / vue indisponible → agrégat vide, `run_found`/`source_available`, jamais 500). **Aucun changement de comportement métier** (vue non modifiée, réponses `/orchestrator/run` inchangées, OBS-001/002 et SAFE-001/002/003 intacts). Pas de migration. |
 | UI-001 | Ajouter cockpit minimal | Liste des sets, preview, dernier JSON, erreurs par set. |
 | TM-001 | Brancher Temporal en cron basique | Une activity appelle `/orchestrator/run` et échoue si `ok=false`. |
 
@@ -777,6 +827,66 @@ Réponse :
 ```
 
 L'API Python utilise cet endpoint lors du « refresh contrats » pour préparer les sets.
+
+## Endpoint Symfony : rapprochement trades par run (OBS-003)
+
+`GET /api/positions/analysis?run_id=…` expose, en **lecture seule**, l'agrégat des
+trades d'un run à partir de la vue `position_trade_analysis`
+(`PositionAnalysisApiController` → `RunTradeOutcomeService`). Consommé par
+l'orchestrateur via `GET /runs/{run_id}/outcome`. Le **PnL n'est jamais recalculé** :
+on somme/moyenne les valeurs déjà exposées par la vue.
+
+| Param | Requis | Rôle |
+| --- | --- | --- |
+| `run_id` | oui | `run_id` de corrélation (déjà borné à 64 par l'appelant). |
+
+Le service borne lui-même `run_id` à 64 caractères (largeur de
+`position_trade_analysis.run_id`) : la même règle s'applique côté orchestrateur, donc
+les deux côtés interrogent le même identifiant.
+
+Réponse (agrégat global + ventilation `by_symbol`) :
+
+```json
+{
+  "run_id": "run_20260621_120000_ab12cd",
+  "available": true,
+  "trade_count": 3,
+  "closed_count": 2,
+  "open_count": 1,
+  "win_count": 1,
+  "loss_count": 1,
+  "win_rate": 0.5,
+  "pnl_usdt": 12.34,
+  "pnl_r": 1.2,
+  "mfe_pct_avg": 0.8,
+  "mfe_pct_median": 0.8,
+  "mae_pct_avg": -0.4,
+  "mae_pct_median": -0.4,
+  "holding_time_sec_avg": 123.0,
+  "by_symbol": [
+    {
+      "symbol": "BTCUSDT",
+      "trade_count": 2,
+      "closed_count": 2,
+      "open_count": 0,
+      "win_count": 1,
+      "loss_count": 1,
+      "win_rate": 0.5,
+      "pnl_usdt": 6.0,
+      "pnl_r": 0.5,
+      "mfe_pct_avg": 0.9,
+      "mfe_pct_median": 0.9,
+      "mae_pct_avg": -0.5,
+      "mae_pct_median": -0.5,
+      "holding_time_sec_avg": 100.0
+    }
+  ]
+}
+```
+
+**Fail-safe** : un `run_id` manquant donne un `400` ; une vue indisponible / erreur SQL
+retombe sur `available: false` (agrégat vide, HTTP 200) ; un run sans trade donne
+`available: true` avec compteurs à 0. Jamais de 500. La vue n'est jamais modifiée.
 
 ## Hors-scope de la première PR code
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -70,6 +70,7 @@ Hors-scope (PR suivantes) :
 | `GET` | `/runs` | Liste les runs (`?dashboard_id=&limit=&offset=`) (PY-006). |
 | `GET` | `/runs/{run_id}` | Dernier JSON global d'un run + détail par set (PY-006). |
 | `GET` | `/runs/{run_id}/sets/{set_id}` | Dernier JSON d'un set (payload + réponse brute) (PY-006). |
+| `GET` | `/runs/{run_id}/outcome` | Rapprochement run ↔ trades (`position_trade_analysis`) : PnL net, win-rate, MFE/MAE, ventilation par symbole (OBS-003). |
 | `GET` | `/metrics` | Métriques d'exécution agrégées (compteurs + histogramme de durée), JSON dérivé du registre (OBS-002). |
 | `GET` | `/docs` | Swagger UI (OpenAPI). |
 
@@ -207,6 +208,52 @@ plus ancien et paginée (`limit` borné à 100, `offset`). `GET /runs/{run_id}` 
 `last_json` global + `sets[]` avec `payload_sent`, `response_json`, `error`,
 `duration_ms`). Ces endpoints n'écrivent rien : la persistance est faite par
 PY-005.
+
+### Rapprochement runs ↔ trades (OBS-003)
+
+`GET /runs/{run_id}/outcome` relie un run d'orchestration à ses **trades
+résultants** exposés par la vue Symfony `position_trade_analysis`, par `run_id`,
+en **lecture seule**. La source est l'endpoint Symfony
+`GET /api/positions/analysis?run_id=…` (consommé en HTTP, le PnL n'est jamais
+recalculé). Le run_id est tronqué à 64 caractères (`reconciled_run_id`) pour
+matcher `trade_lifecycle_event.run_id` (VARCHAR(64)) ; ce même run_id est désormais
+propagé à Symfony via l'en-tête `X-Run-Id` et **utilisé** comme run_id du run (avant
+OBS-003, Symfony générait un UUID et le join restait vide).
+
+```bash
+curl -s 'localhost:8099/runs/run_dashA_20260617T083000Z/outcome'
+```
+
+```json
+{
+  "run_id": "run_dashA_20260617T083000Z",
+  "reconciled_run_id": "run_dashA_20260617T083000Z",
+  "run_found": true,
+  "source_available": true,
+  "trade_count": 3,
+  "closed_count": 2,
+  "open_count": 1,
+  "win_count": 1,
+  "loss_count": 1,
+  "win_rate": 0.5,
+  "pnl_usdt": 12.34,
+  "pnl_r": 1.2,
+  "mfe_pct_avg": 0.8,
+  "mfe_pct_median": 0.8,
+  "mae_pct_avg": -0.4,
+  "mae_pct_median": -0.4,
+  "holding_time_sec_avg": 123.0,
+  "by_symbol": [
+    { "symbol": "BTCUSDT", "trade_count": 2, "pnl_usdt": 6.0, "pnl_r": 0.5, "win_rate": 0.5 }
+  ]
+}
+```
+
+**Fail-safe** : un run inconnu, un run **sans trade** ou une **vue Symfony
+indisponible** renvoient un agrégat vide explicite (HTTP 200, jamais de 500).
+`run_found` indique si le run existe côté orchestration ; `source_available` si la
+vue a répondu (False = agrégat vide non fiable). Aucune variable d'env ajoutée :
+l'endpoint réutilise `SYMFONY_BASE_URL`.
 
 ## Lancement local
 

--- a/python-orchestrator/app/routers/runs.py
+++ b/python-orchestrator/app/routers/runs.py
@@ -14,20 +14,53 @@ cette PR n'ajoute que la surface de lecture consommée par le cockpit
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from app.db import repositories as repo
 from app.db.engine import get_session
 from app.db.models import RunSet
-from app.schemas import RunDetailRead, RunSetRead, RunSummaryRead
+from app.schemas import RunDetailRead, RunOutcomeRead, RunSetRead, RunSummaryRead
+from app.services.symfony_client import fetch_run_trade_outcome
+from app.settings import get_settings
 
 router = APIRouter(prefix="/runs", tags=["runs"])
 
 # Borne la taille de page pour ne jamais renvoyer un historique non borné.
 _MAX_PAGE_SIZE = 100
+
+# Règle de réconciliation du run_id (OBS-003) : `position_trade_analysis.run_id`
+# (== `trade_lifecycle_event.run_id`) est un VARCHAR(64), alors que l'orchestration
+# `runs.run_id` peut atteindre 255 (forme hachée = 68). Le runner Symfony tronque
+# X-Run-Id à 64 avant de le stocker ; on interroge donc la vue avec le même
+# `run_id[:64]` pour que les deux côtés utilisent strictement le même identifiant.
+_SYMFONY_RUN_ID_MAXLEN = 64
+
+# Timeout (s) de l'appel de lecture Symfony pour le rapprochement (lecture seule,
+# court : pas de run/dispatch derrière, contrairement à `_HTTP_TIMEOUT` du runner).
+_OUTCOME_HTTP_TIMEOUT = 30.0
+
+# Type de la fonction de récupération de l'agrégat, injectable (tests).
+OutcomeFetcher = Callable[[str], Awaitable[dict]]
+
+
+async def _fetch_outcome_via_symfony(run_id: str) -> dict:
+    """Récupère l'agrégat de rapprochement auprès de Symfony (HTTP, lecture seule)."""
+    settings = get_settings()
+    async with httpx.AsyncClient(timeout=_OUTCOME_HTTP_TIMEOUT) as client:
+        return await fetch_run_trade_outcome(client, settings.symfony_base_url, run_id)
+
+
+def get_outcome_fetcher() -> OutcomeFetcher:
+    """Dépendance fournissant le fetcher d'agrégat (surchargée par les tests).
+
+    Le runtime appelle Symfony en HTTP (séparation propre, pas de couplage de
+    l'orchestrateur au schéma interne Symfony) ; les tests injectent un stub.
+    """
+    return _fetch_outcome_via_symfony
 
 
 @router.get("", response_model=list[RunSummaryRead])
@@ -52,6 +85,36 @@ def get_run(run_id: str, session: Session = Depends(get_session)) -> RunDetailRe
     if run is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="run not found")
     return RunDetailRead.from_run(run, repo.list_run_sets(session, run_id))
+
+
+@router.get("/{run_id}/outcome", response_model=RunOutcomeRead)
+async def get_run_outcome(
+    run_id: str,
+    session: Session = Depends(get_session),
+    fetch: OutcomeFetcher = Depends(get_outcome_fetcher),
+) -> RunOutcomeRead:
+    """Rapproche un run d'orchestration de ses trades (OBS-003), en LECTURE SEULE.
+
+    Relie le run (schéma ``orchestration``) à la vue Symfony
+    ``position_trade_analysis`` par ``run_id`` : nombre de trades, PnL net (USDT / R),
+    win-rate, MFE/MAE moyens et médians, durée de détention — avec ventilation par
+    symbole. Le PnL n'est jamais recalculé (Symfony est la source).
+
+    Fail-safe : un run inconnu, un run sans trade ou une vue indisponible renvoient un
+    agrégat vide explicite (jamais un 500). ``run_found`` et ``source_available``
+    qualifient le résultat.
+    """
+    run = repo.get_run(session, run_id)
+    # Réconciliation : on requête la vue avec le run_id tronqué à 64 (forme réellement
+    # stockée côté Symfony). `reconciled_run_id` documente l'identifiant utilisé.
+    reconciled_run_id = run_id[:_SYMFONY_RUN_ID_MAXLEN]
+    source = await fetch(reconciled_run_id)
+    return RunOutcomeRead.from_source(
+        run_id=run_id,
+        reconciled_run_id=reconciled_run_id,
+        run_found=run is not None,
+        source=source,
+    )
 
 
 @router.get("/{run_id}/sets/{set_id}", response_model=RunSetRead)

--- a/python-orchestrator/app/schemas.py
+++ b/python-orchestrator/app/schemas.py
@@ -318,6 +318,109 @@ class RunDetailRead(RunSummaryRead):
 
 
 # ---------------------------------------------------------------------------
+# Rapprochement run ↔ trades (OBS-003)
+#
+# Surface de LECTURE SEULE reliant un run d'orchestration (schéma `orchestration`)
+# à ses résultats de trading exposés par la vue Symfony `position_trade_analysis`,
+# par `run_id`. Le PnL n'est jamais recalculé : ces schémas ne font que transporter
+# l'agrégat fourni par Symfony (`GET /api/positions/analysis`). Fail-safe : un run
+# inconnu / sans trade / une vue indisponible donnent un agrégat vide explicite.
+# ---------------------------------------------------------------------------
+
+
+class RunOutcomeSymbolRead(BaseModel):
+    """Agrégat de trades d'un run pour un symbole (ventilation)."""
+
+    symbol: str
+    trade_count: int = 0
+    closed_count: int = 0
+    open_count: int = 0
+    win_count: int = 0
+    loss_count: int = 0
+    win_rate: Optional[float] = None
+    pnl_usdt: Optional[float] = None
+    pnl_r: Optional[float] = None
+    mfe_pct_avg: Optional[float] = None
+    mfe_pct_median: Optional[float] = None
+    mae_pct_avg: Optional[float] = None
+    mae_pct_median: Optional[float] = None
+    holding_time_sec_avg: Optional[float] = None
+
+
+class RunOutcomeRead(BaseModel):
+    """Rapprochement d'un run d'orchestration avec ses trades (`position_trade_analysis`).
+
+    ``run_id`` est l'identifiant d'orchestration demandé ; ``reconciled_run_id`` est
+    la forme ≤64 caractères réellement utilisée pour interroger la vue (règle de
+    réconciliation, cf. ``GET /runs/{run_id}/outcome``). ``run_found`` indique si le
+    run existe côté orchestration ; ``source_available`` si la source Symfony a
+    répondu (False = vue indisponible/injoignable, agrégat vide non fiable).
+    """
+
+    run_id: str
+    reconciled_run_id: str
+    run_found: bool = False
+    source_available: bool = False
+    trade_count: int = 0
+    closed_count: int = 0
+    open_count: int = 0
+    win_count: int = 0
+    loss_count: int = 0
+    win_rate: Optional[float] = None
+    pnl_usdt: Optional[float] = None
+    pnl_r: Optional[float] = None
+    mfe_pct_avg: Optional[float] = None
+    mfe_pct_median: Optional[float] = None
+    mae_pct_avg: Optional[float] = None
+    mae_pct_median: Optional[float] = None
+    holding_time_sec_avg: Optional[float] = None
+    by_symbol: List[RunOutcomeSymbolRead] = Field(default_factory=list)
+
+    @classmethod
+    def from_source(
+        cls,
+        *,
+        run_id: str,
+        reconciled_run_id: str,
+        run_found: bool,
+        source: dict,
+    ) -> "RunOutcomeRead":
+        """Assemble la réponse depuis l'agrégat Symfony (fail-safe sur clés absentes).
+
+        ``source`` est le dict renvoyé par ``fetch_run_trade_outcome`` (réponse de
+        ``GET /api/positions/analysis`` ou agrégat vide ``available=False``). On lit
+        chaque champ défensivement : une réponse partielle ne doit jamais lever.
+        """
+        src = source if isinstance(source, dict) else {}
+        raw_symbols = src.get("by_symbol")
+        by_symbol = [
+            RunOutcomeSymbolRead.model_validate(s)
+            for s in (raw_symbols if isinstance(raw_symbols, list) else [])
+            if isinstance(s, dict)
+        ]
+        return cls(
+            run_id=run_id,
+            reconciled_run_id=reconciled_run_id,
+            run_found=run_found,
+            source_available=bool(src.get("available", False)),
+            trade_count=int(src.get("trade_count") or 0),
+            closed_count=int(src.get("closed_count") or 0),
+            open_count=int(src.get("open_count") or 0),
+            win_count=int(src.get("win_count") or 0),
+            loss_count=int(src.get("loss_count") or 0),
+            win_rate=src.get("win_rate"),
+            pnl_usdt=src.get("pnl_usdt"),
+            pnl_r=src.get("pnl_r"),
+            mfe_pct_avg=src.get("mfe_pct_avg"),
+            mfe_pct_median=src.get("mfe_pct_median"),
+            mae_pct_avg=src.get("mae_pct_avg"),
+            mae_pct_median=src.get("mae_pct_median"),
+            holding_time_sec_avg=src.get("holding_time_sec_avg"),
+            by_symbol=by_symbol,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Gestion des dashboards et des sets (PY-002)
 #
 # Schémas d'entrée/sortie de l'API de configuration : création, lecture, mise à

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -424,6 +424,82 @@ async def run_mtf_set(
     return await _dispatch_mtf_run(client, base_url, a_set.set_id, payload)
 
 
+# Clés de l'agrégat de rapprochement run ↔ trades (OBS-003), miroir de la réponse
+# de `GET /api/positions/analysis` côté Symfony. Source unique de la forme attendue ;
+# `_empty_run_outcome` les remplit à vide quand la source est indisponible.
+_OUTCOME_NUMERIC_FIELDS = (
+    "trade_count",
+    "closed_count",
+    "open_count",
+    "win_count",
+    "loss_count",
+)
+
+
+def _empty_run_outcome(run_id: str, *, available: bool) -> Dict[str, Any]:
+    """Agrégat de rapprochement vide explicite (source indisponible / run sans trade).
+
+    ``available`` distingue « la source a répondu, mais 0 trade » (True) de « la
+    source Symfony est injoignable / a renvoyé une réponse invalide » (False). Dans
+    les deux cas, c'est un résultat exploitable, jamais une exception.
+    """
+    outcome: Dict[str, Any] = {
+        "run_id": run_id,
+        "available": available,
+        "win_rate": None,
+        "pnl_usdt": None,
+        "pnl_r": None,
+        "mfe_pct_avg": None,
+        "mfe_pct_median": None,
+        "mae_pct_avg": None,
+        "mae_pct_median": None,
+        "holding_time_sec_avg": None,
+        "by_symbol": [],
+    }
+    for field in _OUTCOME_NUMERIC_FIELDS:
+        outcome[field] = 0
+    return outcome
+
+
+async def fetch_run_trade_outcome(
+    client: httpx.AsyncClient,
+    base_url: str,
+    run_id: str,
+) -> Dict[str, Any]:
+    """Rapproche un run de ses trades via Symfony (OBS-003), en LECTURE SEULE.
+
+    Appelle ``GET /api/positions/analysis?run_id=…`` (vue ``position_trade_analysis``
+    agrégée par run_id, côté Symfony) et renvoie l'agrégat tel quel. Le PnL n'est
+    jamais recalculé ici : Symfony est la source de vérité des valeurs.
+
+    Fail-safe : toute défaillance (erreur réseau, HTTP != 200, JSON invalide, forme
+    inattendue) retombe sur un agrégat vide EXPLICITE (``available=False``) — jamais
+    une exception, pour que ``GET /runs/{run_id}/outcome`` ne renvoie pas de 500.
+
+    NB : ``run_id`` doit déjà être borné à 64 caractères par l'appelant (règle de
+    réconciliation : c'est la largeur de ``position_trade_analysis.run_id``, et le
+    runner Symfony tronque X-Run-Id à la même longueur avant de le stocker).
+    """
+    url = f"{base_url.rstrip('/')}/api/positions/analysis"
+    try:
+        response = await client.get(url, params={"run_id": run_id})
+    except httpx.HTTPError:
+        return _empty_run_outcome(run_id, available=False)
+
+    if response.status_code != 200:
+        return _empty_run_outcome(run_id, available=False)
+
+    try:
+        body = response.json()
+    except ValueError:
+        return _empty_run_outcome(run_id, available=False)
+
+    if not isinstance(body, dict):
+        return _empty_run_outcome(run_id, available=False)
+
+    return body
+
+
 async def run_persisted_set(
     client: httpx.AsyncClient,
     base_url: str,

--- a/python-orchestrator/tests/test_runs_api.py
+++ b/python-orchestrator/tests/test_runs_api.py
@@ -327,3 +327,131 @@ def test_run_with_slash_bearing_key_is_fetchable(orchestrator_env, monkeypatch):
     assert "/" not in run_id
     assert client.get(f"/runs/{run_id}").status_code == 200
     assert client.get(f"/runs/{run_id}/sets/a").status_code == 200
+
+
+# --------------------------------------------------------------------------
+# GET /runs/{run_id}/outcome (OBS-003) — rapprochement run ↔ trades
+# --------------------------------------------------------------------------
+
+
+def _override_outcome(client_app, source):
+    """Surcharge le fetcher d'agrégat par un stub renvoyant ``source``.
+
+    ``source`` peut être un dict (réponse Symfony simulée) ou un callable
+    ``run_id -> dict`` pour inspecter le run_id réellement requêté.
+    """
+    from app.main import app
+    from app.routers.runs import get_outcome_fetcher
+
+    async def _fake_fetch(run_id: str) -> dict:
+        return source(run_id) if callable(source) else source
+
+    app.dependency_overrides[get_outcome_fetcher] = lambda: _fake_fetch
+    return get_outcome_fetcher
+
+
+def _clear_outcome_override(key):
+    from app.main import app
+
+    app.dependency_overrides.pop(key, None)
+
+
+def test_run_outcome_with_trades(orchestrator_env):
+    client, session = orchestrator_env
+    _seed_run(session, "run_o1")
+    aggregate = {
+        "run_id": "run_o1",
+        "available": True,
+        "trade_count": 3,
+        "closed_count": 3,
+        "open_count": 0,
+        "win_count": 2,
+        "loss_count": 1,
+        "win_rate": 0.6667,
+        "pnl_usdt": 12.0,
+        "pnl_r": 1.0,
+        "mfe_pct_avg": 2.0,
+        "mfe_pct_median": 2.0,
+        "mae_pct_avg": -1.5,
+        "mae_pct_median": -1.5,
+        "holding_time_sec_avg": 200.0,
+        "by_symbol": [{"symbol": "BTCUSDT", "trade_count": 2, "pnl_usdt": 6.0, "win_rate": 0.5}],
+    }
+    key = _override_outcome(client, aggregate)
+    try:
+        body = client.get("/runs/run_o1/outcome").json()
+    finally:
+        _clear_outcome_override(key)
+
+    assert body["run_id"] == "run_o1"
+    assert body["reconciled_run_id"] == "run_o1"
+    assert body["run_found"] is True
+    assert body["source_available"] is True
+    assert body["trade_count"] == 3
+    assert body["pnl_usdt"] == 12.0
+    assert body["pnl_r"] == 1.0
+    assert body["win_rate"] == 0.6667
+    assert body["by_symbol"][0]["symbol"] == "BTCUSDT"
+    assert body["by_symbol"][0]["pnl_usdt"] == 6.0
+
+
+def test_run_outcome_without_trades_is_empty_but_available(orchestrator_env):
+    client, session = orchestrator_env
+    _seed_run(session, "run_empty")
+    # Source a répondu, 0 trade : agrégat vide explicite, available=True.
+    empty = {"run_id": "run_empty", "available": True, "trade_count": 0, "by_symbol": []}
+    key = _override_outcome(client, empty)
+    try:
+        resp = client.get("/runs/run_empty/outcome")
+    finally:
+        _clear_outcome_override(key)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_found"] is True
+    assert body["source_available"] is True
+    assert body["trade_count"] == 0
+    assert body["win_rate"] is None
+    assert body["pnl_usdt"] is None
+    assert body["by_symbol"] == []
+
+
+def test_run_outcome_unknown_run_and_unavailable_source_is_failsafe(orchestrator_env):
+    client, _session = orchestrator_env
+    # Run inconnu côté orchestration ET source indisponible : pas de 500, agrégat vide.
+    unavailable = {"run_id": "ghost", "available": False, "trade_count": 0, "by_symbol": []}
+    key = _override_outcome(client, unavailable)
+    try:
+        resp = client.get("/runs/ghost/outcome")
+    finally:
+        _clear_outcome_override(key)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_found"] is False
+    assert body["source_available"] is False
+    assert body["trade_count"] == 0
+
+
+def test_run_outcome_reconciles_run_id_to_64_chars(orchestrator_env):
+    client, session = orchestrator_env
+    long_run_id = "run_" + ("a" * 80)  # 84 chars > 64
+    _seed_run(session, long_run_id)
+    seen = {}
+
+    def _source(run_id: str) -> dict:
+        seen["run_id"] = run_id
+        return {"run_id": run_id, "available": True, "trade_count": 0, "by_symbol": []}
+
+    key = _override_outcome(client, _source)
+    try:
+        body = client.get(f"/runs/{long_run_id}/outcome").json()
+    finally:
+        _clear_outcome_override(key)
+
+    # La vue est requêtée avec le run_id tronqué à 64 (forme stockée côté Symfony).
+    assert len(seen["run_id"]) == 64
+    assert seen["run_id"] == long_run_id[:64]
+    assert body["reconciled_run_id"] == long_run_id[:64]
+    # run_id complet conservé dans la réponse (identifiant d'orchestration demandé).
+    assert body["run_id"] == long_run_id

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -17,6 +17,7 @@ from app.services.symfony_client import (
     build_mtf_payload,
     effective_set_payload,
     fetch_open_state,
+    fetch_run_trade_outcome,
     fetch_selected_contracts,
     generate_set_payload,
     is_business_success,
@@ -696,3 +697,87 @@ def test_run_persisted_set_not_materialized_without_symbols():
     assert result["payload_sent"] is None
     assert "not materialized" in result["body"]
     assert calls == []  # aucun appel HTTP
+
+
+# ---------------------------------------------------------------------------
+# fetch_run_trade_outcome (OBS-003) — rapprochement run ↔ trades, fail-safe
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_run_trade_outcome_passes_through_symfony_aggregate():
+    aggregate = {
+        "run_id": "run_42",
+        "available": True,
+        "trade_count": 2,
+        "closed_count": 2,
+        "win_count": 1,
+        "loss_count": 1,
+        "win_rate": 0.5,
+        "pnl_usdt": 6.0,
+        "pnl_r": 0.5,
+        "by_symbol": [{"symbol": "BTCUSDT", "trade_count": 2}],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/positions/analysis"
+        assert request.url.params["run_id"] == "run_42"
+        return httpx.Response(200, json=aggregate)
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://symfony", "run_42")
+
+    outcome = asyncio.run(_run())
+    assert outcome == aggregate
+
+
+def test_fetch_run_trade_outcome_failsafe_on_http_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://symfony", "run_x")
+
+    outcome = asyncio.run(_run())
+    # Source injoignable : agrégat vide explicite, jamais d'exception.
+    assert outcome["available"] is False
+    assert outcome["trade_count"] == 0
+    assert outcome["by_symbol"] == []
+
+
+def test_fetch_run_trade_outcome_failsafe_on_non_200():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"status": "error"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://symfony", "run_x")
+
+    outcome = asyncio.run(_run())
+    assert outcome["available"] is False
+    assert outcome["trade_count"] == 0
+
+
+def test_fetch_run_trade_outcome_failsafe_on_invalid_json():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not-json")
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://symfony", "run_x")
+
+    outcome = asyncio.run(_run())
+    assert outcome["available"] is False
+
+
+def test_fetch_run_trade_outcome_failsafe_on_non_dict_body():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=["unexpected"])
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://symfony", "run_x")
+
+    outcome = asyncio.run(_run())
+    assert outcome["available"] is False

--- a/trading-app/src/Controller/Api/PositionAnalysisApiController.php
+++ b/trading-app/src/Controller/Api/PositionAnalysisApiController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Api;
+
+use App\Trading\Service\RunTradeOutcomeService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * OBS-003 — Expose, en LECTURE SEULE, le rapprochement d'un run d'orchestration avec
+ * ses trades résultants (`position_trade_analysis`), agrégé par `run_id`.
+ *
+ * Consommé par l'orchestrateur Python via HTTP (`GET /runs/{run_id}/outcome`), sans
+ * coupler l'orchestrateur au schéma interne Symfony. Le PnL n'est jamais recalculé : on
+ * ne fait que sommer/moyenner les valeurs déjà exposées par la vue.
+ *
+ * Fail-safe : une vue indisponible, un run inconnu ou un run sans trade renvoient un
+ * agrégat vide explicite en HTTP 200 (jamais un 500). Seul un `run_id` manquant donne
+ * un 400 (paramètre requis).
+ */
+class PositionAnalysisApiController extends AbstractController
+{
+    public function __construct(
+        private readonly RunTradeOutcomeService $outcomeService,
+    ) {
+    }
+
+    #[Route('/api/positions/analysis', name: 'api_positions_analysis', methods: ['GET'])]
+    public function analysis(Request $request): JsonResponse
+    {
+        $runId = (string) ($request->query->get('run_id', ''));
+        if (trim($runId) === '') {
+            return $this->json([
+                'status' => 'error',
+                'message' => 'run_id is required',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        // Le service est fail-safe : il ne lève jamais (vue absente / erreur SQL → agrégat
+        // vide `available=false`). On renvoie donc toujours 200 avec un agrégat explicite.
+        $outcome = $this->outcomeService->aggregateByRunId($runId);
+
+        return $this->json($outcome);
+    }
+}

--- a/trading-app/src/Controller/RunnerController.php
+++ b/trading-app/src/Controller/RunnerController.php
@@ -54,6 +54,14 @@ class RunnerController extends AbstractController
             $openStateSnapshot = $data['open_state_snapshot'] ?? null;
             $openStateSnapshot = is_array($openStateSnapshot) ? $openStateSnapshot : null;
 
+            // OBS-001/OBS-003 : run_id de corrélation propagé par l'orchestrateur via
+            // l'en-tête `X-Run-Id`. Utilisé comme run_id du run (stocké sur les events)
+            // pour rapprocher un run d'orchestration de ses trades. Absent (CLI / appel
+            // direct) : le runner retombe sur un UUID, comportement inchangé. Le corps
+            // JSON ne porte pas cette clé (elle vient de l'en-tête HTTP), mais on laisse
+            // un éventuel `run_id` du body comme repli défensif.
+            $runId = $request->headers->get('X-Run-Id') ?? ($data['run_id'] ?? null);
+
             // Normaliser les symboles fournis sans appliquer de fallback/queue
             $symbols = [];
             if (is_string($symbolsInput)) {
@@ -105,6 +113,7 @@ class RunnerController extends AbstractController
                 'context_mode' => $data['context_mode'] ?? null,
                 'mode' => $data['mode'] ?? null,
                 'open_state_snapshot' => $openStateSnapshot,
+                'run_id' => $runId,
             ]);
             $result = $runMtfCycle->run($runnerRequest);
 

--- a/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
@@ -39,6 +39,15 @@ final class MtfRunnerRequestDto
          * @var array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
          */
         public readonly ?array $openStateSnapshot = null,
+        /**
+         * Identifiant de run de corrélation propagé par l'orchestrateur via l'en-tête
+         * HTTP `X-Run-Id` (OBS-001/OBS-003). Quand il est fourni, il est utilisé comme
+         * `run_id` du run (stocké sur les trade_lifecycle_event) au lieu d'un UUID
+         * généré, ce qui permet de rapprocher un run d'orchestration de ses trades
+         * (`position_trade_analysis`). Absent (CLI, appel direct) : fallback UUID,
+         * comportement inchangé.
+         */
+        public readonly ?string $runId = null,
     ) {}
 
     public static function fromArray(array $data): self
@@ -65,6 +74,7 @@ final class MtfRunnerRequestDto
             profile: $profile,
             validationMode: $validationMode,
             openStateSnapshot: self::extractOpenStateSnapshot($data),
+            runId: self::extractRunId($data),
         );
     }
 
@@ -89,7 +99,34 @@ final class MtfRunnerRequestDto
             'profile' => $this->profile,
             'validation_mode' => $this->validationMode,
             'open_state_snapshot' => $this->openStateSnapshot,
+            'run_id' => $this->runId,
         ];
+    }
+
+    /**
+     * Normalise le `run_id` de corrélation fourni par l'orchestrateur (X-Run-Id).
+     *
+     * Une valeur vide/blanche est traitée comme absente (fallback UUID). La valeur
+     * est bornée à 64 caractères : c'est la largeur de `trade_lifecycle_event.run_id`
+     * (et donc de `position_trade_analysis.run_id`). Au-delà, PostgreSQL rejetterait
+     * l'insertion ; on tronque donc de façon déterministe pour que la même règle
+     * s'applique des deux côtés du rapprochement OBS-003 (l'orchestrateur requête la
+     * vue avec le même `run_id[:64]`).
+     *
+     * @param array<string,mixed> $data
+     */
+    private static function extractRunId(array $data): ?string
+    {
+        $raw = $data['run_id'] ?? null;
+        if (!is_string($raw)) {
+            return null;
+        }
+        $trimmed = trim($raw);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        return mb_substr($trimmed, 0, 64);
     }
 
     /**

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -90,7 +90,15 @@ final class MtfRunnerService
     public function run(RunnerRequestDto $request): array
     {
         $profiler = new PerformanceProfiler();
-        $runId = Uuid::uuid4()->toString();
+        // OBS-001/OBS-003 : si l'orchestrateur a propagé un run_id de corrélation
+        // (en-tête X-Run-Id, déjà borné à 64 caractères dans le DTO), on l'utilise
+        // comme run_id du run afin que les trade_lifecycle_event portent ce même
+        // identifiant et que la vue `position_trade_analysis` soit rapprochable du run
+        // d'orchestration. Sans en-tête (CLI / appel direct), on retombe sur un UUID :
+        // comportement strictement inchangé.
+        $runId = ($request->runId !== null && $request->runId !== '')
+            ? $request->runId
+            : Uuid::uuid4()->toString();
         $startTime = microtime(true);
         $openPositions = null;
         $openOrders = null;

--- a/trading-app/src/Repository/PositionTradeAnalysisRepository.php
+++ b/trading-app/src/Repository/PositionTradeAnalysisRepository.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Service\PositionTradeAnalysisReaderInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
-final class PositionTradeAnalysisRepository extends ServiceEntityRepository
+final class PositionTradeAnalysisRepository extends ServiceEntityRepository implements PositionTradeAnalysisReaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -69,5 +70,27 @@ final class PositionTradeAnalysisRepository extends ServiceEntityRepository
         $qb->orderBy('pta.' . $sort, $direction);
 
         return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Toutes les lignes de la vue rattachées à un `run_id` (OBS-003).
+     *
+     * Lecture seule, bornée par run : un run touche au plus l'univers actif (~100
+     * symboles) et n'ouvre en pratique que peu de trades. Tri stable par symbole puis
+     * date d'entrée pour une agrégation déterministe. Une borne `$limit` garde la
+     * requête courte même si un run_id (tronqué à 64) venait à collisionner.
+     *
+     * @return PositionTradeAnalysis[]
+     */
+    public function findByRunId(string $runId, int $limit = 1000): array
+    {
+        return $this->createQueryBuilder('pta')
+            ->andWhere('pta.runId = :runId')
+            ->setParameter('runId', $runId)
+            ->orderBy('pta.symbol', 'ASC')
+            ->addOrderBy('pta.entryTime', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
     }
 }

--- a/trading-app/src/Trading/Service/PositionTradeAnalysisReaderInterface.php
+++ b/trading-app/src/Trading/Service/PositionTradeAnalysisReaderInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Service;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+
+/**
+ * OBS-003 — Source de lecture des trades d'un run (`position_trade_analysis`).
+ *
+ * Découple {@see RunTradeOutcomeService} de l'implémentation Doctrine concrète
+ * (repository `final`, non doublable) : les tests fournissent un stub, le runtime
+ * câble la vraie {@see \App\Repository\PositionTradeAnalysisRepository}.
+ */
+interface PositionTradeAnalysisReaderInterface
+{
+    /**
+     * Toutes les lignes de la vue rattachées à un `run_id` (lecture seule, bornée).
+     *
+     * @return PositionTradeAnalysis[]
+     */
+    public function findByRunId(string $runId, int $limit = 1000): array;
+}

--- a/trading-app/src/Trading/Service/RunTradeOutcomeService.php
+++ b/trading-app/src/Trading/Service/RunTradeOutcomeService.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Service;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+use Psr\Log\LoggerInterface;
+
+/**
+ * OBS-003 — Rapproche un run d'orchestration de ses trades (`position_trade_analysis`).
+ *
+ * Service de LECTURE SEULE, fail-safe : il agrège, pour un `run_id` donné, les lignes
+ * de la vue `position_trade_analysis` (jointure ORDER_SUBMITTED / POSITION_CLOSED /
+ * indicator_snapshots, en lecture seule) en :
+ *  - un agrégat global du run (nombre de trades, PnL net en USDT et en R, win-rate,
+ *    MFE/MAE moyens et médians, durée de détention moyenne) ;
+ *  - une ventilation par symbole.
+ *
+ * Il ne recalcule JAMAIS le PnL : il ne fait que sommer/moyenner les valeurs déjà
+ * exposées par la vue. Toute indisponibilité (vue absente, erreur SQL, run inconnu)
+ * retombe sur un agrégat vide EXPLICITE (`available=false` / compteurs à 0), jamais une
+ * exception : l'endpoint ne doit jamais renvoyer un 500.
+ *
+ * Réconciliation du `run_id` : `trade_lifecycle_event.run_id` (et donc la vue) est un
+ * VARCHAR(64), alors que l'orchestration `runs.run_id` peut aller jusqu'à 255 caractères
+ * (forme hachée = 68). Le run_id propagé par X-Run-Id est déjà tronqué à 64 côté runner ;
+ * on applique ici la MÊME règle à la valeur requêtée pour que les deux côtés du
+ * rapprochement utilisent strictement le même identifiant.
+ */
+final class RunTradeOutcomeService
+{
+    /** Largeur de `trade_lifecycle_event.run_id` (== `position_trade_analysis.run_id`). */
+    public const RUN_ID_MAX_LENGTH = 64;
+
+    public function __construct(
+        private readonly PositionTradeAnalysisReaderInterface $repository,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * Agrège les trades d'un run par `run_id` (+ ventilation par symbole).
+     *
+     * @return array<string,mixed> Agrégat JSON-sérialisable (toujours renseigné).
+     */
+    public function aggregateByRunId(string $runId): array
+    {
+        $normalized = mb_substr(trim($runId), 0, self::RUN_ID_MAX_LENGTH);
+        if ($normalized === '') {
+            return $this->emptyOutcome('', true);
+        }
+
+        try {
+            $rows = $this->repository->findByRunId($normalized);
+        } catch (\Throwable $e) {
+            // Vue indisponible / erreur SQL : fail-safe, agrégat vide non disponible.
+            $this->logger->warning('[RunTradeOutcome] Failed to read position_trade_analysis', [
+                'run_id' => $normalized,
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->emptyOutcome($normalized, false);
+        }
+
+        if ($rows === []) {
+            // Run connu côté orchestrateur mais sans trade (ou run inconnu) : agrégat
+            // vide explicite, disponible (la source a répondu), pas une erreur.
+            return $this->emptyOutcome($normalized, true);
+        }
+
+        $outcome = $this->aggregateRows($rows);
+        $outcome['run_id'] = $normalized;
+        $outcome['available'] = true;
+
+        return $outcome;
+    }
+
+    /**
+     * @param PositionTradeAnalysis[] $rows
+     * @return array<string,mixed>
+     */
+    private function aggregateRows(array $rows): array
+    {
+        $global = $this->aggregateGroup($rows);
+
+        $bySymbol = [];
+        $groups = [];
+        foreach ($rows as $row) {
+            $groups[$row->getSymbol()][] = $row;
+        }
+        // Tri par symbole pour une sortie déterministe.
+        ksort($groups);
+        foreach ($groups as $symbol => $symbolRows) {
+            $symbolStats = $this->aggregateGroup($symbolRows);
+            $symbolStats['symbol'] = $symbol;
+            $bySymbol[] = $symbolStats;
+        }
+
+        $global['by_symbol'] = $bySymbol;
+
+        return $global;
+    }
+
+    /**
+     * Statistiques d'un groupe de trades (global ou par symbole).
+     *
+     * @param PositionTradeAnalysis[] $rows
+     * @return array<string,mixed>
+     */
+    private function aggregateGroup(array $rows): array
+    {
+        $tradeCount = count($rows);
+        $closedCount = 0;
+        $winCount = 0;
+        $lossCount = 0;
+        $pnlUsdt = 0.0;
+        $pnlR = 0.0;
+        $hasPnlUsdt = false;
+        $hasPnlR = false;
+        $mfeValues = [];
+        $maeValues = [];
+        $holdingValues = [];
+
+        foreach ($rows as $row) {
+            $pnl = $row->getPnlUsdt();
+            if ($pnl !== null) {
+                $closedCount++;
+                $pnlUsdt += $pnl;
+                $hasPnlUsdt = true;
+                if ($pnl > 0) {
+                    $winCount++;
+                } elseif ($pnl < 0) {
+                    $lossCount++;
+                }
+            }
+            if ($row->getPnlR() !== null) {
+                $pnlR += $row->getPnlR();
+                $hasPnlR = true;
+            }
+            if ($row->getMfePct() !== null) {
+                $mfeValues[] = $row->getMfePct();
+            }
+            if ($row->getMaePct() !== null) {
+                $maeValues[] = $row->getMaePct();
+            }
+            if ($row->getHoldingTimeSec() !== null) {
+                $holdingValues[] = $row->getHoldingTimeSec();
+            }
+        }
+
+        return [
+            'trade_count' => $tradeCount,
+            'closed_count' => $closedCount,
+            'open_count' => $tradeCount - $closedCount,
+            'win_count' => $winCount,
+            'loss_count' => $lossCount,
+            // Win-rate sur les trades CLOTURÉS uniquement (un trade encore ouvert n'a pas
+            // d'issue). Null si aucun trade clôturé (pas de division par zéro trompeuse).
+            'win_rate' => $closedCount > 0 ? round($winCount / $closedCount, 4) : null,
+            // PnL net : somme des valeurs de la vue (jamais recalculé). Null si aucune
+            // valeur disponible (distinct d'un vrai 0).
+            'pnl_usdt' => $hasPnlUsdt ? round($pnlUsdt, 8) : null,
+            'pnl_r' => $hasPnlR ? round($pnlR, 8) : null,
+            'mfe_pct_avg' => $this->avg($mfeValues),
+            'mfe_pct_median' => $this->median($mfeValues),
+            'mae_pct_avg' => $this->avg($maeValues),
+            'mae_pct_median' => $this->median($maeValues),
+            'holding_time_sec_avg' => $this->avg($holdingValues),
+        ];
+    }
+
+    /**
+     * Agrégat vide explicite (run sans trade, run inconnu ou source indisponible).
+     *
+     * @return array<string,mixed>
+     */
+    private function emptyOutcome(string $runId, bool $available): array
+    {
+        return [
+            'run_id' => $runId,
+            'available' => $available,
+            'trade_count' => 0,
+            'closed_count' => 0,
+            'open_count' => 0,
+            'win_count' => 0,
+            'loss_count' => 0,
+            'win_rate' => null,
+            'pnl_usdt' => null,
+            'pnl_r' => null,
+            'mfe_pct_avg' => null,
+            'mfe_pct_median' => null,
+            'mae_pct_avg' => null,
+            'mae_pct_median' => null,
+            'holding_time_sec_avg' => null,
+            'by_symbol' => [],
+        ];
+    }
+
+    /**
+     * @param float[] $values
+     */
+    private function avg(array $values): ?float
+    {
+        if ($values === []) {
+            return null;
+        }
+
+        return round(array_sum($values) / count($values), 8);
+    }
+
+    /**
+     * @param float[] $values
+     */
+    private function median(array $values): ?float
+    {
+        if ($values === []) {
+            return null;
+        }
+        sort($values);
+        $count = count($values);
+        $mid = intdiv($count, 2);
+        if ($count % 2 === 1) {
+            return round($values[$mid], 8);
+        }
+
+        return round(($values[$mid - 1] + $values[$mid]) / 2, 8);
+    }
+}

--- a/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+++ b/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
@@ -116,6 +116,38 @@ final class MtfRunnerRequestDtoTest extends TestCase
         ])->openStateSnapshot);
     }
 
+    public function testFromArrayKeepsCorrelationRunId(): void
+    {
+        // OBS-003 : run_id de corrélation propagé par l'orchestrateur (X-Run-Id).
+        $request = MtfRunnerRequestDto::fromArray(['run_id' => 'run_20260621_abc123']);
+
+        self::assertSame('run_20260621_abc123', $request->runId);
+    }
+
+    public function testFromArrayDefaultsRunIdToNull(): void
+    {
+        self::assertNull(MtfRunnerRequestDto::fromArray([])->runId);
+    }
+
+    public function testFromArrayTreatsBlankRunIdAsAbsent(): void
+    {
+        self::assertNull(MtfRunnerRequestDto::fromArray(['run_id' => '   '])->runId);
+        self::assertNull(MtfRunnerRequestDto::fromArray(['run_id' => ['nope']])->runId);
+    }
+
+    public function testFromArrayTruncatesRunIdTo64Chars(): void
+    {
+        // L'orchestration run_id peut atteindre 255 (forme hachée = 68) alors que
+        // trade_lifecycle_event.run_id / position_trade_analysis.run_id est VARCHAR(64).
+        // On tronque de façon déterministe pour ne pas faire échouer l'INSERT et pour
+        // que les deux côtés du rapprochement (OBS-003) utilisent le même identifiant.
+        $longRunId = 'run_' . str_repeat('a', 80);
+        $request = MtfRunnerRequestDto::fromArray(['run_id' => $longRunId]);
+
+        self::assertSame(64, mb_strlen((string) $request->runId));
+        self::assertSame(mb_substr($longRunId, 0, 64), $request->runId);
+    }
+
     public function testFromArrayIgnoresNonArrayOpenStateSnapshot(): void
     {
         self::assertNull(MtfRunnerRequestDto::fromArray(['open_state_snapshot' => 'nope'])->openStateSnapshot);

--- a/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
+++ b/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Service;
+
+use App\Trading\Service\PositionTradeAnalysisReaderInterface;
+use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Service\RunTradeOutcomeService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(RunTradeOutcomeService::class)]
+final class RunTradeOutcomeServiceTest extends TestCase
+{
+    /**
+     * Construit une ligne de vue `position_trade_analysis` (entité readOnly sans
+     * setters) via réflexion, pour piloter les agrégats du service.
+     *
+     * @param array<string,float|null> $metrics
+     */
+    private function makeRow(string $symbol, array $metrics): PositionTradeAnalysis
+    {
+        $row = (new \ReflectionClass(PositionTradeAnalysis::class))->newInstanceWithoutConstructor();
+        $set = static function (string $prop, mixed $value) use ($row): void {
+            $ref = new \ReflectionProperty(PositionTradeAnalysis::class, $prop);
+            $ref->setValue($row, $value);
+        };
+        $set('symbol', $symbol);
+        $set('pnlUsdt', $metrics['pnl_usdt'] ?? null);
+        $set('pnlR', $metrics['pnl_r'] ?? null);
+        $set('mfePct', $metrics['mfe_pct'] ?? null);
+        $set('maePct', $metrics['mae_pct'] ?? null);
+        $set('holdingTimeSec', $metrics['holding_time_sec'] ?? null);
+
+        return $row;
+    }
+
+    private function service(PositionTradeAnalysisReaderInterface $repo): RunTradeOutcomeService
+    {
+        return new RunTradeOutcomeService($repo, new NullLogger());
+    }
+
+    public function testAggregatesTradesByRunId(): void
+    {
+        $rows = [
+            $this->makeRow('BTCUSDT', [
+                'pnl_usdt' => 10.0, 'pnl_r' => 1.0, 'mfe_pct' => 2.0, 'mae_pct' => -1.0, 'holding_time_sec' => 100.0,
+            ]),
+            $this->makeRow('BTCUSDT', [
+                'pnl_usdt' => -4.0, 'pnl_r' => -0.5, 'mfe_pct' => 1.0, 'mae_pct' => -3.0, 'holding_time_sec' => 300.0,
+            ]),
+            $this->makeRow('ETHUSDT', [
+                'pnl_usdt' => 6.0, 'pnl_r' => 0.5, 'mfe_pct' => 4.0, 'mae_pct' => -2.0, 'holding_time_sec' => 200.0,
+            ]),
+        ];
+
+        $repo = $this->createMock(PositionTradeAnalysisReaderInterface::class);
+        $repo->expects(self::once())
+            ->method('findByRunId')
+            ->with('run_42')
+            ->willReturn($rows);
+
+        $outcome = $this->service($repo)->aggregateByRunId('run_42');
+
+        self::assertTrue($outcome['available']);
+        self::assertSame('run_42', $outcome['run_id']);
+        self::assertSame(3, $outcome['trade_count']);
+        self::assertSame(3, $outcome['closed_count']);
+        self::assertSame(2, $outcome['win_count']);
+        self::assertSame(1, $outcome['loss_count']);
+        self::assertSame(round(2 / 3, 4), $outcome['win_rate']);
+        // PnL net = somme exacte des valeurs de la vue (jamais recalculé).
+        self::assertSame(12.0, $outcome['pnl_usdt']);
+        self::assertSame(1.0, $outcome['pnl_r']);
+        // MFE moyen = (2 + 1 + 4) / 3 ; médian = 2.
+        self::assertEqualsWithDelta(7 / 3, $outcome['mfe_pct_avg'], 1e-6);
+        self::assertSame(2.0, $outcome['mfe_pct_median']);
+        self::assertSame(200.0, $outcome['holding_time_sec_avg']);
+
+        // Ventilation par symbole, triée.
+        $symbols = array_column($outcome['by_symbol'], 'symbol');
+        self::assertSame(['BTCUSDT', 'ETHUSDT'], $symbols);
+        $btc = $outcome['by_symbol'][0];
+        self::assertSame(2, $btc['trade_count']);
+        self::assertSame(6.0, $btc['pnl_usdt']);
+        self::assertSame(0.5, $btc['win_rate']);
+    }
+
+    public function testRunWithoutTradesReturnsEmptyAvailableAggregate(): void
+    {
+        $repo = $this->createMock(PositionTradeAnalysisReaderInterface::class);
+        $repo->method('findByRunId')->willReturn([]);
+
+        $outcome = $this->service($repo)->aggregateByRunId('run_empty');
+
+        self::assertTrue($outcome['available']);
+        self::assertSame(0, $outcome['trade_count']);
+        self::assertNull($outcome['win_rate']);
+        self::assertNull($outcome['pnl_usdt']);
+        self::assertSame([], $outcome['by_symbol']);
+    }
+
+    public function testUnavailableViewIsFailSafe(): void
+    {
+        $repo = $this->createMock(PositionTradeAnalysisReaderInterface::class);
+        $repo->method('findByRunId')->willThrowException(new \RuntimeException('relation does not exist'));
+
+        $outcome = $this->service($repo)->aggregateByRunId('run_boom');
+
+        // Pas d'exception propagée : agrégat vide explicite, marqué non disponible.
+        self::assertFalse($outcome['available']);
+        self::assertSame(0, $outcome['trade_count']);
+        self::assertSame([], $outcome['by_symbol']);
+    }
+
+    public function testRunIdIsTruncatedTo64CharsBeforeQuery(): void
+    {
+        $longRunId = 'run_' . str_repeat('z', 80);
+        $expected = mb_substr($longRunId, 0, 64);
+
+        $repo = $this->createMock(PositionTradeAnalysisReaderInterface::class);
+        $repo->expects(self::once())
+            ->method('findByRunId')
+            ->with($expected)
+            ->willReturn([]);
+
+        $outcome = $this->service($repo)->aggregateByRunId($longRunId);
+
+        self::assertSame($expected, $outcome['run_id']);
+        self::assertSame(64, mb_strlen($outcome['run_id']));
+    }
+
+    public function testBlankRunIdReturnsEmptyAggregate(): void
+    {
+        $repo = $this->createMock(PositionTradeAnalysisReaderInterface::class);
+        $repo->expects(self::never())->method('findByRunId');
+
+        $outcome = $this->service($repo)->aggregateByRunId('   ');
+
+        self::assertTrue($outcome['available']);
+        self::assertSame(0, $outcome['trade_count']);
+    }
+
+    public function testOpenTradesAreCountedButNotClosed(): void
+    {
+        $rows = [
+            $this->makeRow('BTCUSDT', ['pnl_usdt' => 5.0]),   // clôturé gagnant
+            $this->makeRow('BTCUSDT', []),                    // encore ouvert (pnl null)
+        ];
+        $repo = $this->createMock(PositionTradeAnalysisReaderInterface::class);
+        $repo->method('findByRunId')->willReturn($rows);
+
+        $outcome = $this->service($repo)->aggregateByRunId('run_open');
+
+        self::assertSame(2, $outcome['trade_count']);
+        self::assertSame(1, $outcome['closed_count']);
+        self::assertSame(1, $outcome['open_count']);
+        self::assertSame(1.0, $outcome['win_rate']); // 1 gagnant / 1 clôturé
+        self::assertSame(5.0, $outcome['pnl_usdt']);
+    }
+}


### PR DESCRIPTION
## Contexte

Suite de OBS-001 (audit des runs, #179) et OBS-002 (métriques d'exécution, #180). OBS-001/002 rendent visible **l'exécution** d'un run, mais pas son **résultat de trading**. OBS-003 ajoute la couche **OUTCOME** : relier un run d'orchestration à ses trades résultants (`position_trade_analysis`) par `run_id`, en lecture seule.

## Finding clé (réconciliation run_id — vérifié et tranché)

Avant cette PR, **Symfony n'utilisait pas l'en-tête `X-Run-Id`** : `RunnerController` l'ignorait et `MtfRunnerService` générait un `Uuid::uuid4()`, qui finissait sur `trade_lifecycle_event.run_id` → la vue. Un join par `run_id` renvoyait donc **0 ligne**. La PR **câble** `X-Run-Id` côté Symfony (utilisé comme `run_id` du run ; fallback UUID si absent → CLI/appel direct inchangés), tronqué à **64** des deux côtés pour matcher `trade_lifecycle_event.run_id` VARCHAR(64) (l'orchestration `runs.run_id` va jusqu'à 255, forme hachée = 68). Le champ `reconciled_run_id` documente l'identifiant utilisé.

## Scope

**Source** (décision produit a) : nouvel endpoint Symfony read-only `GET /api/positions/analysis?run_id=…` (`PositionAnalysisApiController` → `RunTradeOutcomeService` → vue `position_trade_analysis`), consommé par l'orchestrateur en HTTP (`symfony_client.fetch_run_trade_outcome`) — pas de couplage au schéma interne Symfony.

**Surface orchestrateur** : `GET /runs/{run_id}/outcome` — agrégat par run (`trade_count`, `pnl_usdt`/`pnl_r`, win-rate, MFE/MAE moyens + médians, holding-time) + **ventilation `by_symbol`**. Le PnL n'est **jamais recalculé** (somme/moyenne des valeurs de la vue).

**Fail-safe** : run inconnu / sans trade / vue indisponible → agrégat vide explicite (HTTP 200, `run_found`/`source_available`), jamais de 500. Lecture seule, transaction courte, aucune écriture sur la vue.

## Hors-scope

Audit OBS-001 / métriques OBS-002 (au-delà de la réutilisation du run_id), garde-fous live (SAFE-003), locks (SAFE-001), idempotence (SAFE-002), recalcul/modification du PnL ou de la vue, front/cockpit, contrat `/orchestrator/run`, schedule Temporal. **Aucune décision métier modifiée**, réponses HTTP de `/orchestrator/run` et forme de `last_json`/`RunSet` inchangées, vue `position_trade_analysis` non modifiée. Pas de migration.

## Vérifications

- `python-orchestrator` : `pytest` → **330 passed, 3 skipped**.
- Symfony (zones touchées) : `phpunit tests/Trading tests/MtfRunner tests/Controller` → **40 passed** ; `lint:container` OK ; PHPStan propre sur les nouveaux fichiers ; route `/api/positions/analysis` enregistrée.
- Docs : `mkdocs build --strict` OK.

Nouveaux tests : run avec trades (count/PnL/MFE-MAE/win-rate/ventilation), run sans trade (agrégat vide explicite), run inconnu / vue indisponible (fail-safe, pas de 500), réconciliation run_id ≤64.

Réf. issue : #155 (checklist OBS-003).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vp7uBmHuwimbxmPUxW9Lsd)_