### PR TITLE
OBS-003 v2: complete orchestration-to-trade lineage and reliable outcomes

### DIFF
--- a/.github/workflows/obs003-trading.yml
+++ b/.github/workflows/obs003-trading.yml
@@ -1,0 +1,109 @@
+name: OBS-003 Trading (outcome + lineage)
+
+# Gate dédié OBS-003 : exécute RÉELLEMENT les suites PHP touchées (Trading, MtfRunner,
+# contrats DTO) ET le test d'intégration PostgreSQL de la vue `position_trade_analysis_v2`
+# (jamais self-skippé : un service PostgreSQL est fourni et le job échoue si le test est
+# ignoré via --fail-on-skipped).
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/obs003-trading.yml'
+      - 'trading-app/src/Trading/**'
+      - 'trading-app/src/Controller/RunnerController.php'
+      - 'trading-app/src/MtfRunner/**'
+      - 'trading-app/src/MtfValidator/**'
+      - 'trading-app/src/Contract/MtfValidator/**'
+      - 'trading-app/migrations/**'
+      - 'trading-app/tests/Trading/**'
+      - 'trading-app/tests/MtfRunner/**'
+      - 'trading-app/tests/Contract/MtfValidator/**'
+      - 'trading-app/config/**'
+      - 'tests/fixtures/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/obs003-trading.yml'
+      - 'trading-app/src/Trading/**'
+      - 'trading-app/src/MtfRunner/**'
+      - 'trading-app/migrations/**'
+      - 'trading-app/tests/Trading/**'
+      - 'tests/fixtures/**'
+
+jobs:
+  obs003-trading:
+    name: OBS-003 Trading (PHP + PostgreSQL view)
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: trading_app_test
+          POSTGRES_USER: trading
+          POSTGRES_PASSWORD: trading
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U trading"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      APP_ENV: test
+      APP_SECRET: ci-obs003-secret
+      DEFAULT_URI: 'http://localhost'
+      REDIS_URL: 'redis://127.0.0.1:6379'
+      # La vue est testée via une connexion DBAL PostgreSQL distincte qui lit DATABASE_URL.
+      # (L'ORM de test reste sur sqlite via config/packages/test/doctrine.yaml ; ces suites
+      # OBS-003 n'utilisent pas l'ORM — readers stubés + connexion vue dédiée.)
+      DATABASE_URL: 'postgresql://trading:trading@127.0.0.1:5432/trading_app_test?serverVersion=16&charset=utf8'
+
+    defaults:
+      run:
+        working-directory: trading-app
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: redis, pdo_pgsql, intl, opcache
+          coverage: none
+          tools: composer:v2
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Lint container
+        run: php bin/console lint:container
+
+      - name: Lint YAML config
+        run: php bin/console lint:yaml config
+
+      - name: PHPUnit — Trading + MtfRunner
+        run: vendor/bin/phpunit tests/Trading tests/MtfRunner
+
+      - name: PHPUnit — Contract MtfValidator DTOs (OBS-003)
+        run: vendor/bin/phpunit tests/Contract/MtfValidator/Dto
+
+      - name: PostgreSQL view test — must run, never skipped
+        # --fail-on-skipped : si la connexion PostgreSQL manque, le test se skip et le job
+        # ÉCHOUE (au lieu de masquer une vue non testée).
+        run: vendor/bin/phpunit --fail-on-skipped tests/Trading/View/PositionTradeAnalysisViewTest.php
+
+      - name: PHPStan — OBS-003 services/validator/controller
+        run: >-
+          vendor/bin/phpstan analyse --no-progress
+          src/Trading/Service/RunTradeOutcomeService.php
+          src/Trading/Service/PositionTradeOutcomeSourceException.php
+          src/Trading/Service/PositionTradeAnalysisReaderInterface.php
+          src/Trading/Service/RunCorrelationId.php
+          src/Trading/Orchestration/OrchestrationContextValidator.php
+          src/Trading/Orchestration/OrchestrationContextException.php
+          src/Trading/Controller/Api/PositionAnalysisApiController.php

--- a/.github/workflows/obs003-trading.yml
+++ b/.github/workflows/obs003-trading.yml
@@ -46,7 +46,7 @@ jobs:
         ports:
           - 5432:5432
         options: >-
-          --health-cmd "pg_isready -U trading"
+          --health-cmd "pg_isready -U trading -d trading_app_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -86,16 +86,20 @@ jobs:
       - name: Lint YAML config
         run: php bin/console lint:yaml config
 
+      # NB : bootstrap = vendor/autoload.php (comme le job trading-core-config) — le
+      # bootstrap par défaut (tests/bootstrap.php) exige un fichier .env absent en CI.
+      # Ces suites OBS-003 n'amorcent pas le kernel (readers stubés + connexion vue dédiée)
+      # et lisent DATABASE_URL depuis les variables d'environnement du job.
       - name: PHPUnit — Trading + MtfRunner
-        run: vendor/bin/phpunit tests/Trading tests/MtfRunner
+        run: vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Trading tests/MtfRunner
 
       - name: PHPUnit — Contract MtfValidator DTOs (OBS-003)
-        run: vendor/bin/phpunit tests/Contract/MtfValidator/Dto
+        run: vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Contract/MtfValidator/Dto
 
       - name: PostgreSQL view test — must run, never skipped
         # --fail-on-skipped : si la connexion PostgreSQL manque, le test se skip et le job
         # ÉCHOUE (au lieu de masquer une vue non testée).
-        run: vendor/bin/phpunit --fail-on-skipped tests/Trading/View/PositionTradeAnalysisViewTest.php
+        run: vendor/bin/phpunit --bootstrap vendor/autoload.php --fail-on-skipped tests/Trading/View/PositionTradeAnalysisViewTest.php
 
       - name: PHPStan — OBS-003 services/validator/controller
         run: >-

--- a/docs/handbook/functional/orchestration-dashboard.md
+++ b/docs/handbook/functional/orchestration-dashboard.md
@@ -178,3 +178,26 @@ Les runs doivent ensuite pouvoir être rapprochés de :
 - trades évités ou bloqués.
 
 L'objectif reste la qualité des setups et l'expectancy nette, pas le nombre brut d'appels ou de trades.
+
+### Rapprochement run → trades (OBS-003)
+
+Le rapprochement run → trades est exposé en lecture seule par
+`GET /runs/{run_id}/outcome` (orchestrateur) qui interroge Symfony
+(`GET /api/positions/analysis`). Pour un run donné, on obtient les trades produits,
+leur **set / profil / exchange** d'origine, le **mode de rapprochement** entrée ↔
+clôture, le PnL **enregistré** et — quand tous les coûts sont disponibles — le PnL
+**net**, plus la ventilation par set / profil / exchange / symbole.
+
+Trois garanties de fiabilité, alignées sur « moins de mauvais trades → données
+fiables » :
+
+- **Attribution certaine** : chaque trade est relié au run par un identifiant de
+  corrélation déterministe (jamais une troncature qui pourrait confondre deux runs),
+  et porte son `set_id` / `dashboard_id` / `exchange` / `profil`.
+- **Rapprochement honnête** : l'entrée est appariée à sa clôture par identifiants
+  exacts (`trade_id` puis `position_id`), jamais « la première clôture du même
+  symbole ». Un trade non rapprochable reste visible (`unmatched`), pas masqué.
+- **PnL non maquillé** : la valeur enregistrée (`recorded_pnl_usdt`) n'est jamais
+  présentée comme « nette ». Le PnL net n'apparaît que si frais + funding + slippage
+  sont présents (`net_pnl_complete`). Une source indisponible est signalée
+  explicitement (jamais affichée comme « 0 trade »).

--- a/docs/handbook/functional/orchestration-dashboard.md
+++ b/docs/handbook/functional/orchestration-dashboard.md
@@ -197,7 +197,12 @@ fiables » :
 - **Rapprochement honnête** : l'entrée est appariée à sa clôture par identifiants
   exacts (`trade_id` puis `position_id`), jamais « la première clôture du même
   symbole ». Un trade non rapprochable reste visible (`unmatched`), pas masqué.
-- **PnL non maquillé** : la valeur enregistrée (`recorded_pnl_usdt`) n'est jamais
-  présentée comme « nette ». Le PnL net n'apparaît que si frais + funding + slippage
-  sont présents (`net_pnl_complete`). Une source indisponible est signalée
-  explicitement (jamais affichée comme « 0 trade »).
+- **PnL jamais maquillé** : la valeur enregistrée (`recorded_pnl_usdt`) n'est jamais
+  présentée comme « nette ». Seule une **estimation** best-effort
+  (`estimated_net_pnl_usdt`) est exposée, accompagnée de `cost_completeness` ; le PnL net
+  **certifié** est réservé au contrat de coûts complet (issue #190, non livré ici) et
+  n'est donc jamais affiché. Une source indisponible est signalée explicitement (jamais
+  affichée comme « 0 trade »).
+- **États distincts** : `matched_closed` (clôturé+rapproché), `unmatched` (état réel
+  inconnu — jamais compté comme position ouverte confirmée), `confirmed_open` et
+  `unknown_state` ; le winrate ne porte que sur les trades clôturés rapprochés avec PnL.

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -432,6 +432,7 @@ PY-006 ajoute la surface **en lecture seule** consommée par le cockpit :
 | `GET` | `/runs` | Liste des runs (vue allégée), filtrable par `dashboard_id`, paginée (`limit` ≤ 100, `offset`), du plus récent au plus ancien. |
 | `GET` | `/runs/{run_id}` | Détail complet : dernier JSON global (`last_json`) + détail par set (`sets[]`). |
 | `GET` | `/runs/{run_id}/sets/{set_id}` | Dernier JSON d'un set : `payload_sent`, `response_json` brute, `error`, `duration_ms`. |
+| `GET` | `/runs/{run_id}/outcome` | Outcome OBS-003 : trades résultants du run (vue Symfony `position_trade_analysis`), agrégat + ventilation `by_set`/`by_profile`/`by_exchange`/`by_symbol`. `404` run inconnu, `503` source indisponible (`source_available=false`), `200` sinon (agrégat éventuellement vide). |
 | `GET` | `/dashboards/{id}/runs` | Runs d'un dashboard (vue allégée, paginée). |
 | `GET` | `/dashboards/{id}/runs/latest` | Dernier run d'un dashboard (détail complet) — le retour affiché par défaut au cockpit ; `404` si aucun run. |
 
@@ -666,6 +667,67 @@ pas de redéfinition de cause métier.
   idempotence, réponses HTTP et forme de `last_json`/`RunSet` inchangés ; OBS-001
   et SAFE-001/002/003 intacts.
 
+### Lineage run → trades + outcomes fiables (OBS-003)
+
+OBS-001/002 rendent visible l'**exécution** d'un run ; OBS-003 ajoute la couche
+**OUTCOME** : relier un run à ses **trades résultants** de façon fiable, en lecture
+seule, sans jamais recalculer le PnL. La priorité produit reste *données fiables →
+expectancy fiable* (jamais « plus de trades »).
+
+**Identifiant de corrélation déterministe (jamais tronqué).** Un run d'orchestration
+porte un `run_id` ORIGINAL (jusqu'à 255 caractères). La colonne
+`trade_lifecycle_event.run_id` est un `VARCHAR(64)`. Pour relier les deux **sans
+collision**, on dérive un identifiant canonique :
+
+1. chaîne vide refusée ;
+2. si `run_id` respecte `^[A-Za-z0-9._:-]+$` **et** ≤ 64 → conservé tel quel ;
+3. sinon → `sha256(run_id)` hex minuscule (exactement 64).
+
+Aucune troncature `run_id[:64]` (deux longs `run_id` au même préfixe entreraient en
+collision), aucun UUID aléatoire pour un run orchestré. L'algorithme est **partagé**
+Python (`app/services/correlation.py`) ↔ PHP (`App\Trading\Service\RunCorrelationId`)
+via les vecteurs communs `tests/fixtures/run_correlation_vectors.json`.
+
+**Propagation du contexte.** À chaque dispatch d'un set, l'orchestrateur envoie à
+`POST /api/mtf/run` les en-têtes `X-Run-Id` (original), `X-Run-Correlation-Id`
+(canonique), `X-Orchestration-Set-Id`, `X-Orchestration-Dashboard-Id`. Symfony
+(`RunnerController` → `MtfRunnerService`) **consomme** le `run_id` comme run_id du run
+(avant OBS-003 : UUID généré, join vide) et inscrit le lineage dans l'`extra` de
+`order_submitted` (`orchestration_run_id`/`orchestration_dashboard_id`/
+`orchestration_set_id`). CLI `mtf:run` et appel HTTP legacy sans en-têtes : comportement
+historique inchangé.
+
+**Rapprochement entrée ↔ clôture par identifiants exacts.** La vue
+`position_trade_analysis` (migration `Version20260622000000`, `CREATE OR REPLACE VIEW`)
+apparie une entrée à sa clôture **(1) par `trade_id` exact, (2) sinon par `position_id`
+exact, (3) sinon `unmatched`** — **jamais** par « première clôture ultérieure du même
+symbole ». L'appariement `ROW_NUMBER` garantit qu'une clôture ne sert qu'une entrée et
+que la jointure ne multiplie pas les lignes. Colonnes `close_match_status`
+(`matched`/`unmatched`) et `close_matched_by` (`matched_trade_id`/`matched_position_id`/
+`unmatched`).
+
+**Sémantique PnL honnête.** La valeur enregistrée est exposée sous `recorded_pnl_usdt`
+(**pas** « PnL net »). `net_pnl_usdt` n'est calculé que si `fees` + `funding` +
+`slippage` sont **tous** présents ; sinon `null` et `net_pnl_complete=false`. Aucun coût
+n'est inventé.
+
+**Surfaces.** Symfony lecture seule `GET /api/positions/analysis?run_id=…[&set_id=…]`
+(`PositionAnalysisApiController` → `RunTradeOutcomeService`, dérive lui-même le même
+identifiant canonique). Orchestrateur `GET /runs/{run_id}/outcome`
+(`symfony_client.fetch_run_trade_outcome`) : agrégat par run + ventilation
+`by_set`/`by_profile`/`by_exchange`/`by_symbol` (winrate sur trades **clôturés ET
+rapprochés** uniquement).
+
+```bash
+curl -s 'http://localhost:8099/runs/run_dashA_20260617T083000Z/outcome' | jq .
+```
+
+**Fail-safe (jamais masquer une indisponibilité).** Run inconnu → **404** ; run connu
+sans trade → **200** `trade_count=0`, `source_available=true` ; source Symfony
+indisponible → **503** `source_available=false` + `error_code`, **jamais** un agrégat
+vide silencieux. Lecture seule : aucune écriture sur la vue, aucune décision métier
+modifiée, OBS-001/002 et SAFE-001/002/003 intacts.
+
 ## Garde-fous fonctionnels
 
 Avant tout run :
@@ -736,6 +798,7 @@ Avant tout run :
 | SAFE-003 ✅ | Centraliser et durcir les garde-fous live | Livré : module unique `app/services/live_guard.py` (`assess_live -> LiveDecision`) consommé par `assert_set_persistable`, `assert_live_allowed` et le runner `_dispatch_set` (plus de logique live dupliquée schemas ↔ runner). Hiérarchie fail-closed : bannissements permanents OKX/Hyperliquid (jamais relâchés) > interrupteur `ORCHESTRATION_LIVE_ENABLED` (défaut OFF) > allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > snapshot d'état ouvert présent. `reason`/`code` stables par cause. Persistance ↔ runtime cohérents. **Le live reste désactivé par défaut** : aucune réactivation effective, seule l'activation devient possible/auditable/testée. Pas de migration. |
 | OBS-001 ✅ | Audit des runs d'orchestration | Livré : couche d'audit structurée, fail-safe et corrélée par `run_id` (`app/services/run_audit.py`, `emit`) sur le logger `orchestrator.audit`, format **JSON line** sur stdout (`app/logging_config.py`), niveau piloté par `ORCHESTRATION_LOG_LEVEL` (défaut INFO, validé au démarrage). Points d'audit : `run_started`, `run_short_circuit` (replay/in_flight/resume/reclaim), `snapshot_fetch`, `set_skipped` (codes live_guard / locked / conflicting_live / open_state_unavailable), `set_dispatched`, `set_result`, `run_finished`. `code`/`reason` identiques à `RunSet.error` (source unique SAFE-003). Trace-id `X-Run-Id` propagé à Symfony. **Aucun changement de comportement** (SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
 | OBS-002 ✅ | Métriques d'exécution par set | Livré : registre de métriques in-process (`app/services/run_metrics.py`) branché aux **mêmes points** qu'OBS-001 (`set_dispatched`/`set_result`/`set_skipped`/`snapshot_fetch`/`run_finished`). Compteurs (runs par status ; sets dispatched/results ok+`business_status`/skipped par `code` ; snapshots ok/indispo) + **histogramme** de durée de dispatch (`set_result.duration_ms`, bornes « le »). Sink = **endpoint JSON dérivé** `GET /metrics` (`app/routers/metrics.py`), aucune migration ni écriture DB. Labels **faible cardinalité** (`exchange`/`market_type`/`mtf_profile` + `code`/`business_status`/`status`), ni `set_id` ni `dashboard_id`. Activation `ORCHESTRATION_METRICS_ENABLED` (défaut ON, validé au démarrage). Réconcilie avec `summary`. **Fail-safe**, **aucun changement de comportement** (OBS-001 et SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
+| OBS-003 ✅ | Lineage run → trades + outcomes fiables | Livré : **couche OUTCOME** read-only reliant un run d'orchestration à ses trades résultants, sans jamais recalculer le PnL. **Corrélation déterministe SANS troncature** : `run_id` ORIGINAL conservé s'il respecte `^[A-Za-z0-9._:-]+$` ET ≤64, sinon `sha256` hex (64) — algorithme PARTAGÉ Python (`app/services/correlation.py`) ↔ PHP (`App\Trading\Service\RunCorrelationId`) avec vecteurs communs `tests/fixtures/run_correlation_vectors.json` (collisions de préfixe couvertes). **Propagation du contexte** : en-têtes `X-Run-Id` / `X-Run-Correlation-Id` / `X-Orchestration-Set-Id` / `X-Orchestration-Dashboard-Id` consommés par `RunnerController`/`MtfRunnerService` (le run_id de corrélation devient le `run_id` du run ; avant : UUID, join vide) puis inscrits dans l'`extra` de `order_submitted` via le dispatcher → `TradingDecisionHandler`. **Rapprochement entrée/clôture par identifiants EXACTS** (`trade_id` puis `position_id`, jamais par symbole) via une nouvelle migration `CREATE OR REPLACE VIEW` (`Version20260622000000`) avec `ROW_NUMBER` 1-pour-1 (aucune clôture réutilisée, aucune multiplication de lignes), colonnes `close_match_status`/`close_matched_by`. **Sémantique PnL explicite** : `recorded_pnl_usdt` (valeur enregistrée, PAS garantie nette) vs `net_pnl_usdt` calculé UNIQUEMENT si `fees`+`funding`+`slippage` présents (`net_pnl_complete`). **Surfaces** : Symfony `GET /api/positions/analysis?run_id=…[&set_id=…]` (`PositionAnalysisApiController` → `RunTradeOutcomeService`) ; orchestrateur `GET /runs/{run_id}/outcome` (`symfony_client.fetch_run_trade_outcome`). **Fail-safe** : source indisponible → 503 `source_available=false` (jamais confondue avec « 0 trade »), run inconnu → 404, run sans trade → 200 agrégat vide. **Aucun changement de stratégie/EntryZone/Risk/SL-TP/live** ; CLI `mtf:run` et HTTP legacy `/api/mtf/run` inchangés (lineage nul). |
 | QA-001 ✅ | Instrumentation de couverture des tests unitaires + gate CI | Livré : mesure `pytest-cov` (config `pyproject.toml` : `source=["app"]`, `branch=true`, `show_missing`/`skip_covered`/`fail_under=95`), rapport `term-missing` + XML archivé en CI. **Baseline mesurée : 95.15 %** (1460/1517 lignes, branches activées). **Seuil de gate retenu : `--cov-fail-under=95`** (baseline arrondie à l'entier inférieur — décision produit) câblé dans `.github/workflows/python-orchestrator.yml`, fait échouer la CI sous le seuil. Tests dédiés ajoutés pour les modules non couverts directement : `app/db/engine.py` (lazy/singleton/`get_session`/`reset_engine` → 100 %), `app/logging_config.py` (formatter audit/non-audit/exc_info, idempotence handler unique, pas de double émission → 100 %), `app/main.py` (CORS + include routers + configure audit/metrics au démarrage → 100 %), `app/routers/metrics.py` (snapshot activé/désactivé). `pytest-cov` en `requirements-dev.txt` uniquement (dev-only, épinglé). **Aucun fichier `app/` modifié** : diff = `tests/` + `pyproject.toml` + `requirements-dev.txt` + workflow CI. |
 | QA-002 ✅ | Tests d'intégration Symfony ↔ orchestrateur (contrat HTTP) | Livré : couche de tests d'**intégration** validant le contrat HTTP réel des appels sortants vers Symfony, **sans socket ni backend Symfony/PostgreSQL applicatif** (persistance SQLite in-memory, comme QA-001). **Frontière de simulation retenue : `httpx.MockTransport` scénarisé** (décision produit, zéro dépendance de test en plus) — `FakeSymfony` (dans `tests/conftest.py`) rejoue les **3 endpoints** (`GET /api/mtf/contracts`, `POST /api/mtf/run`, `GET /api/exchange/open-state`) via un **vrai** `httpx.AsyncClient` (sérialisation/parsing JSON, en-têtes, codes HTTP réels) ; fixture `symfony` qui câble le stub sur le runner. Périmètre : contrat **exact** des requêtes sortantes (méthode/chemin/params/corps JSON/`X-Run-Id`), payload `/api/mtf/run` (`sync_tables`/`process_tp_sl=false`, override `dry_run`, snapshot, allow-list de clés), réponses dégradées (`502`, timeout/connexion `httpx.HTTPError`, JSON malformé, `ok=false` → `Run.ok=false`), fail-closed live 502 **sans écriture partielle**, **parallélisme borné** (`MAX_CONCURRENCY`, rendu déterministe via `asyncio.sleep(0)`), idempotence (SAFE-002), audit (OBS-001) et métriques (OBS-002). Couvre les branches d'erreur de `symfony_client.py` (`symfony_client.py` → 100 %) ; couverture globale au-dessus de la baseline QA-001, **gate `--cov-fail-under=95` inchangé** (décision produit). **Aucun fichier `app/` modifié** : diff = `tests/` + doc. Hors-scope : Temporal (QA-003), vrai Symfony/PostgreSQL de prod, modifs comportementales. |
 | QA-003 ✅ | Couverture unitaire + gate CI du cron Temporal (`OrchestratorCronWorkflow`) | Livré : même filet que QA-001 porté au cron `cron_symfony_mtf_workers/`, **sans serveur Temporal ni dépendance réseau** (primitives `workflow.*` patchées, fakes `httpx`, pattern `asyncio.run`). **Forme CI retenue : workflow dédié `.github/workflows/temporal-cron.yml`** (path-filtré `cron_symfony_mtf_workers/**`, miroir de `python-orchestrator.yml`, aucun service Temporal/PostgreSQL). **Périmètre de couverture (décision produit) : fichiers du cron orchestrateur UNIQUEMENT** — `activities/orchestrator_http.py`, `workflows/orchestrator_cron.py`, `scripts/manage_orchestrator_schedule.py` (config `pyproject.toml` : `source` sur les paquets `activities`/`workflows`/`scripts` + `omit` du legacy MTF — pour que coverage découvre les fichiers cibles même non importés et compte un cible non testé comme 0 % au lieu de le sortir du dénominateur ; `branch=true`, `show_missing`/`skip_covered`) ; le code legacy MTF est exclu pour ne pas écraser la baseline. **Baseline mesurée : 99.12 %** (branches activées ; seule la ligne `if __name__ == "__main__": main()` reste non couverte). **Seuil de gate : `--cov-fail-under=99`** (entier inférieur de la baseline — décision produit, cohérent QA-001). Tests complétés (sans réécriture) : activity (timeout explicite), script de schedule (import réel des classes Temporal, `get_client`, routage `async_main` create/pause/resume/delete/status, `delete`/`describe`, re-levée d'erreur inattendue, `main()`). `pytest`/`pytest-cov` en `requirements-dev.txt` uniquement (dev-only, épinglés, jamais dans l'image). **Aucun fichier applicatif modifié** : diff = `tests/` + `requirements-dev.txt` + `pyproject.toml` + `.github/workflows/temporal-cron.yml` + `.gitignore` + doc. |

--- a/docs/handbook/technical/python-orchestrator.md
+++ b/docs/handbook/technical/python-orchestrator.md
@@ -432,7 +432,7 @@ PY-006 ajoute la surface **en lecture seule** consommée par le cockpit :
 | `GET` | `/runs` | Liste des runs (vue allégée), filtrable par `dashboard_id`, paginée (`limit` ≤ 100, `offset`), du plus récent au plus ancien. |
 | `GET` | `/runs/{run_id}` | Détail complet : dernier JSON global (`last_json`) + détail par set (`sets[]`). |
 | `GET` | `/runs/{run_id}/sets/{set_id}` | Dernier JSON d'un set : `payload_sent`, `response_json` brute, `error`, `duration_ms`. |
-| `GET` | `/runs/{run_id}/outcome` | Outcome OBS-003 : trades résultants du run (vue Symfony `position_trade_analysis`), agrégat + ventilation `by_set`/`by_profile`/`by_exchange`/`by_symbol`. `404` run inconnu, `503` source indisponible (`source_available=false`), `200` sinon (agrégat éventuellement vide). |
+| `GET` | `/runs/{run_id}/outcome` | Outcome OBS-003 : trades résultants du run (vue Symfony `position_trade_analysis_v2`), agrégat (recorded vs estimated PnL, `cost_completeness`, compteurs matched/unmatched) + ventilation `by_set`/`by_profile`/`by_exchange`/`by_symbol`. `404` run inconnu, `503` source indisponible (`source_available=false`), `200` sinon (agrégat éventuellement vide). |
 | `GET` | `/dashboards/{id}/runs` | Runs d'un dashboard (vue allégée, paginée). |
 | `GET` | `/dashboards/{id}/runs/latest` | Dernier run d'un dashboard (détail complet) — le retour affiché par défaut au cockpit ; `404` si aucun run. |
 
@@ -679,44 +679,65 @@ porte un `run_id` ORIGINAL (jusqu'à 255 caractères). La colonne
 `trade_lifecycle_event.run_id` est un `VARCHAR(64)`. Pour relier les deux **sans
 collision**, on dérive un identifiant canonique :
 
-1. chaîne vide refusée ;
-2. si `run_id` respecte `^[A-Za-z0-9._:-]+$` **et** ≤ 64 → conservé tel quel ;
-3. sinon → `sha256(run_id)` hex minuscule (exactement 64).
+1. *trim* des espaces de bord (miroir exact du `trim()` PHP ↔ `str.strip()` Python) ;
+2. chaîne vide (après trim) refusée ;
+3. si `run_id` respecte `^[A-Za-z0-9._:-]+$` **et** ≤ 64 → conservé tel quel ;
+4. sinon → `sha256(run_id)` hex minuscule (exactement 64).
 
 Aucune troncature `run_id[:64]` (deux longs `run_id` au même préfixe entreraient en
-collision), aucun UUID aléatoire pour un run orchestré. L'algorithme est **partagé**
-Python (`app/services/correlation.py`) ↔ PHP (`App\Trading\Service\RunCorrelationId`)
-via les vecteurs communs `tests/fixtures/run_correlation_vectors.json`.
+collision), aucun UUID aléatoire pour un run orchestré. L'algorithme est **strictement
+identique** Python (`app/services/correlation.py`) ↔ PHP
+(`App\Trading\Service\RunCorrelationId`), y compris le *trim*, via les vecteurs communs
+`tests/fixtures/run_correlation_vectors.json` (cas d'espaces inclus).
 
-**Propagation du contexte.** À chaque dispatch d'un set, l'orchestrateur envoie à
-`POST /api/mtf/run` les en-têtes `X-Run-Id` (original), `X-Run-Correlation-Id`
-(canonique), `X-Orchestration-Set-Id`, `X-Orchestration-Dashboard-Id`. Symfony
-(`RunnerController` → `MtfRunnerService`) **consomme** le `run_id` comme run_id du run
-(avant OBS-003 : UUID généré, join vide) et inscrit le lineage dans l'`extra` de
-`order_submitted` (`orchestration_run_id`/`orchestration_dashboard_id`/
-`orchestration_set_id`). CLI `mtf:run` et appel HTTP legacy sans en-têtes : comportement
-historique inchangé.
+**Propagation + validation fail-closed du contexte.** À chaque dispatch d'un set,
+l'orchestrateur envoie à `POST /api/mtf/run` les en-têtes `X-Run-Id` (original),
+`X-Run-Correlation-Id` (canonique), `X-Orchestration-Set-Id`,
+`X-Orchestration-Dashboard-Id`. Symfony (`RunnerController` → `MtfRunnerService`)
+**consomme** le `run_id` comme run_id du run (avant OBS-003 : UUID généré, join vide) et
+inscrit le lineage dans l'`extra` de `order_submitted`. Avant tout traitement, un
+`OrchestrationContextValidator` **refuse fail-closed (HTTP 422, code stable)** toute
+contradiction VÉRIFIABLE dans la requête : `ORCHESTRATION_CORRELATION_MISMATCH` (la
+corrélation fournie ≠ canonique de `X-Run-Id`), `…_SET_MISMATCH` / `…_DASHBOARD_MISMATCH`
+(en-tête vs payload), `…_PROFILE_MISMATCH` (`profile` vs `mtf_profile`),
+`…_EXCHANGE_MISMATCH` (`exchange` vs `cex`), `…_MARKET_TYPE_MISMATCH` (`market_type` vs
+`type_contract`). **Limite documentée** : la relation set ⇄ dashboard exige les données
+de l'orchestrateur et n'est pas vérifiable côté Symfony (responsabilité orchestrateur).
+CLI `mtf:run` et appel HTTP legacy sans en-têtes : comportement historique inchangé.
 
-**Rapprochement entrée ↔ clôture par identifiants exacts.** La vue
-`position_trade_analysis` (migration `Version20260622000000`, `CREATE OR REPLACE VIEW`)
-apparie une entrée à sa clôture **(1) par `trade_id` exact, (2) sinon par `position_id`
-exact, (3) sinon `unmatched`** — **jamais** par « première clôture ultérieure du même
-symbole ». L'appariement `ROW_NUMBER` garantit qu'une clôture ne sert qu'une entrée et
-que la jointure ne multiplie pas les lignes. Colonnes `close_match_status`
-(`matched`/`unmatched`) et `close_matched_by` (`matched_trade_id`/`matched_position_id`/
-`unmatched`).
+**Rapprochement entrée ↔ clôture par identifiants exacts.** La nouvelle vue VERSIONNÉE
+`position_trade_analysis_v2` (migration `Version20260622000000`) apparie une entrée à sa
+clôture **(1) par `trade_id` exact, (2) sinon par `position_id` exact — borné à la même
+venue (symbole + exchange + market_type) et à une clôture postérieure à l'entrée —, (3)
+sinon `unmatched`** — **jamais** par « première clôture ultérieure du même symbole ».
+Pont `trade_id → position_id` via `position_opened` (porte les deux). `ROW_NUMBER`
+garantit qu'une clôture ne sert qu'une entrée, sans multiplication de lignes. Colonnes
+`close_match_status`, `close_matched_by`, `analysis_status` (`matched_closed`/`unmatched`).
+**Bascule progressive (issue #190)** : la vue historique `position_trade_analysis` (v1)
+n'est PAS modifiée — comparaison v1/v2, rollback et consommateurs existants préservés ;
+le remplacement de la v1 est un jalon ultérieur.
 
-**Sémantique PnL honnête.** La valeur enregistrée est exposée sous `recorded_pnl_usdt`
-(**pas** « PnL net »). `net_pnl_usdt` n'est calculé que si `fees` + `funding` +
-`slippage` sont **tous** présents ; sinon `null` et `net_pnl_complete=false`. Aucun coût
-n'est inventé.
+**Sémantique PnL — jamais d'estimé présenté comme certifié (issue #190).** La valeur
+enregistrée est `recorded_pnl_usdt` (**ni brute ni nette garanties**). On expose en plus
+`fees_usdt`/`funding_usdt`/`slippage_usdt` (NULL si absents, **jamais 0**),
+`estimated_net_pnl_usdt` (ESTIMATION best-effort `recorded - fees - funding - slippage`,
+seulement si les trois sont présents) et `cost_completeness`
+(`not_applicable`/`unknown`/`partial`/`complete`). `complete` est **réservé** au contrat
+#190 complet (brut + frais entrée/sortie séparés + spread + funding signé + borrow) et
+n'est **jamais** émis ici : il n'existe donc **pas** de `net_pnl_usdt` certifié dans v2.
+
+**États distincts (issue #190).** Les agrégats distinguent `matched_closed_count`
+(clôturé+rapproché, seule base certifiée), `unmatched_count` (état réel INCONNU),
+`confirmed_open_count` (= 0 : aucune preuve d'ouverture dans une vue read-only) et
+`unknown_state_count`. Une ligne `unmatched` n'est **jamais** comptée comme position
+ouverte confirmée. `data_complete` est faux dès qu'une ligne est unmatched ou à coûts
+incomplets ; le winrate ne porte que sur les `matched_closed` disposant d'un PnL.
 
 **Surfaces.** Symfony lecture seule `GET /api/positions/analysis?run_id=…[&set_id=…]`
 (`PositionAnalysisApiController` → `RunTradeOutcomeService`, dérive lui-même le même
 identifiant canonique). Orchestrateur `GET /runs/{run_id}/outcome`
 (`symfony_client.fetch_run_trade_outcome`) : agrégat par run + ventilation
-`by_set`/`by_profile`/`by_exchange`/`by_symbol` (winrate sur trades **clôturés ET
-rapprochés** uniquement).
+`by_set`/`by_profile`/`by_exchange`/`by_symbol`.
 
 ```bash
 curl -s 'http://localhost:8099/runs/run_dashA_20260617T083000Z/outcome' | jq .
@@ -798,7 +819,7 @@ Avant tout run :
 | SAFE-003 ✅ | Centraliser et durcir les garde-fous live | Livré : module unique `app/services/live_guard.py` (`assess_live -> LiveDecision`) consommé par `assert_set_persistable`, `assert_live_allowed` et le runner `_dispatch_set` (plus de logique live dupliquée schemas ↔ runner). Hiérarchie fail-closed : bannissements permanents OKX/Hyperliquid (jamais relâchés) > interrupteur `ORCHESTRATION_LIVE_ENABLED` (défaut OFF) > allow-list `ORCHESTRATION_LIVE_EXCHANGES` (défaut vide) > snapshot d'état ouvert présent. `reason`/`code` stables par cause. Persistance ↔ runtime cohérents. **Le live reste désactivé par défaut** : aucune réactivation effective, seule l'activation devient possible/auditable/testée. Pas de migration. |
 | OBS-001 ✅ | Audit des runs d'orchestration | Livré : couche d'audit structurée, fail-safe et corrélée par `run_id` (`app/services/run_audit.py`, `emit`) sur le logger `orchestrator.audit`, format **JSON line** sur stdout (`app/logging_config.py`), niveau piloté par `ORCHESTRATION_LOG_LEVEL` (défaut INFO, validé au démarrage). Points d'audit : `run_started`, `run_short_circuit` (replay/in_flight/resume/reclaim), `snapshot_fetch`, `set_skipped` (codes live_guard / locked / conflicting_live / open_state_unavailable), `set_dispatched`, `set_result`, `run_finished`. `code`/`reason` identiques à `RunSet.error` (source unique SAFE-003). Trace-id `X-Run-Id` propagé à Symfony. **Aucun changement de comportement** (SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
 | OBS-002 ✅ | Métriques d'exécution par set | Livré : registre de métriques in-process (`app/services/run_metrics.py`) branché aux **mêmes points** qu'OBS-001 (`set_dispatched`/`set_result`/`set_skipped`/`snapshot_fetch`/`run_finished`). Compteurs (runs par status ; sets dispatched/results ok+`business_status`/skipped par `code` ; snapshots ok/indispo) + **histogramme** de durée de dispatch (`set_result.duration_ms`, bornes « le »). Sink = **endpoint JSON dérivé** `GET /metrics` (`app/routers/metrics.py`), aucune migration ni écriture DB. Labels **faible cardinalité** (`exchange`/`market_type`/`mtf_profile` + `code`/`business_status`/`status`), ni `set_id` ni `dashboard_id`. Activation `ORCHESTRATION_METRICS_ENABLED` (défaut ON, validé au démarrage). Réconcilie avec `summary`. **Fail-safe**, **aucun changement de comportement** (OBS-001 et SAFE-001/002/003 intacts, réponses HTTP inchangées). Pas de migration. |
-| OBS-003 ✅ | Lineage run → trades + outcomes fiables | Livré : **couche OUTCOME** read-only reliant un run d'orchestration à ses trades résultants, sans jamais recalculer le PnL. **Corrélation déterministe SANS troncature** : `run_id` ORIGINAL conservé s'il respecte `^[A-Za-z0-9._:-]+$` ET ≤64, sinon `sha256` hex (64) — algorithme PARTAGÉ Python (`app/services/correlation.py`) ↔ PHP (`App\Trading\Service\RunCorrelationId`) avec vecteurs communs `tests/fixtures/run_correlation_vectors.json` (collisions de préfixe couvertes). **Propagation du contexte** : en-têtes `X-Run-Id` / `X-Run-Correlation-Id` / `X-Orchestration-Set-Id` / `X-Orchestration-Dashboard-Id` consommés par `RunnerController`/`MtfRunnerService` (le run_id de corrélation devient le `run_id` du run ; avant : UUID, join vide) puis inscrits dans l'`extra` de `order_submitted` via le dispatcher → `TradingDecisionHandler`. **Rapprochement entrée/clôture par identifiants EXACTS** (`trade_id` puis `position_id`, jamais par symbole) via une nouvelle migration `CREATE OR REPLACE VIEW` (`Version20260622000000`) avec `ROW_NUMBER` 1-pour-1 (aucune clôture réutilisée, aucune multiplication de lignes), colonnes `close_match_status`/`close_matched_by`. **Sémantique PnL explicite** : `recorded_pnl_usdt` (valeur enregistrée, PAS garantie nette) vs `net_pnl_usdt` calculé UNIQUEMENT si `fees`+`funding`+`slippage` présents (`net_pnl_complete`). **Surfaces** : Symfony `GET /api/positions/analysis?run_id=…[&set_id=…]` (`PositionAnalysisApiController` → `RunTradeOutcomeService`) ; orchestrateur `GET /runs/{run_id}/outcome` (`symfony_client.fetch_run_trade_outcome`). **Fail-safe** : source indisponible → 503 `source_available=false` (jamais confondue avec « 0 trade »), run inconnu → 404, run sans trade → 200 agrégat vide. **Aucun changement de stratégie/EntryZone/Risk/SL-TP/live** ; CLI `mtf:run` et HTTP legacy `/api/mtf/run` inchangés (lineage nul). |
+| OBS-003 ✅ | Lineage run → trades + outcomes fiables | Livré : **couche OUTCOME** read-only reliant un run d'orchestration à ses trades résultants, sans jamais recalculer le PnL. **Corrélation déterministe SANS troncature** : `run_id` ORIGINAL conservé s'il respecte `^[A-Za-z0-9._:-]+$` ET ≤64, sinon `sha256` hex (64) — algorithme PARTAGÉ Python (`app/services/correlation.py`) ↔ PHP (`App\Trading\Service\RunCorrelationId`) avec vecteurs communs `tests/fixtures/run_correlation_vectors.json` (collisions de préfixe couvertes). **Propagation du contexte** : en-têtes `X-Run-Id` / `X-Run-Correlation-Id` / `X-Orchestration-Set-Id` / `X-Orchestration-Dashboard-Id` consommés par `RunnerController`/`MtfRunnerService` (le run_id de corrélation devient le `run_id` du run ; avant : UUID, join vide) puis inscrits dans l'`extra` de `order_submitted` via le dispatcher → `TradingDecisionHandler`. **Validation fail-closed** du contexte (en-têtes vs payload) en 422 à codes stables (`ORCHESTRATION_*_MISMATCH`). **Rapprochement entrée/clôture par identifiants EXACTS** (`trade_id` puis `position_id` borné à la venue, jamais par symbole) via la **vue versionnée** `position_trade_analysis_v2` (`Version20260622000000`, v1 conservée pour bascule progressive #190) avec `ROW_NUMBER` 1-pour-1 (aucune clôture réutilisée), colonnes `close_match_status`/`close_matched_by`/`analysis_status`. **Sémantique PnL explicite (jamais d'estimé certifié)** : `recorded_pnl_usdt` (ni brut ni net garantis), `estimated_net_pnl_usdt` (estimation best-effort) + `cost_completeness` (`complete` réservé au contrat #190, jamais émis) — pas de `net_pnl_usdt` certifié. **États distincts** : `matched_closed`/`unmatched`/`confirmed_open=0`/`unknown_state` (unmatched n'est jamais « open confirmé »). **Surfaces** : Symfony `GET /api/positions/analysis?run_id=…[&set_id=…]` ; orchestrateur `GET /runs/{run_id}/outcome`. **Fail-safe** : source indisponible → 503 `source_available=false` (jamais « 0 trade »), run inconnu → 404, run sans trade → 200 agrégat vide. **Aucun changement de stratégie/EntryZone/Risk/SL-TP/live** ; CLI `mtf:run` et HTTP legacy inchangés. **Part of #189 / #190** (lineage + PnL partiels, voir issues). |
 | QA-001 ✅ | Instrumentation de couverture des tests unitaires + gate CI | Livré : mesure `pytest-cov` (config `pyproject.toml` : `source=["app"]`, `branch=true`, `show_missing`/`skip_covered`/`fail_under=95`), rapport `term-missing` + XML archivé en CI. **Baseline mesurée : 95.15 %** (1460/1517 lignes, branches activées). **Seuil de gate retenu : `--cov-fail-under=95`** (baseline arrondie à l'entier inférieur — décision produit) câblé dans `.github/workflows/python-orchestrator.yml`, fait échouer la CI sous le seuil. Tests dédiés ajoutés pour les modules non couverts directement : `app/db/engine.py` (lazy/singleton/`get_session`/`reset_engine` → 100 %), `app/logging_config.py` (formatter audit/non-audit/exc_info, idempotence handler unique, pas de double émission → 100 %), `app/main.py` (CORS + include routers + configure audit/metrics au démarrage → 100 %), `app/routers/metrics.py` (snapshot activé/désactivé). `pytest-cov` en `requirements-dev.txt` uniquement (dev-only, épinglé). **Aucun fichier `app/` modifié** : diff = `tests/` + `pyproject.toml` + `requirements-dev.txt` + workflow CI. |
 | QA-002 ✅ | Tests d'intégration Symfony ↔ orchestrateur (contrat HTTP) | Livré : couche de tests d'**intégration** validant le contrat HTTP réel des appels sortants vers Symfony, **sans socket ni backend Symfony/PostgreSQL applicatif** (persistance SQLite in-memory, comme QA-001). **Frontière de simulation retenue : `httpx.MockTransport` scénarisé** (décision produit, zéro dépendance de test en plus) — `FakeSymfony` (dans `tests/conftest.py`) rejoue les **3 endpoints** (`GET /api/mtf/contracts`, `POST /api/mtf/run`, `GET /api/exchange/open-state`) via un **vrai** `httpx.AsyncClient` (sérialisation/parsing JSON, en-têtes, codes HTTP réels) ; fixture `symfony` qui câble le stub sur le runner. Périmètre : contrat **exact** des requêtes sortantes (méthode/chemin/params/corps JSON/`X-Run-Id`), payload `/api/mtf/run` (`sync_tables`/`process_tp_sl=false`, override `dry_run`, snapshot, allow-list de clés), réponses dégradées (`502`, timeout/connexion `httpx.HTTPError`, JSON malformé, `ok=false` → `Run.ok=false`), fail-closed live 502 **sans écriture partielle**, **parallélisme borné** (`MAX_CONCURRENCY`, rendu déterministe via `asyncio.sleep(0)`), idempotence (SAFE-002), audit (OBS-001) et métriques (OBS-002). Couvre les branches d'erreur de `symfony_client.py` (`symfony_client.py` → 100 %) ; couverture globale au-dessus de la baseline QA-001, **gate `--cov-fail-under=95` inchangé** (décision produit). **Aucun fichier `app/` modifié** : diff = `tests/` + doc. Hors-scope : Temporal (QA-003), vrai Symfony/PostgreSQL de prod, modifs comportementales. |
 | QA-003 ✅ | Couverture unitaire + gate CI du cron Temporal (`OrchestratorCronWorkflow`) | Livré : même filet que QA-001 porté au cron `cron_symfony_mtf_workers/`, **sans serveur Temporal ni dépendance réseau** (primitives `workflow.*` patchées, fakes `httpx`, pattern `asyncio.run`). **Forme CI retenue : workflow dédié `.github/workflows/temporal-cron.yml`** (path-filtré `cron_symfony_mtf_workers/**`, miroir de `python-orchestrator.yml`, aucun service Temporal/PostgreSQL). **Périmètre de couverture (décision produit) : fichiers du cron orchestrateur UNIQUEMENT** — `activities/orchestrator_http.py`, `workflows/orchestrator_cron.py`, `scripts/manage_orchestrator_schedule.py` (config `pyproject.toml` : `source` sur les paquets `activities`/`workflows`/`scripts` + `omit` du legacy MTF — pour que coverage découvre les fichiers cibles même non importés et compte un cible non testé comme 0 % au lieu de le sortir du dénominateur ; `branch=true`, `show_missing`/`skip_covered`) ; le code legacy MTF est exclu pour ne pas écraser la baseline. **Baseline mesurée : 99.12 %** (branches activées ; seule la ligne `if __name__ == "__main__": main()` reste non couverte). **Seuil de gate : `--cov-fail-under=99`** (entier inférieur de la baseline — décision produit, cohérent QA-001). Tests complétés (sans réécriture) : activity (timeout explicite), script de schedule (import réel des classes Temporal, `get_client`, routage `async_main` create/pause/resume/delete/status, `delete`/`describe`, re-levée d'erreur inattendue, `main()`). `pytest`/`pytest-cov` en `requirements-dev.txt` uniquement (dev-only, épinglés, jamais dans l'image). **Aucun fichier applicatif modifié** : diff = `tests/` + `requirements-dev.txt` + `pyproject.toml` + `.github/workflows/temporal-cron.yml` + `.gitignore` + doc. |

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -70,6 +70,7 @@ Hors-scope (PR suivantes) :
 | `GET` | `/runs` | Liste les runs (`?dashboard_id=&limit=&offset=`) (PY-006). |
 | `GET` | `/runs/{run_id}` | Dernier JSON global d'un run + détail par set (PY-006). |
 | `GET` | `/runs/{run_id}/sets/{set_id}` | Dernier JSON d'un set (payload + réponse brute) (PY-006). |
+| `GET` | `/runs/{run_id}/outcome` | Outcome du run : trades résultants (vue `position_trade_analysis`), agrégat + ventilation `by_set`/`by_profile`/`by_exchange`/`by_symbol`. `404` inconnu, `503` source indispo, `200` sinon (OBS-003). |
 | `GET` | `/metrics` | Métriques d'exécution agrégées (compteurs + histogramme de durée), JSON dérivé du registre (OBS-002). |
 | `GET` | `/docs` | Swagger UI (OpenAPI). |
 
@@ -442,6 +443,33 @@ curl -s http://localhost:8099/metrics | jq .
 via `ORCHESTRATION_METRICS_ENABLED=false`. **Aucun changement de comportement** :
 dispatch, décisions live/lock/idempotence, réponses HTTP et forme de
 `last_json`/`RunSet` inchangés ; OBS-001 et SAFE-001/002/003 intacts.
+
+## Lineage run → trades + outcomes (OBS-003)
+
+OBS-001/002 rendent visible l'**exécution** d'un run ; OBS-003 ajoute la couche
+**OUTCOME** : relier un run à ses **trades résultants** de façon fiable, en lecture
+seule, sans jamais recalculer le PnL.
+
+- **Corrélation déterministe sans troncature** : `run_id` ORIGINAL conservé s'il
+  respecte `^[A-Za-z0-9._:-]+$` et ≤ 64, sinon `sha256` hex (64). Algorithme
+  **partagé** Python (`app/services/correlation.py`) ↔ PHP (`RunCorrelationId`) via
+  `tests/fixtures/run_correlation_vectors.json` (collisions de préfixe couvertes).
+- **Propagation** : en-têtes `X-Run-Id` / `X-Run-Correlation-Id` /
+  `X-Orchestration-Set-Id` / `X-Orchestration-Dashboard-Id` ajoutés à chaque
+  `POST /api/mtf/run`. Symfony consomme le run_id de corrélation (avant : join vide)
+  et inscrit le lineage dans l'`extra` de `order_submitted`.
+- **Rapprochement entrée/clôture EXACT** (`trade_id` puis `position_id`, jamais par
+  symbole) via la vue Symfony `position_trade_analysis` ; `recorded_pnl_usdt` ≠
+  `net_pnl_usdt` (ce dernier seulement si frais+funding+slippage présents).
+- **Surface** : `GET /runs/{run_id}/outcome` (source =
+  `GET /api/positions/analysis` côté Symfony). `404` run inconnu, `503`
+  `source_available=false` si la source est indisponible (jamais confondue avec
+  « 0 trade »), `200` sinon — agrégat + ventilation
+  `by_set`/`by_profile`/`by_exchange`/`by_symbol`.
+
+```bash
+curl -s http://localhost:8099/runs/run_dashA_20260617T083000Z/outcome | jq .
+```
 
 ## Persistance (DB-001)
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -70,7 +70,7 @@ Hors-scope (PR suivantes) :
 | `GET` | `/runs` | Liste les runs (`?dashboard_id=&limit=&offset=`) (PY-006). |
 | `GET` | `/runs/{run_id}` | Dernier JSON global d'un run + détail par set (PY-006). |
 | `GET` | `/runs/{run_id}/sets/{set_id}` | Dernier JSON d'un set (payload + réponse brute) (PY-006). |
-| `GET` | `/runs/{run_id}/outcome` | Outcome du run : trades résultants (vue `position_trade_analysis`), agrégat + ventilation `by_set`/`by_profile`/`by_exchange`/`by_symbol`. `404` inconnu, `503` source indispo, `200` sinon (OBS-003). |
+| `GET` | `/runs/{run_id}/outcome` | Outcome du run : trades résultants (vue `position_trade_analysis_v2`), agrégat (recorded vs estimated PnL, `cost_completeness`) + ventilation `by_set`/`by_profile`/`by_exchange`/`by_symbol`. `404` inconnu, `503` source indispo, `200` sinon (OBS-003). |
 | `GET` | `/metrics` | Métriques d'exécution agrégées (compteurs + histogramme de durée), JSON dérivé du registre (OBS-002). |
 | `GET` | `/docs` | Swagger UI (OpenAPI). |
 
@@ -450,22 +450,25 @@ OBS-001/002 rendent visible l'**exécution** d'un run ; OBS-003 ajoute la couche
 **OUTCOME** : relier un run à ses **trades résultants** de façon fiable, en lecture
 seule, sans jamais recalculer le PnL.
 
-- **Corrélation déterministe sans troncature** : `run_id` ORIGINAL conservé s'il
-  respecte `^[A-Za-z0-9._:-]+$` et ≤ 64, sinon `sha256` hex (64). Algorithme
-  **partagé** Python (`app/services/correlation.py`) ↔ PHP (`RunCorrelationId`) via
-  `tests/fixtures/run_correlation_vectors.json` (collisions de préfixe couvertes).
-- **Propagation** : en-têtes `X-Run-Id` / `X-Run-Correlation-Id` /
-  `X-Orchestration-Set-Id` / `X-Orchestration-Dashboard-Id` ajoutés à chaque
-  `POST /api/mtf/run`. Symfony consomme le run_id de corrélation (avant : join vide)
-  et inscrit le lineage dans l'`extra` de `order_submitted`.
-- **Rapprochement entrée/clôture EXACT** (`trade_id` puis `position_id`, jamais par
-  symbole) via la vue Symfony `position_trade_analysis` ; `recorded_pnl_usdt` ≠
-  `net_pnl_usdt` (ce dernier seulement si frais+funding+slippage présents).
+- **Corrélation déterministe sans troncature** : *trim* puis — si `^[A-Za-z0-9._:-]+$`
+  et ≤ 64 — conservé, sinon `sha256` hex (64). Algorithme **strictement identique**
+  Python (`app/services/correlation.py`) ↔ PHP (`RunCorrelationId`), *trim* compris, via
+  `tests/fixtures/run_correlation_vectors.json` (préfixes + espaces couverts).
+- **Propagation + validation fail-closed** : en-têtes `X-Run-Id` / `X-Run-Correlation-Id`
+  / `X-Orchestration-Set-Id` / `X-Orchestration-Dashboard-Id` ajoutés à chaque
+  `POST /api/mtf/run`. Symfony consomme le run_id de corrélation (avant : join vide),
+  inscrit le lineage dans l'`extra` de `order_submitted`, et **refuse en 422** toute
+  contradiction vérifiable en-têtes/payload (codes `ORCHESTRATION_*_MISMATCH`).
+- **Rapprochement entrée/clôture EXACT** (`trade_id` puis `position_id` borné à la venue,
+  jamais par symbole) via la vue **versionnée** `position_trade_analysis_v2` (v1 conservée,
+  bascule progressive #190). PnL **jamais certifié net** : `recorded_pnl_usdt` (ni brut ni
+  net garantis), `estimated_net_pnl_usdt` (estimation) + `cost_completeness` ; pas de
+  `net_pnl_usdt` certifié.
 - **Surface** : `GET /runs/{run_id}/outcome` (source =
   `GET /api/positions/analysis` côté Symfony). `404` run inconnu, `503`
   `source_available=false` si la source est indisponible (jamais confondue avec
-  « 0 trade »), `200` sinon — agrégat + ventilation
-  `by_set`/`by_profile`/`by_exchange`/`by_symbol`.
+  « 0 trade »), `200` sinon — agrégat (compteurs `matched_closed`/`unmatched`/
+  `confirmed_open=0`) + ventilation `by_set`/`by_profile`/`by_exchange`/`by_symbol`.
 
 ```bash
 curl -s http://localhost:8099/runs/run_dashA_20260617T083000Z/outcome | jq .

--- a/python-orchestrator/app/routers/runs.py
+++ b/python-orchestrator/app/routers/runs.py
@@ -133,6 +133,9 @@ async def get_run_outcome(
             "set_id": set_id,
             "run_found": True,
             "source_available": True,
+            # Relayé tel quel : si Symfony a tronqué l'agrégat (run très large), on le
+            # signale (data_complete est alors faux côté source) plutôt que de le masquer.
+            "truncated": outcome.get("truncated"),
             "data_complete": outcome.get("data_complete"),
             "summary": outcome.get("summary"),
             "by_set": outcome.get("by_set"),

--- a/python-orchestrator/app/routers/runs.py
+++ b/python-orchestrator/app/routers/runs.py
@@ -135,7 +135,10 @@ async def get_run_outcome(
             "source_available": True,
             # Relayé tel quel : si Symfony a tronqué l'agrégat (run très large), on le
             # signale (data_complete est alors faux côté source) plutôt que de le masquer.
+            # `row_cap` accompagne `truncated` pour que les dashboards/clients connaissent le
+            # seuil derrière des agrégats partiels (sinon impossible d'expliquer/paginer).
             "truncated": outcome.get("truncated"),
+            "row_cap": outcome.get("row_cap"),
             "data_complete": outcome.get("data_complete"),
             "summary": outcome.get("summary"),
             "by_set": outcome.get("by_set"),

--- a/python-orchestrator/app/routers/runs.py
+++ b/python-orchestrator/app/routers/runs.py
@@ -16,18 +16,29 @@ from __future__ import annotations
 
 from typing import Optional
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.db import repositories as repo
 from app.db.engine import get_session
 from app.db.models import RunSet
 from app.schemas import RunDetailRead, RunSetRead, RunSummaryRead
+from app.services.correlation import canonical_correlation_id
+from app.services.symfony_client import (
+    OutcomeUnavailableError,
+    fetch_run_trade_outcome,
+)
+from app.settings import get_settings
 
 router = APIRouter(prefix="/runs", tags=["runs"])
 
 # Borne la taille de page pour ne jamais renvoyer un historique non borné.
 _MAX_PAGE_SIZE = 100
+
+# Timeout court de l'appel outcome (lecture seule, pas d'effet de bord côté Symfony).
+_OUTCOME_TIMEOUT = 30.0
 
 
 @router.get("", response_model=list[RunSummaryRead])
@@ -63,3 +74,70 @@ def get_run_set(
     if run_set is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="run set not found")
     return run_set
+
+
+@router.get("/{run_id}/outcome")
+async def get_run_outcome(
+    run_id: str,
+    set_id: Optional[str] = Query(
+        default=None, description="Filtre l'outcome sur un set d'orchestration."
+    ),
+    session: Session = Depends(get_session),
+) -> JSONResponse:
+    """Outcome (trades résultants) d'un run d'orchestration (OBS-003).
+
+    Relie le run à ses trades via la vue Symfony ``position_trade_analysis``, par
+    identifiant de corrélation. Le PnL n'est jamais recalculé (agrégat relayé).
+
+    Sémantique (jamais confondre indisponibilité et « 0 trade ») :
+
+    - **404** si le run est inconnu de l'orchestrateur ;
+    - **200** si le run est connu et la source répond — agrégat éventuellement vide
+      (``trade_count=0``), ``source_available=true`` ;
+    - **503** si la source Symfony est indisponible — ``source_available=false`` +
+      ``error_code`` explicite, jamais un agrégat vide silencieux.
+
+    Les agrégats historiques multi-runs restent hors-scope.
+    """
+    run = repo.get_run(session, run_id)
+    if run is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="run not found")
+
+    settings = get_settings()
+    try:
+        async with httpx.AsyncClient(timeout=_OUTCOME_TIMEOUT) as client:
+            outcome = await fetch_run_trade_outcome(
+                client, settings.symfony_base_url, run_id, set_id
+            )
+    except OutcomeUnavailableError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={
+                "run_id": run_id,
+                "correlation_run_id": canonical_correlation_id(run_id),
+                "dashboard_id": run.dashboard_id,
+                "set_id": set_id,
+                "run_found": True,
+                "source_available": False,
+                "error_code": "outcome_source_unavailable",
+                "detail": str(exc),
+            },
+        )
+
+    return JSONResponse(
+        status_code=status.HTTP_200_OK,
+        content={
+            "run_id": run_id,
+            "correlation_run_id": outcome.get("correlation_run_id"),
+            "dashboard_id": run.dashboard_id,
+            "set_id": set_id,
+            "run_found": True,
+            "source_available": True,
+            "data_complete": outcome.get("data_complete"),
+            "summary": outcome.get("summary"),
+            "by_set": outcome.get("by_set"),
+            "by_profile": outcome.get("by_profile"),
+            "by_exchange": outcome.get("by_exchange"),
+            "by_symbol": outcome.get("by_symbol"),
+        },
+    )

--- a/python-orchestrator/app/services/correlation.py
+++ b/python-orchestrator/app/services/correlation.py
@@ -10,11 +10,14 @@ canonique* déterministe, et **identique** à l'implémentation PHP
 
 Règle (cf. ``tests/fixtures/run_correlation_vectors.json``, partagé Python ↔ PHP) :
 
-1. une chaîne vide est refusée (``ValueError``) — un run d'orchestration a toujours
-   un ``run_id`` ;
-2. si ``run_id`` respecte ``^[A-Za-z0-9._:-]+$`` ET ``len <= 64`` : il est conservé
+1. la valeur est d'abord *trim* (espaces/tabs/retours en tête et fin retirés) —
+   normalisation identique au ``trim()`` PHP ; un ``run_id`` n'est jamais censé porter
+   d'espaces de bord, et cela garantit le MÊME résultat dans les deux langages ;
+2. une chaîne vide (après trim) est refusée (``ValueError``) — un run d'orchestration a
+   toujours un ``run_id`` ;
+3. si ``run_id`` respecte ``^[A-Za-z0-9._:-]+$`` ET ``len <= 64`` : il est conservé
    tel quel (lisible, déjà compatible avec la colonne) ;
-3. sinon : ``sha256(run_id)`` en hexadécimal minuscule (exactement 64 caractères).
+4. sinon : ``sha256(run_id)`` en hexadécimal minuscule (exactement 64 caractères).
 
 Interdits explicites : aucune troncature silencieuse (``run_id[:64]``), aucun UUID
 aléatoire pour un run issu de l'orchestrateur, aucune divergence d'algorithme entre
@@ -38,11 +41,16 @@ def canonical_correlation_id(run_id: str) -> str:
 
     Déterministe et sans collision : deux ``run_id`` distincts produisent toujours
     deux identifiants distincts (les longs/non-sûrs passent par ``sha256``, jamais
-    par une troncature). Voir le module pour la règle complète.
+    par une troncature). La valeur est *trim* d'abord (miroir exact du ``trim()`` PHP).
+    Voir le module pour la règle complète.
 
-    :raises ValueError: si ``run_id`` est vide ou n'est pas une chaîne.
+    :raises ValueError: si ``run_id`` est vide (après trim) ou n'est pas une chaîne.
     """
-    if not isinstance(run_id, str) or run_id == "":
+    if not isinstance(run_id, str):
+        raise ValueError("run_id must be a non-empty string")
+
+    run_id = run_id.strip()
+    if run_id == "":
         raise ValueError("run_id must be a non-empty string")
 
     if len(run_id) <= CORRELATION_ID_MAX_LEN and _SAFE_RUN_ID.match(run_id):

--- a/python-orchestrator/app/services/correlation.py
+++ b/python-orchestrator/app/services/correlation.py
@@ -1,0 +1,51 @@
+"""Identifiant de corrélation canonique run d'orchestration ↔ trades (OBS-003).
+
+Un run d'orchestration porte un ``run_id`` d'origine (``runs.run_id``, jusqu'à 255
+caractères, éventuellement haché et préfixé ``run_``). Côté Symfony, les trades sont
+rattachés via ``trade_lifecycle_event.run_id`` qui est un ``VARCHAR(64)``. Pour relier
+les deux **sans collision** (deux identifiants longs partageant les mêmes 64 premiers
+caractères ne doivent pas se confondre), on dérive un *identifiant de corrélation
+canonique* déterministe, et **identique** à l'implémentation PHP
+(``App\\Trading\\Service\\RunCorrelationId``).
+
+Règle (cf. ``tests/fixtures/run_correlation_vectors.json``, partagé Python ↔ PHP) :
+
+1. une chaîne vide est refusée (``ValueError``) — un run d'orchestration a toujours
+   un ``run_id`` ;
+2. si ``run_id`` respecte ``^[A-Za-z0-9._:-]+$`` ET ``len <= 64`` : il est conservé
+   tel quel (lisible, déjà compatible avec la colonne) ;
+3. sinon : ``sha256(run_id)`` en hexadécimal minuscule (exactement 64 caractères).
+
+Interdits explicites : aucune troncature silencieuse (``run_id[:64]``), aucun UUID
+aléatoire pour un run issu de l'orchestrateur, aucune divergence d'algorithme entre
+Python et PHP.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+# Caractères « sûrs » d'un identifiant conservé tel quel (miroir exact du PHP).
+_SAFE_RUN_ID = re.compile(r"^[A-Za-z0-9._:-]+$")
+
+# Largeur de ``trade_lifecycle_event.run_id`` (== ``position_trade_analysis.run_id``).
+CORRELATION_ID_MAX_LEN = 64
+
+
+def canonical_correlation_id(run_id: str) -> str:
+    """Dérive l'identifiant de corrélation canonique (≤ 64 caractères) d'un run.
+
+    Déterministe et sans collision : deux ``run_id`` distincts produisent toujours
+    deux identifiants distincts (les longs/non-sûrs passent par ``sha256``, jamais
+    par une troncature). Voir le module pour la règle complète.
+
+    :raises ValueError: si ``run_id`` est vide ou n'est pas une chaîne.
+    """
+    if not isinstance(run_id, str) or run_id == "":
+        raise ValueError("run_id must be a non-empty string")
+
+    if len(run_id) <= CORRELATION_ID_MAX_LEN and _SAFE_RUN_ID.match(run_id):
+        return run_id
+
+    return hashlib.sha256(run_id.encode("utf-8")).hexdigest()

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, Optional, Tuple
 import httpx
 
 from app.schemas import MAX_WORKERS_PER_SET, OrchestratorSet
+from app.services.correlation import canonical_correlation_id
 
 # Clé de cache d'un snapshot : (exchange, market_type).
 SnapshotKey = Tuple[str, str]
@@ -37,6 +38,15 @@ class ContractsUnavailableError(RuntimeError):
 
     Levée par ``fetch_selected_contracts`` ; le refresh est *fail-closed* : un
     groupe dont le fetch échoue interdit toute écriture partielle des sets.
+    """
+
+
+class OutcomeUnavailableError(RuntimeError):
+    """L'outcome d'un run n'a pas pu être récupéré côté Symfony (OBS-003).
+
+    Levée par ``fetch_run_trade_outcome`` quand la source est indisponible (erreur
+    HTTP, 503/5xx, JSON invalide, ``source_available=false``). Une indisponibilité
+    ne doit JAMAIS être présentée comme « 0 trade » : l'appelant la traduit en 503.
     """
 
 
@@ -381,20 +391,35 @@ async def _dispatch_mtf_run(
     payload: Dict[str, Any],
     *,
     run_id: Optional[str] = None,
+    dashboard_id: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """POST ``/api/mtf/run`` et normalise le résultat (succès métier + corps brut).
 
     Source unique de l'envoi : partagée entre ``run_mtf_set`` (set pydantic) et
     ``run_persisted_set`` (set ORM persisté) pour éviter toute dérive.
 
-    OBS-001 : quand un ``run_id`` est fourni, il est propagé en **en-tête de
-    corrélation** ``X-Run-Id`` sur l'appel Symfony (trace-id), pour relier les
-    logs Symfony au run d'orchestration. L'en-tête n'est ajouté que s'il est
-    présent (aucun changement de payload, contrat ``/api/mtf/run`` inchangé).
+    OBS-001/OBS-003 : quand un ``run_id`` est fourni, le lineage d'orchestration est
+    propagé en **en-têtes de corrélation** sur l'appel Symfony (aucun changement de
+    payload, contrat ``/api/mtf/run`` inchangé) :
+
+    - ``X-Run-Id`` : run_id ORIGINAL du run d'orchestration (trace-id, OBS-001) ;
+    - ``X-Run-Correlation-Id`` : identifiant canonique (≤64, jamais tronqué) dérivé
+      du run_id par l'algorithme PARTAGÉ avec Symfony (``canonical_correlation_id``) ;
+    - ``X-Orchestration-Set-Id`` : set réellement dispatché ;
+    - ``X-Orchestration-Dashboard-Id`` : dashboard réellement exécuté (si connu).
+
+    Sans ``run_id`` (appel non orchestré / legacy), aucun en-tête n'est ajouté.
     """
     url = f"{base_url.rstrip('/')}/api/mtf/run"
+    headers: Dict[str, str] = {}
     if run_id is not None:
-        response = await client.post(url, json=payload, headers={"X-Run-Id": run_id})
+        headers["X-Run-Id"] = run_id
+        headers["X-Run-Correlation-Id"] = canonical_correlation_id(run_id)
+        headers["X-Orchestration-Set-Id"] = set_id
+        if dashboard_id is not None:
+            headers["X-Orchestration-Dashboard-Id"] = str(dashboard_id)
+    if headers:
+        response = await client.post(url, json=payload, headers=headers)
     else:
         response = await client.post(url, json=payload)
     try:
@@ -476,6 +501,63 @@ async def run_persisted_set(
         payload["dry_run"] = dry_run
     if snapshot is not None:
         payload["open_state_snapshot"] = snapshot
-    result = await _dispatch_mtf_run(client, base_url, orm_set.set_id, payload, run_id=run_id)
+    result = await _dispatch_mtf_run(
+        client,
+        base_url,
+        orm_set.set_id,
+        payload,
+        run_id=run_id,
+        dashboard_id=getattr(orm_set, "dashboard_id", None),
+    )
     result["payload_sent"] = payload
     return result
+
+
+async def fetch_run_trade_outcome(
+    client: httpx.AsyncClient,
+    base_url: str,
+    run_id: str,
+    set_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Récupère l'outcome (trades résultants) d'un run via Symfony (OBS-003).
+
+    Appelle ``GET /api/positions/analysis?run_id=…[&set_id=…]`` (lecture seule). Le
+    ``run_id`` ORIGINAL est transmis tel quel : Symfony dérive le même identifiant de
+    corrélation canonique. Le PnL n'est jamais recalculé ici — on relaie l'agrégat.
+
+    Lève ``OutcomeUnavailableError`` si l'appel échoue (erreur réseau, HTTP 5xx/503,
+    JSON invalide, ``source_available=false``) afin que l'indisponibilité ne soit
+    JAMAIS confondue avec « 0 trade ». Un run sans trade (HTTP 200,
+    ``trade_count=0``) est un succès et renvoie l'agrégat vide tel quel.
+    """
+    url = f"{base_url.rstrip('/')}/api/positions/analysis"
+    params = {"run_id": run_id}
+    if set_id is not None and set_id != "":
+        params["set_id"] = set_id
+
+    try:
+        response = await client.get(url, params=params)
+    except httpx.HTTPError as exc:  # noqa: BLE001 - on remonte une erreur métier claire
+        raise OutcomeUnavailableError(f"outcome fetch failed for {run_id}: {exc}") from exc
+
+    if response.status_code >= 500:
+        raise OutcomeUnavailableError(
+            f"outcome fetch returned HTTP {response.status_code} for {run_id}"
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise OutcomeUnavailableError(
+            f"outcome response is not valid JSON for {run_id}"
+        ) from exc
+
+    if not isinstance(body, dict):
+        raise OutcomeUnavailableError(f"outcome response has unexpected shape for {run_id}")
+
+    # Symfony signale explicitement une source indisponible (503 + flag) : on relaie
+    # l'indisponibilité plutôt que de la masquer derrière un agrégat vide.
+    if body.get("source_available") is False:
+        raise OutcomeUnavailableError(f"outcome source unavailable for {run_id}")
+
+    return body

--- a/python-orchestrator/app/services/symfony_client.py
+++ b/python-orchestrator/app/services/symfony_client.py
@@ -540,7 +540,11 @@ async def fetch_run_trade_outcome(
     except httpx.HTTPError as exc:  # noqa: BLE001 - on remonte une erreur métier claire
         raise OutcomeUnavailableError(f"outcome fetch failed for {run_id}: {exc}") from exc
 
-    if response.status_code >= 500:
+    # Toute réponse non-2xx est une indisponibilité de la source : la route peut être
+    # absente (déploiement échelonné), ou un proxy/une couche d'auth renvoyer 401/403/404.
+    # L'orchestrateur a déjà vérifié que le run existe localement, donc un non-succès ici
+    # n'est jamais « 0 trade » — on lève (l'appelant répondra 503), jamais un agrégat vide.
+    if not response.is_success:
         raise OutcomeUnavailableError(
             f"outcome fetch returned HTTP {response.status_code} for {run_id}"
         )

--- a/python-orchestrator/tests/test_correlation.py
+++ b/python-orchestrator/tests/test_correlation.py
@@ -1,0 +1,72 @@
+"""Vecteurs partagés de l'identifiant de corrélation canonique (OBS-003).
+
+Lit ``tests/fixtures/run_correlation_vectors.json`` (racine du dépôt), le MÊME
+fichier que le test PHP ``RunCorrelationIdTest`` : Python et PHP doivent produire
+exactement le même résultat pour chaque vecteur (identifiant court conservé, ≤64
+conservé, long/non-sûr haché, collisions de préfixe évitées, chaîne vide rejetée).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.correlation import CORRELATION_ID_MAX_LEN, canonical_correlation_id
+
+# python-orchestrator/tests/ -> racine du dépôt -> tests/fixtures/...
+_FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "fixtures"
+    / "run_correlation_vectors.json"
+)
+
+
+def _load_fixture() -> dict:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_is_present_and_shared():
+    """Le fichier de vecteurs partagé existe et déclare la règle attendue."""
+    data = _load_fixture()
+    assert data["max_len"] == CORRELATION_ID_MAX_LEN
+    assert data["empty_must_raise"] is True
+    assert data["vectors"], "au moins un vecteur attendu"
+
+
+@pytest.mark.parametrize("vector", _load_fixture()["vectors"], ids=lambda v: v["name"])
+def test_canonical_matches_shared_vectors(vector):
+    """Chaque vecteur partagé produit l'``expected`` (identique côté PHP)."""
+    result = canonical_correlation_id(vector["input"])
+    assert result == vector["expected"]
+
+    if vector["transform"] == "identity":
+        assert result == vector["input"]
+        assert len(result) <= CORRELATION_ID_MAX_LEN
+    else:
+        assert vector["transform"] == "sha256"
+        # Hash hex minuscule de 64 caractères, jamais une troncature du préfixe.
+        assert len(result) == 64
+        assert result != vector["input"][:64]
+
+
+def test_empty_string_is_rejected():
+    """Une chaîne vide n'est jamais corrélée (un run a toujours un id)."""
+    with pytest.raises(ValueError):
+        canonical_correlation_id("")
+
+
+def test_prefix_collisions_do_not_collide():
+    """Deux longs ``run_id`` au même préfixe 64 donnent deux identifiants distincts.
+
+    C'est l'invariant central : une troncature ``run_id[:64]`` les confondrait.
+    """
+    data = _load_fixture()
+    by_name = {v["name"]: v for v in data["vectors"]}
+    a = by_name["prefix_collision_a"]
+    b = by_name["prefix_collision_b"]
+
+    assert a["input"][:64] == b["input"][:64], "les inputs partagent bien le préfixe 64"
+    assert canonical_correlation_id(a["input"]) != canonical_correlation_id(b["input"])

--- a/python-orchestrator/tests/test_correlation.py
+++ b/python-orchestrator/tests/test_correlation.py
@@ -42,9 +42,13 @@ def test_canonical_matches_shared_vectors(vector):
     result = canonical_correlation_id(vector["input"])
     assert result == vector["expected"]
 
-    if vector["transform"] == "identity":
-        assert result == vector["input"]
+    if vector["transform"] in ("identity", "trim"):
+        # identity : conservé tel quel ; trim : conservé après suppression des espaces.
         assert len(result) <= CORRELATION_ID_MAX_LEN
+        if vector["transform"] == "identity":
+            assert result == vector["input"]
+        else:
+            assert result == vector["input"].strip()
     else:
         assert vector["transform"] == "sha256"
         # Hash hex minuscule de 64 caractères, jamais une troncature du préfixe.

--- a/python-orchestrator/tests/test_runs_api.py
+++ b/python-orchestrator/tests/test_runs_api.py
@@ -287,6 +287,124 @@ def test_executed_run_is_readable_end_to_end(orchestrator_env, monkeypatch):
     assert latest["run_id"] == run_id
 
 
+# --------------------------------------------------------------------------
+# GET /runs/{run_id}/outcome (OBS-003)
+# --------------------------------------------------------------------------
+
+
+def test_run_outcome_404_when_run_unknown(orchestrator_env):
+    client, _session = orchestrator_env
+    assert client.get("/runs/nope/outcome").status_code == 404
+
+
+def test_run_outcome_200_with_trades(orchestrator_env, monkeypatch):
+    from app.routers import runs as runs_router
+
+    client, session = orchestrator_env
+    dash = _seed_dashboard(session)
+    _seed_run(session, "run_obs", dashboard_id=dash.id)
+
+    async def fake_outcome(http_client, base_url, run_id, set_id=None):
+        assert run_id == "run_obs"
+        return {
+            "run_id": run_id,
+            "correlation_run_id": run_id,
+            "source_available": True,
+            "data_complete": True,
+            "summary": {"trade_count": 2, "recorded_pnl_usdt": 8.0, "win_rate_closed": 0.5},
+            "by_set": [{"key": "s1", "trade_count": 2}],
+            "by_profile": [{"key": "scalper", "trade_count": 2}],
+            "by_exchange": [{"key": "bitmart", "trade_count": 2}],
+            "by_symbol": [{"key": "BTCUSDT", "trade_count": 2}],
+        }
+
+    monkeypatch.setattr(runs_router, "fetch_run_trade_outcome", fake_outcome)
+
+    resp = client.get("/runs/run_obs/outcome")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_found"] is True
+    assert body["source_available"] is True
+    assert body["dashboard_id"] == dash.id
+    assert body["summary"]["trade_count"] == 2
+    assert body["by_symbol"][0]["key"] == "BTCUSDT"
+
+
+def test_run_outcome_200_run_without_trade_is_explicit_empty(orchestrator_env, monkeypatch):
+    from app.routers import runs as runs_router
+
+    client, session = orchestrator_env
+    _seed_run(session, "run_empty")
+
+    async def fake_outcome(http_client, base_url, run_id, set_id=None):
+        return {
+            "run_id": run_id,
+            "correlation_run_id": run_id,
+            "source_available": True,
+            "data_complete": True,
+            "summary": {"trade_count": 0, "win_rate_closed": None, "recorded_pnl_usdt": None},
+            "by_set": [],
+            "by_profile": [],
+            "by_exchange": [],
+            "by_symbol": [],
+        }
+
+    monkeypatch.setattr(runs_router, "fetch_run_trade_outcome", fake_outcome)
+
+    body = client.get("/runs/run_empty/outcome").json()
+    assert body["source_available"] is True
+    assert body["summary"]["trade_count"] == 0
+    assert body["by_symbol"] == []
+
+
+def test_run_outcome_503_when_source_unavailable(orchestrator_env, monkeypatch):
+    from app.routers import runs as runs_router
+    from app.services.symfony_client import OutcomeUnavailableError
+
+    client, session = orchestrator_env
+    _seed_run(session, "run_down")
+
+    async def fake_outcome(http_client, base_url, run_id, set_id=None):
+        raise OutcomeUnavailableError("view down")
+
+    monkeypatch.setattr(runs_router, "fetch_run_trade_outcome", fake_outcome)
+
+    resp = client.get("/runs/run_down/outcome")
+    assert resp.status_code == 503
+    body = resp.json()
+    # L'indisponibilité est explicite, jamais un "0 trade".
+    assert body["source_available"] is False
+    assert body["error_code"] == "outcome_source_unavailable"
+    assert "summary" not in body
+
+
+def test_run_outcome_forwards_set_id_filter(orchestrator_env, monkeypatch):
+    from app.routers import runs as runs_router
+
+    client, session = orchestrator_env
+    _seed_run(session, "run_set")
+    seen = {}
+
+    async def fake_outcome(http_client, base_url, run_id, set_id=None):
+        seen["set_id"] = set_id
+        return {
+            "correlation_run_id": run_id,
+            "source_available": True,
+            "data_complete": True,
+            "summary": {"trade_count": 0},
+            "by_set": [],
+            "by_profile": [],
+            "by_exchange": [],
+            "by_symbol": [],
+        }
+
+    monkeypatch.setattr(runs_router, "fetch_run_trade_outcome", fake_outcome)
+
+    body = client.get("/runs/run_set/outcome", params={"set_id": "s7"}).json()
+    assert seen["set_id"] == "s7"
+    assert body["set_id"] == "s7"
+
+
 def test_run_with_slash_bearing_key_is_fetchable(orchestrator_env, monkeypatch):
     # Régression : un idempotency_key porteur de `/` ne doit pas produire un run_id
     # non récupérable via GET /runs/{run_id} (segment de chemin sans slash).

--- a/python-orchestrator/tests/test_runs_api.py
+++ b/python-orchestrator/tests/test_runs_api.py
@@ -357,6 +357,38 @@ def test_run_outcome_200_run_without_trade_is_explicit_empty(orchestrator_env, m
     assert body["by_symbol"] == []
 
 
+def test_run_outcome_relays_truncation_with_row_cap(orchestrator_env, monkeypatch):
+    from app.routers import runs as runs_router
+
+    client, session = orchestrator_env
+    _seed_run(session, "run_big")
+
+    async def fake_outcome(http_client, base_url, run_id, set_id=None):
+        return {
+            "run_id": run_id,
+            "correlation_run_id": run_id,
+            "source_available": True,
+            # Source tronquée : agrégats partiels, jamais présentés comme complets.
+            "truncated": True,
+            "row_cap": 5000,
+            "data_complete": False,
+            "summary": {"trade_count": 5000},
+            "by_set": [],
+            "by_profile": [],
+            "by_exchange": [],
+            "by_symbol": [],
+        }
+
+    monkeypatch.setattr(runs_router, "fetch_run_trade_outcome", fake_outcome)
+
+    body = client.get("/runs/run_big/outcome").json()
+    assert body["source_available"] is True
+    assert body["truncated"] is True
+    # `row_cap` doit accompagner `truncated` (sinon dashboards/clients ne peuvent expliquer).
+    assert body["row_cap"] == 5000
+    assert body["data_complete"] is False
+
+
 def test_run_outcome_503_when_source_unavailable(orchestrator_env, monkeypatch):
     from app.routers import runs as runs_router
     from app.services.symfony_client import OutcomeUnavailableError

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -11,12 +11,15 @@ import httpx
 import pytest
 
 from app.schemas import OrchestratorSet
+from app.services.correlation import canonical_correlation_id
 from app.services.symfony_client import (
     ContractsUnavailableError,
     OpenStateUnavailableError,
+    OutcomeUnavailableError,
     build_mtf_payload,
     effective_set_payload,
     fetch_open_state,
+    fetch_run_trade_outcome,
     fetch_selected_contracts,
     generate_set_payload,
     is_business_success,
@@ -696,3 +699,157 @@ def test_run_persisted_set_not_materialized_without_symbols():
     assert result["payload_sent"] is None
     assert "not materialized" in result["body"]
     assert calls == []  # aucun appel HTTP
+
+
+# --- OBS-003 : en-têtes de lineage + fetch_run_trade_outcome ----------------
+
+
+def test_run_persisted_set_propagates_orchestration_headers():
+    orm = _orm_set(set_id="s1", dashboard_id=42, symbols=["BTCUSDT"])
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"status": "success"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await run_persisted_set(
+                client, "http://sym", orm, None, dry_run=True, run_id="run_dashA_20260617"
+            )
+
+    asyncio.run(_run())
+    headers = captured["headers"]
+    assert headers["x-run-id"] == "run_dashA_20260617"
+    # corrélation = algorithme PARTAGÉ avec Symfony (identité ici car court+sûr).
+    assert headers["x-run-correlation-id"] == canonical_correlation_id("run_dashA_20260617")
+    assert headers["x-orchestration-set-id"] == "s1"
+    assert headers["x-orchestration-dashboard-id"] == "42"
+
+
+def test_run_persisted_set_hashes_long_run_id_in_correlation_header():
+    orm = _orm_set(set_id="s1", dashboard_id=1, symbols=["BTCUSDT"])
+    long_run = "run_" + "b" * 64  # 68 chars > 64
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"status": "success"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await run_persisted_set(
+                client, "http://sym", orm, None, dry_run=True, run_id=long_run
+            )
+
+    asyncio.run(_run())
+    headers = captured["headers"]
+    assert headers["x-run-id"] == long_run  # original conservé
+    corr = headers["x-run-correlation-id"]
+    assert len(corr) == 64 and corr != long_run[:64]  # haché, jamais tronqué
+
+
+def test_run_persisted_set_without_run_id_sends_no_orchestration_headers():
+    orm = _orm_set(set_id="s1", dashboard_id=42, symbols=["BTCUSDT"])
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"status": "success"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await run_persisted_set(client, "http://sym", orm, None, dry_run=True)
+
+    asyncio.run(_run())
+    headers = captured["headers"]
+    assert "x-run-id" not in headers
+    assert "x-run-correlation-id" not in headers
+    assert "x-orchestration-set-id" not in headers
+
+
+def test_fetch_run_trade_outcome_returns_body_and_forwards_params():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["params"] = dict(request.url.params)
+        return httpx.Response(200, json={
+            "run_id": "run_x",
+            "correlation_run_id": "run_x",
+            "source_available": True,
+            "summary": {"trade_count": 3},
+        })
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://sym", "run_x", "s1")
+
+    body = asyncio.run(_run())
+    assert captured["path"] == "/api/positions/analysis"
+    assert captured["params"] == {"run_id": "run_x", "set_id": "s1"}
+    assert body["summary"]["trade_count"] == 3
+
+
+def test_fetch_run_trade_outcome_run_without_trade_is_success():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "correlation_run_id": "run_x",
+            "source_available": True,
+            "summary": {"trade_count": 0},
+        })
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://sym", "run_x")
+
+    body = asyncio.run(_run())
+    assert body["summary"]["trade_count"] == 0
+
+
+def test_fetch_run_trade_outcome_raises_on_source_unavailable_flag():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"source_available": False, "error": "source_unavailable"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://sym", "run_x")
+
+    with pytest.raises(OutcomeUnavailableError):
+        asyncio.run(_run())
+
+
+def test_fetch_run_trade_outcome_raises_on_5xx():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://sym", "run_x")
+
+    with pytest.raises(OutcomeUnavailableError):
+        asyncio.run(_run())
+
+
+def test_fetch_run_trade_outcome_raises_on_http_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://sym", "run_x")
+
+    with pytest.raises(OutcomeUnavailableError):
+        asyncio.run(_run())
+
+
+def test_fetch_run_trade_outcome_raises_on_invalid_json():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not-json", headers={"content-type": "application/json"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://sym", "run_x")
+
+    with pytest.raises(OutcomeUnavailableError):
+        asyncio.run(_run())

--- a/python-orchestrator/tests/test_symfony_client.py
+++ b/python-orchestrator/tests/test_symfony_client.py
@@ -853,3 +853,17 @@ def test_fetch_run_trade_outcome_raises_on_invalid_json():
 
     with pytest.raises(OutcomeUnavailableError):
         asyncio.run(_run())
+
+
+def test_fetch_run_trade_outcome_raises_on_4xx():
+    # 404/403 (route absente pendant un deploy, proxy/auth) = indisponibilite, jamais
+    # un agregat vide "0 trade" : le run est deja confirme cote orchestrateur.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"error": "not found"})
+
+    async def _run():
+        async with _client_with(handler) as client:
+            return await fetch_run_trade_outcome(client, "http://sym", "run_x")
+
+    with pytest.raises(OutcomeUnavailableError):
+        asyncio.run(_run())

--- a/tests/fixtures/run_correlation_vectors.json
+++ b/tests/fixtures/run_correlation_vectors.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Shared canonical-correlation-id vectors for OBS-003. Read by BOTH Python (tests/test_correlation.py) and PHP (RunCorrelationIdTest). Rule: reject empty; keep run_id if it matches ^[A-Za-z0-9._:-]+$ AND len<=64; otherwise sha256 hex (lowercase, 64 chars). Never silently truncate.",
+  "_comment": "Shared canonical-correlation-id vectors for OBS-003. Read by BOTH Python (tests/test_correlation.py) and PHP (RunCorrelationIdTest). Rule (identical in both languages): (1) trim leading/trailing whitespace (PHP trim() == Python str.strip()); (2) reject empty after trim; (3) keep run_id if it matches ^[A-Za-z0-9._:-]+$ AND len<=64; (4) otherwise sha256 hex (lowercase, 64 chars) of the TRIMMED value. Never silently truncate. transform: identity = kept as-is; trim = kept after trimming; sha256 = hashed.",
   "safe_pattern": "^[A-Za-z0-9._:-]+$",
   "max_len": 64,
   "vectors": [
@@ -8,6 +8,30 @@
       "input": "run_dashA_20260617T083000Z",
       "transform": "identity",
       "expected": "run_dashA_20260617T083000Z"
+    },
+    {
+      "name": "surrounding_spaces_trimmed",
+      "input": " abc ",
+      "transform": "trim",
+      "expected": "abc"
+    },
+    {
+      "name": "trailing_space_trimmed",
+      "input": "abc ",
+      "transform": "trim",
+      "expected": "abc"
+    },
+    {
+      "name": "leading_space_trimmed",
+      "input": " abc",
+      "transform": "trim",
+      "expected": "abc"
+    },
+    {
+      "name": "tabs_newlines_trimmed",
+      "input": "\tabc\n",
+      "transform": "trim",
+      "expected": "abc"
     },
     {
       "name": "exactly_64_safe_unchanged",

--- a/tests/fixtures/run_correlation_vectors.json
+++ b/tests/fixtures/run_correlation_vectors.json
@@ -1,0 +1,50 @@
+{
+  "_comment": "Shared canonical-correlation-id vectors for OBS-003. Read by BOTH Python (tests/test_correlation.py) and PHP (RunCorrelationIdTest). Rule: reject empty; keep run_id if it matches ^[A-Za-z0-9._:-]+$ AND len<=64; otherwise sha256 hex (lowercase, 64 chars). Never silently truncate.",
+  "safe_pattern": "^[A-Za-z0-9._:-]+$",
+  "max_len": 64,
+  "vectors": [
+    {
+      "name": "short_safe_unchanged",
+      "input": "run_dashA_20260617T083000Z",
+      "transform": "identity",
+      "expected": "run_dashA_20260617T083000Z"
+    },
+    {
+      "name": "exactly_64_safe_unchanged",
+      "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "transform": "identity",
+      "expected": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    },
+    {
+      "name": "length_65_hashed",
+      "input": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "transform": "sha256",
+      "expected": "635361c48bb9eab14198e76ea8ab7f1a41685d6ad62aa9146d301d4f17eb0ae0"
+    },
+    {
+      "name": "run_prefixed_68_hashed",
+      "input": "run_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "transform": "sha256",
+      "expected": "2b32d0527c6757ecabe29505f37b5b3ac4cd7c613667a07bd2ec64031231b341"
+    },
+    {
+      "name": "unsafe_chars_hashed",
+      "input": "run/dashA 2026#06:17",
+      "transform": "sha256",
+      "expected": "8cf76b39f0306e7c44965851bca1cdd1db873a1140047f623b002a04d3d96426"
+    },
+    {
+      "name": "prefix_collision_a",
+      "input": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc_alpha",
+      "transform": "sha256",
+      "expected": "5c64791f01ad417c050643bfeaddeb649dcd473f0050d18fb0ada1084cf25966"
+    },
+    {
+      "name": "prefix_collision_b",
+      "input": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc_beta",
+      "transform": "sha256",
+      "expected": "48535e7cf51aa701ef2a04d9834c1c8e5a9dd1899679342e1632ede24293543c"
+    }
+  ],
+  "empty_must_raise": true
+}

--- a/trading-app/config/routes.yaml
+++ b/trading-app/config/routes.yaml
@@ -60,6 +60,11 @@ mtf_api_audit:
   resource: '../src/MtfValidator/Controller/Api/MtfAuditController.php'
   type: attribute
 
+# Trading API controllers (OBS-003: outcome read surface)
+trading_api:
+  resource: '../src/Trading/Controller/'
+  type: attribute
+
 # Indicator controllers
 indicator_web:
   resource: '../src/Indicator/Controller/IndicatorTestController.php'

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -525,8 +525,8 @@ services:
     App\Trading\Storage\PositionStateRepositoryInterface: '@App\Trading\Storage\PositionPositionStateRepository'
     App\Trading\Storage\OrderStateRepositoryInterface: '@App\Trading\Storage\FuturesOrderOrderStateRepository'
 
-    # OBS-003 — source de lecture des trades d'un run (vue position_trade_analysis)
-    App\Trading\Service\PositionTradeAnalysisReaderInterface: '@App\Repository\PositionTradeAnalysisRepository'
+    # OBS-003 — source de lecture des trades d'un run (vue versionnée position_trade_analysis_v2)
+    App\Trading\Service\PositionTradeAnalysisReaderInterface: '@App\Repository\PositionTradeAnalysisV2Repository'
 
     # TradingStateSyncRunner - utilise les providers depuis MainProvider
     App\Trading\Sync\TradingStateSyncRunner:

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -525,6 +525,9 @@ services:
     App\Trading\Storage\PositionStateRepositoryInterface: '@App\Trading\Storage\PositionPositionStateRepository'
     App\Trading\Storage\OrderStateRepositoryInterface: '@App\Trading\Storage\FuturesOrderOrderStateRepository'
 
+    # OBS-003 — source de lecture des trades d'un run (vue position_trade_analysis)
+    App\Trading\Service\PositionTradeAnalysisReaderInterface: '@App\Repository\PositionTradeAnalysisRepository'
+
     # TradingStateSyncRunner - utilise les providers depuis MainProvider
     App\Trading\Sync\TradingStateSyncRunner:
         arguments:

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * OBS-003 v2 — Rapprochement fiable entrée/clôture + lineage d'orchestration.
+ *
+ * Remplace la vue `position_trade_analysis` (créée par Version20251129000000) qui
+ * rapprochait une entrée de la PREMIÈRE clôture ultérieure du même symbole
+ * (`LEFT JOIN LATERAL ... ORDER BY happened_at LIMIT 1`) — un rapprochement ambigu
+ * dès que plusieurs trades portent sur le même symbole/run (une clôture pouvait être
+ * réutilisée par plusieurs entrées, et deux trades du même symbole se mélangeaient).
+ *
+ * Nouvelle règle de rapprochement, par identifiants EXACTS et en 1-pour-1 :
+ *   1. `trade_id` exact (entrée.extra->>'trade_id' = clôture.extra->>'trade_id') ;
+ *   2. sinon `position_id` exact (entrée.position_id|extra = clôture.position_id|extra) ;
+ *   3. sinon `unmatched` (aucune clôture rattachée, le trade reste visible « ouvert »).
+ * Jamais de repli par symbole. L'appariement utilise `ROW_NUMBER()` par clé pour
+ * garantir qu'une clôture n'est jamais réutilisée par deux entrées et que la jointure
+ * ne multiplie pas les lignes (exactement une ligne par entrée).
+ *
+ * Colonnes ajoutées :
+ *  - lineage : `correlation_run_id`, `orchestration_run_id`, `dashboard_id`, `set_id`,
+ *    `exchange`, `market_type`, `mtf_profile`, `position_id` ;
+ *  - rapprochement : `close_match_status`, `close_matched_by` ;
+ *  - PnL : `pnl_usdt` est renommé `recorded_pnl_usdt` (la valeur enregistrée, dont on
+ *    ne garantit PAS qu'elle est nette de tous les coûts), et l'on expose `fees_usdt`,
+ *    `funding_usdt`, `slippage_usdt`, `net_pnl_usdt` (calculé UNIQUEMENT si tous les
+ *    coûts sont présents) et `net_pnl_complete`.
+ *
+ * Lecture seule, aucune table modifiée : `CREATE OR REPLACE VIEW`. La colonne `run_id`
+ * (héritée) est conservée pour compat et vaut l'identifiant de corrélation stocké sur
+ * `trade_lifecycle_event.run_id`.
+ */
+final class Version20260622000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'OBS-003 v2: rebuild position_trade_analysis with exact entry/close matching, orchestration lineage and recorded/net PnL semantics';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // La vue existante (Version20251129000000) a un autre jeu/ordre de colonnes :
+        // `CREATE OR REPLACE` interdit le renommage de colonnes, on DROP puis CREATE.
+        $this->addSql('DROP VIEW IF EXISTS position_trade_analysis');
+        $this->addSql(<<<'SQL'
+CREATE VIEW position_trade_analysis AS
+WITH entry_events AS (
+  SELECT
+    e.id,
+    e.symbol,
+    COALESCE(NULLIF(e.timeframe, ''), NULLIF(e.extra->> 'timeframe', '')) AS timeframe,
+    e.run_id,
+    e.exchange,
+    e.market_type,
+    COALESCE(NULLIF(e.config_profile, ''), NULLIF(e.extra->> 'mtf_profile', '')) AS mtf_profile,
+    NULLIF(e.extra->> 'orchestration_run_id', '')       AS orchestration_run_id,
+    NULLIF(e.extra->> 'orchestration_dashboard_id', '') AS dashboard_id,
+    NULLIF(e.extra->> 'orchestration_set_id', '')       AS set_id,
+    NULLIF(e.extra->> 'trade_id', '')                   AS match_trade_id,
+    COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) AS match_position_id,
+    e.happened_at,
+    e.extra,
+    (
+      SELECT s.id
+      FROM indicator_snapshots s
+      WHERE s.symbol = e.symbol
+        AND s.timeframe = COALESCE(NULLIF(e.timeframe, ''), NULLIF(e.extra->> 'timeframe', ''))
+        AND s.kline_time <= e.happened_at
+      ORDER BY s.kline_time DESC
+      LIMIT 1
+    ) AS snapshot_id
+  FROM trade_lifecycle_event e
+  WHERE e.event_type = 'order_submitted'
+),
+close_events AS (
+  SELECT
+    e.id,
+    e.symbol,
+    e.run_id,
+    e.happened_at,
+    e.extra,
+    NULLIF(e.extra->> 'trade_id', '') AS match_trade_id,
+    COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) AS match_position_id
+  FROM trade_lifecycle_event e
+  WHERE e.event_type = 'position_closed'
+),
+snapshot_values AS (
+  SELECT
+    es.id               AS event_id,
+    s.kline_time        AS snapshot_kline_time,
+    s.values->> 'rsi'   AS entry_rsi,
+    s.values->> 'atr'   AS entry_atr,
+    s.values->> 'macd'  AS entry_macd,
+    s.values->> 'ma9'   AS entry_ma9,
+    s.values->> 'ma21'  AS entry_ma21,
+    s.values->> 'vwap'  AS entry_vwap
+  FROM entry_events es
+  JOIN indicator_snapshots s ON s.id = es.snapshot_id
+),
+-- (1) Appariement 1-pour-1 par trade_id : i-ème entrée <-> i-ème clôture du même
+-- trade_id (ROW_NUMBER déterministe). trade_id étant unique par trade, c'est en
+-- pratique un appariement direct ; le rang garantit l'absence de réutilisation.
+entry_tid AS (
+  SELECT id, match_trade_id,
+         ROW_NUMBER() OVER (PARTITION BY match_trade_id ORDER BY happened_at, id) AS rn
+  FROM entry_events WHERE match_trade_id IS NOT NULL
+),
+close_tid AS (
+  SELECT id, match_trade_id,
+         ROW_NUMBER() OVER (PARTITION BY match_trade_id ORDER BY happened_at, id) AS rn
+  FROM close_events WHERE match_trade_id IS NOT NULL
+),
+tid_pairs AS (
+  SELECT e.id AS entry_event_id, c.id AS close_event_id
+  FROM entry_tid e
+  JOIN close_tid c ON c.match_trade_id = e.match_trade_id AND c.rn = e.rn
+),
+-- (2) Appariement par position_id, UNIQUEMENT pour les entrées et clôtures non
+-- déjà appariées par trade_id (aucune clôture réutilisée entre les deux passes).
+entry_pid AS (
+  SELECT id, match_position_id,
+         ROW_NUMBER() OVER (PARTITION BY match_position_id ORDER BY happened_at, id) AS rn
+  FROM entry_events
+  WHERE match_position_id IS NOT NULL
+    AND id NOT IN (SELECT entry_event_id FROM tid_pairs)
+),
+close_pid AS (
+  SELECT id, match_position_id,
+         ROW_NUMBER() OVER (PARTITION BY match_position_id ORDER BY happened_at, id) AS rn
+  FROM close_events
+  WHERE match_position_id IS NOT NULL
+    AND id NOT IN (SELECT close_event_id FROM tid_pairs)
+),
+pid_pairs AS (
+  SELECT e.id AS entry_event_id, c.id AS close_event_id
+  FROM entry_pid e
+  JOIN close_pid c ON c.match_position_id = e.match_position_id AND c.rn = e.rn
+),
+matched AS (
+  SELECT entry_event_id, close_event_id, 'matched_trade_id'    AS matched_by FROM tid_pairs
+  UNION ALL
+  SELECT entry_event_id, close_event_id, 'matched_position_id' AS matched_by FROM pid_pairs
+)
+SELECT
+  ee.id                         AS entry_event_id,
+  m.close_event_id              AS close_event_id,
+  ee.symbol,
+  ee.timeframe,
+  -- run_id (compat) == identifiant de corrélation stocké sur l'événement.
+  ee.run_id                     AS run_id,
+  ee.run_id                     AS correlation_run_id,
+  ee.orchestration_run_id,
+  ee.dashboard_id,
+  ee.set_id,
+  ee.exchange,
+  ee.market_type,
+  ee.mtf_profile,
+  COALESCE(ee.match_trade_id, ce.match_trade_id)        AS trade_id,
+  COALESCE(ce.match_position_id, ee.match_position_id)  AS position_id,
+  ee.happened_at                AS entry_time,
+  ce.happened_at                AS close_time,
+  CASE WHEN m.close_event_id IS NOT NULL THEN 'matched' ELSE 'unmatched' END AS close_match_status,
+  COALESCE(m.matched_by, 'unmatched')                  AS close_matched_by,
+  -- métriques de plan / sizing à l'entrée
+  (ee.extra->> 'r_multiple_final')::numeric       AS expected_r_multiple,
+  (ee.extra->> 'risk_usdt')::numeric              AS risk_usdt,
+  (ee.extra->> 'notional_usdt')::numeric          AS notional_usdt,
+  (ee.extra->> 'atr_pct_entry')::numeric          AS atr_pct_entry,
+  (ee.extra->> 'volume_ratio')::numeric           AS entry_volume_ratio,
+  -- indicateurs au moment de l'entrée (snapshot)
+  sv.snapshot_kline_time,
+  sv.entry_rsi::numeric                           AS entry_rsi,
+  sv.entry_atr::numeric                           AS entry_atr,
+  sv.entry_macd::numeric                          AS entry_macd,
+  sv.entry_ma9::numeric                           AS entry_ma9,
+  sv.entry_ma21::numeric                          AS entry_ma21,
+  sv.entry_vwap::numeric                          AS entry_vwap,
+  -- métriques de sortie (POSITION_CLOSED.extra)
+  (ce.extra->> 'pnl_R')::numeric                  AS pnl_r,
+  -- PnL ENREGISTRÉ tel quel (PAS garanti net de tous les coûts) — cf. net_pnl_*.
+  (ce.extra->> 'pnl')::numeric                    AS recorded_pnl_usdt,
+  (ce.extra->> 'pnl_pct')::numeric                AS pnl_pct,
+  (ce.extra->> 'mfe_pct')::numeric                AS mfe_pct,
+  (ce.extra->> 'mae_pct')::numeric                AS mae_pct,
+  (ce.extra->> 'holding_time_sec')::numeric       AS holding_time_sec,
+  -- composantes de coût (null tant que la source ne les fournit pas — jamais inventées)
+  (ce.extra->> 'fees')::numeric                   AS fees_usdt,
+  (ce.extra->> 'funding')::numeric                AS funding_usdt,
+  (ce.extra->> 'slippage')::numeric               AS slippage_usdt,
+  -- net complet UNIQUEMENT si recorded + tous les coûts sont présents.
+  (
+    (ce.extra->> 'pnl')      IS NOT NULL AND
+    (ce.extra->> 'fees')     IS NOT NULL AND
+    (ce.extra->> 'funding')  IS NOT NULL AND
+    (ce.extra->> 'slippage') IS NOT NULL
+  )                                               AS net_pnl_complete,
+  CASE WHEN
+    (ce.extra->> 'pnl')      IS NOT NULL AND
+    (ce.extra->> 'fees')     IS NOT NULL AND
+    (ce.extra->> 'funding')  IS NOT NULL AND
+    (ce.extra->> 'slippage') IS NOT NULL
+  THEN
+    (ce.extra->> 'pnl')::numeric
+      - (ce.extra->> 'fees')::numeric
+      - (ce.extra->> 'funding')::numeric
+      - (ce.extra->> 'slippage')::numeric
+  ELSE NULL END                                   AS net_pnl_usdt
+FROM entry_events ee
+LEFT JOIN matched m        ON m.entry_event_id = ee.id
+LEFT JOIN close_events ce  ON ce.id = m.close_event_id
+LEFT JOIN snapshot_values sv ON sv.event_id = ee.id;
+SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Restaure la définition précédente (Version20251129000000).
+        $this->addSql('DROP VIEW IF EXISTS position_trade_analysis');
+        $this->addSql(<<<'SQL'
+CREATE VIEW position_trade_analysis AS
+WITH entry_events AS (
+  SELECT
+    e.id,
+    e.symbol,
+    COALESCE(NULLIF(e.timeframe, ''), NULLIF(e.extra->> 'timeframe', '')) AS timeframe,
+    e.run_id,
+    e.happened_at,
+    e.extra,
+    (
+      SELECT s.id
+      FROM indicator_snapshots s
+      WHERE s.symbol = e.symbol
+        AND s.timeframe = COALESCE(NULLIF(e.timeframe, ''), NULLIF(e.extra->> 'timeframe', ''))
+        AND s.kline_time <= e.happened_at
+      ORDER BY s.kline_time DESC
+      LIMIT 1
+    ) AS snapshot_id
+  FROM trade_lifecycle_event e
+  WHERE e.event_type = 'order_submitted'
+),
+snapshot_values AS (
+  SELECT
+    es.id               AS event_id,
+    s.kline_time        AS snapshot_kline_time,
+    s.values->> 'rsi'   AS entry_rsi,
+    s.values->> 'atr'   AS entry_atr,
+    s.values->> 'macd'  AS entry_macd,
+    s.values->> 'ma9'   AS entry_ma9,
+    s.values->> 'ma21'  AS entry_ma21,
+    s.values->> 'vwap'  AS entry_vwap
+  FROM entry_events es
+  JOIN indicator_snapshots s ON s.id = es.snapshot_id
+),
+close_events AS (
+  SELECT
+    e.id,
+    e.symbol,
+    e.run_id,
+    e.position_id,
+    e.happened_at,
+    e.extra
+  FROM trade_lifecycle_event e
+  WHERE e.event_type = 'position_closed'
+)
+SELECT
+  ee.id                         AS entry_event_id,
+  ce.id                         AS close_event_id,
+  ee.symbol,
+  ee.timeframe,
+  ee.run_id,
+  COALESCE(ee.extra->> 'trade_id', ce.extra->> 'trade_id') AS trade_id,
+  ee.happened_at                AS entry_time,
+  ce.happened_at                AS close_time,
+  (ee.extra->> 'r_multiple_final')::numeric       AS expected_r_multiple,
+  (ee.extra->> 'risk_usdt')::numeric              AS risk_usdt,
+  (ee.extra->> 'notional_usdt')::numeric          AS notional_usdt,
+  (ee.extra->> 'atr_pct_entry')::numeric          AS atr_pct_entry,
+  (ee.extra->> 'volume_ratio')::numeric           AS entry_volume_ratio,
+  sv.snapshot_kline_time,
+  sv.entry_rsi::numeric                           AS entry_rsi,
+  sv.entry_atr::numeric                           AS entry_atr,
+  sv.entry_macd::numeric                          AS entry_macd,
+  sv.entry_ma9::numeric                           AS entry_ma9,
+  sv.entry_ma21::numeric                          AS entry_ma21,
+  sv.entry_vwap::numeric                          AS entry_vwap,
+  (ce.extra->> 'pnl_R')::numeric                  AS pnl_R,
+  (ce.extra->> 'pnl')::numeric                    AS pnl_usdt,
+  (ce.extra->> 'pnl_pct')::numeric                AS pnl_pct,
+  (ce.extra->> 'mfe_pct')::numeric                AS mfe_pct,
+  (ce.extra->> 'mae_pct')::numeric                AS mae_pct,
+  (ce.extra->> 'holding_time_sec')::numeric       AS holding_time_sec
+FROM entry_events ee
+LEFT JOIN snapshot_values sv ON sv.event_id = ee.id
+LEFT JOIN LATERAL (
+  SELECT c.*
+  FROM close_events c
+  WHERE c.symbol = ee.symbol
+    AND (c.run_id IS NULL OR c.run_id = ee.run_id)
+    AND c.happened_at >= ee.happened_at
+  ORDER BY c.happened_at
+  LIMIT 1
+) ce ON TRUE;
+SQL);
+    }
+}

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -147,21 +147,49 @@ snapshot_values AS (
   FROM entry_events es
   JOIN indicator_snapshots s ON s.id = es.snapshot_id
 ),
--- (1) Appariement 1-pour-1 par trade_id (unique par trade ; rang = anti-réutilisation).
+-- (1) Appariement 1-pour-1 par trade_id, BORNÉ à la même VENUE (symbole + exchange +
+-- market_type) et à une clôture postérieure à l'entrée. Le trade_id n'est unique que
+-- par (exchange, market_type, trade_id) côté table : sans le périmètre venue, deux
+-- exchanges/marchés émettant le même trade_id échangeraient leurs outcomes (cross-venue
+-- swap). On applique le même garde temporel que le passage position_id.
 entry_tid AS (
-  SELECT id, match_trade_id,
-         ROW_NUMBER() OVER (PARTITION BY match_trade_id ORDER BY happened_at, id) AS rn
+  SELECT id, match_trade_id, symbol, exchange, market_type, happened_at,
+         ROW_NUMBER() OVER (
+           PARTITION BY match_trade_id, symbol, exchange, market_type
+           ORDER BY happened_at, id
+         ) AS rn
   FROM entry_events WHERE match_trade_id IS NOT NULL
 ),
+-- Ne RANGE que les clôtures ÉLIGIBLES (précédées d'au moins une entrée de même venue ET
+-- même trade_id) : une clôture orpheline/antérieure ne vole pas le rang 1 à la vraie
+-- clôture postérieure (symétrique au passage position_id).
 close_tid AS (
-  SELECT id, match_trade_id,
-         ROW_NUMBER() OVER (PARTITION BY match_trade_id ORDER BY happened_at, id) AS rn
-  FROM close_events WHERE match_trade_id IS NOT NULL
+  SELECT c.id, c.match_trade_id, c.symbol, c.exchange, c.market_type, c.effective_close_time,
+         ROW_NUMBER() OVER (
+           PARTITION BY c.match_trade_id, c.symbol, c.exchange, c.market_type
+           ORDER BY c.effective_close_time, c.id
+         ) AS rn
+  FROM close_events c
+  WHERE c.match_trade_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM entry_events e
+      WHERE e.match_trade_id = c.match_trade_id
+        AND e.symbol = c.symbol
+        AND e.exchange = c.exchange
+        AND e.market_type = c.market_type
+        AND e.happened_at <= c.effective_close_time
+    )
 ),
 tid_pairs AS (
   SELECT e.id AS entry_event_id, c.id AS close_event_id
   FROM entry_tid e
-  JOIN close_tid c ON c.match_trade_id = e.match_trade_id AND c.rn = e.rn
+  JOIN close_tid c
+    ON c.match_trade_id = e.match_trade_id
+   AND c.rn = e.rn
+   AND c.symbol = e.symbol
+   AND c.exchange = e.exchange
+   AND c.market_type = e.market_type
+   AND c.effective_close_time >= e.happened_at
 ),
 -- (2) Appariement par position_id effectif, non déjà appariés par trade_id.
 entry_pid_base AS (

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -8,62 +8,56 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
 /**
- * OBS-003 v2 — Rapprochement fiable entrée/clôture + lineage d'orchestration.
+ * OBS-003 v2 — Vue VERSIONNÉE `position_trade_analysis_v2` (rapprochement fiable +
+ * lineage d'orchestration + contrat PnL explicite).
  *
- * Remplace la vue `position_trade_analysis` (créée par Version20251129000000) qui
- * rapprochait une entrée de la PREMIÈRE clôture ultérieure du même symbole
- * (`LEFT JOIN LATERAL ... ORDER BY happened_at LIMIT 1`) — un rapprochement ambigu
- * dès que plusieurs trades portent sur le même symbole/run (une clôture pouvait être
- * réutilisée par plusieurs entrées, et deux trades du même symbole se mélangeaient).
+ * Bascule PROGRESSIVE (issue #190, étape 8) : on NE touche PAS la vue historique
+ * `position_trade_analysis` (v1, Version20251129000000). On crée une vue parallèle `_v2`
+ * que le nouvel endpoint outcome consomme explicitement. Cela préserve la comparaison
+ * v1/v2, le rollback et les consommateurs SQL/Twig existants ; le remplacement de la v1
+ * sera un jalon ultérieur documenté.
  *
- * Nouvelle règle de rapprochement, par identifiants EXACTS et en 1-pour-1 :
- *   1. `trade_id` exact (entrée.extra->>'trade_id' = clôture.extra->>'trade_id') ;
- *   2. sinon `position_id` EFFECTIF exact, borné au même symbole et à une clôture
- *      postérieure à l'entrée ;
- *   3. sinon `unmatched` (aucune clôture rattachée, le trade reste visible « ouvert »).
- * Jamais de repli par symbole seul. L'appariement utilise `ROW_NUMBER()` par clé pour
- * garantir qu'une clôture n'est jamais réutilisée par deux entrées et que la jointure
- * ne multiplie pas les lignes (exactement une ligne par entrée).
+ * Règle de rapprochement entrée(`order_submitted`)/clôture(`position_closed`), par
+ * identifiants EXACTS et en 1-pour-1 — jamais par symbole/timestamp/run_id seuls :
+ *   1. `trade_id` exact ;
+ *   2. sinon `position_id` EFFECTIF exact, borné à la même VENUE (symbole + exchange +
+ *      market_type) et à une clôture postérieure à l'entrée ;
+ *   3. sinon `unmatched` (état réel inconnu : ni ouvert confirmé ni clôturé certifié).
+ * `ROW_NUMBER()` garantit qu'une clôture ne sert qu'une entrée et que la jointure ne
+ * multiplie pas les lignes. Pont `trade_id -> position_id` via `position_opened` (qui
+ * porte les deux) pour le cycle MTF normal où `order_submitted` n'a que le trade_id et la
+ * clôture synchronisée que le position_id.
  *
- * Pont trade_id ↔ position_id : dans le cycle MTF normal, `order_submitted` ne porte que
- * le `trade_id` et la clôture synchronisée que le `position_id` — les deux côtés n'ont
- * donc pas de clé commune. L'événement `position_opened` (issu du flux MTF) porte les
- * DEUX ; on l'utilise comme pont pour résoudre le `position_id` effectif d'une entrée
- * (sinon le rapprochement exact laisserait tout `unmatched`). Cf. revue OBS-003 v2 (P1).
+ * Contrat PnL EXPLICITE (issue #190) — aucune valeur estimée présentée comme certifiée :
+ *   - `recorded_pnl_usdt` : valeur enregistrée telle quelle (ni brute ni nette garanties) ;
+ *   - `fees_usdt` / `funding_usdt` / `slippage_usdt` : composantes brutes si présentes
+ *     (jamais 0 par défaut : absentes => NULL) ;
+ *   - `estimated_net_pnl_usdt` : ESTIMATION best-effort (`recorded - fees - funding -
+ *     slippage`) UNIQUEMENT si les trois composantes sont présentes. La convention de
+ *     signe du funding et l'absence de spread/brut/frais entrée-sortie séparés sont des
+ *     limites connues (contrat #190 complet à venir) : c'est une estimation, pas une
+ *     mesure nette certifiée ;
+ *   - `cost_completeness` : `not_applicable` (pas de clôture) | `unknown` (clôturé sans
+ *     aucune composante) | `partial` (au moins une composante). `complete` est RÉSERVÉ au
+ *     contrat #190 complet et n'est jamais émis ici. Il n'existe donc pas de `net_pnl_usdt`
+ *     certifié dans cette vue.
+ *   - `analysis_status` : `matched_closed` | `unmatched` (statut de qualité de la ligne).
  *
- * Garde anti-clôture périmée / cross-venue (P2) : le rapprochement par `position_id`
- * partitionne ET joint par la VENUE complète (`symbol` + `exchange` + `market_type`) et
- * exige `close.happened_at >= entry.happened_at`. Un `position_id` réutilisé (autre
- * symbole, autre exchange/marché) ou une clôture importée ancienne n'attribue donc jamais
- * un PnL erroné/périmé au run courant (ni au mauvais bucket `by_exchange`).
- *
- * Colonnes ajoutées :
- *  - lineage : `correlation_run_id`, `orchestration_run_id`, `dashboard_id`, `set_id`,
- *    `exchange`, `market_type`, `mtf_profile`, `position_id` ;
- *  - rapprochement : `close_match_status`, `close_matched_by` ;
- *  - PnL : `pnl_usdt` est renommé `recorded_pnl_usdt` (la valeur enregistrée, dont on
- *    ne garantit PAS qu'elle est nette de tous les coûts), et l'on expose `fees_usdt`,
- *    `funding_usdt`, `slippage_usdt`, `net_pnl_usdt` (calculé UNIQUEMENT si tous les
- *    coûts sont présents) et `net_pnl_complete`.
- *
- * Lecture seule, aucune table modifiée : `CREATE OR REPLACE VIEW`. La colonne `run_id`
- * (héritée) est conservée pour compat et vaut l'identifiant de corrélation stocké sur
- * `trade_lifecycle_event.run_id`.
+ * Lecture seule, aucune table modifiée.
  */
 final class Version20260622000000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'OBS-003 v2: rebuild position_trade_analysis with exact entry/close matching, orchestration lineage and recorded/net PnL semantics';
+        return 'OBS-003 v2: create versioned view position_trade_analysis_v2 (exact entry/close matching, orchestration lineage, explicit recorded/estimated PnL) alongside v1';
     }
 
     public function up(Schema $schema): void
     {
-        // La vue existante (Version20251129000000) a un autre jeu/ordre de colonnes :
-        // `CREATE OR REPLACE` interdit le renommage de colonnes, on DROP puis CREATE.
-        $this->addSql('DROP VIEW IF EXISTS position_trade_analysis');
+        // Bascule progressive : on garde la v1 intacte et on crée une vue parallèle _v2.
+        $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
-CREATE VIEW position_trade_analysis AS
+CREATE VIEW position_trade_analysis_v2 AS
 WITH entry_events AS (
   SELECT
     e.id,
@@ -106,11 +100,7 @@ close_events AS (
   FROM trade_lifecycle_event e
   WHERE e.event_type = 'position_closed'
 ),
--- Pont trade_id -> position_id : l'événement `position_opened` issu du flux MTF porte
--- À LA FOIS le `trade_id` (contexte lifecycle) ET le `position_id` (métadonnée d'ordre).
--- `order_submitted` n'a que le trade_id et la clôture synchronisée n'a que le
--- position_id ; sans ce pont, le rapprochement exact ne matcherait jamais le cycle
--- normal. Les `position_opened` de synchro pure (sans trade_id) sont naturellement exclus.
+-- Pont trade_id -> position_id : `position_opened` (flux MTF) porte les DEUX.
 opened_bridge AS (
   SELECT
     NULLIF(e.extra->> 'trade_id', '') AS trade_id,
@@ -124,8 +114,6 @@ opened_bridge AS (
     AND NULLIF(e.extra->> 'trade_id', '') IS NOT NULL
     AND COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) IS NOT NULL
 ),
--- position_id EFFECTIF d'une entrée : le sien s'il existe, sinon celui résolu via le
--- pont (premier `position_opened` partageant le même trade_id).
 entry_resolved AS (
   SELECT
     ee.*,
@@ -146,9 +134,7 @@ snapshot_values AS (
   FROM entry_events es
   JOIN indicator_snapshots s ON s.id = es.snapshot_id
 ),
--- (1) Appariement 1-pour-1 par trade_id : i-ème entrée <-> i-ème clôture du même
--- trade_id (ROW_NUMBER déterministe). trade_id étant unique par trade, c'est en
--- pratique un appariement direct ; le rang garantit l'absence de réutilisation.
+-- (1) Appariement 1-pour-1 par trade_id (unique par trade ; rang = anti-réutilisation).
 entry_tid AS (
   SELECT id, match_trade_id,
          ROW_NUMBER() OVER (PARTITION BY match_trade_id ORDER BY happened_at, id) AS rn
@@ -164,8 +150,7 @@ tid_pairs AS (
   FROM entry_tid e
   JOIN close_tid c ON c.match_trade_id = e.match_trade_id AND c.rn = e.rn
 ),
--- (2) Appariement par position_id, UNIQUEMENT pour les entrées et clôtures non
--- déjà appariées par trade_id (aucune clôture réutilisée entre les deux passes).
+-- (2) Appariement par position_id effectif, non déjà appariés par trade_id.
 entry_pid_base AS (
   SELECT id, eff_position_id, symbol, exchange, market_type, happened_at
   FROM entry_resolved
@@ -173,11 +158,8 @@ entry_pid_base AS (
     AND id NOT IN (SELECT entry_event_id FROM tid_pairs)
 ),
 entry_pid AS (
-  -- Rang par (position_id effectif, symbole, exchange, market_type) : un position_id
-  -- réutilisé sur deux symboles OU deux venues (le même symbole dispatché sur plusieurs
-  -- exchanges/marchés peut porter des position_id qui se recoupent) ne doit pas mélanger
-  -- les rangs, sinon les gardes `symbol`/`exchange`/`market_type` du join rejetteraient
-  -- des clôtures pourtant valides. Cf. revue OBS-003 v2 (P2).
+  -- Rang par (position_id effectif + venue complète) : un position_id réutilisé sur
+  -- un autre symbole/exchange/marché ne mélange pas les rangs.
   SELECT id, eff_position_id, symbol, exchange, market_type, happened_at,
          ROW_NUMBER() OVER (
            PARTITION BY eff_position_id, symbol, exchange, market_type
@@ -185,11 +167,9 @@ entry_pid AS (
          ) AS rn
   FROM entry_pid_base
 ),
--- P2 : ne RANGE que les clôtures ÉLIGIBLES — celles précédées d'au moins une entrée
--- (même position_id effectif + même symbole + même venue) à cet instant. Une clôture
--- orpheline / périmée ANTÉRIEURE à l'entrée est ainsi écartée du jeu de candidats AVANT
--- le ROW_NUMBER (et non rejetée après), de sorte qu'elle ne « vole » pas le rang 1 à la
--- vraie clôture postérieure : un trade réellement clôturé ne reste donc pas `unmatched`.
+-- Ne RANGE que les clôtures ÉLIGIBLES (précédées d'au moins une entrée même venue) :
+-- une clôture orpheline/périmée antérieure est écartée AVANT le rang (et non rejetée
+-- après), donc elle ne vole pas le rang 1 à la vraie clôture postérieure.
 close_pid AS (
   SELECT c.id, c.match_position_id, c.symbol, c.exchange, c.market_type, c.happened_at,
          ROW_NUMBER() OVER (
@@ -209,10 +189,6 @@ close_pid AS (
     )
 ),
 pid_pairs AS (
-  -- Appariement 1-pour-1 par position_id EFFECTIF, borné à la même venue (symbole +
-  -- exchange + market_type) ET à une clôture postérieure à l'entrée. Combiné à
-  -- l'éligibilité ci-dessus : ni clôture périmée/cross-venue attribuée (vieux/mauvais
-  -- PnL, mauvais bucket `by_exchange`), ni trade clôturé laissé `unmatched`.
   SELECT e.id AS entry_event_id, c.id AS close_event_id
   FROM entry_pid e
   JOIN close_pid c
@@ -233,7 +209,6 @@ SELECT
   m.close_event_id              AS close_event_id,
   ee.symbol,
   ee.timeframe,
-  -- run_id (compat) == identifiant de corrélation stocké sur l'événement.
   ee.run_id                     AS run_id,
   ee.run_id                     AS correlation_run_id,
   ee.orchestration_run_id,
@@ -243,18 +218,19 @@ SELECT
   ee.market_type,
   ee.mtf_profile,
   COALESCE(ee.match_trade_id, ce.match_trade_id)        AS trade_id,
-  COALESCE(ce.match_position_id, ee.eff_position_id)    AS position_id,
+  COALESCE(ce.match_position_id, ee.eff_position_id)     AS position_id,
   ee.happened_at                AS entry_time,
   ce.happened_at                AS close_time,
   CASE WHEN m.close_event_id IS NOT NULL THEN 'matched' ELSE 'unmatched' END AS close_match_status,
-  COALESCE(m.matched_by, 'unmatched')                  AS close_matched_by,
-  -- métriques de plan / sizing à l'entrée
+  COALESCE(m.matched_by, 'unmatched')                   AS close_matched_by,
+  -- Statut de qualité de la ligne (issue #190, étape 7). On ne prétend pas « ouvert » :
+  -- une ligne non rapprochée est d'état réel INCONNU (peut être clôturée non-rapprochable).
+  CASE WHEN m.close_event_id IS NOT NULL THEN 'matched_closed' ELSE 'unmatched' END AS analysis_status,
   (ee.extra->> 'r_multiple_final')::numeric       AS expected_r_multiple,
   (ee.extra->> 'risk_usdt')::numeric              AS risk_usdt,
   (ee.extra->> 'notional_usdt')::numeric          AS notional_usdt,
   (ee.extra->> 'atr_pct_entry')::numeric          AS atr_pct_entry,
   (ee.extra->> 'volume_ratio')::numeric           AS entry_volume_ratio,
-  -- indicateurs au moment de l'entrée (snapshot)
   sv.snapshot_kline_time,
   sv.entry_rsi::numeric                           AS entry_rsi,
   sv.entry_atr::numeric                           AS entry_atr,
@@ -262,25 +238,19 @@ SELECT
   sv.entry_ma9::numeric                           AS entry_ma9,
   sv.entry_ma21::numeric                          AS entry_ma21,
   sv.entry_vwap::numeric                          AS entry_vwap,
-  -- métriques de sortie (POSITION_CLOSED.extra)
   (ce.extra->> 'pnl_R')::numeric                  AS pnl_r,
-  -- PnL ENREGISTRÉ tel quel (PAS garanti net de tous les coûts) — cf. net_pnl_*.
+  -- PnL ENREGISTRÉ tel quel (ni brut ni net garantis).
   (ce.extra->> 'pnl')::numeric                    AS recorded_pnl_usdt,
   (ce.extra->> 'pnl_pct')::numeric                AS pnl_pct,
   (ce.extra->> 'mfe_pct')::numeric                AS mfe_pct,
   (ce.extra->> 'mae_pct')::numeric                AS mae_pct,
   (ce.extra->> 'holding_time_sec')::numeric       AS holding_time_sec,
-  -- composantes de coût (null tant que la source ne les fournit pas — jamais inventées)
+  -- Composantes de coût (NULL si absentes, jamais 0 par défaut).
   (ce.extra->> 'fees')::numeric                   AS fees_usdt,
   (ce.extra->> 'funding')::numeric                AS funding_usdt,
   (ce.extra->> 'slippage')::numeric               AS slippage_usdt,
-  -- net complet UNIQUEMENT si recorded + tous les coûts sont présents.
-  (
-    (ce.extra->> 'pnl')      IS NOT NULL AND
-    (ce.extra->> 'fees')     IS NOT NULL AND
-    (ce.extra->> 'funding')  IS NOT NULL AND
-    (ce.extra->> 'slippage') IS NOT NULL
-  )                                               AS net_pnl_complete,
+  -- ESTIMATION best-effort, jamais certifiée : uniquement si les 3 composantes existent.
+  -- (Convention de signe funding + absence spread/brut = limites connues, contrat #190.)
   CASE WHEN
     (ce.extra->> 'pnl')      IS NOT NULL AND
     (ce.extra->> 'fees')     IS NOT NULL AND
@@ -291,7 +261,15 @@ SELECT
       - (ce.extra->> 'fees')::numeric
       - (ce.extra->> 'funding')::numeric
       - (ce.extra->> 'slippage')::numeric
-  ELSE NULL END                                   AS net_pnl_usdt
+  ELSE NULL END                                   AS estimated_net_pnl_usdt,
+  -- Complétude des coûts : jamais 'complete' (contrat #190 complet non atteignable ici).
+  CASE
+    WHEN m.close_event_id IS NULL THEN 'not_applicable'
+    WHEN (ce.extra->> 'fees') IS NULL
+     AND (ce.extra->> 'funding') IS NULL
+     AND (ce.extra->> 'slippage') IS NULL THEN 'unknown'
+    ELSE 'partial'
+  END                                             AS cost_completeness
 FROM entry_resolved ee
 LEFT JOIN matched m        ON m.entry_event_id = ee.id
 LEFT JOIN close_events ce  ON ce.id = m.close_event_id
@@ -301,92 +279,7 @@ SQL);
 
     public function down(Schema $schema): void
     {
-        // Restaure la définition précédente (Version20251129000000).
-        $this->addSql('DROP VIEW IF EXISTS position_trade_analysis');
-        $this->addSql(<<<'SQL'
-CREATE VIEW position_trade_analysis AS
-WITH entry_events AS (
-  SELECT
-    e.id,
-    e.symbol,
-    COALESCE(NULLIF(e.timeframe, ''), NULLIF(e.extra->> 'timeframe', '')) AS timeframe,
-    e.run_id,
-    e.happened_at,
-    e.extra,
-    (
-      SELECT s.id
-      FROM indicator_snapshots s
-      WHERE s.symbol = e.symbol
-        AND s.timeframe = COALESCE(NULLIF(e.timeframe, ''), NULLIF(e.extra->> 'timeframe', ''))
-        AND s.kline_time <= e.happened_at
-      ORDER BY s.kline_time DESC
-      LIMIT 1
-    ) AS snapshot_id
-  FROM trade_lifecycle_event e
-  WHERE e.event_type = 'order_submitted'
-),
-snapshot_values AS (
-  SELECT
-    es.id               AS event_id,
-    s.kline_time        AS snapshot_kline_time,
-    s.values->> 'rsi'   AS entry_rsi,
-    s.values->> 'atr'   AS entry_atr,
-    s.values->> 'macd'  AS entry_macd,
-    s.values->> 'ma9'   AS entry_ma9,
-    s.values->> 'ma21'  AS entry_ma21,
-    s.values->> 'vwap'  AS entry_vwap
-  FROM entry_events es
-  JOIN indicator_snapshots s ON s.id = es.snapshot_id
-),
-close_events AS (
-  SELECT
-    e.id,
-    e.symbol,
-    e.run_id,
-    e.position_id,
-    e.happened_at,
-    e.extra
-  FROM trade_lifecycle_event e
-  WHERE e.event_type = 'position_closed'
-)
-SELECT
-  ee.id                         AS entry_event_id,
-  ce.id                         AS close_event_id,
-  ee.symbol,
-  ee.timeframe,
-  ee.run_id,
-  COALESCE(ee.extra->> 'trade_id', ce.extra->> 'trade_id') AS trade_id,
-  ee.happened_at                AS entry_time,
-  ce.happened_at                AS close_time,
-  (ee.extra->> 'r_multiple_final')::numeric       AS expected_r_multiple,
-  (ee.extra->> 'risk_usdt')::numeric              AS risk_usdt,
-  (ee.extra->> 'notional_usdt')::numeric          AS notional_usdt,
-  (ee.extra->> 'atr_pct_entry')::numeric          AS atr_pct_entry,
-  (ee.extra->> 'volume_ratio')::numeric           AS entry_volume_ratio,
-  sv.snapshot_kline_time,
-  sv.entry_rsi::numeric                           AS entry_rsi,
-  sv.entry_atr::numeric                           AS entry_atr,
-  sv.entry_macd::numeric                          AS entry_macd,
-  sv.entry_ma9::numeric                           AS entry_ma9,
-  sv.entry_ma21::numeric                          AS entry_ma21,
-  sv.entry_vwap::numeric                          AS entry_vwap,
-  (ce.extra->> 'pnl_R')::numeric                  AS pnl_R,
-  (ce.extra->> 'pnl')::numeric                    AS pnl_usdt,
-  (ce.extra->> 'pnl_pct')::numeric                AS pnl_pct,
-  (ce.extra->> 'mfe_pct')::numeric                AS mfe_pct,
-  (ce.extra->> 'mae_pct')::numeric                AS mae_pct,
-  (ce.extra->> 'holding_time_sec')::numeric       AS holding_time_sec
-FROM entry_events ee
-LEFT JOIN snapshot_values sv ON sv.event_id = ee.id
-LEFT JOIN LATERAL (
-  SELECT c.*
-  FROM close_events c
-  WHERE c.symbol = ee.symbol
-    AND (c.run_id IS NULL OR c.run_id = ee.run_id)
-    AND c.happened_at >= ee.happened_at
-  ORDER BY c.happened_at
-  LIMIT 1
-) ce ON TRUE;
-SQL);
+        // Rollback sûr : on ne supprime que la vue versionnée, la v1 n'a jamais été touchée.
+        $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
     }
 }

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -31,9 +31,11 @@ use Doctrine\Migrations\AbstractMigration;
  * DEUX ; on l'utilise comme pont pour résoudre le `position_id` effectif d'une entrée
  * (sinon le rapprochement exact laisserait tout `unmatched`). Cf. revue OBS-003 v2 (P1).
  *
- * Garde anti-clôture périmée (P2) : le rapprochement par `position_id` exige la même
- * `symbol` et `close.happened_at >= entry.happened_at`, pour qu'un `position_id` réutilisé
- * ou une clôture importée ancienne n'attribue jamais un vieux PnL au run courant.
+ * Garde anti-clôture périmée / cross-venue (P2) : le rapprochement par `position_id`
+ * partitionne ET joint par la VENUE complète (`symbol` + `exchange` + `market_type`) et
+ * exige `close.happened_at >= entry.happened_at`. Un `position_id` réutilisé (autre
+ * symbole, autre exchange/marché) ou une clôture importée ancienne n'attribue donc jamais
+ * un PnL erroné/périmé au run courant (ni au mauvais bucket `by_exchange`).
  *
  * Colonnes ajoutées :
  *  - lineage : `correlation_run_id`, `orchestration_run_id`, `dashboard_id`, `set_id`,
@@ -94,6 +96,8 @@ close_events AS (
   SELECT
     e.id,
     e.symbol,
+    e.exchange,
+    e.market_type,
     e.run_id,
     e.happened_at,
     e.extra,
@@ -163,27 +167,35 @@ tid_pairs AS (
 -- (2) Appariement par position_id, UNIQUEMENT pour les entrées et clôtures non
 -- déjà appariées par trade_id (aucune clôture réutilisée entre les deux passes).
 entry_pid_base AS (
-  SELECT id, eff_position_id, symbol, happened_at
+  SELECT id, eff_position_id, symbol, exchange, market_type, happened_at
   FROM entry_resolved
   WHERE eff_position_id IS NOT NULL
     AND id NOT IN (SELECT entry_event_id FROM tid_pairs)
 ),
 entry_pid AS (
-  -- Rang par (position_id effectif, symbole) : un position_id réutilisé sur deux
-  -- symboles ne doit pas mélanger les rangs (le garde `c.symbol = e.symbol` au join
-  -- rejetterait alors des clôtures pourtant valides). Cf. revue OBS-003 v2 (P2).
-  SELECT id, eff_position_id, symbol, happened_at,
-         ROW_NUMBER() OVER (PARTITION BY eff_position_id, symbol ORDER BY happened_at, id) AS rn
+  -- Rang par (position_id effectif, symbole, exchange, market_type) : un position_id
+  -- réutilisé sur deux symboles OU deux venues (le même symbole dispatché sur plusieurs
+  -- exchanges/marchés peut porter des position_id qui se recoupent) ne doit pas mélanger
+  -- les rangs, sinon les gardes `symbol`/`exchange`/`market_type` du join rejetteraient
+  -- des clôtures pourtant valides. Cf. revue OBS-003 v2 (P2).
+  SELECT id, eff_position_id, symbol, exchange, market_type, happened_at,
+         ROW_NUMBER() OVER (
+           PARTITION BY eff_position_id, symbol, exchange, market_type
+           ORDER BY happened_at, id
+         ) AS rn
   FROM entry_pid_base
 ),
 -- P2 : ne RANGE que les clôtures ÉLIGIBLES — celles précédées d'au moins une entrée
--- (même position_id effectif + même symbole) à cet instant. Une clôture orpheline /
--- périmée ANTÉRIEURE à l'entrée est ainsi écartée du jeu de candidats AVANT le
--- ROW_NUMBER (et non rejetée après), de sorte qu'elle ne « vole » pas le rang 1 à la
+-- (même position_id effectif + même symbole + même venue) à cet instant. Une clôture
+-- orpheline / périmée ANTÉRIEURE à l'entrée est ainsi écartée du jeu de candidats AVANT
+-- le ROW_NUMBER (et non rejetée après), de sorte qu'elle ne « vole » pas le rang 1 à la
 -- vraie clôture postérieure : un trade réellement clôturé ne reste donc pas `unmatched`.
 close_pid AS (
-  SELECT c.id, c.match_position_id, c.symbol, c.happened_at,
-         ROW_NUMBER() OVER (PARTITION BY c.match_position_id, c.symbol ORDER BY c.happened_at, c.id) AS rn
+  SELECT c.id, c.match_position_id, c.symbol, c.exchange, c.market_type, c.happened_at,
+         ROW_NUMBER() OVER (
+           PARTITION BY c.match_position_id, c.symbol, c.exchange, c.market_type
+           ORDER BY c.happened_at, c.id
+         ) AS rn
   FROM close_events c
   WHERE c.match_position_id IS NOT NULL
     AND c.id NOT IN (SELECT close_event_id FROM tid_pairs)
@@ -191,19 +203,24 @@ close_pid AS (
       SELECT 1 FROM entry_pid_base e
       WHERE e.eff_position_id = c.match_position_id
         AND e.symbol = c.symbol
+        AND e.exchange = c.exchange
+        AND e.market_type = c.market_type
         AND e.happened_at <= c.happened_at
     )
 ),
 pid_pairs AS (
-  -- Appariement 1-pour-1 par position_id EFFECTIF, borné au même symbole ET à une
-  -- clôture postérieure à l'entrée. Combiné à l'éligibilité ci-dessus : ni clôture
-  -- périmée attribuée (vieux PnL), ni trade clôturé laissé `unmatched`.
+  -- Appariement 1-pour-1 par position_id EFFECTIF, borné à la même venue (symbole +
+  -- exchange + market_type) ET à une clôture postérieure à l'entrée. Combiné à
+  -- l'éligibilité ci-dessus : ni clôture périmée/cross-venue attribuée (vieux/mauvais
+  -- PnL, mauvais bucket `by_exchange`), ni trade clôturé laissé `unmatched`.
   SELECT e.id AS entry_event_id, c.id AS close_event_id
   FROM entry_pid e
   JOIN close_pid c
     ON c.match_position_id = e.eff_position_id
    AND c.rn = e.rn
    AND c.symbol = e.symbol
+   AND c.exchange = e.exchange
+   AND c.market_type = e.market_type
    AND c.happened_at >= e.happened_at
 ),
 matched AS (

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -44,6 +44,21 @@ use Doctrine\Migrations\AbstractMigration;
  * surface d'analyse fiable + le contrat PnL explicite). Le pont reste en place pour le
  * jour où `position_opened` portera le `trade_id`, et est couvert par les tests de la vue.
  *
+ * LIMITE D'ORDONNANCEMENT CONNUE (rapprochement FIFO par rang — suivi #200) : le
+ * rapprochement 1-pour-1 repose sur `ROW_NUMBER()` (rang d'entrée vs rang de clôture par
+ * clé+venue) plus un garde temporel `effective_close_time >= happened_at`. Si une clôture
+ * SUPPLÉMENTAIRE/DOUBLON existe pour la même clé+venue ENTRE deux entrées, elle consomme un
+ * rang et décale la vraie clôture postérieure au rang suivant : l'entrée concernée est
+ * alors laissée `unmatched`. C'est un échec SÛR (état honnête « inconnu », jamais une
+ * mauvaise attribution de PnL) tant qu'il n'existe pas de clôture doublon. Une mauvaise
+ * attribution exigerait un VRAI doublon de clôture pour la même clé+venue, ce que le chemin
+ * live ne produit pas (`TradingStateSyncRunner` n'émet qu'une `position_closed` par
+ * disparition de position suivie, et les clôtures live ne portent pas de `trade_id` —
+ * `close_tid` est donc vide en prod). Un rapprochement correct pour TOUTES les imbrications
+ * (y compris doublons) demanderait un appariement FIFO récursif (pile open/close) dans la
+ * vue ; ce durcissement est suivi par #200 et non requis tant que les données live restent
+ * bien formées.
+ *
  * Contrat PnL EXPLICITE (issue #190) — aucune valeur estimée présentée comme certifiée :
  *   - `recorded_pnl_usdt` : valeur enregistrée telle quelle (ni brute ni nette garanties) ;
  *   - `fees_usdt` / `funding_usdt` / `slippage_usdt` : composantes brutes si présentes
@@ -180,6 +195,9 @@ snapshot_values AS (
 -- par (exchange, market_type, trade_id) côté table : sans le périmètre venue, deux
 -- exchanges/marchés émettant le même trade_id échangeraient leurs outcomes (cross-venue
 -- swap). On applique le même garde temporel que le passage position_id.
+-- NB (suivi #200) : le rang FIFO est sûr tant qu'il n'existe pas de clôture DOUBLON pour la
+-- même clé+venue entre deux entrées (sinon l'entrée concernée reste `unmatched` — échec sûr,
+-- jamais une mauvaise attribution). Voir la « LIMITE D'ORDONNANCEMENT CONNUE » du docblock.
 entry_tid AS (
   SELECT id, match_trade_id, symbol, exchange, market_type, happened_at,
          ROW_NUMBER() OVER (

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -28,6 +28,22 @@ use Doctrine\Migrations\AbstractMigration;
  * porte les deux) pour le cycle MTF normal où `order_submitted` n'a que le trade_id et la
  * clôture synchronisée que le position_id.
  *
+ * LIMITE DE PRODUCTION CONNUE (clé de rapprochement partagée — suivi #190/#189) : la vue
+ * est CORRECTE mais ne peut relier que ce que les producteurs émettent. Dans le chemin
+ * runtime ACTUEL, `order_submitted` (TradeEntryService) porte le `trade_id` (via
+ * LifecycleContextBuilder) mais pas le `position_id`, tandis que les `position_opened` /
+ * `position_closed` synchronisés (`TradingStateSyncRunner`) portent le `position_id` de
+ * l'exchange mais PAS le `trade_id`. Aucune clé n'est donc partagée des deux côtés :
+ *   - le passage `trade_id` ne s'arme pas (la clôture n'a pas de `trade_id`) ;
+ *   - le pont `trade_id -> position_id` ne s'arme pas (`position_opened` n'a pas de
+ *     `trade_id`), donc `eff_position_id` reste NULL et le passage `position_id` non plus.
+ * Conséquence : un trade MTF réel ressort `unmatched` (état HONNÊTE « inconnu », jamais un
+ * faux rapprochement ni un PnL inventé), tant que les producteurs ne propagent pas une clé
+ * commune (trade_id sur open/close, ou un order_id partagé). Propager cette clé touche le
+ * chemin live et fait l'objet d'un SUIVI dédié (hors périmètre de cette PR, qui livre la
+ * surface d'analyse fiable + le contrat PnL explicite). Le pont reste en place pour le
+ * jour où `position_opened` portera le `trade_id`, et est couvert par les tests de la vue.
+ *
  * Contrat PnL EXPLICITE (issue #190) — aucune valeur estimée présentée comme certifiée :
  *   - `recorded_pnl_usdt` : valeur enregistrée telle quelle (ni brute ni nette garanties) ;
  *   - `fees_usdt` / `funding_usdt` / `slippage_usdt` : composantes brutes si présentes

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -18,11 +18,22 @@ use Doctrine\Migrations\AbstractMigration;
  *
  * Nouvelle règle de rapprochement, par identifiants EXACTS et en 1-pour-1 :
  *   1. `trade_id` exact (entrée.extra->>'trade_id' = clôture.extra->>'trade_id') ;
- *   2. sinon `position_id` exact (entrée.position_id|extra = clôture.position_id|extra) ;
+ *   2. sinon `position_id` EFFECTIF exact, borné au même symbole et à une clôture
+ *      postérieure à l'entrée ;
  *   3. sinon `unmatched` (aucune clôture rattachée, le trade reste visible « ouvert »).
- * Jamais de repli par symbole. L'appariement utilise `ROW_NUMBER()` par clé pour
+ * Jamais de repli par symbole seul. L'appariement utilise `ROW_NUMBER()` par clé pour
  * garantir qu'une clôture n'est jamais réutilisée par deux entrées et que la jointure
  * ne multiplie pas les lignes (exactement une ligne par entrée).
+ *
+ * Pont trade_id ↔ position_id : dans le cycle MTF normal, `order_submitted` ne porte que
+ * le `trade_id` et la clôture synchronisée que le `position_id` — les deux côtés n'ont
+ * donc pas de clé commune. L'événement `position_opened` (issu du flux MTF) porte les
+ * DEUX ; on l'utilise comme pont pour résoudre le `position_id` effectif d'une entrée
+ * (sinon le rapprochement exact laisserait tout `unmatched`). Cf. revue OBS-003 v2 (P1).
+ *
+ * Garde anti-clôture périmée (P2) : le rapprochement par `position_id` exige la même
+ * `symbol` et `close.happened_at >= entry.happened_at`, pour qu'un `position_id` réutilisé
+ * ou une clôture importée ancienne n'attribue jamais un vieux PnL au run courant.
  *
  * Colonnes ajoutées :
  *  - lineage : `correlation_run_id`, `orchestration_run_id`, `dashboard_id`, `set_id`,
@@ -91,6 +102,33 @@ close_events AS (
   FROM trade_lifecycle_event e
   WHERE e.event_type = 'position_closed'
 ),
+-- Pont trade_id -> position_id : l'événement `position_opened` issu du flux MTF porte
+-- À LA FOIS le `trade_id` (contexte lifecycle) ET le `position_id` (métadonnée d'ordre).
+-- `order_submitted` n'a que le trade_id et la clôture synchronisée n'a que le
+-- position_id ; sans ce pont, le rapprochement exact ne matcherait jamais le cycle
+-- normal. Les `position_opened` de synchro pure (sans trade_id) sont naturellement exclus.
+opened_bridge AS (
+  SELECT
+    NULLIF(e.extra->> 'trade_id', '') AS trade_id,
+    COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) AS position_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY NULLIF(e.extra->> 'trade_id', '')
+      ORDER BY e.happened_at, e.id
+    ) AS rn
+  FROM trade_lifecycle_event e
+  WHERE e.event_type = 'position_opened'
+    AND NULLIF(e.extra->> 'trade_id', '') IS NOT NULL
+    AND COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) IS NOT NULL
+),
+-- position_id EFFECTIF d'une entrée : le sien s'il existe, sinon celui résolu via le
+-- pont (premier `position_opened` partageant le même trade_id).
+entry_resolved AS (
+  SELECT
+    ee.*,
+    COALESCE(ee.match_position_id, ob.position_id) AS eff_position_id
+  FROM entry_events ee
+  LEFT JOIN opened_bridge ob ON ob.trade_id = ee.match_trade_id AND ob.rn = 1
+),
 snapshot_values AS (
   SELECT
     es.id               AS event_id,
@@ -125,23 +163,30 @@ tid_pairs AS (
 -- (2) Appariement par position_id, UNIQUEMENT pour les entrées et clôtures non
 -- déjà appariées par trade_id (aucune clôture réutilisée entre les deux passes).
 entry_pid AS (
-  SELECT id, match_position_id,
-         ROW_NUMBER() OVER (PARTITION BY match_position_id ORDER BY happened_at, id) AS rn
-  FROM entry_events
-  WHERE match_position_id IS NOT NULL
+  SELECT id, eff_position_id, symbol, happened_at,
+         ROW_NUMBER() OVER (PARTITION BY eff_position_id ORDER BY happened_at, id) AS rn
+  FROM entry_resolved
+  WHERE eff_position_id IS NOT NULL
     AND id NOT IN (SELECT entry_event_id FROM tid_pairs)
 ),
 close_pid AS (
-  SELECT id, match_position_id,
+  SELECT id, match_position_id, symbol, happened_at,
          ROW_NUMBER() OVER (PARTITION BY match_position_id ORDER BY happened_at, id) AS rn
   FROM close_events
   WHERE match_position_id IS NOT NULL
     AND id NOT IN (SELECT close_event_id FROM tid_pairs)
 ),
 pid_pairs AS (
+  -- P2 : appariement par position_id EFFECTIF, borné au même symbole ET à une clôture
+  -- postérieure à l'entrée. Une clôture périmée / un position_id réutilisé ne peut donc
+  -- pas attribuer un vieux PnL au run courant ; au pire l'entrée reste `unmatched`.
   SELECT e.id AS entry_event_id, c.id AS close_event_id
   FROM entry_pid e
-  JOIN close_pid c ON c.match_position_id = e.match_position_id AND c.rn = e.rn
+  JOIN close_pid c
+    ON c.match_position_id = e.eff_position_id
+   AND c.rn = e.rn
+   AND c.symbol = e.symbol
+   AND c.happened_at >= e.happened_at
 ),
 matched AS (
   SELECT entry_event_id, close_event_id, 'matched_trade_id'    AS matched_by FROM tid_pairs
@@ -163,7 +208,7 @@ SELECT
   ee.market_type,
   ee.mtf_profile,
   COALESCE(ee.match_trade_id, ce.match_trade_id)        AS trade_id,
-  COALESCE(ce.match_position_id, ee.match_position_id)  AS position_id,
+  COALESCE(ce.match_position_id, ee.eff_position_id)    AS position_id,
   ee.happened_at                AS entry_time,
   ce.happened_at                AS close_time,
   CASE WHEN m.close_event_id IS NOT NULL THEN 'matched' ELSE 'unmatched' END AS close_match_status,
@@ -212,7 +257,7 @@ SELECT
       - (ce.extra->> 'funding')::numeric
       - (ce.extra->> 'slippage')::numeric
   ELSE NULL END                                   AS net_pnl_usdt
-FROM entry_events ee
+FROM entry_resolved ee
 LEFT JOIN matched m        ON m.entry_event_id = ee.id
 LEFT JOIN close_events ce  ON ce.id = m.close_event_id
 LEFT JOIN snapshot_values sv ON sv.event_id = ee.id;

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -169,8 +169,11 @@ entry_pid_base AS (
     AND id NOT IN (SELECT entry_event_id FROM tid_pairs)
 ),
 entry_pid AS (
+  -- Rang par (position_id effectif, symbole) : un position_id réutilisé sur deux
+  -- symboles ne doit pas mélanger les rangs (le garde `c.symbol = e.symbol` au join
+  -- rejetterait alors des clôtures pourtant valides). Cf. revue OBS-003 v2 (P2).
   SELECT id, eff_position_id, symbol, happened_at,
-         ROW_NUMBER() OVER (PARTITION BY eff_position_id ORDER BY happened_at, id) AS rn
+         ROW_NUMBER() OVER (PARTITION BY eff_position_id, symbol ORDER BY happened_at, id) AS rn
   FROM entry_pid_base
 ),
 -- P2 : ne RANGE que les clôtures ÉLIGIBLES — celles précédées d'au moins une entrée
@@ -180,7 +183,7 @@ entry_pid AS (
 -- vraie clôture postérieure : un trade réellement clôturé ne reste donc pas `unmatched`.
 close_pid AS (
   SELECT c.id, c.match_position_id, c.symbol, c.happened_at,
-         ROW_NUMBER() OVER (PARTITION BY c.match_position_id ORDER BY c.happened_at, c.id) AS rn
+         ROW_NUMBER() OVER (PARTITION BY c.match_position_id, c.symbol ORDER BY c.happened_at, c.id) AS rn
   FROM close_events c
   WHERE c.match_position_id IS NOT NULL
     AND c.id NOT IN (SELECT close_event_id FROM tid_pairs)

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -198,8 +198,15 @@ snapshot_values AS (
 -- NB (suivi #200) : le rang FIFO est sûr tant qu'il n'existe pas de clôture DOUBLON pour la
 -- même clé+venue entre deux entrées (sinon l'entrée concernée reste `unmatched` — échec sûr,
 -- jamais une mauvaise attribution). Voir la « LIMITE D'ORDONNANCEMENT CONNUE » du docblock.
+-- Garde de RUN (parité v1) : une clôture ne peut être consommée que par une entrée du
+-- MÊME run (ou une clôture sans run — `run_id IS NULL` — qui reste rapprochable par tout
+-- run, cas du chemin live où la synchro émet les clôtures sans run_id). Sans ce garde, si
+-- deux runs produisent le même identifiant exact sur la même venue, la clôture d'un autre
+-- run pourrait être consommée et son PnL attribué au run demandé (l'API filtre les entrées
+-- par run APRÈS l'appariement). Appliqué à l'éligibilité ET à la jointure (échec sûr en cas
+-- de collision multi-run : entrée laissée `unmatched`, jamais une mauvaise attribution).
 entry_tid AS (
-  SELECT id, match_trade_id, symbol, exchange, market_type, happened_at,
+  SELECT id, match_trade_id, symbol, exchange, market_type, run_id, happened_at,
          ROW_NUMBER() OVER (
            PARTITION BY match_trade_id, symbol, exchange, market_type
            ORDER BY happened_at, id
@@ -207,10 +214,10 @@ entry_tid AS (
   FROM entry_events WHERE match_trade_id IS NOT NULL
 ),
 -- Ne RANGE que les clôtures ÉLIGIBLES (précédées d'au moins une entrée de même venue ET
--- même trade_id) : une clôture orpheline/antérieure ne vole pas le rang 1 à la vraie
--- clôture postérieure (symétrique au passage position_id).
+-- même trade_id ET même run) : une clôture orpheline/antérieure ne vole pas le rang 1 à la
+-- vraie clôture postérieure (symétrique au passage position_id).
 close_tid AS (
-  SELECT c.id, c.match_trade_id, c.symbol, c.exchange, c.market_type, c.effective_close_time,
+  SELECT c.id, c.match_trade_id, c.symbol, c.exchange, c.market_type, c.run_id, c.effective_close_time,
          ROW_NUMBER() OVER (
            PARTITION BY c.match_trade_id, c.symbol, c.exchange, c.market_type
            ORDER BY c.effective_close_time, c.id
@@ -223,6 +230,7 @@ close_tid AS (
         AND e.symbol = c.symbol
         AND e.exchange = c.exchange
         AND e.market_type = c.market_type
+        AND (c.run_id IS NULL OR c.run_id = e.run_id)
         AND e.happened_at <= c.effective_close_time
     )
 ),
@@ -235,11 +243,12 @@ tid_pairs AS (
    AND c.symbol = e.symbol
    AND c.exchange = e.exchange
    AND c.market_type = e.market_type
+   AND (c.run_id IS NULL OR c.run_id = e.run_id)
    AND c.effective_close_time >= e.happened_at
 ),
 -- (2) Appariement par position_id effectif, non déjà appariés par trade_id.
 entry_pid_base AS (
-  SELECT id, eff_position_id, symbol, exchange, market_type, happened_at
+  SELECT id, eff_position_id, symbol, exchange, market_type, run_id, happened_at
   FROM entry_resolved
   WHERE eff_position_id IS NOT NULL
     AND id NOT IN (SELECT entry_event_id FROM tid_pairs)
@@ -247,18 +256,18 @@ entry_pid_base AS (
 entry_pid AS (
   -- Rang par (position_id effectif + venue complète) : un position_id réutilisé sur
   -- un autre symbole/exchange/marché ne mélange pas les rangs.
-  SELECT id, eff_position_id, symbol, exchange, market_type, happened_at,
+  SELECT id, eff_position_id, symbol, exchange, market_type, run_id, happened_at,
          ROW_NUMBER() OVER (
            PARTITION BY eff_position_id, symbol, exchange, market_type
            ORDER BY happened_at, id
          ) AS rn
   FROM entry_pid_base
 ),
--- Ne RANGE que les clôtures ÉLIGIBLES (précédées d'au moins une entrée même venue) :
--- une clôture orpheline/périmée antérieure est écartée AVANT le rang (et non rejetée
--- après), donc elle ne vole pas le rang 1 à la vraie clôture postérieure.
+-- Ne RANGE que les clôtures ÉLIGIBLES (précédées d'au moins une entrée même venue ET même
+-- run) : une clôture orpheline/périmée antérieure (ou d'un autre run) est écartée AVANT le
+-- rang (et non rejetée après), donc elle ne vole pas le rang 1 à la vraie clôture postérieure.
 close_pid AS (
-  SELECT c.id, c.match_position_id, c.symbol, c.exchange, c.market_type, c.effective_close_time,
+  SELECT c.id, c.match_position_id, c.symbol, c.exchange, c.market_type, c.run_id, c.effective_close_time,
          ROW_NUMBER() OVER (
            PARTITION BY c.match_position_id, c.symbol, c.exchange, c.market_type
            ORDER BY c.effective_close_time, c.id
@@ -272,6 +281,7 @@ close_pid AS (
         AND e.symbol = c.symbol
         AND e.exchange = c.exchange
         AND e.market_type = c.market_type
+        AND (c.run_id IS NULL OR c.run_id = e.run_id)
         AND e.happened_at <= c.effective_close_time
     )
 ),
@@ -284,6 +294,7 @@ pid_pairs AS (
    AND c.symbol = e.symbol
    AND c.exchange = e.exchange
    AND c.market_type = e.market_type
+   AND (c.run_id IS NULL OR c.run_id = e.run_id)
    AND c.effective_close_time >= e.happened_at
 ),
 matched AS (

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -96,7 +96,20 @@ close_events AS (
     e.happened_at,
     e.extra,
     NULLIF(e.extra->> 'trade_id', '') AS match_trade_id,
-    COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) AS match_position_id
+    COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) AS match_position_id,
+    -- Temps de clôture EFFECTIF : `happened_at` est le moment où la synchro LOGGE
+    -- l'événement (peut être très postérieur à la clôture réelle pour un import tardif).
+    -- La vraie heure d'exchange est dans extra.close_time ('Y-m-d H:i:s' UTC) : on l'utilise
+    -- pour le rang/l'éligibilité/le garde temporel, avec repli sur happened_at si absente
+    -- ou mal formée (cast sûr via garde regex).
+    COALESCE(
+      CASE
+        WHEN (e.extra->> 'close_time') ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}[ T][0-9]{2}:[0-9]{2}:[0-9]{2}'
+        THEN (e.extra->> 'close_time')::timestamp AT TIME ZONE 'UTC'
+        ELSE NULL
+      END,
+      e.happened_at
+    ) AS effective_close_time
   FROM trade_lifecycle_event e
   WHERE e.event_type = 'position_closed'
 ),
@@ -171,10 +184,10 @@ entry_pid AS (
 -- une clôture orpheline/périmée antérieure est écartée AVANT le rang (et non rejetée
 -- après), donc elle ne vole pas le rang 1 à la vraie clôture postérieure.
 close_pid AS (
-  SELECT c.id, c.match_position_id, c.symbol, c.exchange, c.market_type, c.happened_at,
+  SELECT c.id, c.match_position_id, c.symbol, c.exchange, c.market_type, c.effective_close_time,
          ROW_NUMBER() OVER (
            PARTITION BY c.match_position_id, c.symbol, c.exchange, c.market_type
-           ORDER BY c.happened_at, c.id
+           ORDER BY c.effective_close_time, c.id
          ) AS rn
   FROM close_events c
   WHERE c.match_position_id IS NOT NULL
@@ -185,7 +198,7 @@ close_pid AS (
         AND e.symbol = c.symbol
         AND e.exchange = c.exchange
         AND e.market_type = c.market_type
-        AND e.happened_at <= c.happened_at
+        AND e.happened_at <= c.effective_close_time
     )
 ),
 pid_pairs AS (
@@ -197,7 +210,7 @@ pid_pairs AS (
    AND c.symbol = e.symbol
    AND c.exchange = e.exchange
    AND c.market_type = e.market_type
-   AND c.happened_at >= e.happened_at
+   AND c.effective_close_time >= e.happened_at
 ),
 matched AS (
   SELECT entry_event_id, close_event_id, 'matched_trade_id'    AS matched_by FROM tid_pairs
@@ -220,7 +233,7 @@ SELECT
   COALESCE(ee.match_trade_id, ce.match_trade_id)        AS trade_id,
   COALESCE(ce.match_position_id, ee.eff_position_id)     AS position_id,
   ee.happened_at                AS entry_time,
-  ce.happened_at                AS close_time,
+  ce.effective_close_time       AS close_time,
   CASE WHEN m.close_event_id IS NOT NULL THEN 'matched' ELSE 'unmatched' END AS close_match_status,
   COALESCE(m.matched_by, 'unmatched')                   AS close_matched_by,
   -- Statut de qualité de la ligne (issue #190, étape 7). On ne prétend pas « ouvert » :

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -113,13 +113,20 @@ close_events AS (
   FROM trade_lifecycle_event e
   WHERE e.event_type = 'position_closed'
 ),
--- Pont trade_id -> position_id : `position_opened` (flux MTF) porte les DEUX.
+-- Pont trade_id -> position_id : `position_opened` (flux MTF) porte les DEUX. Le pont est
+-- BORNÉ à la même VENUE (symbole + exchange + market_type) : le trade_id n'étant unique que
+-- par (exchange, market_type, trade_id), un même trade_id réutilisé sur une autre venue ne
+-- doit pas faire hériter à une entrée le position_id d'une autre venue (mauvais bucket
+-- by_exchange). Le rang est donc partitionné par (trade_id + venue complète).
 opened_bridge AS (
   SELECT
     NULLIF(e.extra->> 'trade_id', '') AS trade_id,
+    e.symbol,
+    e.exchange,
+    e.market_type,
     COALESCE(NULLIF(e.position_id, ''), NULLIF(e.extra->> 'position_id', '')) AS position_id,
     ROW_NUMBER() OVER (
-      PARTITION BY NULLIF(e.extra->> 'trade_id', '')
+      PARTITION BY NULLIF(e.extra->> 'trade_id', ''), e.symbol, e.exchange, e.market_type
       ORDER BY e.happened_at, e.id
     ) AS rn
   FROM trade_lifecycle_event e
@@ -132,7 +139,12 @@ entry_resolved AS (
     ee.*,
     COALESCE(ee.match_position_id, ob.position_id) AS eff_position_id
   FROM entry_events ee
-  LEFT JOIN opened_bridge ob ON ob.trade_id = ee.match_trade_id AND ob.rn = 1
+  LEFT JOIN opened_bridge ob
+    ON ob.trade_id = ee.match_trade_id
+   AND ob.symbol = ee.symbol
+   AND ob.exchange = ee.exchange
+   AND ob.market_type = ee.market_type
+   AND ob.rn = 1
 ),
 snapshot_values AS (
   SELECT

--- a/trading-app/migrations/Version20260622000000.php
+++ b/trading-app/migrations/Version20260622000000.php
@@ -162,24 +162,39 @@ tid_pairs AS (
 ),
 -- (2) Appariement par position_id, UNIQUEMENT pour les entrées et clôtures non
 -- déjà appariées par trade_id (aucune clôture réutilisée entre les deux passes).
-entry_pid AS (
-  SELECT id, eff_position_id, symbol, happened_at,
-         ROW_NUMBER() OVER (PARTITION BY eff_position_id ORDER BY happened_at, id) AS rn
+entry_pid_base AS (
+  SELECT id, eff_position_id, symbol, happened_at
   FROM entry_resolved
   WHERE eff_position_id IS NOT NULL
     AND id NOT IN (SELECT entry_event_id FROM tid_pairs)
 ),
+entry_pid AS (
+  SELECT id, eff_position_id, symbol, happened_at,
+         ROW_NUMBER() OVER (PARTITION BY eff_position_id ORDER BY happened_at, id) AS rn
+  FROM entry_pid_base
+),
+-- P2 : ne RANGE que les clôtures ÉLIGIBLES — celles précédées d'au moins une entrée
+-- (même position_id effectif + même symbole) à cet instant. Une clôture orpheline /
+-- périmée ANTÉRIEURE à l'entrée est ainsi écartée du jeu de candidats AVANT le
+-- ROW_NUMBER (et non rejetée après), de sorte qu'elle ne « vole » pas le rang 1 à la
+-- vraie clôture postérieure : un trade réellement clôturé ne reste donc pas `unmatched`.
 close_pid AS (
-  SELECT id, match_position_id, symbol, happened_at,
-         ROW_NUMBER() OVER (PARTITION BY match_position_id ORDER BY happened_at, id) AS rn
-  FROM close_events
-  WHERE match_position_id IS NOT NULL
-    AND id NOT IN (SELECT close_event_id FROM tid_pairs)
+  SELECT c.id, c.match_position_id, c.symbol, c.happened_at,
+         ROW_NUMBER() OVER (PARTITION BY c.match_position_id ORDER BY c.happened_at, c.id) AS rn
+  FROM close_events c
+  WHERE c.match_position_id IS NOT NULL
+    AND c.id NOT IN (SELECT close_event_id FROM tid_pairs)
+    AND EXISTS (
+      SELECT 1 FROM entry_pid_base e
+      WHERE e.eff_position_id = c.match_position_id
+        AND e.symbol = c.symbol
+        AND e.happened_at <= c.happened_at
+    )
 ),
 pid_pairs AS (
-  -- P2 : appariement par position_id EFFECTIF, borné au même symbole ET à une clôture
-  -- postérieure à l'entrée. Une clôture périmée / un position_id réutilisé ne peut donc
-  -- pas attribuer un vieux PnL au run courant ; au pire l'entrée reste `unmatched`.
+  -- Appariement 1-pour-1 par position_id EFFECTIF, borné au même symbole ET à une
+  -- clôture postérieure à l'entrée. Combiné à l'éligibilité ci-dessus : ni clôture
+  -- périmée attribuée (vieux PnL), ni trade clôturé laissé `unmatched`.
   SELECT e.id AS entry_event_id, c.id AS close_event_id
   FROM entry_pid e
   JOIN close_pid c

--- a/trading-app/src/Contract/MtfValidator/Dto/MtfRunRequestDto.php
+++ b/trading-app/src/Contract/MtfValidator/Dto/MtfRunRequestDto.php
@@ -26,6 +26,18 @@ final class MtfRunRequestDto
         public readonly ?MarketType $marketType = null,
         public readonly ?string $profile = null,
         public readonly ?string $mode = null,
+        /**
+         * OBS-003 — identifiant de corrélation (≤64) à utiliser comme `run_id` du run
+         * (et donc des `trade_lifecycle_event`). Null → l'identifiant historique
+         * (UUID généré en aval) reste en place (CLI / appel direct inchangé).
+         */
+        public readonly ?string $requestId = null,
+        /** OBS-003 — identifiant ORIGINAL du run d'orchestration (peut dépasser 64). */
+        public readonly ?string $orchestrationRunId = null,
+        /** OBS-003 — dashboard d'orchestration réellement exécuté. */
+        public readonly ?string $dashboardId = null,
+        /** OBS-003 — set d'orchestration réellement dispatché. */
+        public readonly ?string $setId = null,
     ) {}
 
     /**
@@ -72,6 +84,11 @@ final class MtfRunRequestDto
             $marketType = MarketType::tryFrom(strtolower($marketTypeRaw)) ?? null;
         }
 
+        $requestId = self::nonEmptyString($data['request_id'] ?? $data['requestId'] ?? null);
+        $orchestrationRunId = self::nonEmptyString($data['orchestration_run_id'] ?? null);
+        $dashboardId = self::nonEmptyString($data['dashboard_id'] ?? $data['orchestration_dashboard_id'] ?? null);
+        $setId = self::nonEmptyString($data['set_id'] ?? $data['orchestration_set_id'] ?? null);
+
         return new self(
             symbols: $symbols,
             dryRun: $dryRun,
@@ -87,7 +104,16 @@ final class MtfRunRequestDto
             marketType: $marketType,
             profile: $profile,
             mode: $validationMode,
+            requestId: $requestId,
+            orchestrationRunId: $orchestrationRunId,
+            dashboardId: $dashboardId,
+            setId: $setId,
         );
+    }
+
+    private static function nonEmptyString(mixed $value): ?string
+    {
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
     }
 
     private static function extractProfileAndMode(array $data): array

--- a/trading-app/src/Controller/RunnerController.php
+++ b/trading-app/src/Controller/RunnerController.php
@@ -129,10 +129,15 @@ class RunnerController extends AbstractController
                 'context_mode' => $data['context_mode'] ?? null,
                 'mode' => $data['mode'] ?? null,
                 'open_state_snapshot' => $openStateSnapshot,
-                'run_id' => $headerRunId ?? ($data['run_id'] ?? null),
+                'run_id' => $headerRunId ?? ($data['run_id'] ?? $data['original_run_id'] ?? null),
                 'correlation_run_id' => $headerCorrelationId ?? ($data['correlation_run_id'] ?? null),
-                'orchestration_dashboard_id' => $headerDashboardId ?? ($data['dashboard_id'] ?? null),
-                'orchestration_set_id' => $headerSetId ?? ($data['set_id'] ?? null),
+                // On accepte les deux formes d'alias dans le corps (`dashboard_id` court ET
+                // `orchestration_dashboard_id` long) pour ne pas perdre le lineage sur le
+                // chemin body-only sans en-têtes (cohérent avec le validateur et le DTO).
+                'orchestration_dashboard_id' => $headerDashboardId
+                    ?? ($data['dashboard_id'] ?? $data['orchestration_dashboard_id'] ?? null),
+                'orchestration_set_id' => $headerSetId
+                    ?? ($data['set_id'] ?? $data['orchestration_set_id'] ?? null),
             ]);
             $result = $runMtfCycle->run($runnerRequest);
 

--- a/trading-app/src/Controller/RunnerController.php
+++ b/trading-app/src/Controller/RunnerController.php
@@ -67,6 +67,16 @@ class RunnerController extends AbstractController
             }
             $symbols = array_values(array_unique($symbols));
 
+            // OBS-003 : lineage d'orchestration porté par les en-têtes HTTP. L'en-tête a
+            // priorité sur le corps ; absence d'en-tête = comportement historique (run_id
+            // UUID généré en aval). Le run_id ORIGINAL (X-Run-Id) est la source de vérité ;
+            // l'identifiant de corrélation canonique est (re)dérivé côté Symfony, jamais
+            // tronqué. X-Run-Correlation-Id n'est qu'un repli/indication.
+            $headerRunId = $request->headers->get('X-Run-Id');
+            $headerCorrelationId = $request->headers->get('X-Run-Correlation-Id');
+            $headerSetId = $request->headers->get('X-Orchestration-Set-Id');
+            $headerDashboardId = $request->headers->get('X-Orchestration-Dashboard-Id');
+
             // Injection automatique du profile depuis la configuration si non fourni
             // ROLLBACK: Si besoin de revenir en arrière, supprimer cette logique et remettre:
             // 'profile' => $data['profile'] ?? $data['mtf_profile'] ?? null,
@@ -105,6 +115,10 @@ class RunnerController extends AbstractController
                 'context_mode' => $data['context_mode'] ?? null,
                 'mode' => $data['mode'] ?? null,
                 'open_state_snapshot' => $openStateSnapshot,
+                'run_id' => $headerRunId ?? ($data['run_id'] ?? null),
+                'correlation_run_id' => $headerCorrelationId ?? ($data['correlation_run_id'] ?? null),
+                'orchestration_dashboard_id' => $headerDashboardId ?? ($data['dashboard_id'] ?? null),
+                'orchestration_set_id' => $headerSetId ?? ($data['set_id'] ?? null),
             ]);
             $result = $runMtfCycle->run($runnerRequest);
 

--- a/trading-app/src/Controller/RunnerController.php
+++ b/trading-app/src/Controller/RunnerController.php
@@ -7,6 +7,8 @@ namespace App\Controller;
 use App\Config\TradeEntryModeContext;
 use App\MtfRunner\Application\RunMtfCycleUseCase;
 use App\MtfRunner\Dto\MtfRunnerRequestDto;
+use App\Trading\Orchestration\OrchestrationContextException;
+use App\Trading\Orchestration\OrchestrationContextValidator;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,6 +21,7 @@ class RunnerController extends AbstractController
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly TradeEntryModeContext $modeContext,
+        private readonly OrchestrationContextValidator $orchestrationContextValidator,
     ) {
     }
 
@@ -76,6 +79,17 @@ class RunnerController extends AbstractController
             $headerCorrelationId = $request->headers->get('X-Run-Correlation-Id');
             $headerSetId = $request->headers->get('X-Orchestration-Set-Id');
             $headerDashboardId = $request->headers->get('X-Orchestration-Dashboard-Id');
+
+            // OBS-003 : refuser fail-closed un contexte d'orchestration contradictoire
+            // (en-têtes vs payload, ou doublons contradictoires du payload). Le chemin
+            // legacy (sans en-tête ni doublon) ne déclenche aucun contrôle.
+            $this->orchestrationContextValidator->validate(
+                $headerRunId,
+                $headerCorrelationId,
+                $headerSetId,
+                $headerDashboardId,
+                $data,
+            );
 
             // Injection automatique du profile depuis la configuration si non fourni
             // ROLLBACK: Si besoin de revenir en arrière, supprimer cette logique et remettre:
@@ -167,6 +181,18 @@ class RunnerController extends AbstractController
                 ],
             ]);
 
+        } catch (OrchestrationContextException $e) {
+            // Incohérence de contexte vérifiable dans la requête : 422 avec code stable.
+            $this->logger->warning('[Runner Controller] Orchestration context mismatch', [
+                'error_code' => $e->errorCode,
+                'error' => $e->getMessage(),
+            ]);
+
+            return $this->json([
+                'status' => 'error',
+                'error_code' => $e->errorCode,
+                'message' => $e->getMessage(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
         } catch (\Throwable $e) {
             $this->logger->error('[Runner Controller] Failed to run MTF cycle', [
                 'error' => $e->getMessage(),

--- a/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
+++ b/trading-app/src/MtfRunner/Dto/MtfRunnerRequestDto.php
@@ -39,6 +39,15 @@ final class MtfRunnerRequestDto
          * @var array{open_positions?: array<int,mixed>, open_orders?: array<int,mixed>}|null
          */
         public readonly ?array $openStateSnapshot = null,
+        /**
+         * OBS-003 — lineage d'orchestration (en-têtes `X-Run-Id` / `X-Run-Correlation-Id`
+         * / `X-Orchestration-Dashboard-Id` / `X-Orchestration-Set-Id`). Tous nullables :
+         * CLI et appel HTTP legacy (sans en-têtes) restent strictement inchangés.
+         */
+        public readonly ?string $originalRunId = null,
+        public readonly ?string $correlationRunId = null,
+        public readonly ?string $dashboardId = null,
+        public readonly ?string $setId = null,
     ) {}
 
     public static function fromArray(array $data): self
@@ -65,7 +74,16 @@ final class MtfRunnerRequestDto
             profile: $profile,
             validationMode: $validationMode,
             openStateSnapshot: self::extractOpenStateSnapshot($data),
+            originalRunId: self::nonEmptyString($data['run_id'] ?? $data['original_run_id'] ?? null),
+            correlationRunId: self::nonEmptyString($data['correlation_run_id'] ?? null),
+            dashboardId: self::nonEmptyString($data['dashboard_id'] ?? $data['orchestration_dashboard_id'] ?? null),
+            setId: self::nonEmptyString($data['set_id'] ?? $data['orchestration_set_id'] ?? null),
         );
+    }
+
+    private static function nonEmptyString(mixed $value): ?string
+    {
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
     }
 
     public function toArray(): array
@@ -89,6 +107,10 @@ final class MtfRunnerRequestDto
             'profile' => $this->profile,
             'validation_mode' => $this->validationMode,
             'open_state_snapshot' => $this->openStateSnapshot,
+            'run_id' => $this->originalRunId,
+            'correlation_run_id' => $this->correlationRunId,
+            'dashboard_id' => $this->dashboardId,
+            'set_id' => $this->setId,
         ];
     }
 

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -427,6 +427,15 @@ final class MtfRunnerService
         $response = $this->mtfValidator->run($mtfRequest);
         $this->tradeDecisionDispatcher->dispatchFromResponse($mtfRequest, $response);
 
+        // OBS-003 : le validateur génère son propre UUID, mais les décisions/lifecycle
+        // events utilisent le run_id de corrélation propagé (`requestId`, prioritaire dans
+        // le dispatcher). On aligne donc le `run_id` du résumé séquentiel sur `$runId`
+        // (comme le fait déjà le chemin parallèle), sinon `/api/mtf/run` et
+        // `RunSet.response_json.summary.run_id` pointeraient un UUID absent des lignes
+        // d'outcome/lifecycle.
+        $summary = $response->toArray();
+        $summary['run_id'] = $runId;
+
         $resultsMap = [];
         foreach ($response->results as $entry) {
             if (!is_array($entry)) {
@@ -453,7 +462,7 @@ final class MtfRunnerService
         }
 
         return [
-            'summary' => $response->toArray(),
+            'summary' => $summary,
             'results' => $resultsMap,
             'errors' => $response->errors,
         ];

--- a/trading-app/src/MtfRunner/Service/MtfRunnerService.php
+++ b/trading-app/src/MtfRunner/Service/MtfRunnerService.php
@@ -23,6 +23,7 @@ use App\MtfValidator\Application\TradeDecisionDispatcherInterface;
 use App\MtfValidator\Repository\MtfLockRepository;
 use App\MtfValidator\Repository\MtfSwitchRepository;
 use App\Provider\Context\ExchangeContext;
+use App\Trading\Service\RunCorrelationId;
 use App\Config\TradeEntryConfigProvider;
 use App\Config\TradeEntryModeContext;
 use App\TradeEntry\Dto\TpSlTwoTargetsRequest;
@@ -90,7 +91,13 @@ final class MtfRunnerService
     public function run(RunnerRequestDto $request): array
     {
         $profiler = new PerformanceProfiler();
-        $runId = Uuid::uuid4()->toString();
+        // OBS-003 : si l'orchestrateur a fourni un run_id (X-Run-Id), on l'utilise comme
+        // identifiant de corrélation canonique (≤64, jamais tronqué) du run — il finit sur
+        // `trade_lifecycle_event.run_id` et permet le rapprochement run ↔ trades. Sans
+        // en-tête (CLI / appel direct), on retombe sur l'UUID historique (inchangé).
+        $runId = RunCorrelationId::canonicalOrNull($request->originalRunId)
+            ?? RunCorrelationId::canonicalOrNull($request->correlationRunId)
+            ?? Uuid::uuid4()->toString();
         $startTime = microtime(true);
         $openPositions = null;
         $openOrders = null;
@@ -192,7 +199,7 @@ final class MtfRunnerService
 
             $result = $request->workers > 1
                 ? $this->runParallel($symbols, $request, $context, $runId)
-                : $this->runSequential($symbols, $request, $context);
+                : $this->runSequential($symbols, $request, $context, $runId);
             $profiler->increment('runner', 'mtf_execution', microtime(true) - $execStart);
 
             $this->postRunProjectionDispatcher->dispatch($result['results'] ?? [], $request, $runId);
@@ -391,7 +398,8 @@ final class MtfRunnerService
     private function runSequential(
         array $symbols,
         RunnerRequestDto $request,
-        ExchangeContext $context
+        ExchangeContext $context,
+        string $runId
     ): array {
         $mtfRequest = new MtfRunRequestDto(
             symbols: $symbols,
@@ -408,6 +416,12 @@ final class MtfRunnerService
             marketType: $context->marketType,
             profile: $request->profile,
             mode: $request->validationMode,
+            // OBS-003 : propage le run_id de corrélation + lineage jusqu'au dispatcher,
+            // afin que `order_submitted` porte ce run_id et le lineage d'orchestration.
+            requestId: $runId,
+            orchestrationRunId: $request->originalRunId,
+            dashboardId: $request->dashboardId,
+            setId: $request->setId,
         );
 
         $response = $this->mtfValidator->run($mtfRequest);
@@ -484,6 +498,11 @@ final class MtfRunnerService
             'market_type' => $context->marketType->value,
             'profile' => $request->profile,
             'validation_mode' => $request->validationMode,
+            // OBS-003 : lineage propagé au worker (puis au dispatcher → order_submitted).
+            'request_id' => $runId,
+            'orchestration_run_id' => $request->originalRunId,
+            'dashboard_id' => $request->dashboardId,
+            'set_id' => $request->setId,
         ];
 
         $this->mtfLogger->info('[MTF Runner] Starting parallel execution', [
@@ -733,6 +752,19 @@ final class MtfRunnerService
         }
         if (!empty($options['validation_mode'])) {
             $command[] = '--validation-mode=' . $options['validation_mode'];
+        }
+        // OBS-003 : lineage d'orchestration transmis au worker.
+        if (!empty($options['request_id'])) {
+            $command[] = '--request-id=' . $options['request_id'];
+        }
+        if (!empty($options['orchestration_run_id'])) {
+            $command[] = '--orchestration-run-id=' . $options['orchestration_run_id'];
+        }
+        if (!empty($options['dashboard_id'])) {
+            $command[] = '--dashboard-id=' . $options['dashboard_id'];
+        }
+        if (!empty($options['set_id'])) {
+            $command[] = '--set-id=' . $options['set_id'];
         }
 
         return $command;

--- a/trading-app/src/MtfValidator/Application/MtfTradeDecisionDispatcher.php
+++ b/trading-app/src/MtfValidator/Application/MtfTradeDecisionDispatcher.php
@@ -38,17 +38,25 @@ final class MtfTradeDecisionDispatcher implements TradeDecisionDispatcherInterfa
                 continue;
             }
 
-            $mtfRun = $this->buildRunDto($request, $response->runId, $result);
+            // OBS-003 : si la requête fournit un run_id de corrélation (X-Run-Id côté
+            // orchestrateur), il prime sur l'identifiant généré par le validateur, afin que
+            // `trade_lifecycle_event.run_id` corresponde au run d'orchestration. Sinon,
+            // comportement historique inchangé (run_id du validateur).
+            $effectiveRunId = ($request->requestId !== null && $request->requestId !== '')
+                ? $request->requestId
+                : $response->runId;
+
+            $mtfRun = $this->buildRunDto($request, $effectiveRunId, $result);
 
             try {
                 $this->messageBus->dispatch(new MtfTradingDecisionMessage(
-                    $response->runId,
+                    $effectiveRunId,
                     $mtfRun,
                     $result,
                 ));
 
                 $this->mtfLogger->debug('[MTF Dispatcher] Trading decision dispatched', [
-                    'run_id' => $response->runId,
+                    'run_id' => $effectiveRunId,
                     'symbol' => $result->symbol,
                     'execution_tf' => $result->executionTimeframe,
                     'side' => $result->side,
@@ -88,6 +96,12 @@ final class MtfTradeDecisionDispatcher implements TradeDecisionDispatcherInterfa
                 'ip_address' => $request->ipAddress,
                 'exchange' => $request->exchange?->value,
                 'market_type' => $request->marketType?->value,
+                // OBS-003 : lineage transporté jusqu'au TradingDecisionHandler, qui
+                // l'inscrit dans l'`extra` de `order_submitted`.
+                'correlation_run_id' => $runId,
+                'orchestration_run_id' => $request->orchestrationRunId,
+                'orchestration_dashboard_id' => $request->dashboardId,
+                'orchestration_set_id' => $request->setId,
             ],
         );
     }

--- a/trading-app/src/MtfValidator/Command/MtfRunWorkerCommand.php
+++ b/trading-app/src/MtfValidator/Command/MtfRunWorkerCommand.php
@@ -45,7 +45,11 @@ final class MtfRunWorkerCommand extends Command
             ->addOption('exchange', null, InputOption::VALUE_OPTIONAL, 'Identifiant de l\'exchange (ex: bitmart)')
             ->addOption('market-type', null, InputOption::VALUE_OPTIONAL, 'Type de marché (perpetual|spot)')
             ->addOption('trade-profile', null, InputOption::VALUE_OPTIONAL, 'Profil TradeEntry/MTF à utiliser (ex: scalper, regular)')
-            ->addOption('validation-mode', null, InputOption::VALUE_OPTIONAL, 'Mode de validation du contexte (pragmatic|strict|ultra-pragmatig)');
+            ->addOption('validation-mode', null, InputOption::VALUE_OPTIONAL, 'Mode de validation du contexte (pragmatic|strict|ultra-pragmatig)')
+            ->addOption('request-id', null, InputOption::VALUE_OPTIONAL, 'OBS-003 : run_id de corrélation (≤64) à utiliser comme run_id du run')
+            ->addOption('orchestration-run-id', null, InputOption::VALUE_OPTIONAL, 'OBS-003 : run_id ORIGINAL du run d\'orchestration')
+            ->addOption('dashboard-id', null, InputOption::VALUE_OPTIONAL, 'OBS-003 : dashboard d\'orchestration exécuté')
+            ->addOption('set-id', null, InputOption::VALUE_OPTIONAL, 'OBS-003 : set d\'orchestration dispatché');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -82,6 +86,11 @@ final class MtfRunWorkerCommand extends Command
         $validationModeOpt = $input->getOption('validation-mode');
         $validationMode = is_string($validationModeOpt) && $validationModeOpt !== '' ? strtolower(trim($validationModeOpt)) : null;
 
+        $requestId = $this->optString($input->getOption('request-id'));
+        $orchestrationRunId = $this->optString($input->getOption('orchestration-run-id'));
+        $dashboardId = $this->optString($input->getOption('dashboard-id'));
+        $setId = $this->optString($input->getOption('set-id'));
+
         try {
             // En mode worker, activer le verrou par symbole pour éviter le blocage global
             $request = MtfRunRequestDto::fromArray([
@@ -99,6 +108,10 @@ final class MtfRunWorkerCommand extends Command
                 'market_type' => $marketTypeOpt !== null && $marketTypeOpt !== '' ? $marketTypeOpt : MarketType::PERPETUAL->value,
                 'profile' => $profile,
                 'validation_mode' => $validationMode,
+                'request_id' => $requestId,
+                'orchestration_run_id' => $orchestrationRunId,
+                'dashboard_id' => $dashboardId,
+                'set_id' => $setId,
             ]);
             $response = $this->mtfValidator->run($request);
             $this->tradeDecisionDispatcher->dispatchFromResponse($request, $response);
@@ -163,5 +176,10 @@ final class MtfRunWorkerCommand extends Command
             ], JSON_THROW_ON_ERROR));
             return Command::FAILURE;
         }
+    }
+
+    private function optString(mixed $value): ?string
+    {
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
     }
 }

--- a/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
+++ b/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
@@ -134,6 +134,14 @@ final class TradingDecisionHandler
             ->merge([
                 'config_version' => $tradeEntryConfig->getVersion(),
                 'run_id' => $runId,
+                // OBS-003 : lineage d'orchestration inscrit dans l'`extra` de
+                // `order_submitted` (merge() ignore les valeurs nulles : CLI/legacy
+                // n'ajoutent rien). `correlation_run_id` == `run_id` (≤64) ; le run_id
+                // ORIGINAL reste disponible via `orchestration_run_id`.
+                'correlation_run_id' => $mtfRunDto->options['correlation_run_id'] ?? null,
+                'orchestration_run_id' => $mtfRunDto->options['orchestration_run_id'] ?? null,
+                'orchestration_dashboard_id' => $mtfRunDto->options['orchestration_dashboard_id'] ?? null,
+                'orchestration_set_id' => $mtfRunDto->options['orchestration_set_id'] ?? null,
             ]);
 
         // 3. Construction via Builder (délégation) avec champs minimaux

--- a/trading-app/src/Repository/PositionTradeAnalysisRepository.php
+++ b/trading-app/src/Repository/PositionTradeAnalysisRepository.php
@@ -5,14 +5,38 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Service\PositionTradeAnalysisReaderInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
-final class PositionTradeAnalysisRepository extends ServiceEntityRepository
+final class PositionTradeAnalysisRepository extends ServiceEntityRepository implements PositionTradeAnalysisReaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PositionTradeAnalysis::class);
+    }
+
+    /**
+     * OBS-003 — toutes les lignes de la vue rattachées à un identifiant de corrélation
+     * (== `trade_lifecycle_event.run_id`), en lecture seule et bornée. `$setId` filtre
+     * en plus sur le set d'orchestration quand il est fourni.
+     *
+     * @return PositionTradeAnalysis[]
+     */
+    public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
+    {
+        $qb = $this->createQueryBuilder('pta')
+            ->andWhere('pta.runId = :rid')
+            ->setParameter('rid', $correlationRunId)
+            ->orderBy('pta.entryTime', 'ASC')
+            ->setMaxResults(max(1, $limit));
+
+        if ($setId !== null && $setId !== '') {
+            $qb->andWhere('pta.setId = :sid')
+                ->setParameter('sid', $setId);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 
     /**
@@ -52,12 +76,18 @@ final class PositionTradeAnalysisRepository extends ServiceEntityRepository
             $direction = 'DESC';
         }
 
+        // Alias de compat : la colonne `pnl_usdt` a été renommée `recorded_pnl_usdt`
+        // (OBS-003). On accepte encore l'ancien nom de tri côté reporting.
+        if ($sort === 'pnlUsdt') {
+            $sort = 'recordedPnlUsdt';
+        }
+
         $allowedSorts = [
             'entryTime',
             'closeTime',
             'expectedRMultiple',
             'pnlR',
-            'pnlUsdt',
+            'recordedPnlUsdt',
             'mfePct',
             'maePct',
         ];

--- a/trading-app/src/Repository/PositionTradeAnalysisRepository.php
+++ b/trading-app/src/Repository/PositionTradeAnalysisRepository.php
@@ -5,38 +5,18 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Trading\Entity\PositionTradeAnalysis;
-use App\Trading\Service\PositionTradeAnalysisReaderInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
-final class PositionTradeAnalysisRepository extends ServiceEntityRepository implements PositionTradeAnalysisReaderInterface
+/**
+ * Repository de la vue HISTORIQUE v1 (`position_trade_analysis`). Inchangé par OBS-003 v2
+ * — la lecture des outcomes passe par {@see PositionTradeAnalysisV2Repository}.
+ */
+final class PositionTradeAnalysisRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, PositionTradeAnalysis::class);
-    }
-
-    /**
-     * OBS-003 — toutes les lignes de la vue rattachées à un identifiant de corrélation
-     * (== `trade_lifecycle_event.run_id`), en lecture seule et bornée. `$setId` filtre
-     * en plus sur le set d'orchestration quand il est fourni.
-     *
-     * @return PositionTradeAnalysis[]
-     */
-    public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
-    {
-        $qb = $this->createQueryBuilder('pta')
-            ->andWhere('pta.runId = :rid')
-            ->setParameter('rid', $correlationRunId)
-            ->orderBy('pta.entryTime', 'ASC')
-            ->setMaxResults(max(1, $limit));
-
-        if ($setId !== null && $setId !== '') {
-            $qb->andWhere('pta.setId = :sid')
-                ->setParameter('sid', $setId);
-        }
-
-        return $qb->getQuery()->getResult();
     }
 
     /**
@@ -76,18 +56,12 @@ final class PositionTradeAnalysisRepository extends ServiceEntityRepository impl
             $direction = 'DESC';
         }
 
-        // Alias de compat : la colonne `pnl_usdt` a été renommée `recorded_pnl_usdt`
-        // (OBS-003). On accepte encore l'ancien nom de tri côté reporting.
-        if ($sort === 'pnlUsdt') {
-            $sort = 'recordedPnlUsdt';
-        }
-
         $allowedSorts = [
             'entryTime',
             'closeTime',
             'expectedRMultiple',
             'pnlR',
-            'recordedPnlUsdt',
+            'pnlUsdt',
             'mfePct',
             'maePct',
         ];

--- a/trading-app/src/Repository/PositionTradeAnalysisV2Repository.php
+++ b/trading-app/src/Repository/PositionTradeAnalysisV2Repository.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Trading\Entity\PositionTradeAnalysisV2;
+use App\Trading\Service\PositionTradeAnalysisReaderInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * OBS-003 — Repository de la vue versionnée `position_trade_analysis_v2`. Implémente la
+ * source de lecture des outcomes (lecture seule, bornée), distincte de la vue v1.
+ */
+final class PositionTradeAnalysisV2Repository extends ServiceEntityRepository implements PositionTradeAnalysisReaderInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, PositionTradeAnalysisV2::class);
+    }
+
+    /**
+     * @return PositionTradeAnalysisV2[]
+     */
+    public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
+    {
+        $qb = $this->createQueryBuilder('pta')
+            ->andWhere('pta.runId = :rid')
+            ->setParameter('rid', $correlationRunId)
+            ->orderBy('pta.entryTime', 'ASC')
+            ->setMaxResults(max(1, $limit));
+
+        if ($setId !== null && $setId !== '') {
+            $qb->andWhere('pta.setId = :sid')
+                ->setParameter('sid', $setId);
+        }
+
+        return $qb->getQuery()->getResult();
+    }
+}

--- a/trading-app/src/Trading/Controller/Api/PositionAnalysisApiController.php
+++ b/trading-app/src/Trading/Controller/Api/PositionAnalysisApiController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Controller\Api;
+
+use App\Trading\Service\PositionTradeOutcomeSourceException;
+use App\Trading\Service\RunCorrelationId;
+use App\Trading\Service\RunTradeOutcomeService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * OBS-003 — Endpoint read-only reliant un run d'orchestration à ses trades résultants.
+ *
+ * `GET /api/positions/analysis?run_id=…[&set_id=…]`. Le `run_id` reçu est l'identifiant
+ * ORIGINAL du run ; l'identifiant de corrélation canonique (≤64) est dérivé côté serveur,
+ * exactement comme côté Python ({@see RunCorrelationId}). Lecture seule, aucune écriture.
+ *
+ * Codes :
+ *  - 400 si `run_id` absent/vide ;
+ *  - 200 + agrégat (éventuellement vide, `trade_count = 0`) si la source répond ;
+ *  - 503 + `source_available = false` si la source est indisponible (jamais un 500, et
+ *    jamais un agrégat vide silencieux qui masquerait l'indisponibilité).
+ */
+final class PositionAnalysisApiController extends AbstractController
+{
+    public function __construct(
+        private readonly RunTradeOutcomeService $outcomeService,
+    ) {
+    }
+
+    #[Route('/api/positions/analysis', name: 'api_positions_analysis', methods: ['GET'])]
+    public function analysis(Request $request): JsonResponse
+    {
+        $runId = trim((string) $request->query->get('run_id', ''));
+        if ($runId === '') {
+            return $this->json([
+                'error' => 'missing_run_id',
+                'message' => 'Query parameter "run_id" is required.',
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        $setIdRaw = $request->query->get('set_id');
+        $setId = is_string($setIdRaw) && trim($setIdRaw) !== '' ? trim($setIdRaw) : null;
+
+        try {
+            $outcome = $this->outcomeService->buildOutcome($runId, $setId);
+        } catch (PositionTradeOutcomeSourceException $e) {
+            // Indisponibilité explicite — surtout pas confondue avec « 0 trade ».
+            return $this->json([
+                'run_id' => $runId,
+                'correlation_run_id' => RunCorrelationId::canonicalOrNull($runId),
+                'set_id' => $setId,
+                'source_available' => false,
+                'error' => 'source_unavailable',
+                'message' => 'position_trade_analysis source is currently unavailable.',
+            ], Response::HTTP_SERVICE_UNAVAILABLE);
+        }
+
+        return $this->json($outcome);
+    }
+}

--- a/trading-app/src/Trading/Entity/PositionTradeAnalysis.php
+++ b/trading-app/src/Trading/Entity/PositionTradeAnalysis.php
@@ -7,6 +7,16 @@ namespace App\Trading\Entity;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
+/**
+ * Vue en lecture seule `position_trade_analysis` (cf. Version20260622000000).
+ *
+ * OBS-003 v2 — la vue rapproche désormais une entrée (`order_submitted`) à sa clôture
+ * (`position_closed`) par identifiants EXACTS (`trade_id` puis `position_id`, jamais par
+ * symbole), et expose le lineage d'orchestration (`correlation_run_id`,
+ * `orchestration_run_id`, `dashboard_id`, `set_id`, `exchange`, `market_type`,
+ * `mtf_profile`) ainsi qu'une sémantique de PnL explicite (`recorded_pnl_usdt` vs
+ * `net_pnl_usdt` + `net_pnl_complete`).
+ */
 #[ORM\Entity(readOnly: true)]
 #[ORM\Table(name: 'position_trade_analysis')]
 class PositionTradeAnalysis
@@ -24,17 +34,57 @@ class PositionTradeAnalysis
     #[ORM\Column(type: Types::STRING, length: 10, nullable: true)]
     private ?string $timeframe = null;
 
+    // --- Lineage d'orchestration -------------------------------------------------
+
+    /** Identifiant de corrélation (== `trade_lifecycle_event.run_id`, VARCHAR(64)). */
     #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'run_id')]
     private ?string $runId = null;
 
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'correlation_run_id')]
+    private ?string $correlationRunId = null;
+
+    /** Identifiant original du run d'orchestration (peut dépasser 64 ; `extra`). */
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true, name: 'orchestration_run_id')]
+    private ?string $orchestrationRunId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'dashboard_id')]
+    private ?string $dashboardId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'set_id')]
+    private ?string $setId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $exchange = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true, name: 'market_type')]
+    private ?string $marketType = null;
+
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'mtf_profile')]
+    private ?string $mtfProfile = null;
+
     #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'trade_id')]
     private ?string $tradeId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'position_id')]
+    private ?string $positionId = null;
 
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, name: 'entry_time')]
     private \DateTimeImmutable $entryTime;
 
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true, name: 'close_time')]
     private ?\DateTimeImmutable $closeTime = null;
+
+    // --- Rapprochement entrée/clôture -------------------------------------------
+
+    /** `matched` si une clôture exacte est rattachée, sinon `unmatched`. */
+    #[ORM\Column(type: Types::STRING, length: 16, name: 'close_match_status')]
+    private string $closeMatchStatus = 'unmatched';
+
+    /** `matched_trade_id` | `matched_position_id` | `unmatched`. */
+    #[ORM\Column(type: Types::STRING, length: 32, name: 'close_matched_by')]
+    private string $closeMatchedBy = 'unmatched';
+
+    // --- Plan / sizing à l'entrée -----------------------------------------------
 
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'expected_r_multiple')]
     private ?float $expectedRMultiple = null;
@@ -72,11 +122,17 @@ class PositionTradeAnalysis
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_vwap')]
     private ?float $entryVwap = null;
 
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_R')]
+    // --- Résultat / PnL ----------------------------------------------------------
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_r')]
     private ?float $pnlR = null;
 
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_usdt')]
-    private ?float $pnlUsdt = null;
+    /**
+     * PnL ENREGISTRÉ tel quel par la source : on ne garantit PAS qu'il est net de tous
+     * les coûts (frais/funding/slippage). Voir {@see getNetPnlUsdt()}/{@see isNetPnlComplete()}.
+     */
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'recorded_pnl_usdt')]
+    private ?float $recordedPnlUsdt = null;
 
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_pct')]
     private ?float $pnlPct = null;
@@ -89,6 +145,22 @@ class PositionTradeAnalysis
 
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'holding_time_sec')]
     private ?float $holdingTimeSec = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'fees_usdt')]
+    private ?float $feesUsdt = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'funding_usdt')]
+    private ?float $fundingUsdt = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'slippage_usdt')]
+    private ?float $slippageUsdt = null;
+
+    /** PnL net UNIQUEMENT si recorded + tous les coûts sont présents, sinon `null`. */
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'net_pnl_usdt')]
+    private ?float $netPnlUsdt = null;
+
+    #[ORM\Column(type: Types::BOOLEAN, name: 'net_pnl_complete')]
+    private bool $netPnlComplete = false;
 
     public function getEntryEventId(): int
     {
@@ -115,9 +187,49 @@ class PositionTradeAnalysis
         return $this->runId;
     }
 
+    public function getCorrelationRunId(): ?string
+    {
+        return $this->correlationRunId;
+    }
+
+    public function getOrchestrationRunId(): ?string
+    {
+        return $this->orchestrationRunId;
+    }
+
+    public function getDashboardId(): ?string
+    {
+        return $this->dashboardId;
+    }
+
+    public function getSetId(): ?string
+    {
+        return $this->setId;
+    }
+
+    public function getExchange(): ?string
+    {
+        return $this->exchange;
+    }
+
+    public function getMarketType(): ?string
+    {
+        return $this->marketType;
+    }
+
+    public function getMtfProfile(): ?string
+    {
+        return $this->mtfProfile;
+    }
+
     public function getTradeId(): ?string
     {
         return $this->tradeId;
+    }
+
+    public function getPositionId(): ?string
+    {
+        return $this->positionId;
     }
 
     public function getEntryTime(): \DateTimeImmutable
@@ -128,6 +240,26 @@ class PositionTradeAnalysis
     public function getCloseTime(): ?\DateTimeImmutable
     {
         return $this->closeTime;
+    }
+
+    public function getCloseMatchStatus(): string
+    {
+        return $this->closeMatchStatus;
+    }
+
+    public function getCloseMatchedBy(): string
+    {
+        return $this->closeMatchedBy;
+    }
+
+    public function isClosed(): bool
+    {
+        return $this->closeEventId !== null;
+    }
+
+    public function isMatched(): bool
+    {
+        return $this->closeMatchStatus === 'matched';
     }
 
     public function getExpectedRMultiple(): ?float
@@ -195,9 +327,20 @@ class PositionTradeAnalysis
         return $this->pnlR;
     }
 
+    public function getRecordedPnlUsdt(): ?float
+    {
+        return $this->recordedPnlUsdt;
+    }
+
+    /**
+     * Alias de compatibilité ascendante pour les consommateurs existants (template Twig
+     * de reporting). Renvoie le PnL ENREGISTRÉ — pas garanti net (cf. {@see getNetPnlUsdt()}).
+     *
+     * @deprecated Utiliser {@see getRecordedPnlUsdt()} (ou {@see getNetPnlUsdt()}).
+     */
     public function getPnlUsdt(): ?float
     {
-        return $this->pnlUsdt;
+        return $this->recordedPnlUsdt;
     }
 
     public function getPnlPct(): ?float
@@ -218,5 +361,30 @@ class PositionTradeAnalysis
     public function getHoldingTimeSec(): ?float
     {
         return $this->holdingTimeSec;
+    }
+
+    public function getFeesUsdt(): ?float
+    {
+        return $this->feesUsdt;
+    }
+
+    public function getFundingUsdt(): ?float
+    {
+        return $this->fundingUsdt;
+    }
+
+    public function getSlippageUsdt(): ?float
+    {
+        return $this->slippageUsdt;
+    }
+
+    public function getNetPnlUsdt(): ?float
+    {
+        return $this->netPnlUsdt;
+    }
+
+    public function isNetPnlComplete(): bool
+    {
+        return $this->netPnlComplete;
     }
 }

--- a/trading-app/src/Trading/Entity/PositionTradeAnalysis.php
+++ b/trading-app/src/Trading/Entity/PositionTradeAnalysis.php
@@ -8,14 +8,12 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * Vue en lecture seule `position_trade_analysis` (cf. Version20260622000000).
+ * Vue HISTORIQUE `position_trade_analysis` (v1, cf. Version20251129000000).
  *
- * OBS-003 v2 — la vue rapproche désormais une entrée (`order_submitted`) à sa clôture
- * (`position_closed`) par identifiants EXACTS (`trade_id` puis `position_id`, jamais par
- * symbole), et expose le lineage d'orchestration (`correlation_run_id`,
- * `orchestration_run_id`, `dashboard_id`, `set_id`, `exchange`, `market_type`,
- * `mtf_profile`) ainsi qu'une sémantique de PnL explicite (`recorded_pnl_usdt` vs
- * `net_pnl_usdt` + `net_pnl_complete`).
+ * OBS-003 v2 ne modifie PAS cette vue : la nouvelle logique de rapprochement et le
+ * contrat PnL fiable vivent dans `position_trade_analysis_v2` ({@see PositionTradeAnalysisV2})
+ * afin de permettre la comparaison v1/v2, le rollback et de ne pas casser les
+ * consommateurs existants (reporting Twig). Migration de bascule documentée (issue #190).
  */
 #[ORM\Entity(readOnly: true)]
 #[ORM\Table(name: 'position_trade_analysis')]
@@ -34,57 +32,17 @@ class PositionTradeAnalysis
     #[ORM\Column(type: Types::STRING, length: 10, nullable: true)]
     private ?string $timeframe = null;
 
-    // --- Lineage d'orchestration -------------------------------------------------
-
-    /** Identifiant de corrélation (== `trade_lifecycle_event.run_id`, VARCHAR(64)). */
     #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'run_id')]
     private ?string $runId = null;
 
-    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'correlation_run_id')]
-    private ?string $correlationRunId = null;
-
-    /** Identifiant original du run d'orchestration (peut dépasser 64 ; `extra`). */
-    #[ORM\Column(type: Types::STRING, length: 255, nullable: true, name: 'orchestration_run_id')]
-    private ?string $orchestrationRunId = null;
-
-    #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'dashboard_id')]
-    private ?string $dashboardId = null;
-
-    #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'set_id')]
-    private ?string $setId = null;
-
-    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
-    private ?string $exchange = null;
-
-    #[ORM\Column(type: Types::STRING, length: 32, nullable: true, name: 'market_type')]
-    private ?string $marketType = null;
-
-    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'mtf_profile')]
-    private ?string $mtfProfile = null;
-
     #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'trade_id')]
     private ?string $tradeId = null;
-
-    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'position_id')]
-    private ?string $positionId = null;
 
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, name: 'entry_time')]
     private \DateTimeImmutable $entryTime;
 
     #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true, name: 'close_time')]
     private ?\DateTimeImmutable $closeTime = null;
-
-    // --- Rapprochement entrée/clôture -------------------------------------------
-
-    /** `matched` si une clôture exacte est rattachée, sinon `unmatched`. */
-    #[ORM\Column(type: Types::STRING, length: 16, name: 'close_match_status')]
-    private string $closeMatchStatus = 'unmatched';
-
-    /** `matched_trade_id` | `matched_position_id` | `unmatched`. */
-    #[ORM\Column(type: Types::STRING, length: 32, name: 'close_matched_by')]
-    private string $closeMatchedBy = 'unmatched';
-
-    // --- Plan / sizing à l'entrée -----------------------------------------------
 
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'expected_r_multiple')]
     private ?float $expectedRMultiple = null;
@@ -122,17 +80,11 @@ class PositionTradeAnalysis
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_vwap')]
     private ?float $entryVwap = null;
 
-    // --- Résultat / PnL ----------------------------------------------------------
-
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_r')]
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_R')]
     private ?float $pnlR = null;
 
-    /**
-     * PnL ENREGISTRÉ tel quel par la source : on ne garantit PAS qu'il est net de tous
-     * les coûts (frais/funding/slippage). Voir {@see getNetPnlUsdt()}/{@see isNetPnlComplete()}.
-     */
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'recorded_pnl_usdt')]
-    private ?float $recordedPnlUsdt = null;
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_usdt')]
+    private ?float $pnlUsdt = null;
 
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_pct')]
     private ?float $pnlPct = null;
@@ -145,22 +97,6 @@ class PositionTradeAnalysis
 
     #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'holding_time_sec')]
     private ?float $holdingTimeSec = null;
-
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'fees_usdt')]
-    private ?float $feesUsdt = null;
-
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'funding_usdt')]
-    private ?float $fundingUsdt = null;
-
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'slippage_usdt')]
-    private ?float $slippageUsdt = null;
-
-    /** PnL net UNIQUEMENT si recorded + tous les coûts sont présents, sinon `null`. */
-    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'net_pnl_usdt')]
-    private ?float $netPnlUsdt = null;
-
-    #[ORM\Column(type: Types::BOOLEAN, name: 'net_pnl_complete')]
-    private bool $netPnlComplete = false;
 
     public function getEntryEventId(): int
     {
@@ -187,49 +123,9 @@ class PositionTradeAnalysis
         return $this->runId;
     }
 
-    public function getCorrelationRunId(): ?string
-    {
-        return $this->correlationRunId;
-    }
-
-    public function getOrchestrationRunId(): ?string
-    {
-        return $this->orchestrationRunId;
-    }
-
-    public function getDashboardId(): ?string
-    {
-        return $this->dashboardId;
-    }
-
-    public function getSetId(): ?string
-    {
-        return $this->setId;
-    }
-
-    public function getExchange(): ?string
-    {
-        return $this->exchange;
-    }
-
-    public function getMarketType(): ?string
-    {
-        return $this->marketType;
-    }
-
-    public function getMtfProfile(): ?string
-    {
-        return $this->mtfProfile;
-    }
-
     public function getTradeId(): ?string
     {
         return $this->tradeId;
-    }
-
-    public function getPositionId(): ?string
-    {
-        return $this->positionId;
     }
 
     public function getEntryTime(): \DateTimeImmutable
@@ -240,26 +136,6 @@ class PositionTradeAnalysis
     public function getCloseTime(): ?\DateTimeImmutable
     {
         return $this->closeTime;
-    }
-
-    public function getCloseMatchStatus(): string
-    {
-        return $this->closeMatchStatus;
-    }
-
-    public function getCloseMatchedBy(): string
-    {
-        return $this->closeMatchedBy;
-    }
-
-    public function isClosed(): bool
-    {
-        return $this->closeEventId !== null;
-    }
-
-    public function isMatched(): bool
-    {
-        return $this->closeMatchStatus === 'matched';
     }
 
     public function getExpectedRMultiple(): ?float
@@ -327,20 +203,9 @@ class PositionTradeAnalysis
         return $this->pnlR;
     }
 
-    public function getRecordedPnlUsdt(): ?float
-    {
-        return $this->recordedPnlUsdt;
-    }
-
-    /**
-     * Alias de compatibilité ascendante pour les consommateurs existants (template Twig
-     * de reporting). Renvoie le PnL ENREGISTRÉ — pas garanti net (cf. {@see getNetPnlUsdt()}).
-     *
-     * @deprecated Utiliser {@see getRecordedPnlUsdt()} (ou {@see getNetPnlUsdt()}).
-     */
     public function getPnlUsdt(): ?float
     {
-        return $this->recordedPnlUsdt;
+        return $this->pnlUsdt;
     }
 
     public function getPnlPct(): ?float
@@ -361,30 +226,5 @@ class PositionTradeAnalysis
     public function getHoldingTimeSec(): ?float
     {
         return $this->holdingTimeSec;
-    }
-
-    public function getFeesUsdt(): ?float
-    {
-        return $this->feesUsdt;
-    }
-
-    public function getFundingUsdt(): ?float
-    {
-        return $this->fundingUsdt;
-    }
-
-    public function getSlippageUsdt(): ?float
-    {
-        return $this->slippageUsdt;
-    }
-
-    public function getNetPnlUsdt(): ?float
-    {
-        return $this->netPnlUsdt;
-    }
-
-    public function isNetPnlComplete(): bool
-    {
-        return $this->netPnlComplete;
     }
 }

--- a/trading-app/src/Trading/Entity/PositionTradeAnalysisV2.php
+++ b/trading-app/src/Trading/Entity/PositionTradeAnalysisV2.php
@@ -1,0 +1,397 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Vue VERSIONNÉE en lecture seule `position_trade_analysis_v2` (OBS-003 v2,
+ * cf. Version20260622000000). Coexiste avec la vue historique v1 (issue #190, bascule
+ * progressive) : rapprochement entrée/clôture par identifiants EXACTS (trade_id puis
+ * position_id, jamais par symbole), lineage d'orchestration, statut de qualité et
+ * contrat PnL EXPLICITE.
+ *
+ * Contrat PnL (issue #190) — on ne présente JAMAIS une valeur estimée comme certifiée :
+ *  - `recorded_pnl_usdt` : valeur enregistrée par la source (PAS garantie brute ni nette) ;
+ *  - `estimated_net_pnl_usdt` : ESTIMATION best-effort (`recorded - fees - funding -
+ *    slippage`) calculée uniquement quand ces composantes sont présentes ;
+ *  - `cost_completeness` : `not_applicable` (pas de clôture) | `unknown` (clôturé sans
+ *    aucune composante de coût) | `partial` (certaines composantes, mais le contrat #190
+ *    complet — brut + frais entrée/sortie séparés + spread + funding signé + borrow —
+ *    n'est pas atteignable avec les producteurs actuels) | `complete` (réservé au
+ *    contrat #190 complet, jamais émis tant que les producteurs ne le fournissent pas).
+ *  Il n'existe donc PAS de `net_pnl_usdt` certifié dans cette vue.
+ */
+#[ORM\Entity(readOnly: true)]
+#[ORM\Table(name: 'position_trade_analysis_v2')]
+class PositionTradeAnalysisV2
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::BIGINT, name: 'entry_event_id')]
+    private int $entryEventId;
+
+    #[ORM\Column(type: Types::BIGINT, name: 'close_event_id', nullable: true)]
+    private ?int $closeEventId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::STRING, length: 10, nullable: true)]
+    private ?string $timeframe = null;
+
+    // --- Lineage d'orchestration -------------------------------------------------
+
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'run_id')]
+    private ?string $runId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'correlation_run_id')]
+    private ?string $correlationRunId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 255, nullable: true, name: 'orchestration_run_id')]
+    private ?string $orchestrationRunId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'dashboard_id')]
+    private ?string $dashboardId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'set_id')]
+    private ?string $setId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true)]
+    private ?string $exchange = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, nullable: true, name: 'market_type')]
+    private ?string $marketType = null;
+
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'mtf_profile')]
+    private ?string $mtfProfile = null;
+
+    #[ORM\Column(type: Types::STRING, length: 128, nullable: true, name: 'trade_id')]
+    private ?string $tradeId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 64, nullable: true, name: 'position_id')]
+    private ?string $positionId = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, name: 'entry_time')]
+    private \DateTimeImmutable $entryTime;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true, name: 'close_time')]
+    private ?\DateTimeImmutable $closeTime = null;
+
+    // --- Rapprochement & qualité -------------------------------------------------
+
+    #[ORM\Column(type: Types::STRING, length: 16, name: 'close_match_status')]
+    private string $closeMatchStatus = 'unmatched';
+
+    #[ORM\Column(type: Types::STRING, length: 32, name: 'close_matched_by')]
+    private string $closeMatchedBy = 'unmatched';
+
+    /** `matched_closed` | `unmatched` (état réel inconnu : ni ouvert confirmé ni clôturé certifié). */
+    #[ORM\Column(type: Types::STRING, length: 32, name: 'analysis_status')]
+    private string $analysisStatus = 'unmatched';
+
+    // --- Plan / sizing à l'entrée -----------------------------------------------
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'expected_r_multiple')]
+    private ?float $expectedRMultiple = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'risk_usdt')]
+    private ?float $riskUsdt = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'notional_usdt')]
+    private ?float $notionalUsdt = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'atr_pct_entry')]
+    private ?float $atrPctEntry = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_volume_ratio')]
+    private ?float $entryVolumeRatio = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE, nullable: true, name: 'snapshot_kline_time')]
+    private ?\DateTimeImmutable $snapshotKlineTime = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_rsi')]
+    private ?float $entryRsi = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_atr')]
+    private ?float $entryAtr = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_macd')]
+    private ?float $entryMacd = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_ma9')]
+    private ?float $entryMa9 = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_ma21')]
+    private ?float $entryMa21 = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'entry_vwap')]
+    private ?float $entryVwap = null;
+
+    // --- Résultat / PnL (contrat explicite, jamais de net certifié) --------------
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_r')]
+    private ?float $pnlR = null;
+
+    /** Valeur ENREGISTRÉE telle quelle — ni brute ni nette garanties (issue #190). */
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'recorded_pnl_usdt')]
+    private ?float $recordedPnlUsdt = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'pnl_pct')]
+    private ?float $pnlPct = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'mfe_pct')]
+    private ?float $mfePct = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'mae_pct')]
+    private ?float $maePct = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'holding_time_sec')]
+    private ?float $holdingTimeSec = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'fees_usdt')]
+    private ?float $feesUsdt = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'funding_usdt')]
+    private ?float $fundingUsdt = null;
+
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'slippage_usdt')]
+    private ?float $slippageUsdt = null;
+
+    /** ESTIMATION best-effort, jamais certifiée (cf. {@see getCostCompleteness()}). */
+    #[ORM\Column(type: Types::FLOAT, nullable: true, name: 'estimated_net_pnl_usdt')]
+    private ?float $estimatedNetPnlUsdt = null;
+
+    /** `not_applicable` | `unknown` | `partial` | `complete` (jamais `complete` à ce stade). */
+    #[ORM\Column(type: Types::STRING, length: 16, name: 'cost_completeness')]
+    private string $costCompleteness = 'unknown';
+
+    public function getEntryEventId(): int
+    {
+        return $this->entryEventId;
+    }
+
+    public function getCloseEventId(): ?int
+    {
+        return $this->closeEventId;
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function getTimeframe(): ?string
+    {
+        return $this->timeframe;
+    }
+
+    public function getRunId(): ?string
+    {
+        return $this->runId;
+    }
+
+    public function getCorrelationRunId(): ?string
+    {
+        return $this->correlationRunId;
+    }
+
+    public function getOrchestrationRunId(): ?string
+    {
+        return $this->orchestrationRunId;
+    }
+
+    public function getDashboardId(): ?string
+    {
+        return $this->dashboardId;
+    }
+
+    public function getSetId(): ?string
+    {
+        return $this->setId;
+    }
+
+    public function getExchange(): ?string
+    {
+        return $this->exchange;
+    }
+
+    public function getMarketType(): ?string
+    {
+        return $this->marketType;
+    }
+
+    public function getMtfProfile(): ?string
+    {
+        return $this->mtfProfile;
+    }
+
+    public function getTradeId(): ?string
+    {
+        return $this->tradeId;
+    }
+
+    public function getPositionId(): ?string
+    {
+        return $this->positionId;
+    }
+
+    public function getEntryTime(): \DateTimeImmutable
+    {
+        return $this->entryTime;
+    }
+
+    public function getCloseTime(): ?\DateTimeImmutable
+    {
+        return $this->closeTime;
+    }
+
+    public function getCloseMatchStatus(): string
+    {
+        return $this->closeMatchStatus;
+    }
+
+    public function getCloseMatchedBy(): string
+    {
+        return $this->closeMatchedBy;
+    }
+
+    public function getAnalysisStatus(): string
+    {
+        return $this->analysisStatus;
+    }
+
+    /** Clôture rapprochée par identifiant exact (la seule base d'un trade certifié). */
+    public function isMatchedClosed(): bool
+    {
+        return $this->closeEventId !== null && $this->closeMatchStatus === 'matched';
+    }
+
+    public function isUnmatched(): bool
+    {
+        return !$this->isMatchedClosed();
+    }
+
+    public function getExpectedRMultiple(): ?float
+    {
+        return $this->expectedRMultiple;
+    }
+
+    public function getRiskUsdt(): ?float
+    {
+        return $this->riskUsdt;
+    }
+
+    public function getNotionalUsdt(): ?float
+    {
+        return $this->notionalUsdt;
+    }
+
+    public function getAtrPctEntry(): ?float
+    {
+        return $this->atrPctEntry;
+    }
+
+    public function getEntryVolumeRatio(): ?float
+    {
+        return $this->entryVolumeRatio;
+    }
+
+    public function getSnapshotKlineTime(): ?\DateTimeImmutable
+    {
+        return $this->snapshotKlineTime;
+    }
+
+    public function getEntryRsi(): ?float
+    {
+        return $this->entryRsi;
+    }
+
+    public function getEntryAtr(): ?float
+    {
+        return $this->entryAtr;
+    }
+
+    public function getEntryMacd(): ?float
+    {
+        return $this->entryMacd;
+    }
+
+    public function getEntryMa9(): ?float
+    {
+        return $this->entryMa9;
+    }
+
+    public function getEntryMa21(): ?float
+    {
+        return $this->entryMa21;
+    }
+
+    public function getEntryVwap(): ?float
+    {
+        return $this->entryVwap;
+    }
+
+    public function getPnlR(): ?float
+    {
+        return $this->pnlR;
+    }
+
+    public function getRecordedPnlUsdt(): ?float
+    {
+        return $this->recordedPnlUsdt;
+    }
+
+    public function getPnlPct(): ?float
+    {
+        return $this->pnlPct;
+    }
+
+    public function getMfePct(): ?float
+    {
+        return $this->mfePct;
+    }
+
+    public function getMaePct(): ?float
+    {
+        return $this->maePct;
+    }
+
+    public function getHoldingTimeSec(): ?float
+    {
+        return $this->holdingTimeSec;
+    }
+
+    public function getFeesUsdt(): ?float
+    {
+        return $this->feesUsdt;
+    }
+
+    public function getFundingUsdt(): ?float
+    {
+        return $this->fundingUsdt;
+    }
+
+    public function getSlippageUsdt(): ?float
+    {
+        return $this->slippageUsdt;
+    }
+
+    public function getEstimatedNetPnlUsdt(): ?float
+    {
+        return $this->estimatedNetPnlUsdt;
+    }
+
+    public function getCostCompleteness(): string
+    {
+        return $this->costCompleteness;
+    }
+
+    /** Coûts au contrat #190 complet — jamais vrai tant que les producteurs ne le fournissent pas. */
+    public function isCostComplete(): bool
+    {
+        return $this->costCompleteness === 'complete';
+    }
+}

--- a/trading-app/src/Trading/Orchestration/OrchestrationContextException.php
+++ b/trading-app/src/Trading/Orchestration/OrchestrationContextException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Orchestration;
+
+/**
+ * OBS-003 — Incohérence détectée dans le contexte d'orchestration d'une requête
+ * `/api/mtf/run` (en-têtes vs payload, ou champs contradictoires du payload).
+ *
+ * Fail-closed : plutôt que d'accepter silencieusement une requête contradictoire (et de
+ * tracer un lineage faux), on refuse avec un code d'erreur STABLE. Le contrôleur traduit
+ * en HTTP 422. Le chemin legacy (sans en-têtes ni doublons) ne déclenche aucun contrôle.
+ */
+final class OrchestrationContextException extends \RuntimeException
+{
+    public function __construct(
+        public readonly string $errorCode,
+        string $message,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
+++ b/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
@@ -53,6 +53,21 @@ final class OrchestrationContextValidator
                 sprintf('run_id (%s) et original_run_id (%s) du payload sont contradictoires.', $bodyRun, $bodyRunOriginal),
             );
         }
+        // L'en-tête X-Run-Id doit aussi correspondre aux alias run_id du payload AVANT le
+        // coalescing (comme les contrôles set/dashboard en-tête vs corps). Sans cela,
+        // `X-Run-Id=runA` + `run_id=runB` (sans correlation) serait silencieusement coalescé
+        // sur l'en-tête : les lignes lifecycle seraient enregistrées sous `runA` alors que le
+        // payload nomme `runB` — incohérence vérifiable qui doit fail-closed (et non passer).
+        if ($runIdHeader !== null) {
+            foreach (['run_id' => $bodyRun, 'original_run_id' => $bodyRunOriginal] as $field => $value) {
+                if ($value !== null && $runIdHeader !== $value) {
+                    throw new OrchestrationContextException(
+                        'ORCHESTRATION_CORRELATION_MISMATCH',
+                        sprintf('X-Run-Id (%s) contredit %s du payload (%s).', $runIdHeader, $field, $value),
+                    );
+                }
+            }
+        }
         $effectiveRunId = $runIdHeader ?? $bodyRun ?? $bodyRunOriginal;
 
         $bodyCorrelation = self::clean($data['correlation_run_id'] ?? null);

--- a/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
+++ b/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Trading\Orchestration;
 
+use App\Provider\Context\ExchangeContextResolver;
 use App\Trading\Service\RunCorrelationId;
 
 /**
@@ -95,18 +96,40 @@ final class OrchestrationContextValidator
             );
         }
 
-        // 6. market_type vs type_contract (alias du même champ).
-        $marketType = self::cleanLower($data['market_type'] ?? null);
-        $typeContract = self::cleanLower($data['type_contract'] ?? null);
-        if ($marketType !== null && $typeContract !== null && $marketType !== $typeContract) {
-            throw new OrchestrationContextException(
-                'ORCHESTRATION_MARKET_TYPE_MISMATCH',
-                sprintf(
-                    'market_type (%s) et type_contract (%s) du payload sont contradictoires.',
-                    $marketType,
-                    $typeContract,
-                ),
-            );
+        // 6. market_type vs type_contract (alias du même champ). On NORMALISE les deux
+        // via ExchangeContextResolver (perp/future/futures ≡ perpetual) AVANT de comparer,
+        // pour ne pas rejeter des alias pourtant équivalents (compat clients legacy qui
+        // envoient les deux champs). Une valeur invalide reste refusée fail-closed.
+        $marketType = self::clean($data['market_type'] ?? null);
+        $typeContract = self::clean($data['type_contract'] ?? null);
+        if ($marketType !== null && $typeContract !== null) {
+            try {
+                $normalizedMarket = ExchangeContextResolver::normalizeMarketType($marketType);
+                $normalizedContract = ExchangeContextResolver::normalizeMarketType($typeContract);
+            } catch (\InvalidArgumentException $e) {
+                throw new OrchestrationContextException(
+                    'ORCHESTRATION_MARKET_TYPE_MISMATCH',
+                    sprintf(
+                        'Type de marché invalide entre market_type (%s) et type_contract (%s) : %s',
+                        $marketType,
+                        $typeContract,
+                        $e->getMessage(),
+                    ),
+                );
+            }
+
+            if ($normalizedMarket !== $normalizedContract) {
+                throw new OrchestrationContextException(
+                    'ORCHESTRATION_MARKET_TYPE_MISMATCH',
+                    sprintf(
+                        'market_type (%s) et type_contract (%s) du payload sont contradictoires (%s vs %s).',
+                        $marketType,
+                        $typeContract,
+                        $normalizedMarket->value,
+                        $normalizedContract->value,
+                    ),
+                );
+            }
         }
     }
 

--- a/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
+++ b/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
@@ -54,8 +54,19 @@ final class OrchestrationContextValidator
             }
         }
 
-        // 2. set_id : en-tête vs payload.
-        $setBody = self::clean($data['set_id'] ?? $data['orchestration_set_id'] ?? null);
+        // 2. set_id : d'abord les DEUX alias du payload entre eux (set_id vs
+        // orchestration_set_id), puis l'en-tête vs le payload. Sans ce contrôle inter-alias,
+        // deux valeurs contradictoires seraient silencieusement coalescées (mauvaise
+        // attribution du set), alors que le validateur doit fail-closed.
+        $setShort = self::clean($data['set_id'] ?? null);
+        $setLong = self::clean($data['orchestration_set_id'] ?? null);
+        if ($setShort !== null && $setLong !== null && $setShort !== $setLong) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_SET_MISMATCH',
+                sprintf('set_id (%s) et orchestration_set_id (%s) du payload sont contradictoires.', $setShort, $setLong),
+            );
+        }
+        $setBody = $setShort ?? $setLong;
         if ($setHeader !== null && $setBody !== null && $setHeader !== $setBody) {
             throw new OrchestrationContextException(
                 'ORCHESTRATION_SET_MISMATCH',
@@ -63,8 +74,20 @@ final class OrchestrationContextValidator
             );
         }
 
-        // 3. dashboard_id : en-tête vs payload.
-        $dashboardBody = self::clean($data['dashboard_id'] ?? $data['orchestration_dashboard_id'] ?? null);
+        // 3. dashboard_id : idem — alias du payload entre eux, puis en-tête vs payload.
+        $dashboardShort = self::clean($data['dashboard_id'] ?? null);
+        $dashboardLong = self::clean($data['orchestration_dashboard_id'] ?? null);
+        if ($dashboardShort !== null && $dashboardLong !== null && $dashboardShort !== $dashboardLong) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_DASHBOARD_MISMATCH',
+                sprintf(
+                    'dashboard_id (%s) et orchestration_dashboard_id (%s) du payload sont contradictoires.',
+                    $dashboardShort,
+                    $dashboardLong,
+                ),
+            );
+        }
+        $dashboardBody = $dashboardShort ?? $dashboardLong;
         if ($dashboardHeader !== null && $dashboardBody !== null && $dashboardHeader !== $dashboardBody) {
             throw new OrchestrationContextException(
                 'ORCHESTRATION_DASHBOARD_MISMATCH',

--- a/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
+++ b/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
@@ -39,15 +39,43 @@ final class OrchestrationContextValidator
         $setHeader = self::clean($setHeader);
         $dashboardHeader = self::clean($dashboardHeader);
 
-        // 1. L'identifiant de corrélation fourni doit correspondre au X-Run-Id canonique.
-        if ($runIdHeader !== null && $correlationHeader !== null) {
-            $expected = RunCorrelationId::canonical($runIdHeader);
-            if (!hash_equals($expected, $correlationHeader)) {
+        // 1. Identifiant de corrélation : il doit correspondre à la forme canonique du
+        // run_id ORIGINAL, que les valeurs viennent des EN-TÊTES ou du CORPS (chemin
+        // body-only). Le `RunnerController` transmet désormais `run_id`/`correlation_run_id`
+        // du payload ; sans ce contrôle, un payload `run_id=runA` + `correlation_run_id=runB`
+        // serait accepté et les lignes lifecycle enregistrées sous `canonical(runA)`,
+        // contredisant le 422 annoncé pour une incohérence vérifiable.
+        $bodyRun = self::clean($data['run_id'] ?? null);
+        $bodyRunOriginal = self::clean($data['original_run_id'] ?? null);
+        if ($bodyRun !== null && $bodyRunOriginal !== null && $bodyRun !== $bodyRunOriginal) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_CORRELATION_MISMATCH',
+                sprintf('run_id (%s) et original_run_id (%s) du payload sont contradictoires.', $bodyRun, $bodyRunOriginal),
+            );
+        }
+        $effectiveRunId = $runIdHeader ?? $bodyRun ?? $bodyRunOriginal;
+
+        $bodyCorrelation = self::clean($data['correlation_run_id'] ?? null);
+        if ($correlationHeader !== null && $bodyCorrelation !== null && !hash_equals($correlationHeader, $bodyCorrelation)) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_CORRELATION_MISMATCH',
+                sprintf(
+                    'X-Run-Correlation-Id (%s) contredit correlation_run_id du payload (%s).',
+                    $correlationHeader,
+                    $bodyCorrelation,
+                ),
+            );
+        }
+        $effectiveCorrelation = $correlationHeader ?? $bodyCorrelation;
+
+        if ($effectiveRunId !== null && $effectiveCorrelation !== null) {
+            $expected = RunCorrelationId::canonical($effectiveRunId);
+            if (!hash_equals($expected, $effectiveCorrelation)) {
                 throw new OrchestrationContextException(
                     'ORCHESTRATION_CORRELATION_MISMATCH',
                     sprintf(
-                        'X-Run-Correlation-Id (%s) ne correspond pas à la forme canonique de X-Run-Id (%s).',
-                        $correlationHeader,
+                        'L\'identifiant de corrélation (%s) ne correspond pas à la forme canonique du run_id (%s).',
+                        $effectiveCorrelation,
                         $expected,
                     ),
                 );

--- a/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
+++ b/trading-app/src/Trading/Orchestration/OrchestrationContextValidator.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Orchestration;
+
+use App\Trading\Service\RunCorrelationId;
+
+/**
+ * OBS-003 — Validation fail-closed du contexte d'orchestration d'une requête
+ * `/api/mtf/run`. Symfony ne connaît pas la topologie dashboard/set de l'orchestrateur ;
+ * il ne peut donc valider que les **contradictions présentes dans la requête elle-même**.
+ * On contrôle ce qui est vérifiable et on refuse les incohérences avec un code stable.
+ *
+ * Limite documentée : la relation set ⇄ dashboard (un set appartient-il bien au dashboard
+ * annoncé ?) nécessite les données de l'orchestrateur et n'est PAS vérifiable côté Symfony.
+ * Elle reste de la responsabilité de l'orchestrateur (qui émet des en-têtes cohérents).
+ *
+ * Aucun contrôle n'est déclenché pour le chemin legacy (ni en-têtes, ni doublons) :
+ * l'absence d'en-tête conserve le comportement historique (UUID généré en aval).
+ */
+final class OrchestrationContextValidator
+{
+    /**
+     * @param array<string,mixed> $data Corps de la requête déjà normalisé en tableau.
+     *
+     * @throws OrchestrationContextException si une incohérence vérifiable est détectée.
+     */
+    public function validate(
+        ?string $runIdHeader,
+        ?string $correlationHeader,
+        ?string $setHeader,
+        ?string $dashboardHeader,
+        array $data,
+    ): void {
+        $runIdHeader = self::clean($runIdHeader);
+        $correlationHeader = self::clean($correlationHeader);
+        $setHeader = self::clean($setHeader);
+        $dashboardHeader = self::clean($dashboardHeader);
+
+        // 1. L'identifiant de corrélation fourni doit correspondre au X-Run-Id canonique.
+        if ($runIdHeader !== null && $correlationHeader !== null) {
+            $expected = RunCorrelationId::canonical($runIdHeader);
+            if (!hash_equals($expected, $correlationHeader)) {
+                throw new OrchestrationContextException(
+                    'ORCHESTRATION_CORRELATION_MISMATCH',
+                    sprintf(
+                        'X-Run-Correlation-Id (%s) ne correspond pas à la forme canonique de X-Run-Id (%s).',
+                        $correlationHeader,
+                        $expected,
+                    ),
+                );
+            }
+        }
+
+        // 2. set_id : en-tête vs payload.
+        $setBody = self::clean($data['set_id'] ?? $data['orchestration_set_id'] ?? null);
+        if ($setHeader !== null && $setBody !== null && $setHeader !== $setBody) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_SET_MISMATCH',
+                sprintf('X-Orchestration-Set-Id (%s) contredit set_id du payload (%s).', $setHeader, $setBody),
+            );
+        }
+
+        // 3. dashboard_id : en-tête vs payload.
+        $dashboardBody = self::clean($data['dashboard_id'] ?? $data['orchestration_dashboard_id'] ?? null);
+        if ($dashboardHeader !== null && $dashboardBody !== null && $dashboardHeader !== $dashboardBody) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_DASHBOARD_MISMATCH',
+                sprintf(
+                    'X-Orchestration-Dashboard-Id (%s) contredit dashboard_id du payload (%s).',
+                    $dashboardHeader,
+                    $dashboardBody,
+                ),
+            );
+        }
+
+        // 4. profile vs mtf_profile (deux sources du même profil dans le payload).
+        $profile = self::clean($data['profile'] ?? null);
+        $mtfProfile = self::clean($data['mtf_profile'] ?? null);
+        if ($profile !== null && $mtfProfile !== null && strcasecmp($profile, $mtfProfile) !== 0) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_PROFILE_MISMATCH',
+                sprintf('profile (%s) et mtf_profile (%s) du payload sont contradictoires.', $profile, $mtfProfile),
+            );
+        }
+
+        // 5. exchange vs cex (alias du même champ).
+        $exchange = self::cleanLower($data['exchange'] ?? null);
+        $cex = self::cleanLower($data['cex'] ?? null);
+        if ($exchange !== null && $cex !== null && $exchange !== $cex) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_EXCHANGE_MISMATCH',
+                sprintf('exchange (%s) et cex (%s) du payload sont contradictoires.', $exchange, $cex),
+            );
+        }
+
+        // 6. market_type vs type_contract (alias du même champ).
+        $marketType = self::cleanLower($data['market_type'] ?? null);
+        $typeContract = self::cleanLower($data['type_contract'] ?? null);
+        if ($marketType !== null && $typeContract !== null && $marketType !== $typeContract) {
+            throw new OrchestrationContextException(
+                'ORCHESTRATION_MARKET_TYPE_MISMATCH',
+                sprintf(
+                    'market_type (%s) et type_contract (%s) du payload sont contradictoires.',
+                    $marketType,
+                    $typeContract,
+                ),
+            );
+        }
+    }
+
+    private static function clean(mixed $value): ?string
+    {
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
+    }
+
+    private static function cleanLower(mixed $value): ?string
+    {
+        $clean = self::clean($value);
+
+        return $clean !== null ? strtolower($clean) : null;
+    }
+}

--- a/trading-app/src/Trading/Service/PositionTradeAnalysisReaderInterface.php
+++ b/trading-app/src/Trading/Service/PositionTradeAnalysisReaderInterface.php
@@ -4,22 +4,22 @@ declare(strict_types=1);
 
 namespace App\Trading\Service;
 
-use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Entity\PositionTradeAnalysisV2;
 
 /**
- * OBS-003 — Source de lecture des trades d'un run (`position_trade_analysis`).
+ * OBS-003 — Source de lecture des trades d'un run (vue `position_trade_analysis_v2`).
  *
  * Découple {@see RunTradeOutcomeService} de l'implémentation Doctrine concrète
  * (repository `final`, non doublable) : les tests fournissent un stub, le runtime
- * câble la vraie {@see \App\Repository\PositionTradeAnalysisRepository}.
+ * câble la vraie {@see \App\Repository\PositionTradeAnalysisV2Repository}.
  */
 interface PositionTradeAnalysisReaderInterface
 {
     /**
-     * Toutes les lignes de la vue rattachées à un `run_id` de corrélation (lecture
+     * Toutes les lignes de la vue v2 rattachées à un `run_id` de corrélation (lecture
      * seule, bornée). `$setId` filtre en plus sur `set_id` quand il est fourni.
      *
-     * @return PositionTradeAnalysis[]
+     * @return PositionTradeAnalysisV2[]
      */
     public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array;
 }

--- a/trading-app/src/Trading/Service/PositionTradeAnalysisReaderInterface.php
+++ b/trading-app/src/Trading/Service/PositionTradeAnalysisReaderInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Service;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+
+/**
+ * OBS-003 — Source de lecture des trades d'un run (`position_trade_analysis`).
+ *
+ * Découple {@see RunTradeOutcomeService} de l'implémentation Doctrine concrète
+ * (repository `final`, non doublable) : les tests fournissent un stub, le runtime
+ * câble la vraie {@see \App\Repository\PositionTradeAnalysisRepository}.
+ */
+interface PositionTradeAnalysisReaderInterface
+{
+    /**
+     * Toutes les lignes de la vue rattachées à un `run_id` de corrélation (lecture
+     * seule, bornée). `$setId` filtre en plus sur `set_id` quand il est fourni.
+     *
+     * @return PositionTradeAnalysis[]
+     */
+    public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array;
+}

--- a/trading-app/src/Trading/Service/PositionTradeOutcomeSourceException.php
+++ b/trading-app/src/Trading/Service/PositionTradeOutcomeSourceException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Service;
+
+/**
+ * OBS-003 — La source OUTCOME (`position_trade_analysis`) est indisponible.
+ *
+ * Levée par {@see RunTradeOutcomeService} quand la lecture échoue (vue absente, erreur
+ * SQL, EntityManager fermé…). Le contrôleur HTTP la traduit en réponse explicite
+ * (`source_available = false`) plutôt qu'en agrégat vide — une indisponibilité ne doit
+ * JAMAIS être confondue avec « 0 trade ».
+ */
+final class PositionTradeOutcomeSourceException extends \RuntimeException
+{
+    public function __construct(string $message = 'outcome source unavailable', ?\Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/trading-app/src/Trading/Service/RunCorrelationId.php
+++ b/trading-app/src/Trading/Service/RunCorrelationId.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Service;
+
+/**
+ * OBS-003 — Identifiant de corrélation canonique run d'orchestration ↔ trades.
+ *
+ * Un run d'orchestration porte un `run_id` d'origine (jusqu'à 255 caractères côté
+ * orchestrateur, éventuellement haché et préfixé `run_`). Les trades sont rattachés via
+ * `trade_lifecycle_event.run_id`, un VARCHAR(64). Pour relier les deux SANS collision
+ * (deux identifiants longs partageant les mêmes 64 premiers caractères ne doivent pas se
+ * confondre), on dérive un identifiant de corrélation canonique déterministe, IDENTIQUE
+ * à l'implémentation Python (`app/services/correlation.py`).
+ *
+ * Règle (cf. `tests/fixtures/run_correlation_vectors.json`, partagé Python ↔ PHP) :
+ *  1. chaîne vide refusée ({@see \InvalidArgumentException}) — un run a toujours un id ;
+ *  2. si le `run_id` respecte `^[A-Za-z0-9._:-]+$` ET `len <= 64` : conservé tel quel ;
+ *  3. sinon : `sha256(run_id)` en hexadécimal minuscule (exactement 64 caractères).
+ *
+ * Interdits : aucune troncature silencieuse (`substr($id, 0, 64)`), aucun algorithme
+ * divergent entre Python et PHP.
+ */
+final class RunCorrelationId
+{
+    /** Largeur de `trade_lifecycle_event.run_id` (== `position_trade_analysis.run_id`). */
+    public const MAX_LENGTH = 64;
+
+    /** Caractères « sûrs » d'un identifiant conservé tel quel (miroir exact du Python). */
+    private const SAFE_PATTERN = '/^[A-Za-z0-9._:-]+$/';
+
+    /**
+     * Dérive l'identifiant de corrélation canonique (≤ 64 caractères) d'un run.
+     *
+     * Déterministe et sans collision : deux `run_id` distincts produisent toujours deux
+     * identifiants distincts (les longs/non-sûrs passent par sha256, jamais par une
+     * troncature). Une valeur entourée d'espaces est d'abord *trim*.
+     *
+     * @throws \InvalidArgumentException si le `run_id` est vide (après trim).
+     */
+    public static function canonical(string $runId): string
+    {
+        $runId = trim($runId);
+        if ($runId === '') {
+            throw new \InvalidArgumentException('run_id must be a non-empty string');
+        }
+
+        if (mb_strlen($runId) <= self::MAX_LENGTH && preg_match(self::SAFE_PATTERN, $runId) === 1) {
+            return $runId;
+        }
+
+        return hash('sha256', $runId);
+    }
+
+    /**
+     * Variante tolérante : renvoie `null` au lieu de lever pour une valeur vide/nulle.
+     *
+     * Utilisée sur le chemin de propagation (CLI / appel direct sans en-tête) où
+     * l'absence de `run_id` est légitime et doit retomber sur le comportement
+     * historique (UUID généré en aval), sans erreur.
+     */
+    public static function canonicalOrNull(?string $runId): ?string
+    {
+        if ($runId === null || trim($runId) === '') {
+            return null;
+        }
+
+        return self::canonical($runId);
+    }
+}

--- a/trading-app/src/Trading/Service/RunTradeOutcomeService.php
+++ b/trading-app/src/Trading/Service/RunTradeOutcomeService.php
@@ -89,11 +89,15 @@ final class RunTradeOutcomeService
             'truncated' => $truncated,
             'row_cap' => $this->rowCap,
             'data_complete' => !$truncated && $this->isDataComplete($rows),
-            'summary' => $this->aggregate($rows),
-            'by_set' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getSetId()),
-            'by_profile' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getMtfProfile()),
-            'by_exchange' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getExchange()),
-            'by_symbol' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getSymbol()),
+            // Tronqué => on PROPAGE l'incomplétude dans summary ET chaque agrégat groupé :
+            // sinon un client lisant `summary.data_complete` ou un `data_complete` de groupe
+            // prendrait des KPI partiels (calculés sur les seules lignes tranchées) pour des
+            // KPI complets malgré la troncature.
+            'summary' => $this->aggregate($rows, $truncated),
+            'by_set' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getSetId(), $truncated),
+            'by_profile' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getMtfProfile(), $truncated),
+            'by_exchange' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getExchange(), $truncated),
+            'by_symbol' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getSymbol(), $truncated),
         ];
     }
 
@@ -102,7 +106,7 @@ final class RunTradeOutcomeService
      * @param callable(PositionTradeAnalysisV2):?string $keyFn
      * @return list<array<string,mixed>>
      */
-    private function group(array $rows, callable $keyFn): array
+    private function group(array $rows, callable $keyFn, bool $forceIncomplete = false): array
     {
         /** @var array<string,PositionTradeAnalysisV2[]> $buckets */
         $buckets = [];
@@ -118,7 +122,7 @@ final class RunTradeOutcomeService
 
         $out = [];
         foreach ($buckets as $key => $bucketRows) {
-            $out[] = ['key' => $key] + $this->aggregate($bucketRows);
+            $out[] = ['key' => $key] + $this->aggregate($bucketRows, $forceIncomplete);
         }
 
         return $out;
@@ -126,9 +130,11 @@ final class RunTradeOutcomeService
 
     /**
      * @param PositionTradeAnalysisV2[] $rows
+     * @param bool $forceIncomplete Force `data_complete=false` (ex. agrégat tronqué) quel que
+     *                              soit l'état des lignes tranchées.
      * @return array<string,mixed>
      */
-    private function aggregate(array $rows): array
+    private function aggregate(array $rows, bool $forceIncomplete = false): array
     {
         $tradeCount = count($rows);
         $matchedClosed = array_values(array_filter(
@@ -178,7 +184,7 @@ final class RunTradeOutcomeService
             'pnl_r' => $pnlR,
             'estimated_net_pnl_usdt' => $estimatedNet,
             'cost_completeness' => $this->aggregateCostCompleteness($rows),
-            'data_complete' => $this->isDataComplete($rows),
+            'data_complete' => !$forceIncomplete && $this->isDataComplete($rows),
             'mfe_pct_avg' => $this->avg($mfeValues),
             'mfe_pct_median' => $this->median($mfeValues),
             'mae_pct_avg' => $this->avg($maeValues),

--- a/trading-app/src/Trading/Service/RunTradeOutcomeService.php
+++ b/trading-app/src/Trading/Service/RunTradeOutcomeService.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Service;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+use Psr\Log\LoggerInterface;
+
+/**
+ * OBS-003 — Agrégation OUTCOME d'un run : relie un run d'orchestration à ses trades
+ * résultants (vue `position_trade_analysis`) par identifiant de corrélation, en lecture
+ * seule. Le PnL n'est JAMAIS recalculé : on agrège les valeurs déjà exposées par la vue
+ * (somme/moyenne/médiane). Le winrate ne porte que sur les trades clôturés ET rapprochés.
+ *
+ * Distinction stricte recorded vs net PnL : `recorded_pnl_usdt` est la valeur enregistrée
+ * (pas garantie nette de tous les coûts), `net_pnl_usdt` n'est agrégé que sur les lignes
+ * dont la vue atteste `net_pnl_complete = true` ; `data_complete` est vrai uniquement si
+ * tous les trades clôturés ont un net complet.
+ *
+ * Fail-safe : la source indisponible (exception du reader) est signalée par
+ * `source_available = false` et NE doit jamais être confondue avec « 0 trade » — c'est à
+ * l'appelant (contrôleur HTTP) de distinguer les deux. Ici, une exception est relancée
+ * pour que le contrôleur réponde explicitement (jamais un agrégat vide silencieux).
+ */
+final class RunTradeOutcomeService
+{
+    public function __construct(
+        private readonly PositionTradeAnalysisReaderInterface $reader,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    /**
+     * Construit l'agrégat OUTCOME pour un `run_id` ORIGINAL (l'identifiant de corrélation
+     * canonique est dérivé ici, identique à Python).
+     *
+     * @return array<string,mixed>
+     *
+     * @throws PositionTradeOutcomeSourceException si la source est indisponible.
+     */
+    public function buildOutcome(string $originalRunId, ?string $setId = null): array
+    {
+        $correlationRunId = RunCorrelationId::canonical($originalRunId);
+
+        try {
+            $rows = $this->reader->findByCorrelationRunId($correlationRunId, $setId);
+        } catch (\Throwable $e) {
+            $this->logger?->warning('obs003.outcome.source_unavailable', [
+                'run_id' => $originalRunId,
+                'correlation_run_id' => $correlationRunId,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new PositionTradeOutcomeSourceException(
+                'position_trade_analysis source unavailable',
+                previous: $e,
+            );
+        }
+
+        return [
+            'run_id' => $originalRunId,
+            'correlation_run_id' => $correlationRunId,
+            'set_id' => $setId,
+            'source_available' => true,
+            'data_complete' => $this->isDataComplete($rows),
+            'summary' => $this->aggregate($rows),
+            'by_set' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getSetId()),
+            'by_profile' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getMtfProfile()),
+            'by_exchange' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getExchange()),
+            'by_symbol' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getSymbol()),
+        ];
+    }
+
+    /**
+     * @param PositionTradeAnalysis[] $rows
+     * @param callable(PositionTradeAnalysis):?string $keyFn
+     * @return list<array<string,mixed>>
+     */
+    private function group(array $rows, callable $keyFn): array
+    {
+        /** @var array<string,PositionTradeAnalysis[]> $buckets */
+        $buckets = [];
+        foreach ($rows as $row) {
+            $key = $keyFn($row);
+            if ($key === null || $key === '') {
+                $key = 'unknown';
+            }
+            $buckets[$key][] = $row;
+        }
+
+        ksort($buckets);
+
+        $out = [];
+        foreach ($buckets as $key => $bucketRows) {
+            $out[] = ['key' => $key] + $this->aggregate($bucketRows);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param PositionTradeAnalysis[] $rows
+     * @return array<string,mixed>
+     */
+    private function aggregate(array $rows): array
+    {
+        $tradeCount = count($rows);
+        $closed = array_values(array_filter($rows, static fn (PositionTradeAnalysis $r): bool => $r->isClosed()));
+        $matchedClosed = array_values(array_filter(
+            $closed,
+            static fn (PositionTradeAnalysis $r): bool => $r->isMatched()
+        ));
+
+        $closedCount = count($closed);
+        $matchedCount = count(array_filter($rows, static fn (PositionTradeAnalysis $r): bool => $r->isMatched()));
+        $unmatchedCount = $tradeCount - $matchedCount;
+
+        // Winrate : trades clôturés ET rapprochés uniquement (PnL fiable).
+        $winCount = 0;
+        $lossCount = 0;
+        foreach ($matchedClosed as $r) {
+            $pnl = $r->getRecordedPnlUsdt();
+            if ($pnl === null) {
+                continue;
+            }
+            if ($pnl > 0.0) {
+                $winCount++;
+            } elseif ($pnl < 0.0) {
+                $lossCount++;
+            }
+        }
+        $decided = $winCount + $lossCount;
+        $winRate = $decided > 0 ? round($winCount / $decided, 6) : null;
+
+        $recordedPnl = $this->sum($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getRecordedPnlUsdt());
+        $pnlR = $this->sum($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getPnlR());
+
+        // Net PnL : somme UNIQUEMENT sur les lignes au net complet ; sinon null + flag.
+        $netComplete = $this->isDataComplete($rows);
+        $netPnl = $netComplete
+            ? $this->sum($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getNetPnlUsdt())
+            : null;
+
+        $mfeValues = $this->values($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getMfePct());
+        $maeValues = $this->values($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getMaePct());
+        $holdValues = $this->values($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getHoldingTimeSec());
+
+        return [
+            'trade_count' => $tradeCount,
+            'closed_count' => $closedCount,
+            'open_count' => $tradeCount - $closedCount,
+            'matched_count' => $matchedCount,
+            'unmatched_count' => $unmatchedCount,
+            'win_count' => $winCount,
+            'loss_count' => $lossCount,
+            'win_rate_closed' => $winRate,
+            'recorded_pnl_usdt' => $recordedPnl,
+            'pnl_r' => $pnlR,
+            'net_pnl_usdt' => $netPnl,
+            'net_pnl_complete' => $netComplete,
+            'mfe_pct_avg' => $this->avg($mfeValues),
+            'mfe_pct_median' => $this->median($mfeValues),
+            'mae_pct_avg' => $this->avg($maeValues),
+            'mae_pct_median' => $this->median($maeValues),
+            'holding_time_sec_avg' => $this->avg($holdValues),
+        ];
+    }
+
+    /**
+     * Net complet ssi tous les trades CLÔTURÉS le sont (un run sans trade clôturé est
+     * « complet » de façon vide : il n'y a aucun PnL net manquant).
+     *
+     * @param PositionTradeAnalysis[] $rows
+     */
+    private function isDataComplete(array $rows): bool
+    {
+        foreach ($rows as $row) {
+            if ($row->isClosed() && !$row->isNetPnlComplete()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param PositionTradeAnalysis[] $rows
+     * @param callable(PositionTradeAnalysis):?float $fn
+     */
+    private function sum(array $rows, callable $fn): ?float
+    {
+        $values = $this->values($rows, $fn);
+        if ($values === []) {
+            return null;
+        }
+
+        return round(array_sum($values), 8);
+    }
+
+    /**
+     * @param PositionTradeAnalysis[] $rows
+     * @param callable(PositionTradeAnalysis):?float $fn
+     * @return list<float>
+     */
+    private function values(array $rows, callable $fn): array
+    {
+        $values = [];
+        foreach ($rows as $row) {
+            $v = $fn($row);
+            if ($v !== null) {
+                $values[] = $v;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param list<float> $values
+     */
+    private function avg(array $values): ?float
+    {
+        if ($values === []) {
+            return null;
+        }
+
+        return round(array_sum($values) / count($values), 8);
+    }
+
+    /**
+     * @param list<float> $values
+     */
+    private function median(array $values): ?float
+    {
+        if ($values === []) {
+            return null;
+        }
+
+        sort($values);
+        $n = count($values);
+        $mid = intdiv($n, 2);
+
+        if ($n % 2 === 1) {
+            return round($values[$mid], 8);
+        }
+
+        return round(($values[$mid - 1] + $values[$mid]) / 2.0, 8);
+    }
+}

--- a/trading-app/src/Trading/Service/RunTradeOutcomeService.php
+++ b/trading-app/src/Trading/Service/RunTradeOutcomeService.php
@@ -34,6 +34,10 @@ final class RunTradeOutcomeService
     public function __construct(
         private readonly PositionTradeAnalysisReaderInterface $reader,
         private readonly ?LoggerInterface $logger = null,
+        // Plafond de lignes agrégées (lecture bornée). On lit `rowCap + 1` pour DÉTECTER
+        // un dépassement et le signaler explicitement (`truncated`) plutôt que de
+        // sous-compter silencieusement les KPI.
+        private readonly int $rowCap = 5000,
     ) {
     }
 
@@ -47,7 +51,8 @@ final class RunTradeOutcomeService
         $correlationRunId = RunCorrelationId::canonical($originalRunId);
 
         try {
-            $rows = $this->reader->findByCorrelationRunId($correlationRunId, $setId);
+            // rowCap + 1 : si on récupère plus que le plafond, le résultat est tronqué.
+            $rows = $this->reader->findByCorrelationRunId($correlationRunId, $setId, $this->rowCap + 1);
         } catch (\Throwable $e) {
             $this->logger?->warning('obs003.outcome.source_unavailable', [
                 'run_id' => $originalRunId,
@@ -61,12 +66,29 @@ final class RunTradeOutcomeService
             );
         }
 
+        // Troncature : les KPI ne porteraient que sur une partie des lignes. On le SIGNALE
+        // explicitement (jamais un agrégat partiel présenté comme complet) et `data_complete`
+        // passe à faux. Un run réel produit bien moins de trades que le plafond ; ce garde
+        // protège les tableaux de bord larges / multi-sets répétés.
+        $truncated = count($rows) > $this->rowCap;
+        if ($truncated) {
+            $rows = array_slice($rows, 0, $this->rowCap);
+            $this->logger?->warning('obs003.outcome.truncated', [
+                'run_id' => $originalRunId,
+                'correlation_run_id' => $correlationRunId,
+                'row_cap' => $this->rowCap,
+            ]);
+        }
+
         return [
             'run_id' => $originalRunId,
             'correlation_run_id' => $correlationRunId,
             'set_id' => $setId,
             'source_available' => true,
-            'data_complete' => $this->isDataComplete($rows),
+            // Tronqué => les agrégats ne sont pas complets, quel que soit l'état des lignes.
+            'truncated' => $truncated,
+            'row_cap' => $this->rowCap,
+            'data_complete' => !$truncated && $this->isDataComplete($rows),
             'summary' => $this->aggregate($rows),
             'by_set' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getSetId()),
             'by_profile' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getMtfProfile()),

--- a/trading-app/src/Trading/Service/RunTradeOutcomeService.php
+++ b/trading-app/src/Trading/Service/RunTradeOutcomeService.php
@@ -4,24 +4,30 @@ declare(strict_types=1);
 
 namespace App\Trading\Service;
 
-use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Entity\PositionTradeAnalysisV2;
 use Psr\Log\LoggerInterface;
 
 /**
  * OBS-003 — Agrégation OUTCOME d'un run : relie un run d'orchestration à ses trades
- * résultants (vue `position_trade_analysis`) par identifiant de corrélation, en lecture
+ * résultants (vue `position_trade_analysis_v2`) par identifiant de corrélation, en lecture
  * seule. Le PnL n'est JAMAIS recalculé : on agrège les valeurs déjà exposées par la vue
- * (somme/moyenne/médiane). Le winrate ne porte que sur les trades clôturés ET rapprochés.
+ * (somme/moyenne/médiane).
  *
- * Distinction stricte recorded vs net PnL : `recorded_pnl_usdt` est la valeur enregistrée
- * (pas garantie nette de tous les coûts), `net_pnl_usdt` n'est agrégé que sur les lignes
- * dont la vue atteste `net_pnl_complete = true` ; `data_complete` est vrai uniquement si
- * tous les trades clôturés ont un net complet.
+ * Qualité (issue #190) — distinctions strictes :
+ *  - `matched_closed` : entrée rapprochée d'une clôture par identifiant exact (seule base
+ *    d'un trade certifié) ;
+ *  - `unmatched` : entrée sans clôture rapprochée — état réel INCONNU (peut être ouverte
+ *    OU clôturée non-rapprochable) ; jamais comptée comme position ouverte confirmée ;
+ *  - `confirmed_open` : 0 ici (la vue read-only ne porte pas de preuve d'ouverture ; le
+ *    confirmer exige l'état ouvert live, hors périmètre OBS-003).
  *
- * Fail-safe : la source indisponible (exception du reader) est signalée par
- * `source_available = false` et NE doit jamais être confondue avec « 0 trade » — c'est à
- * l'appelant (contrôleur HTTP) de distinguer les deux. Ici, une exception est relancée
- * pour que le contrôleur réponde explicitement (jamais un agrégat vide silencieux).
+ * PnL — on n'expose JAMAIS un net certifié : `recorded_pnl_usdt` (enregistré) et
+ * `estimated_net_pnl_usdt` (estimation best-effort, cf. `cost_completeness`) sont distincts.
+ * `data_complete` n'est vrai que si toutes les lignes pertinentes sont rapprochées ET au
+ * contrat de coûts complet (jamais le cas tant que le contrat #190 n'est pas livré).
+ *
+ * Fail-safe : la source indisponible (exception du reader) est relancée pour que le
+ * contrôleur HTTP réponde explicitement (jamais un agrégat vide silencieux).
  */
 final class RunTradeOutcomeService
 {
@@ -32,9 +38,6 @@ final class RunTradeOutcomeService
     }
 
     /**
-     * Construit l'agrégat OUTCOME pour un `run_id` ORIGINAL (l'identifiant de corrélation
-     * canonique est dérivé ici, identique à Python).
-     *
      * @return array<string,mixed>
      *
      * @throws PositionTradeOutcomeSourceException si la source est indisponible.
@@ -65,21 +68,21 @@ final class RunTradeOutcomeService
             'source_available' => true,
             'data_complete' => $this->isDataComplete($rows),
             'summary' => $this->aggregate($rows),
-            'by_set' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getSetId()),
-            'by_profile' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getMtfProfile()),
-            'by_exchange' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getExchange()),
-            'by_symbol' => $this->group($rows, static fn (PositionTradeAnalysis $r) => $r->getSymbol()),
+            'by_set' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getSetId()),
+            'by_profile' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getMtfProfile()),
+            'by_exchange' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getExchange()),
+            'by_symbol' => $this->group($rows, static fn (PositionTradeAnalysisV2 $r) => $r->getSymbol()),
         ];
     }
 
     /**
-     * @param PositionTradeAnalysis[] $rows
-     * @param callable(PositionTradeAnalysis):?string $keyFn
+     * @param PositionTradeAnalysisV2[] $rows
+     * @param callable(PositionTradeAnalysisV2):?string $keyFn
      * @return list<array<string,mixed>>
      */
     private function group(array $rows, callable $keyFn): array
     {
-        /** @var array<string,PositionTradeAnalysis[]> $buckets */
+        /** @var array<string,PositionTradeAnalysisV2[]> $buckets */
         $buckets = [];
         foreach ($rows as $row) {
             $key = $keyFn($row);
@@ -100,23 +103,20 @@ final class RunTradeOutcomeService
     }
 
     /**
-     * @param PositionTradeAnalysis[] $rows
+     * @param PositionTradeAnalysisV2[] $rows
      * @return array<string,mixed>
      */
     private function aggregate(array $rows): array
     {
         $tradeCount = count($rows);
-        $closed = array_values(array_filter($rows, static fn (PositionTradeAnalysis $r): bool => $r->isClosed()));
         $matchedClosed = array_values(array_filter(
-            $closed,
-            static fn (PositionTradeAnalysis $r): bool => $r->isMatched()
+            $rows,
+            static fn (PositionTradeAnalysisV2 $r): bool => $r->isMatchedClosed()
         ));
+        $matchedClosedCount = count($matchedClosed);
+        $unmatchedCount = $tradeCount - $matchedClosedCount;
 
-        $closedCount = count($closed);
-        $matchedCount = count(array_filter($rows, static fn (PositionTradeAnalysis $r): bool => $r->isMatched()));
-        $unmatchedCount = $tradeCount - $matchedCount;
-
-        // Winrate : trades clôturés ET rapprochés uniquement (PnL fiable).
+        // Winrate : trades clôturés ET rapprochés disposant d'un PnL enregistré uniquement.
         $winCount = 0;
         $lossCount = 0;
         foreach ($matchedClosed as $r) {
@@ -133,32 +133,30 @@ final class RunTradeOutcomeService
         $decided = $winCount + $lossCount;
         $winRate = $decided > 0 ? round($winCount / $decided, 6) : null;
 
-        $recordedPnl = $this->sum($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getRecordedPnlUsdt());
-        $pnlR = $this->sum($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getPnlR());
+        $recordedPnl = $this->sum($rows, static fn (PositionTradeAnalysisV2 $r): ?float => $r->getRecordedPnlUsdt());
+        $pnlR = $this->sum($rows, static fn (PositionTradeAnalysisV2 $r): ?float => $r->getPnlR());
+        // Somme d'ESTIMATIONS (best-effort), jamais présentée comme nette certifiée.
+        $estimatedNet = $this->sum($rows, static fn (PositionTradeAnalysisV2 $r): ?float => $r->getEstimatedNetPnlUsdt());
 
-        // Net PnL : somme UNIQUEMENT sur les lignes au net complet ; sinon null + flag.
-        $netComplete = $this->isDataComplete($rows);
-        $netPnl = $netComplete
-            ? $this->sum($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getNetPnlUsdt())
-            : null;
-
-        $mfeValues = $this->values($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getMfePct());
-        $maeValues = $this->values($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getMaePct());
-        $holdValues = $this->values($rows, static fn (PositionTradeAnalysis $r): ?float => $r->getHoldingTimeSec());
+        $mfeValues = $this->values($rows, static fn (PositionTradeAnalysisV2 $r): ?float => $r->getMfePct());
+        $maeValues = $this->values($rows, static fn (PositionTradeAnalysisV2 $r): ?float => $r->getMaePct());
+        $holdValues = $this->values($rows, static fn (PositionTradeAnalysisV2 $r): ?float => $r->getHoldingTimeSec());
 
         return [
             'trade_count' => $tradeCount,
-            'closed_count' => $closedCount,
-            'open_count' => $tradeCount - $closedCount,
-            'matched_count' => $matchedCount,
+            // unmatched n'est JAMAIS compté comme position ouverte confirmée.
+            'matched_closed_count' => $matchedClosedCount,
             'unmatched_count' => $unmatchedCount,
+            'confirmed_open_count' => 0,
+            'unknown_state_count' => $unmatchedCount,
             'win_count' => $winCount,
             'loss_count' => $lossCount,
             'win_rate_closed' => $winRate,
             'recorded_pnl_usdt' => $recordedPnl,
             'pnl_r' => $pnlR,
-            'net_pnl_usdt' => $netPnl,
-            'net_pnl_complete' => $netComplete,
+            'estimated_net_pnl_usdt' => $estimatedNet,
+            'cost_completeness' => $this->aggregateCostCompleteness($rows),
+            'data_complete' => $this->isDataComplete($rows),
             'mfe_pct_avg' => $this->avg($mfeValues),
             'mfe_pct_median' => $this->median($mfeValues),
             'mae_pct_avg' => $this->avg($maeValues),
@@ -168,15 +166,44 @@ final class RunTradeOutcomeService
     }
 
     /**
-     * Net complet ssi tous les trades CLÔTURÉS le sont (un run sans trade clôturé est
-     * « complet » de façon vide : il n'y a aucun PnL net manquant).
+     * Complétude agrégée des coûts sur les lignes clôturées-rapprochées :
+     * `not_applicable` (aucune), `complete`/`partial`/`unknown` sinon, `mixed` si plusieurs
+     * niveaux coexistent. Jamais `complete` tant que le contrat #190 n'est pas livré.
      *
-     * @param PositionTradeAnalysis[] $rows
+     * @param PositionTradeAnalysisV2[] $rows
+     */
+    private function aggregateCostCompleteness(array $rows): string
+    {
+        $levels = [];
+        foreach ($rows as $row) {
+            if ($row->isMatchedClosed()) {
+                $levels[$row->getCostCompleteness()] = true;
+            }
+        }
+        if ($levels === []) {
+            return 'not_applicable';
+        }
+        if (count($levels) === 1) {
+            return array_key_first($levels);
+        }
+
+        return 'mixed';
+    }
+
+    /**
+     * Données complètes ssi tout est exploitable comme KPI certifié : aucune ligne
+     * unmatched ET tous les trades clôturés au contrat de coûts complet (jamais le cas
+     * tant que les producteurs #190 ne fournissent pas brut + frais détaillés + spread).
+     *
+     * @param PositionTradeAnalysisV2[] $rows
      */
     private function isDataComplete(array $rows): bool
     {
         foreach ($rows as $row) {
-            if ($row->isClosed() && !$row->isNetPnlComplete()) {
+            if (!$row->isMatchedClosed()) {
+                return false;
+            }
+            if (!$row->isCostComplete()) {
                 return false;
             }
         }
@@ -185,8 +212,8 @@ final class RunTradeOutcomeService
     }
 
     /**
-     * @param PositionTradeAnalysis[] $rows
-     * @param callable(PositionTradeAnalysis):?float $fn
+     * @param PositionTradeAnalysisV2[] $rows
+     * @param callable(PositionTradeAnalysisV2):?float $fn
      */
     private function sum(array $rows, callable $fn): ?float
     {
@@ -199,8 +226,8 @@ final class RunTradeOutcomeService
     }
 
     /**
-     * @param PositionTradeAnalysis[] $rows
-     * @param callable(PositionTradeAnalysis):?float $fn
+     * @param PositionTradeAnalysisV2[] $rows
+     * @param callable(PositionTradeAnalysisV2):?float $fn
      * @return list<float>
      */
     private function values(array $rows, callable $fn): array

--- a/trading-app/tests/Contract/MtfValidator/Dto/MtfRunRequestDtoTest.php
+++ b/trading-app/tests/Contract/MtfValidator/Dto/MtfRunRequestDtoTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Contract\MtfValidator\Dto;
+
+use App\Contract\MtfValidator\Dto\MtfRunRequestDto;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * OBS-003 — Le DTO de requête MTF porte le run_id de corrélation (`requestId`) et le
+ * lineage d'orchestration jusqu'au dispatcher (puis l'`extra` de `order_submitted`).
+ */
+#[CoversClass(MtfRunRequestDto::class)]
+final class MtfRunRequestDtoTest extends TestCase
+{
+    public function testParsesRequestIdAndOrchestrationLineage(): void
+    {
+        $dto = MtfRunRequestDto::fromArray([
+            'symbols' => ['BTCUSDT'],
+            'request_id' => 'run_dashA',
+            'orchestration_run_id' => 'run_dashA_full_original',
+            'dashboard_id' => 'dashA',
+            'set_id' => 's1',
+        ]);
+
+        self::assertSame('run_dashA', $dto->requestId);
+        self::assertSame('run_dashA_full_original', $dto->orchestrationRunId);
+        self::assertSame('dashA', $dto->dashboardId);
+        self::assertSame('s1', $dto->setId);
+    }
+
+    public function testAcceptsOrchestrationDashboardAndSetAliases(): void
+    {
+        $dto = MtfRunRequestDto::fromArray([
+            'symbols' => ['BTCUSDT'],
+            'orchestration_dashboard_id' => 'dashB',
+            'orchestration_set_id' => 's2',
+        ]);
+
+        self::assertSame('dashB', $dto->dashboardId);
+        self::assertSame('s2', $dto->setId);
+    }
+
+    public function testLegacyRequestHasNullLineage(): void
+    {
+        $dto = MtfRunRequestDto::fromArray(['symbols' => ['BTCUSDT']]);
+
+        self::assertNull($dto->requestId);
+        self::assertNull($dto->orchestrationRunId);
+        self::assertNull($dto->dashboardId);
+        self::assertNull($dto->setId);
+    }
+
+    public function testBlankValuesAreNull(): void
+    {
+        $dto = MtfRunRequestDto::fromArray([
+            'symbols' => ['BTCUSDT'],
+            'request_id' => '  ',
+            'set_id' => '',
+        ]);
+
+        self::assertNull($dto->requestId);
+        self::assertNull($dto->setId);
+    }
+}

--- a/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
+++ b/trading-app/tests/MtfRunner/Dto/MtfRunnerRequestDtoTest.php
@@ -120,4 +120,72 @@ final class MtfRunnerRequestDtoTest extends TestCase
     {
         self::assertNull(MtfRunnerRequestDto::fromArray(['open_state_snapshot' => 'nope'])->openStateSnapshot);
     }
+
+    // --- OBS-003 : lineage d'orchestration --------------------------------------
+
+    public function testFromArrayParsesOrchestrationLineage(): void
+    {
+        $dto = MtfRunnerRequestDto::fromArray([
+            'symbols' => ['BTCUSDT'],
+            'run_id' => 'run_dashA_20260617',
+            'correlation_run_id' => 'run_dashA_20260617',
+            'orchestration_dashboard_id' => 'dashA',
+            'orchestration_set_id' => 's1',
+        ]);
+
+        self::assertSame('run_dashA_20260617', $dto->originalRunId);
+        self::assertSame('run_dashA_20260617', $dto->correlationRunId);
+        self::assertSame('dashA', $dto->dashboardId);
+        self::assertSame('s1', $dto->setId);
+    }
+
+    public function testFromArrayAcceptsShortDashboardAndSetAliases(): void
+    {
+        $dto = MtfRunnerRequestDto::fromArray([
+            'symbols' => ['BTCUSDT'],
+            'dashboard_id' => 'dashB',
+            'set_id' => 's2',
+        ]);
+
+        self::assertSame('dashB', $dto->dashboardId);
+        self::assertSame('s2', $dto->setId);
+    }
+
+    public function testLegacyRequestHasNullLineage(): void
+    {
+        $dto = MtfRunnerRequestDto::fromArray(['symbols' => ['BTCUSDT']]);
+
+        self::assertNull($dto->originalRunId);
+        self::assertNull($dto->correlationRunId);
+        self::assertNull($dto->dashboardId);
+        self::assertNull($dto->setId);
+    }
+
+    public function testBlankLineageValuesAreNormalisedToNull(): void
+    {
+        $dto = MtfRunnerRequestDto::fromArray([
+            'symbols' => ['BTCUSDT'],
+            'run_id' => '   ',
+            'set_id' => '',
+        ]);
+
+        self::assertNull($dto->originalRunId);
+        self::assertNull($dto->setId);
+    }
+
+    public function testToArrayRoundTripsLineage(): void
+    {
+        $array = MtfRunnerRequestDto::fromArray([
+            'symbols' => ['BTCUSDT'],
+            'run_id' => 'orig',
+            'correlation_run_id' => 'corr',
+            'dashboard_id' => 'd',
+            'set_id' => 's',
+        ])->toArray();
+
+        self::assertSame('orig', $array['run_id']);
+        self::assertSame('corr', $array['correlation_run_id']);
+        self::assertSame('d', $array['dashboard_id']);
+        self::assertSame('s', $array['set_id']);
+    }
 }

--- a/trading-app/tests/MtfRunner/Service/MtfRunnerServiceSyncTablesTest.php
+++ b/trading-app/tests/MtfRunner/Service/MtfRunnerServiceSyncTablesTest.php
@@ -158,6 +158,38 @@ final class MtfRunnerServiceSyncTablesTest extends TestCase
         self::assertNotSame('rejected', $result['summary']['status'] ?? null);
     }
 
+    /**
+     * OBS-003 — en séquentiel (workers=1), le `run_id` du résumé doit être le run_id de
+     * corrélation propagé (et non l'UUID interne du validateur), pour rester cohérent avec
+     * `trade_lifecycle_event.run_id` / l'outcome et avec le chemin parallèle.
+     */
+    public function testSequentialSummaryUsesPropagatedCorrelationRunId(): void
+    {
+        $syncProvider = $this->createMock(MainProviderInterface::class);
+        $syncProvider->method('forContext')->willReturnSelf();
+        $syncProvider->method('getAccountProvider')->willReturn(null);
+        $syncProvider->method('getOrderProvider')->willReturn(null);
+
+        $service = $this->buildService($syncProvider);
+
+        $request = new MtfRunnerRequestDto(
+            symbols: ['BTCUSDT'],
+            dryRun: true,
+            skipOpenStateFilter: true,
+            exchange: Exchange::BITMART,
+            marketType: MarketType::PERPETUAL,
+            workers: 1,
+            syncTables: false,
+            processTpSl: false,
+            originalRunId: 'run_dashA_20260617', // court + sûr => identité (≤64)
+        );
+
+        $result = $service->run($request);
+
+        // Et surtout PAS le runId interne du validateur ('test-run').
+        self::assertSame('run_dashA_20260617', $result['summary']['run_id'] ?? null);
+    }
+
     private function request(bool $syncTables): MtfRunnerRequestDto
     {
         // Pas de profil : couvre aussi le chemin sans profil (cf. guard resolveTimeframes).

--- a/trading-app/tests/Trading/Controller/Api/PositionAnalysisApiControllerTest.php
+++ b/trading-app/tests/Trading/Controller/Api/PositionAnalysisApiControllerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Controller\Api;
+
+use App\Trading\Controller\Api\PositionAnalysisApiController;
+use App\Trading\Service\PositionTradeAnalysisReaderInterface;
+use App\Trading\Service\RunTradeOutcomeService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * OBS-003 — Endpoint `GET /api/positions/analysis` : run_id requis (400), agrégat
+ * explicite même vide (200), indisponibilité de la source NON masquée (503,
+ * `source_available = false`), jamais de 500.
+ */
+#[CoversClass(PositionAnalysisApiController::class)]
+final class PositionAnalysisApiControllerTest extends TestCase
+{
+    public function testMissingRunIdReturns400(): void
+    {
+        $controller = $this->controller($this->reader([]));
+        $response = $controller->analysis(new Request());
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertSame('missing_run_id', $this->json($response)['error']);
+    }
+
+    public function testKnownRunReturns200WithAggregate(): void
+    {
+        $controller = $this->controller($this->reader([]));
+        $response = $controller->analysis(new Request(['run_id' => 'run_dashA']));
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('run_dashA', $body['run_id']);
+        self::assertSame('run_dashA', $body['correlation_run_id']);
+        self::assertTrue($body['source_available']);
+        self::assertSame(0, $body['summary']['trade_count']);
+    }
+
+    public function testSourceUnavailableReturns503AndFlagsIt(): void
+    {
+        $reader = new class implements PositionTradeAnalysisReaderInterface {
+            public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
+            {
+                throw new \RuntimeException('view unavailable');
+            }
+        };
+
+        $controller = $this->controller($reader);
+        $response = $controller->analysis(new Request(['run_id' => 'run_dashA']));
+
+        self::assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertFalse($body['source_available']);
+        self::assertSame('source_unavailable', $body['error']);
+        // l'indisponibilité ne doit jamais ressembler à "0 trade"
+        self::assertArrayNotHasKey('summary', $body);
+    }
+
+    public function testLongRunIdIsHashedInCorrelation(): void
+    {
+        $controller = $this->controller($this->reader([]));
+        $long = str_repeat('a', 65);
+        $response = $controller->analysis(new Request(['run_id' => $long]));
+
+        $body = $this->json($response);
+        self::assertSame(64, strlen($body['correlation_run_id']));
+        self::assertNotSame(substr($long, 0, 64), $body['correlation_run_id']);
+    }
+
+    private function controller(PositionTradeAnalysisReaderInterface $reader): PositionAnalysisApiController
+    {
+        $controller = new PositionAnalysisApiController(new RunTradeOutcomeService($reader));
+
+        // Container minimal : AbstractController::json() teste `has('serializer')`.
+        $container = new class implements ContainerInterface {
+            public function get(string $id): mixed
+            {
+                throw new \RuntimeException('not available: ' . $id);
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        };
+        $controller->setContainer($container);
+
+        return $controller;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function json(Response $response): array
+    {
+        return json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function reader(array $rows): PositionTradeAnalysisReaderInterface
+    {
+        return new class($rows) implements PositionTradeAnalysisReaderInterface {
+            public function __construct(private readonly array $rows)
+            {
+            }
+
+            public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
+            {
+                return $this->rows;
+            }
+        };
+    }
+}

--- a/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
+++ b/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Orchestration;
+
+use App\Trading\Orchestration\OrchestrationContextException;
+use App\Trading\Orchestration\OrchestrationContextValidator;
+use App\Trading\Service\RunCorrelationId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * OBS-003 — Validation fail-closed du contexte d'orchestration : contradictions
+ * vérifiables dans la requête refusées avec un code stable ; chemin legacy intact.
+ */
+#[CoversClass(OrchestrationContextValidator::class)]
+final class OrchestrationContextValidatorTest extends TestCase
+{
+    private OrchestrationContextValidator $validator;
+
+    protected function setUp(): void
+    {
+        $this->validator = new OrchestrationContextValidator();
+    }
+
+    public function testLegacyRequestWithoutHeadersPasses(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->validator->validate(null, null, null, null, ['symbols' => ['BTCUSDT']]);
+    }
+
+    public function testConsistentContextPasses(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $runId = 'run_dashA_20260617';
+        $this->validator->validate(
+            $runId,
+            RunCorrelationId::canonical($runId),
+            's1',
+            'dashA',
+            ['set_id' => 's1', 'dashboard_id' => 'dashA', 'profile' => 'scalper', 'exchange' => 'bitmart'],
+        );
+    }
+
+    public function testCorrelationMismatchIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_CORRELATION_MISMATCH', function (): void {
+            $this->validator->validate('run_dashA_20260617', 'not-the-canonical', null, null, []);
+        });
+    }
+
+    public function testCorrelationMatchesCanonicalOfLongRunId(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $long = 'run_' . str_repeat('b', 64); // > 64 => haché
+        $this->validator->validate($long, RunCorrelationId::canonical($long), null, null, []);
+    }
+
+    public function testSetMismatchIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_SET_MISMATCH', function (): void {
+            $this->validator->validate(null, null, 's1', null, ['set_id' => 's2']);
+        });
+    }
+
+    public function testDashboardMismatchIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_DASHBOARD_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, 'dashA', ['dashboard_id' => 'dashB']);
+        });
+    }
+
+    public function testProfileMismatchIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_PROFILE_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, ['profile' => 'scalper', 'mtf_profile' => 'regular']);
+        });
+    }
+
+    public function testProfileCaseInsensitiveEqualPasses(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->validator->validate(null, null, null, null, ['profile' => 'Scalper', 'mtf_profile' => 'scalper']);
+    }
+
+    public function testExchangeMismatchIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_EXCHANGE_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, ['exchange' => 'bitmart', 'cex' => 'okx']);
+        });
+    }
+
+    public function testMarketTypeMismatchIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_MARKET_TYPE_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, ['market_type' => 'perpetual', 'type_contract' => 'spot']);
+        });
+    }
+
+    public function testHeaderTakesPriorityWhenBodyAbsent(): void
+    {
+        // En-tête présent mais pas de doublon dans le payload : aucune contradiction.
+        $this->expectNotToPerformAssertions();
+        $this->validator->validate(null, null, 's1', 'dashA', ['symbols' => ['BTCUSDT']]);
+    }
+
+    private function assertCode(string $expectedCode, callable $fn): void
+    {
+        try {
+            $fn();
+            self::fail("Expected OrchestrationContextException with code {$expectedCode}");
+        } catch (OrchestrationContextException $e) {
+            self::assertSame($expectedCode, $e->errorCode);
+        }
+    }
+}

--- a/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
+++ b/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
@@ -100,6 +100,31 @@ final class OrchestrationContextValidatorTest extends TestCase
         });
     }
 
+    public function testHeaderRunIdVsBodyRunIdMismatchIsRejected(): void
+    {
+        // X-Run-Id=runA + run_id=runB (sans correlation) : contradiction vérifiable du
+        // run_id en-tête vs payload, à fail-closer AVANT le coalescing sur l'en-tête.
+        $this->assertCode('ORCHESTRATION_CORRELATION_MISMATCH', function (): void {
+            $this->validator->validate('runA', null, null, null, ['run_id' => 'runB']);
+        });
+    }
+
+    public function testHeaderRunIdVsBodyOriginalRunIdMismatchIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_CORRELATION_MISMATCH', function (): void {
+            $this->validator->validate('runA', null, null, null, ['original_run_id' => 'runB']);
+        });
+    }
+
+    public function testHeaderRunIdEqualBodyRunIdAliasesPasses(): void
+    {
+        // En-tête et alias du corps identiques : aucune contradiction.
+        $this->expectNotToPerformAssertions();
+        $this->validator->validate('runA', null, null, null, [
+            'run_id' => 'runA', 'original_run_id' => 'runA',
+        ]);
+    }
+
     public function testSetMismatchIsRejected(): void
     {
         $this->assertCode('ORCHESTRATION_SET_MISMATCH', function (): void {

--- a/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
+++ b/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
@@ -58,6 +58,48 @@ final class OrchestrationContextValidatorTest extends TestCase
         $this->validator->validate($long, RunCorrelationId::canonical($long), null, null, []);
     }
 
+    public function testBodyOnlyCorrelationMismatchIsRejected(): void
+    {
+        // Aucun en-tête : run_id + correlation_run_id du payload (chemin body-only) doivent
+        // tout de même être cohérents, sinon fail-closed.
+        $this->assertCode('ORCHESTRATION_CORRELATION_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, [
+                'run_id' => 'runA',
+                'correlation_run_id' => 'runB',
+            ]);
+        });
+    }
+
+    public function testBodyOnlyCorrelationMatchingCanonicalPasses(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $runId = 'run_dashA_20260617';
+        $this->validator->validate(null, null, null, null, [
+            'run_id' => $runId,
+            'correlation_run_id' => RunCorrelationId::canonical($runId),
+        ]);
+    }
+
+    public function testBodyRunIdAndOriginalRunIdContradictionIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_CORRELATION_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, [
+                'run_id' => 'runA',
+                'original_run_id' => 'runB',
+            ]);
+        });
+    }
+
+    public function testHeaderCorrelationContradictingBodyCorrelationIsRejected(): void
+    {
+        $runId = 'run_dashA_20260617';
+        $this->assertCode('ORCHESTRATION_CORRELATION_MISMATCH', function () use ($runId): void {
+            $this->validator->validate($runId, RunCorrelationId::canonical($runId), null, null, [
+                'correlation_run_id' => 'not-the-canonical',
+            ]);
+        });
+    }
+
     public function testSetMismatchIsRejected(): void
     {
         $this->assertCode('ORCHESTRATION_SET_MISMATCH', function (): void {

--- a/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
+++ b/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
@@ -72,6 +72,33 @@ final class OrchestrationContextValidatorTest extends TestCase
         });
     }
 
+    public function testContradictorySetAliasesInBodyAreRejected(): void
+    {
+        // Body-only : set_id et orchestration_set_id différents => fail-closed.
+        $this->assertCode('ORCHESTRATION_SET_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, ['set_id' => 's1', 'orchestration_set_id' => 's2']);
+        });
+    }
+
+    public function testContradictoryDashboardAliasesInBodyAreRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_DASHBOARD_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, [
+                'dashboard_id' => 'dashA',
+                'orchestration_dashboard_id' => 'dashB',
+            ]);
+        });
+    }
+
+    public function testEqualSetAndDashboardAliasesPass(): void
+    {
+        $this->expectNotToPerformAssertions();
+        $this->validator->validate(null, null, null, null, [
+            'set_id' => 's1', 'orchestration_set_id' => 's1',
+            'dashboard_id' => 'dashA', 'orchestration_dashboard_id' => 'dashA',
+        ]);
+    }
+
     public function testProfileMismatchIsRejected(): void
     {
         $this->assertCode('ORCHESTRATION_PROFILE_MISMATCH', function (): void {

--- a/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
+++ b/trading-app/tests/Trading/Orchestration/OrchestrationContextValidatorTest.php
@@ -8,6 +8,7 @@ use App\Trading\Orchestration\OrchestrationContextException;
 use App\Trading\Orchestration\OrchestrationContextValidator;
 use App\Trading\Service\RunCorrelationId;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -95,6 +96,44 @@ final class OrchestrationContextValidatorTest extends TestCase
     {
         $this->assertCode('ORCHESTRATION_MARKET_TYPE_MISMATCH', function (): void {
             $this->validator->validate(null, null, null, null, ['market_type' => 'perpetual', 'type_contract' => 'spot']);
+        });
+    }
+
+    /**
+     * @return iterable<string,array{0:string,1:string}>
+     */
+    public static function equivalentMarketAliasProvider(): iterable
+    {
+        // Tous équivalents à MarketType::PERPETUAL côté ExchangeContextResolver.
+        yield 'perpetual + perp'   => ['perpetual', 'perp'];
+        yield 'futures + perpetual' => ['futures', 'perpetual'];
+        yield 'future + perp'      => ['future', 'perp'];
+        yield 'casse/espaces'      => [' Perpetual ', 'PERP'];
+    }
+
+    #[DataProvider('equivalentMarketAliasProvider')]
+    public function testEquivalentMarketAliasesAreAccepted(string $marketType, string $typeContract): void
+    {
+        // Alias équivalents : aucune contradiction (compat clients legacy).
+        $this->expectNotToPerformAssertions();
+        $this->validator->validate(null, null, null, null, [
+            'market_type' => $marketType,
+            'type_contract' => $typeContract,
+        ]);
+    }
+
+    public function testRealMarketTypeMismatchPerpVsSpotIsRejected(): void
+    {
+        $this->assertCode('ORCHESTRATION_MARKET_TYPE_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, ['market_type' => 'perp', 'type_contract' => 'spot']);
+        });
+    }
+
+    public function testInvalidMarketTypeIsRejectedFailClosed(): void
+    {
+        // Valeur invalide quand les deux champs sont fournis : refus structuré fail-closed.
+        $this->assertCode('ORCHESTRATION_MARKET_TYPE_MISMATCH', function (): void {
+            $this->validator->validate(null, null, null, null, ['market_type' => 'perpetual', 'type_contract' => 'bogus']);
         });
     }
 

--- a/trading-app/tests/Trading/Service/RunCorrelationIdTest.php
+++ b/trading-app/tests/Trading/Service/RunCorrelationIdTest.php
@@ -61,9 +61,14 @@ final class RunCorrelationIdTest extends TestCase
         $result = RunCorrelationId::canonical($vector['input']);
         self::assertSame($vector['expected'], $result);
 
-        if ($vector['transform'] === 'identity') {
-            self::assertSame($vector['input'], $result);
+        if ($vector['transform'] === 'identity' || $vector['transform'] === 'trim') {
+            // identity : conservé tel quel ; trim : conservé après trim des espaces.
             self::assertLessThanOrEqual(RunCorrelationId::MAX_LENGTH, mb_strlen($result));
+            if ($vector['transform'] === 'identity') {
+                self::assertSame($vector['input'], $result);
+            } else {
+                self::assertSame(trim($vector['input']), $result);
+            }
         } else {
             self::assertSame('sha256', $vector['transform']);
             // Hash hex de 64 caractères, jamais une troncature du préfixe.

--- a/trading-app/tests/Trading/Service/RunCorrelationIdTest.php
+++ b/trading-app/tests/Trading/Service/RunCorrelationIdTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Service;
+
+use App\Trading\Service\RunCorrelationId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * OBS-003 — Vecteurs PARTAGÉS de l'identifiant de corrélation canonique.
+ *
+ * Lit `tests/fixtures/run_correlation_vectors.json` (racine du dépôt), le MÊME fichier
+ * que le test Python `test_correlation.py` : PHP et Python doivent produire exactement
+ * le même résultat pour chaque vecteur. Garantit notamment qu'aucune collision de
+ * préfixe n'est possible (pas de troncature `substr($id, 0, 64)`).
+ */
+#[CoversClass(RunCorrelationId::class)]
+final class RunCorrelationIdTest extends TestCase
+{
+    /** @return array<string,mixed> */
+    private static function fixture(): array
+    {
+        // trading-app/tests/Trading/Service/ -> racine du dépôt -> tests/fixtures/...
+        $path = \dirname(__DIR__, 4) . '/tests/fixtures/run_correlation_vectors.json';
+        $raw = file_get_contents($path);
+        self::assertIsString($raw, 'shared correlation fixture must be readable');
+
+        /** @var array<string,mixed> $data */
+        $data = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+
+        return $data;
+    }
+
+    public function testFixtureIsPresentAndShared(): void
+    {
+        $data = self::fixture();
+        self::assertSame(RunCorrelationId::MAX_LENGTH, $data['max_len']);
+        self::assertTrue($data['empty_must_raise']);
+        self::assertNotEmpty($data['vectors']);
+    }
+
+    /**
+     * @return iterable<string,array{0:array<string,mixed>}>
+     */
+    public static function vectorProvider(): iterable
+    {
+        foreach (self::fixture()['vectors'] as $vector) {
+            yield $vector['name'] => [$vector];
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $vector
+     */
+    #[DataProvider('vectorProvider')]
+    public function testCanonicalMatchesSharedVectors(array $vector): void
+    {
+        $result = RunCorrelationId::canonical($vector['input']);
+        self::assertSame($vector['expected'], $result);
+
+        if ($vector['transform'] === 'identity') {
+            self::assertSame($vector['input'], $result);
+            self::assertLessThanOrEqual(RunCorrelationId::MAX_LENGTH, mb_strlen($result));
+        } else {
+            self::assertSame('sha256', $vector['transform']);
+            // Hash hex de 64 caractères, jamais une troncature du préfixe.
+            self::assertSame(64, mb_strlen($result));
+            self::assertNotSame(mb_substr($vector['input'], 0, 64), $result);
+        }
+    }
+
+    public function testEmptyStringIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        RunCorrelationId::canonical('   ');
+    }
+
+    public function testCanonicalOrNullFallsBackForBlankInput(): void
+    {
+        self::assertNull(RunCorrelationId::canonicalOrNull(null));
+        self::assertNull(RunCorrelationId::canonicalOrNull(''));
+        self::assertNull(RunCorrelationId::canonicalOrNull('   '));
+        self::assertSame('run_abc', RunCorrelationId::canonicalOrNull('run_abc'));
+    }
+
+    public function testPrefixCollisionsDoNotCollide(): void
+    {
+        $byName = [];
+        foreach (self::fixture()['vectors'] as $vector) {
+            $byName[$vector['name']] = $vector;
+        }
+        $a = $byName['prefix_collision_a']['input'];
+        $b = $byName['prefix_collision_b']['input'];
+
+        self::assertSame(mb_substr($a, 0, 64), mb_substr($b, 0, 64));
+        self::assertNotSame(RunCorrelationId::canonical($a), RunCorrelationId::canonical($b));
+    }
+}

--- a/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
+++ b/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
@@ -54,6 +54,7 @@ final class RunTradeOutcomeServiceTest extends TestCase
         self::assertSame('run_dashA', $out['run_id']);
         self::assertSame('run_dashA', $out['correlation_run_id']);
         self::assertTrue($out['source_available']);
+        self::assertFalse($out['truncated']);
         // Une ligne unmatched + des coûts incomplets => données non complètes.
         self::assertFalse($out['data_complete']);
 
@@ -179,6 +180,34 @@ final class RunTradeOutcomeServiceTest extends TestCase
         self::assertSame('partial', $out['summary']['cost_completeness']);
         self::assertNull($out['summary']['estimated_net_pnl_usdt']);
         self::assertSame(5.0, $out['summary']['recorded_pnl_usdt']);
+    }
+
+    public function testRowCapTruncationIsFlaggedNotSilentlyUndercounted(): void
+    {
+        $rows = [
+            $this->row(['symbol' => 'BTCUSDT', 'closeEventId' => 1, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id', 'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => 1.0, 'costCompleteness' => 'partial']),
+            $this->row(['symbol' => 'ETHUSDT', 'closeEventId' => 2, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id', 'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => 2.0, 'costCompleteness' => 'partial']),
+            $this->row(['symbol' => 'SOLUSDT', 'closeEventId' => 3, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id', 'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => 3.0, 'costCompleteness' => 'partial']),
+        ];
+
+        // Plafond bas (2) pour 3 lignes => troncature signalée, jamais sous-comptée en silence.
+        $service = new RunTradeOutcomeService($this->reader($rows), null, 2);
+        $out = $service->buildOutcome('run_big');
+
+        self::assertTrue($out['truncated']);
+        self::assertSame(2, $out['row_cap']);
+        self::assertFalse($out['data_complete']);
+        // Agrégat calculé sur les lignes capées (2), pas faussement présenté comme complet.
+        self::assertSame(2, $out['summary']['trade_count']);
+    }
+
+    public function testWithinRowCapIsNotTruncated(): void
+    {
+        $service = new RunTradeOutcomeService($this->reader([]), null, 2);
+        $out = $service->buildOutcome('run_small');
+
+        self::assertFalse($out['truncated']);
+        self::assertSame(0, $out['summary']['trade_count']);
     }
 
     private function reader(array $rows): PositionTradeAnalysisReaderInterface

--- a/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
+++ b/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Trading\Service;
 
-use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Entity\PositionTradeAnalysisV2;
 use App\Trading\Service\PositionTradeAnalysisReaderInterface;
 use App\Trading\Service\PositionTradeOutcomeSourceException;
 use App\Trading\Service\RunTradeOutcomeService;
@@ -12,37 +12,39 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
- * OBS-003 — Agrégation OUTCOME : couvre run avec trades (count/PnL/MFE-MAE/win-rate +
- * ventilations), run sans trade (agrégat vide explicite), source indisponible (fail-safe,
- * exception jamais agrégat vide), filtre set_id, sémantique recorded/net PnL.
+ * OBS-003 — Agrégation OUTCOME : couvre run avec trades (compteurs matched/unmatched,
+ * recorded vs estimated PnL, win-rate sur matched_closed), run sans trade, source
+ * indisponible (fail-safe), filtre set_id, distinction des états et complétude des coûts.
  */
 #[CoversClass(RunTradeOutcomeService::class)]
 final class RunTradeOutcomeServiceTest extends TestCase
 {
     public function testRunWithTradesAggregatesAndVentilates(): void
     {
-        // Run = "run_dashA" (court, sûr) -> correlation == identité.
         $rows = [
-            // BTC, set s1, profil scalper, exchange bitmart : gagnant clôturé+rapproché, net complet
+            // BTC / s1 / scalper : gagnant clôturé+rapproché, coûts partiels, net estimé.
             $this->row([
                 'symbol' => 'BTCUSDT', 'setId' => 's1', 'mtfProfile' => 'scalper', 'exchange' => 'bitmart',
                 'closeEventId' => 10, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id',
-                'recordedPnlUsdt' => 12.0, 'pnlR' => 1.5, 'mfePct' => 2.0, 'maePct' => -0.5, 'holdingTimeSec' => 100.0,
-                'feesUsdt' => 1.0, 'fundingUsdt' => 0.2, 'slippageUsdt' => 0.1, 'netPnlUsdt' => 10.7, 'netPnlComplete' => true,
+                'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => 12.0, 'pnlR' => 1.5,
+                'mfePct' => 2.0, 'maePct' => -0.5, 'holdingTimeSec' => 100.0,
+                'feesUsdt' => 1.0, 'fundingUsdt' => 0.2, 'slippageUsdt' => 0.1,
+                'estimatedNetPnlUsdt' => 10.7, 'costCompleteness' => 'partial',
             ]),
-            // BTC, set s2, profil regular : perdant clôturé+rapproché, net complet
+            // BTC / s2 / regular : perdant clôturé+rapproché, aucun coût (unknown).
             $this->row([
                 'symbol' => 'BTCUSDT', 'setId' => 's2', 'mtfProfile' => 'regular', 'exchange' => 'bitmart',
                 'closeEventId' => 11, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_position_id',
-                'recordedPnlUsdt' => -4.0, 'pnlR' => -1.0, 'mfePct' => 0.5, 'maePct' => -1.5, 'holdingTimeSec' => 200.0,
-                'feesUsdt' => 1.0, 'fundingUsdt' => 0.0, 'slippageUsdt' => 0.0, 'netPnlUsdt' => -5.0, 'netPnlComplete' => true,
+                'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => -4.0, 'pnlR' => -1.0,
+                'mfePct' => 0.5, 'maePct' => -1.5, 'holdingTimeSec' => 200.0,
+                'costCompleteness' => 'unknown',
             ]),
-            // ETH, set s1, profil scalper : trade ouvert (pas de clôture) -> exclu du winrate
+            // ETH / s1 / scalper : non rapproché -> état réel INCONNU (jamais "open confirmé").
             $this->row([
                 'symbol' => 'ETHUSDT', 'setId' => 's1', 'mtfProfile' => 'scalper', 'exchange' => 'bitmart',
                 'closeEventId' => null, 'closeMatchStatus' => 'unmatched', 'closeMatchedBy' => 'unmatched',
-                'recordedPnlUsdt' => null, 'pnlR' => null, 'mfePct' => 1.0, 'maePct' => -0.2, 'holdingTimeSec' => null,
-                'netPnlComplete' => false,
+                'analysisStatus' => 'unmatched', 'recordedPnlUsdt' => null, 'pnlR' => null,
+                'mfePct' => 1.0, 'maePct' => -0.2, 'costCompleteness' => 'not_applicable',
             ]),
         ];
 
@@ -52,32 +54,33 @@ final class RunTradeOutcomeServiceTest extends TestCase
         self::assertSame('run_dashA', $out['run_id']);
         self::assertSame('run_dashA', $out['correlation_run_id']);
         self::assertTrue($out['source_available']);
-        // un trade ouvert sans net complet n'invalide pas data_complete (seuls les clôturés comptent)
-        self::assertTrue($out['data_complete']);
+        // Une ligne unmatched + des coûts incomplets => données non complètes.
+        self::assertFalse($out['data_complete']);
 
         $s = $out['summary'];
         self::assertSame(3, $s['trade_count']);
-        self::assertSame(2, $s['closed_count']);
-        self::assertSame(1, $s['open_count']);
-        self::assertSame(2, $s['matched_count']);
+        self::assertSame(2, $s['matched_closed_count']);
         self::assertSame(1, $s['unmatched_count']);
+        self::assertSame(0, $s['confirmed_open_count']);
+        self::assertSame(1, $s['unknown_state_count']);
         self::assertSame(1, $s['win_count']);
         self::assertSame(1, $s['loss_count']);
         self::assertSame(0.5, $s['win_rate_closed']);
-        self::assertSame(8.0, $s['recorded_pnl_usdt']); // 12 - 4
-        self::assertSame(0.5, $s['pnl_r']);              // 1.5 - 1.0
-        self::assertTrue($s['net_pnl_complete']);
-        self::assertEqualsWithDelta(5.7, $s['net_pnl_usdt'], 1e-9); // 10.7 - 5.0
+        self::assertSame(8.0, $s['recorded_pnl_usdt']);
+        self::assertSame(0.5, $s['pnl_r']);
+        self::assertEqualsWithDelta(10.7, $s['estimated_net_pnl_usdt'], 1e-9);
+        self::assertSame('mixed', $s['cost_completeness']); // partial + unknown
+        self::assertFalse($s['data_complete']);
         self::assertEqualsWithDelta((2.0 + 0.5 + 1.0) / 3, $s['mfe_pct_avg'], 1e-6);
         self::assertSame(1.0, $s['mfe_pct_median']);
 
-        // Ventilations
         $bySymbol = $this->byKey($out['by_symbol']);
         self::assertSame(2, $bySymbol['BTCUSDT']['trade_count']);
         self::assertSame(1, $bySymbol['ETHUSDT']['trade_count']);
 
         $bySet = $this->byKey($out['by_set']);
         self::assertSame(2, $bySet['s1']['trade_count']);
+        self::assertSame(1, $bySet['s1']['matched_closed_count']); // R1 matched, R3 unmatched
         self::assertSame(1, $bySet['s2']['trade_count']);
 
         $byProfile = $this->byKey($out['by_profile']);
@@ -94,11 +97,15 @@ final class RunTradeOutcomeServiceTest extends TestCase
         $out = $service->buildOutcome('run_empty');
 
         self::assertTrue($out['source_available']);
-        self::assertTrue($out['data_complete']);
-        self::assertSame(0, $out['summary']['trade_count']);
-        self::assertNull($out['summary']['win_rate_closed']);
-        self::assertNull($out['summary']['recorded_pnl_usdt']);
-        self::assertNull($out['summary']['net_pnl_usdt']);
+        self::assertTrue($out['data_complete']); // aucune ligne => vacuously complet
+        $s = $out['summary'];
+        self::assertSame(0, $s['trade_count']);
+        self::assertSame(0, $s['matched_closed_count']);
+        self::assertSame(0, $s['unmatched_count']);
+        self::assertNull($s['win_rate_closed']);
+        self::assertNull($s['recorded_pnl_usdt']);
+        self::assertNull($s['estimated_net_pnl_usdt']);
+        self::assertSame('not_applicable', $s['cost_completeness']);
         self::assertSame([], $out['by_symbol']);
     }
 
@@ -134,31 +141,50 @@ final class RunTradeOutcomeServiceTest extends TestCase
         self::assertSame('s42', $out['set_id']);
     }
 
-    public function testNetPnlIncompleteWhenAClosedTradeMissesCosts(): void
+    public function testUnmatchedIsNeverCountedAsConfirmedOpen(): void
+    {
+        $rows = [
+            $this->row([
+                'symbol' => 'BTCUSDT', 'closeEventId' => null, 'closeMatchStatus' => 'unmatched',
+                'closeMatchedBy' => 'unmatched', 'analysisStatus' => 'unmatched',
+                'recordedPnlUsdt' => null, 'costCompleteness' => 'not_applicable',
+            ]),
+        ];
+
+        $service = new RunTradeOutcomeService($this->reader($rows));
+        $s = $service->buildOutcome('run_x')['summary'];
+
+        self::assertSame(1, $s['trade_count']);
+        self::assertSame(0, $s['matched_closed_count']);
+        self::assertSame(1, $s['unmatched_count']);
+        self::assertSame(0, $s['confirmed_open_count']);
+        self::assertSame(1, $s['unknown_state_count']);
+        self::assertNull($s['win_rate_closed']);
+    }
+
+    public function testCostCompletenessAndEstimatedNetAreNotCertified(): void
     {
         $rows = [
             $this->row([
                 'symbol' => 'BTCUSDT', 'closeEventId' => 1, 'closeMatchStatus' => 'matched',
-                'closeMatchedBy' => 'matched_trade_id', 'recordedPnlUsdt' => 5.0, 'netPnlComplete' => false,
+                'closeMatchedBy' => 'matched_trade_id', 'analysisStatus' => 'matched_closed',
+                'recordedPnlUsdt' => 5.0, 'estimatedNetPnlUsdt' => null, 'costCompleteness' => 'partial',
             ]),
         ];
 
         $service = new RunTradeOutcomeService($this->reader($rows));
         $out = $service->buildOutcome('run_x');
 
-        self::assertFalse($out['data_complete']);
-        self::assertFalse($out['summary']['net_pnl_complete']);
-        self::assertNull($out['summary']['net_pnl_usdt']);
+        self::assertFalse($out['data_complete']); // partial != complete
+        self::assertSame('partial', $out['summary']['cost_completeness']);
+        self::assertNull($out['summary']['estimated_net_pnl_usdt']);
         self::assertSame(5.0, $out['summary']['recorded_pnl_usdt']);
     }
 
-    /**
-     * @param array<string,mixed> $rows
-     */
     private function reader(array $rows): PositionTradeAnalysisReaderInterface
     {
         return new class($rows) implements PositionTradeAnalysisReaderInterface {
-            /** @param PositionTradeAnalysis[] $rows */
+            /** @param PositionTradeAnalysisV2[] $rows */
             public function __construct(private readonly array $rows)
             {
             }
@@ -171,7 +197,7 @@ final class RunTradeOutcomeServiceTest extends TestCase
 
                 return array_values(array_filter(
                     $this->rows,
-                    static fn (PositionTradeAnalysis $r): bool => $r->getSetId() === $setId
+                    static fn (PositionTradeAnalysisV2 $r): bool => $r->getSetId() === $setId
                 ));
             }
         };
@@ -192,11 +218,9 @@ final class RunTradeOutcomeServiceTest extends TestCase
     }
 
     /**
-     * Construit une ligne de vue (entité readOnly) via réflexion.
-     *
      * @param array<string,mixed> $overrides
      */
-    private function row(array $overrides): PositionTradeAnalysis
+    private function row(array $overrides): PositionTradeAnalysisV2
     {
         static $autoId = 1;
         $defaults = [
@@ -205,11 +229,12 @@ final class RunTradeOutcomeServiceTest extends TestCase
             'entryTime' => new \DateTimeImmutable('2026-06-17T08:30:00+00:00'),
             'closeMatchStatus' => 'unmatched',
             'closeMatchedBy' => 'unmatched',
-            'netPnlComplete' => false,
+            'analysisStatus' => 'unmatched',
+            'costCompleteness' => 'not_applicable',
         ];
         $data = array_merge($defaults, $overrides);
 
-        $entity = (new \ReflectionClass(PositionTradeAnalysis::class))->newInstanceWithoutConstructor();
+        $entity = (new \ReflectionClass(PositionTradeAnalysisV2::class))->newInstanceWithoutConstructor();
         $ref = new \ReflectionObject($entity);
         foreach ($data as $prop => $value) {
             if (!$ref->hasProperty($prop)) {

--- a/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
+++ b/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
@@ -201,6 +201,31 @@ final class RunTradeOutcomeServiceTest extends TestCase
         self::assertSame(2, $out['summary']['trade_count']);
     }
 
+    public function testTruncationForcesNestedDataCompleteFalse(): void
+    {
+        // Lignes qui SERAIENT complètes (matched_closed + cost 'complete') : sans propagation,
+        // `summary.data_complete` et les `data_complete` de groupe seraient vrais sur les
+        // lignes capées, présentant des KPI partiels comme complets malgré la troncature.
+        $rows = [
+            $this->row(['symbol' => 'BTCUSDT', 'setId' => 's1', 'closeEventId' => 1, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id', 'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => 1.0, 'costCompleteness' => 'complete']),
+            $this->row(['symbol' => 'ETHUSDT', 'setId' => 's2', 'closeEventId' => 2, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id', 'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => 2.0, 'costCompleteness' => 'complete']),
+            $this->row(['symbol' => 'SOLUSDT', 'setId' => 's3', 'closeEventId' => 3, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id', 'analysisStatus' => 'matched_closed', 'recordedPnlUsdt' => 3.0, 'costCompleteness' => 'complete']),
+        ];
+
+        $service = new RunTradeOutcomeService($this->reader($rows), null, 2);
+        $out = $service->buildOutcome('run_big');
+
+        self::assertTrue($out['truncated']);
+        self::assertFalse($out['data_complete']);
+        // Propagation : summary ET chaque agrégat groupé signalent l'incomplétude.
+        self::assertFalse($out['summary']['data_complete']);
+        foreach (['by_set', 'by_profile', 'by_exchange', 'by_symbol'] as $group) {
+            foreach ($out[$group] as $bucket) {
+                self::assertFalse($bucket['data_complete'], "data_complete propagé sur {$group}");
+            }
+        }
+    }
+
     public function testWithinRowCapIsNotTruncated(): void
     {
         $service = new RunTradeOutcomeService($this->reader([]), null, 2);

--- a/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
+++ b/trading-app/tests/Trading/Service/RunTradeOutcomeServiceTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Service;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Service\PositionTradeAnalysisReaderInterface;
+use App\Trading\Service\PositionTradeOutcomeSourceException;
+use App\Trading\Service\RunTradeOutcomeService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * OBS-003 — Agrégation OUTCOME : couvre run avec trades (count/PnL/MFE-MAE/win-rate +
+ * ventilations), run sans trade (agrégat vide explicite), source indisponible (fail-safe,
+ * exception jamais agrégat vide), filtre set_id, sémantique recorded/net PnL.
+ */
+#[CoversClass(RunTradeOutcomeService::class)]
+final class RunTradeOutcomeServiceTest extends TestCase
+{
+    public function testRunWithTradesAggregatesAndVentilates(): void
+    {
+        // Run = "run_dashA" (court, sûr) -> correlation == identité.
+        $rows = [
+            // BTC, set s1, profil scalper, exchange bitmart : gagnant clôturé+rapproché, net complet
+            $this->row([
+                'symbol' => 'BTCUSDT', 'setId' => 's1', 'mtfProfile' => 'scalper', 'exchange' => 'bitmart',
+                'closeEventId' => 10, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_trade_id',
+                'recordedPnlUsdt' => 12.0, 'pnlR' => 1.5, 'mfePct' => 2.0, 'maePct' => -0.5, 'holdingTimeSec' => 100.0,
+                'feesUsdt' => 1.0, 'fundingUsdt' => 0.2, 'slippageUsdt' => 0.1, 'netPnlUsdt' => 10.7, 'netPnlComplete' => true,
+            ]),
+            // BTC, set s2, profil regular : perdant clôturé+rapproché, net complet
+            $this->row([
+                'symbol' => 'BTCUSDT', 'setId' => 's2', 'mtfProfile' => 'regular', 'exchange' => 'bitmart',
+                'closeEventId' => 11, 'closeMatchStatus' => 'matched', 'closeMatchedBy' => 'matched_position_id',
+                'recordedPnlUsdt' => -4.0, 'pnlR' => -1.0, 'mfePct' => 0.5, 'maePct' => -1.5, 'holdingTimeSec' => 200.0,
+                'feesUsdt' => 1.0, 'fundingUsdt' => 0.0, 'slippageUsdt' => 0.0, 'netPnlUsdt' => -5.0, 'netPnlComplete' => true,
+            ]),
+            // ETH, set s1, profil scalper : trade ouvert (pas de clôture) -> exclu du winrate
+            $this->row([
+                'symbol' => 'ETHUSDT', 'setId' => 's1', 'mtfProfile' => 'scalper', 'exchange' => 'bitmart',
+                'closeEventId' => null, 'closeMatchStatus' => 'unmatched', 'closeMatchedBy' => 'unmatched',
+                'recordedPnlUsdt' => null, 'pnlR' => null, 'mfePct' => 1.0, 'maePct' => -0.2, 'holdingTimeSec' => null,
+                'netPnlComplete' => false,
+            ]),
+        ];
+
+        $service = new RunTradeOutcomeService($this->reader($rows));
+        $out = $service->buildOutcome('run_dashA');
+
+        self::assertSame('run_dashA', $out['run_id']);
+        self::assertSame('run_dashA', $out['correlation_run_id']);
+        self::assertTrue($out['source_available']);
+        // un trade ouvert sans net complet n'invalide pas data_complete (seuls les clôturés comptent)
+        self::assertTrue($out['data_complete']);
+
+        $s = $out['summary'];
+        self::assertSame(3, $s['trade_count']);
+        self::assertSame(2, $s['closed_count']);
+        self::assertSame(1, $s['open_count']);
+        self::assertSame(2, $s['matched_count']);
+        self::assertSame(1, $s['unmatched_count']);
+        self::assertSame(1, $s['win_count']);
+        self::assertSame(1, $s['loss_count']);
+        self::assertSame(0.5, $s['win_rate_closed']);
+        self::assertSame(8.0, $s['recorded_pnl_usdt']); // 12 - 4
+        self::assertSame(0.5, $s['pnl_r']);              // 1.5 - 1.0
+        self::assertTrue($s['net_pnl_complete']);
+        self::assertEqualsWithDelta(5.7, $s['net_pnl_usdt'], 1e-9); // 10.7 - 5.0
+        self::assertEqualsWithDelta((2.0 + 0.5 + 1.0) / 3, $s['mfe_pct_avg'], 1e-6);
+        self::assertSame(1.0, $s['mfe_pct_median']);
+
+        // Ventilations
+        $bySymbol = $this->byKey($out['by_symbol']);
+        self::assertSame(2, $bySymbol['BTCUSDT']['trade_count']);
+        self::assertSame(1, $bySymbol['ETHUSDT']['trade_count']);
+
+        $bySet = $this->byKey($out['by_set']);
+        self::assertSame(2, $bySet['s1']['trade_count']);
+        self::assertSame(1, $bySet['s2']['trade_count']);
+
+        $byProfile = $this->byKey($out['by_profile']);
+        self::assertSame(2, $byProfile['scalper']['trade_count']);
+        self::assertSame(1, $byProfile['regular']['trade_count']);
+
+        $byExchange = $this->byKey($out['by_exchange']);
+        self::assertSame(3, $byExchange['bitmart']['trade_count']);
+    }
+
+    public function testRunWithoutTradeReturnsExplicitEmptyAggregate(): void
+    {
+        $service = new RunTradeOutcomeService($this->reader([]));
+        $out = $service->buildOutcome('run_empty');
+
+        self::assertTrue($out['source_available']);
+        self::assertTrue($out['data_complete']);
+        self::assertSame(0, $out['summary']['trade_count']);
+        self::assertNull($out['summary']['win_rate_closed']);
+        self::assertNull($out['summary']['recorded_pnl_usdt']);
+        self::assertNull($out['summary']['net_pnl_usdt']);
+        self::assertSame([], $out['by_symbol']);
+    }
+
+    public function testSourceUnavailableThrowsAndIsNeverAnEmptyAggregate(): void
+    {
+        $reader = new class implements PositionTradeAnalysisReaderInterface {
+            public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
+            {
+                throw new \RuntimeException('view missing');
+            }
+        };
+
+        $service = new RunTradeOutcomeService($reader);
+        $this->expectException(PositionTradeOutcomeSourceException::class);
+        $service->buildOutcome('run_x');
+    }
+
+    public function testSetIdFilterIsForwardedToReader(): void
+    {
+        $reader = new class implements PositionTradeAnalysisReaderInterface {
+            public ?string $seenSetId = 'NOT_SET';
+            public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
+            {
+                $this->seenSetId = $setId;
+                return [];
+            }
+        };
+
+        $service = new RunTradeOutcomeService($reader);
+        $out = $service->buildOutcome('run_x', 's42');
+
+        self::assertSame('s42', $reader->seenSetId);
+        self::assertSame('s42', $out['set_id']);
+    }
+
+    public function testNetPnlIncompleteWhenAClosedTradeMissesCosts(): void
+    {
+        $rows = [
+            $this->row([
+                'symbol' => 'BTCUSDT', 'closeEventId' => 1, 'closeMatchStatus' => 'matched',
+                'closeMatchedBy' => 'matched_trade_id', 'recordedPnlUsdt' => 5.0, 'netPnlComplete' => false,
+            ]),
+        ];
+
+        $service = new RunTradeOutcomeService($this->reader($rows));
+        $out = $service->buildOutcome('run_x');
+
+        self::assertFalse($out['data_complete']);
+        self::assertFalse($out['summary']['net_pnl_complete']);
+        self::assertNull($out['summary']['net_pnl_usdt']);
+        self::assertSame(5.0, $out['summary']['recorded_pnl_usdt']);
+    }
+
+    /**
+     * @param array<string,mixed> $rows
+     */
+    private function reader(array $rows): PositionTradeAnalysisReaderInterface
+    {
+        return new class($rows) implements PositionTradeAnalysisReaderInterface {
+            /** @param PositionTradeAnalysis[] $rows */
+            public function __construct(private readonly array $rows)
+            {
+            }
+
+            public function findByCorrelationRunId(string $correlationRunId, ?string $setId = null, int $limit = 2000): array
+            {
+                if ($setId === null) {
+                    return $this->rows;
+                }
+
+                return array_values(array_filter(
+                    $this->rows,
+                    static fn (PositionTradeAnalysis $r): bool => $r->getSetId() === $setId
+                ));
+            }
+        };
+    }
+
+    /**
+     * @param list<array<string,mixed>> $groups
+     * @return array<string,array<string,mixed>>
+     */
+    private function byKey(array $groups): array
+    {
+        $out = [];
+        foreach ($groups as $g) {
+            $out[$g['key']] = $g;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Construit une ligne de vue (entité readOnly) via réflexion.
+     *
+     * @param array<string,mixed> $overrides
+     */
+    private function row(array $overrides): PositionTradeAnalysis
+    {
+        static $autoId = 1;
+        $defaults = [
+            'entryEventId' => $autoId++,
+            'symbol' => 'BTCUSDT',
+            'entryTime' => new \DateTimeImmutable('2026-06-17T08:30:00+00:00'),
+            'closeMatchStatus' => 'unmatched',
+            'closeMatchedBy' => 'unmatched',
+            'netPnlComplete' => false,
+        ];
+        $data = array_merge($defaults, $overrides);
+
+        $entity = (new \ReflectionClass(PositionTradeAnalysis::class))->newInstanceWithoutConstructor();
+        $ref = new \ReflectionObject($entity);
+        foreach ($data as $prop => $value) {
+            if (!$ref->hasProperty($prop)) {
+                continue;
+            }
+            $p = $ref->getProperty($prop);
+            $p->setAccessible(true);
+            $p->setValue($entity, $value);
+        }
+
+        return $entity;
+    }
+}

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -239,6 +239,41 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertEqualsWithDelta(3.0, (float) $bySymbol['ETHUSDT']['recorded_pnl_usdt'], 1e-9);
     }
 
+    public function testReusedPositionIdAcrossVenuesDoesNotCrossMatch(): void
+    {
+        $run = 'run_venue';
+        // Même symbole BTC + même position_id `PV`, mais deux venues (bitmart / okx).
+        // Une clôture OKX ne doit pas être appariée à l'entrée bitmart (PnL au mauvais
+        // bucket by_exchange) et inversement.
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TBB'], '2026-06-17 09:00:00+00', 920);
+        $this->opened('BTCUSDT', $run, 'TBB', 'PV', '2026-06-17 09:00:30+00', 921);
+        $this->entry('BTCUSDT', $run, 's2', 'scalper', 'okx', 'perpetual', ['trade_id' => 'TBO'], '2026-06-17 09:05:00+00', 922);
+        $this->opened('BTCUSDT', $run, 'TBO', 'PV', '2026-06-17 09:05:30+00', 923);
+        $this->close('BTCUSDT', $run, ['pnl' => 5.0], 'PV', '2026-06-17 09:30:00+00', 924, 'bitmart', 'perpetual');
+        $this->close('BTCUSDT', $run, ['pnl' => 8.0], 'PV', '2026-06-17 09:35:00+00', 925, 'okx', 'perpetual');
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT exchange, trade_id, close_match_status, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis WHERE run_id = ? ORDER BY exchange',
+            [$run]
+        );
+
+        self::assertCount(2, $rows);
+        $byExchange = [];
+        foreach ($rows as $r) {
+            $byExchange[$r['exchange']] = $r;
+        }
+
+        // Chaque venue est rapprochée de SA propre clôture, jamais en cross-venue.
+        self::assertSame('matched', $byExchange['bitmart']['close_match_status']);
+        self::assertSame(924, (int) $byExchange['bitmart']['close_event_id']);
+        self::assertEqualsWithDelta(5.0, (float) $byExchange['bitmart']['recorded_pnl_usdt'], 1e-9);
+
+        self::assertSame('matched', $byExchange['okx']['close_match_status']);
+        self::assertSame(925, (int) $byExchange['okx']['close_event_id']);
+        self::assertEqualsWithDelta(8.0, (float) $byExchange['okx']['recorded_pnl_usdt'], 1e-9);
+    }
+
     private function createMinimalSchema(): void
     {
         $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
@@ -329,12 +364,20 @@ SQL);
     /**
      * @param array<string,mixed> $extra
      */
-    private function close(string $symbol, string $runId, array $extra, ?string $positionId, string $happenedAt, int $forcedId): void
-    {
+    private function close(
+        string $symbol,
+        string $runId,
+        array $extra,
+        ?string $positionId,
+        string $happenedAt,
+        int $forcedId,
+        string $exchange = 'bitmart',
+        string $marketType = 'perpetual',
+    ): void {
         $this->conn->executeStatement(
-            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, extra, happened_at)
-             VALUES (?, ?, \'position_closed\', ?, ?, ?::jsonb, ?)',
-            [$forcedId, $symbol, $runId, $positionId, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, exchange, market_type, extra, happened_at)
+             VALUES (?, ?, \'position_closed\', ?, ?, ?, ?, ?::jsonb, ?)',
+            [$forcedId, $symbol, $runId, $positionId, $exchange, $marketType, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
         );
     }
 

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
 /**
- * OBS-003 — Test d'INTÉGRATION de la vue `position_trade_analysis` sur un vrai PostgreSQL.
+ * OBS-003 — Test d'INTÉGRATION de la vue `position_trade_analysis_v2` sur un vrai PostgreSQL.
  *
  * Exécute le SQL RÉEL de la migration {@see Version20260622000000} (via `getSql()`),
  * sur des tables minimales `trade_lifecycle_event` + `indicator_snapshots`, puis vérifie
@@ -48,7 +48,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
     protected function tearDown(): void
     {
         if (isset($this->conn)) {
-            $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
+            $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis_v2');
             $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
             $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
             $this->conn->close();
@@ -85,7 +85,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
         $this->close('SOLUSDT', $run, ['trade_id' => 'ORPHAN', 'pnl' => 99.0], 'PX', '2026-06-17 08:50:00+00', 999);
 
         $rows = $this->conn->fetchAllAssociative(
-            'SELECT * FROM position_trade_analysis WHERE run_id = ? ORDER BY entry_time',
+            'SELECT * FROM position_trade_analysis_v2 WHERE run_id = ? ORDER BY entry_time',
             [$run]
         );
 
@@ -113,23 +113,28 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertSame('perpetual', $t1['market_type']);
         self::assertSame($run, $t1['orchestration_run_id']);
         self::assertSame($run, $t1['correlation_run_id']);
+        self::assertSame('matched_closed', $t1['analysis_status']);
         self::assertEqualsWithDelta(12.0, (float) $t1['recorded_pnl_usdt'], 1e-9);
-        self::assertTrue($this->asBool($t1['net_pnl_complete']));
-        self::assertEqualsWithDelta(10.7, (float) $t1['net_pnl_usdt'], 1e-9); // 12 - 1 - 0.2 - 0.1
+        // Coûts présents mais contrat #190 incomplet (ni spread ni brut) => 'partial',
+        // JAMAIS 'complete'. estimated_net est une ESTIMATION best-effort, pas un net certifié.
+        self::assertSame('partial', $t1['cost_completeness']);
+        self::assertEqualsWithDelta(10.7, (float) $t1['estimated_net_pnl_usdt'], 1e-9); // 12 - 1 - 0.2 - 0.1
 
-        // T2 : rapproché par position_id, net INCOMPLET (pas de fees/funding/slippage).
+        // T2 : rapproché par position_id, aucune composante de coût => 'unknown', sans estimation.
         $t2 = $byTrade['T2'];
         self::assertSame('matched', $t2['close_match_status']);
         self::assertSame('matched_position_id', $t2['close_matched_by']);
         self::assertSame('P2', $t2['position_id']);
         self::assertEqualsWithDelta(-4.0, (float) $t2['recorded_pnl_usdt'], 1e-9);
-        self::assertFalse($this->asBool($t2['net_pnl_complete']));
-        self::assertNull($t2['net_pnl_usdt']);
+        self::assertSame('unknown', $t2['cost_completeness']);
+        self::assertNull($t2['estimated_net_pnl_usdt']);
 
-        // ETH : aucune clôture -> unmatched / ouvert, pas de PnL.
+        // ETH : aucune clôture -> unmatched, état réel INCONNU (jamais "open confirmé"), pas de PnL.
         $eth = $byTrade['T3'];
         self::assertSame('unmatched', $eth['close_match_status']);
         self::assertSame('unmatched', $eth['close_matched_by']);
+        self::assertSame('unmatched', $eth['analysis_status']);
+        self::assertSame('not_applicable', $eth['cost_completeness']);
         self::assertNull($eth['close_event_id']);
         self::assertNull($eth['recorded_pnl_usdt']);
     }
@@ -145,7 +150,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
         $this->close('BTCUSDT', $run, ['pnl' => 2.0], 'PSHARED', '2026-06-17 09:11:00+00', 401);
 
         $rows = $this->conn->fetchAllAssociative(
-            'SELECT entry_event_id, close_event_id FROM position_trade_analysis WHERE run_id = ? ORDER BY entry_time',
+            'SELECT entry_event_id, close_event_id FROM position_trade_analysis_v2 WHERE run_id = ? ORDER BY entry_time',
             [$run]
         );
 
@@ -167,7 +172,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
 
         $rows = $this->conn->fetchAllAssociative(
             'SELECT trade_id, close_match_status, close_event_id, recorded_pnl_usdt
-             FROM position_trade_analysis WHERE run_id = ?',
+             FROM position_trade_analysis_v2 WHERE run_id = ?',
             [$run]
         );
 
@@ -191,7 +196,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
 
         $rows = $this->conn->fetchAllAssociative(
             'SELECT trade_id, close_match_status, close_matched_by, close_event_id, recorded_pnl_usdt
-             FROM position_trade_analysis WHERE run_id = ?',
+             FROM position_trade_analysis_v2 WHERE run_id = ?',
             [$run]
         );
 
@@ -219,7 +224,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
 
         $rows = $this->conn->fetchAllAssociative(
             'SELECT symbol, trade_id, close_match_status, close_event_id, recorded_pnl_usdt
-             FROM position_trade_analysis WHERE run_id = ? ORDER BY symbol',
+             FROM position_trade_analysis_v2 WHERE run_id = ? ORDER BY symbol',
             [$run]
         );
 
@@ -254,7 +259,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
 
         $rows = $this->conn->fetchAllAssociative(
             'SELECT exchange, trade_id, close_match_status, close_event_id, recorded_pnl_usdt
-             FROM position_trade_analysis WHERE run_id = ? ORDER BY exchange',
+             FROM position_trade_analysis_v2 WHERE run_id = ? ORDER BY exchange',
             [$run]
         );
 
@@ -276,7 +281,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
 
     private function createMinimalSchema(): void
     {
-        $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
+        $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
         $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
 
@@ -379,10 +384,5 @@ SQL);
              VALUES (?, ?, \'position_closed\', ?, ?, ?, ?, ?::jsonb, ?)',
             [$forcedId, $symbol, $runId, $positionId, $exchange, $marketType, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
         );
-    }
-
-    private function asBool(mixed $value): bool
-    {
-        return $value === true || $value === 't' || $value === '1' || $value === 1;
     }
 }

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -204,6 +204,41 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertEqualsWithDelta(7.0, (float) $rows[0]['recorded_pnl_usdt'], 1e-9);
     }
 
+    public function testReusedPositionIdAcrossTwoSymbolsMatchesEachOnItsOwnClose(): void
+    {
+        $run = 'run_xsym';
+        // Même position_id `PX` réutilisé sur BTC et ETH. L'entrée BTC est la première,
+        // mais la clôture ETH arrive AVANT la clôture BTC : sans partition par symbole,
+        // les rangs se croiseraient et le garde de symbole rejetterait les deux clôtures.
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TB'], '2026-06-17 09:00:00+00', 900);
+        $this->opened('BTCUSDT', $run, 'TB', 'PX', '2026-06-17 09:00:30+00', 901);
+        $this->entry('ETHUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TE'], '2026-06-17 09:10:00+00', 902);
+        $this->opened('ETHUSDT', $run, 'TE', 'PX', '2026-06-17 09:10:30+00', 903);
+        $this->close('ETHUSDT', $run, ['pnl' => 3.0], 'PX', '2026-06-17 09:20:00+00', 904);
+        $this->close('BTCUSDT', $run, ['pnl' => 5.0], 'PX', '2026-06-17 09:30:00+00', 905);
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT symbol, trade_id, close_match_status, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis WHERE run_id = ? ORDER BY symbol',
+            [$run]
+        );
+
+        self::assertCount(2, $rows);
+        $bySymbol = [];
+        foreach ($rows as $r) {
+            $bySymbol[$r['symbol']] = $r;
+        }
+
+        // Chaque symbole est rapproché de SA propre clôture (pas de croisement de rangs).
+        self::assertSame('matched', $bySymbol['BTCUSDT']['close_match_status']);
+        self::assertSame(905, (int) $bySymbol['BTCUSDT']['close_event_id']);
+        self::assertEqualsWithDelta(5.0, (float) $bySymbol['BTCUSDT']['recorded_pnl_usdt'], 1e-9);
+
+        self::assertSame('matched', $bySymbol['ETHUSDT']['close_match_status']);
+        self::assertSame(904, (int) $bySymbol['ETHUSDT']['close_event_id']);
+        self::assertEqualsWithDelta(3.0, (float) $bySymbol['ETHUSDT']['recorded_pnl_usdt'], 1e-9);
+    }
+
     private function createMinimalSchema(): void
     {
         $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -178,6 +178,32 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertNull($rows[0]['recorded_pnl_usdt'], 'aucun vieux PnL attribué au run courant');
     }
 
+    public function testRealCloseAfterEntryMatchesDespiteAnOrphanStaleCloseBefore(): void
+    {
+        $run = 'run_orphan_then_real';
+        // Clôture orpheline/périmée AVANT l'entrée (position_id réutilisé `PO`, aucune
+        // entrée antérieure) — elle ne doit pas voler le rang à la vraie clôture.
+        $this->close('BTCUSDT', $run, ['pnl' => 999.0], 'PO', '2026-06-17 08:00:00+00', 800);
+        // Entrée réelle (trade TO) + pont vers `PO` + VRAIE clôture postérieure.
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TO'], '2026-06-17 09:00:00+00', 801);
+        $this->opened('BTCUSDT', $run, 'TO', 'PO', '2026-06-17 09:00:30+00', 802);
+        $this->close('BTCUSDT', $run, ['pnl' => 7.0, 'pnl_R' => 1.0], 'PO', '2026-06-17 10:00:00+00', 803);
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT trade_id, close_match_status, close_matched_by, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis WHERE run_id = ?',
+            [$run]
+        );
+
+        self::assertCount(1, $rows, 'une seule entrée (la clôture orpheline ne crée pas de ligne)');
+        self::assertSame('TO', $rows[0]['trade_id']);
+        // La vraie clôture postérieure est rapprochée (pas laissée unmatched par la périmée).
+        self::assertSame('matched', $rows[0]['close_match_status']);
+        self::assertSame('matched_position_id', $rows[0]['close_matched_by']);
+        self::assertSame(803, (int) $rows[0]['close_event_id']);
+        self::assertEqualsWithDelta(7.0, (float) $rows[0]['recorded_pnl_usdt'], 1e-9);
+    }
+
     private function createMinimalSchema(): void
     {
         $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -357,6 +357,44 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertEqualsWithDelta(8.0, (float) $byExchange['okx']['recorded_pnl_usdt'], 1e-9);
     }
 
+    public function testCloseMatchingIsScopedByRun(): void
+    {
+        // (a) Anti cross-run : entrée runA + clôture TAGUÉE runB (même trade_id + venue).
+        // La clôture d'un AUTRE run ne doit pas être consommée par l'entrée runA (sinon son
+        // PnL serait attribué à runA, que l'API filtre par run APRÈS l'appariement).
+        $this->entry('BTCUSDT', 'runA', 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TR'], '2026-06-17 09:00:00+00', 1400);
+        $this->close('BTCUSDT', 'runB', ['trade_id' => 'TR', 'pnl' => 8.0], null, '2026-06-17 09:30:00+00', 1401, 'bitmart', 'perpetual');
+
+        $rowsA = $this->conn->fetchAllAssociative(
+            'SELECT trade_id, close_match_status, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis_v2 WHERE run_id = ?',
+            ['runA']
+        );
+        self::assertCount(1, $rowsA);
+        self::assertSame('unmatched', $rowsA[0]['close_match_status']);
+        self::assertNull($rowsA[0]['close_event_id']);
+        self::assertNull($rowsA[0]['recorded_pnl_usdt'], 'aucune clôture d\'un autre run attribuée');
+
+        // (b) Chemin LIVE : la synchro émet les clôtures SANS run_id (run_id NULL) — elles
+        // restent rapprochables par le run de l'entrée (le garde est permissif sur NULL).
+        $this->entry('ETHUSDT', 'runC', 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TN'], '2026-06-17 09:00:00+00', 1410);
+        $this->conn->executeStatement(
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, exchange, market_type, extra, happened_at)
+             VALUES (?, ?, \'position_closed\', NULL, NULL, ?, ?, ?::jsonb, ?)',
+            [1411, 'ETHUSDT', 'bitmart', 'perpetual', json_encode(['trade_id' => 'TN', 'pnl' => 3.0], JSON_THROW_ON_ERROR), '2026-06-17 09:30:00+00']
+        );
+
+        $rowsC = $this->conn->fetchAllAssociative(
+            'SELECT trade_id, close_match_status, close_matched_by, recorded_pnl_usdt
+             FROM position_trade_analysis_v2 WHERE run_id = ?',
+            ['runC']
+        );
+        self::assertCount(1, $rowsC);
+        self::assertSame('matched', $rowsC[0]['close_match_status']);
+        self::assertSame('matched_trade_id', $rowsC[0]['close_matched_by']);
+        self::assertEqualsWithDelta(3.0, (float) $rowsC[0]['recorded_pnl_usdt'], 1e-9);
+    }
+
     public function testStaleCloseDetectedViaRealCloseTimeNotLogTime(): void
     {
         $run = 'run_realtime';

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -67,10 +67,13 @@ final class PositionTradeAnalysisViewTest extends TestCase
             'mae_pct' => -0.5, 'holding_time_sec' => 100, 'fees' => 1.0, 'funding' => 0.2, 'slippage' => 0.1,
         ], null, '2026-06-17 08:40:00+00', 200);
 
-        // Entrée T2 (BTC, set s2, regular) : pas de trade_id sur la clôture -> match par position_id.
+        // Entrée T2 (BTC, set s2, regular) : cycle NORMAL — `order_submitted` n'a que le
+        // trade_id, la clôture synchronisée n'a que le position_id. Le pont `position_opened`
+        // (trade_id T2 -> position_id P2) permet le rapprochement par position_id (P1).
         $this->entry('BTCUSDT', $run, 's2', 'regular', 'bitmart', 'perpetual', [
-            'trade_id' => 'T2', 'position_id' => 'P2',
+            'trade_id' => 'T2',
         ], '2026-06-17 08:31:00+00', 101);
+        $this->opened('BTCUSDT', $run, 'T2', 'P2', '2026-06-17 08:32:30+00', 150);
         $this->close('BTCUSDT', $run, ['pnl' => -4.0, 'pnl_R' => -1.0], 'P2', '2026-06-17 08:45:00+00', 201);
 
         // Entrée ETH (set s1, scalper) : aucune clôture -> unmatched / ouvert.
@@ -152,6 +155,29 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertSame($closeIds, array_unique($closeIds), 'chaque clôture sert une seule entrée');
     }
 
+    public function testStaleReusedPositionIdIsNotAttributedToCurrentEntry(): void
+    {
+        $run = 'run_stale';
+        // Une clôture ANCIENNE (08:00) porte un position_id `PR` qui sera réutilisé.
+        $this->close('BTCUSDT', $run, ['pnl' => 999.0], 'PR', '2026-06-17 08:00:00+00', 700);
+        // Nouvelle entrée (09:00) réutilisant `PR` via le pont : la clôture périmée
+        // (antérieure à l'entrée) ne doit PAS lui être attribuée -> unmatched, pas de PnL.
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TS'], '2026-06-17 09:00:00+00', 701);
+        $this->opened('BTCUSDT', $run, 'TS', 'PR', '2026-06-17 09:00:30+00', 702);
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT trade_id, close_match_status, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis WHERE run_id = ?',
+            [$run]
+        );
+
+        self::assertCount(1, $rows, 'une seule entrée (la clôture orpheline ne crée pas de ligne)');
+        self::assertSame('TS', $rows[0]['trade_id']);
+        self::assertSame('unmatched', $rows[0]['close_match_status']);
+        self::assertNull($rows[0]['close_event_id']);
+        self::assertNull($rows[0]['recorded_pnl_usdt'], 'aucun vieux PnL attribué au run courant');
+    }
+
     private function createMinimalSchema(): void
     {
         $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
@@ -223,6 +249,19 @@ SQL);
             'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, config_profile, exchange, market_type, extra, happened_at)
              VALUES (?, ?, \'order_submitted\', ?, ?, ?, ?, ?::jsonb, ?)',
             [$forcedId, $symbol, $runId, $profile, $exchange, $marketType, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
+        );
+    }
+
+    /**
+     * Événement `position_opened` du flux MTF : porte À LA FOIS le `trade_id` (contexte
+     * lifecycle) et le `position_id` (métadonnée d'ordre) — c'est le pont OBS-003 v2.
+     */
+    private function opened(string $symbol, string $runId, string $tradeId, string $positionId, string $happenedAt, int $forcedId): void
+    {
+        $this->conn->executeStatement(
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, extra, happened_at)
+             VALUES (?, ?, \'position_opened\', ?, ?, ?::jsonb, ?)',
+            [$forcedId, $symbol, $runId, $positionId, json_encode(['trade_id' => $tradeId], JSON_THROW_ON_ERROR), $happenedAt]
         );
     }
 

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\View;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
+use DoctrineMigrations\Version20260622000000;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * OBS-003 — Test d'INTÉGRATION de la vue `position_trade_analysis` sur un vrai PostgreSQL.
+ *
+ * Exécute le SQL RÉEL de la migration {@see Version20260622000000} (via `getSql()`),
+ * sur des tables minimales `trade_lifecycle_event` + `indicator_snapshots`, puis vérifie
+ * le rapprochement par identifiants EXACTS (trade_id puis position_id, jamais par symbole),
+ * l'absence de duplication / de réutilisation de clôture, le lineage et la sémantique PnL.
+ *
+ * Skippé proprement si aucun PostgreSQL n'est disponible (DATABASE_URL non-postgres).
+ */
+#[CoversClass(Version20260622000000::class)]
+final class PositionTradeAnalysisViewTest extends TestCase
+{
+    private Connection $conn;
+
+    protected function setUp(): void
+    {
+        $dsn = $_ENV['DATABASE_URL'] ?? $_SERVER['DATABASE_URL'] ?? getenv('DATABASE_URL') ?: '';
+        if (!is_string($dsn) || !preg_match('/^(postgres|postgresql|pdo-pgsql)/', $dsn)) {
+            self::markTestSkipped('PostgreSQL DATABASE_URL required for the view integration test.');
+        }
+
+        try {
+            $this->conn = DriverManager::getConnection(['url' => $dsn]);
+            $this->conn->executeQuery('SELECT 1');
+        } catch (\Throwable $e) {
+            self::markTestSkipped('PostgreSQL not reachable: ' . $e->getMessage());
+        }
+
+        $this->createMinimalSchema();
+        $this->applyViewMigration();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->conn)) {
+            $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
+            $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
+            $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
+            $this->conn->close();
+        }
+    }
+
+    public function testExactMatchingLineageAndPnlSemantics(): void
+    {
+        $run = 'run_dashA_20260617';
+
+        // Entrée T1 (BTC, set s1, scalper) : clôture rapprochée par trade_id, net complet.
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', [
+            'trade_id' => 'T1', 'r_multiple_final' => 1.5,
+        ], '2026-06-17 08:30:00+00', 100);
+        $this->close('BTCUSDT', $run, ['trade_id' => 'T1', 'pnl' => 12.0, 'pnl_R' => 1.5, 'mfe_pct' => 2.0,
+            'mae_pct' => -0.5, 'holding_time_sec' => 100, 'fees' => 1.0, 'funding' => 0.2, 'slippage' => 0.1,
+        ], null, '2026-06-17 08:40:00+00', 200);
+
+        // Entrée T2 (BTC, set s2, regular) : pas de trade_id sur la clôture -> match par position_id.
+        $this->entry('BTCUSDT', $run, 's2', 'regular', 'bitmart', 'perpetual', [
+            'trade_id' => 'T2', 'position_id' => 'P2',
+        ], '2026-06-17 08:31:00+00', 101);
+        $this->close('BTCUSDT', $run, ['pnl' => -4.0, 'pnl_R' => -1.0], 'P2', '2026-06-17 08:45:00+00', 201);
+
+        // Entrée ETH (set s1, scalper) : aucune clôture -> unmatched / ouvert.
+        $this->entry('ETHUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', [
+            'trade_id' => 'T3',
+        ], '2026-06-17 08:32:00+00', 102);
+
+        // Clôture orpheline (aucune entrée correspondante) -> ne doit créer AUCUNE ligne.
+        $this->close('SOLUSDT', $run, ['trade_id' => 'ORPHAN', 'pnl' => 99.0], 'PX', '2026-06-17 08:50:00+00', 999);
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT * FROM position_trade_analysis WHERE run_id = ? ORDER BY entry_time',
+            [$run]
+        );
+
+        // 3 entrées exactement (l'orphelin n'apparaît pas), aucune duplication.
+        self::assertCount(3, $rows);
+        $entryIds = array_column($rows, 'entry_event_id');
+        self::assertSame($entryIds, array_unique($entryIds), 'une ligne par entrée, pas de duplication');
+
+        // Aucune clôture réutilisée : chaque close_event_id non-null est unique.
+        $closeIds = array_values(array_filter(array_column($rows, 'close_event_id'), static fn ($v) => $v !== null));
+        self::assertSame($closeIds, array_unique($closeIds), 'aucune clôture réutilisée par deux entrées');
+
+        $byTrade = [];
+        foreach ($rows as $r) {
+            $byTrade[$r['trade_id']] = $r;
+        }
+
+        // T1 : rapproché par trade_id, lineage complet, net complet.
+        $t1 = $byTrade['T1'];
+        self::assertSame('matched', $t1['close_match_status']);
+        self::assertSame('matched_trade_id', $t1['close_matched_by']);
+        self::assertSame('s1', $t1['set_id']);
+        self::assertSame('scalper', $t1['mtf_profile']);
+        self::assertSame('bitmart', $t1['exchange']);
+        self::assertSame('perpetual', $t1['market_type']);
+        self::assertSame($run, $t1['orchestration_run_id']);
+        self::assertSame($run, $t1['correlation_run_id']);
+        self::assertEqualsWithDelta(12.0, (float) $t1['recorded_pnl_usdt'], 1e-9);
+        self::assertTrue($this->asBool($t1['net_pnl_complete']));
+        self::assertEqualsWithDelta(10.7, (float) $t1['net_pnl_usdt'], 1e-9); // 12 - 1 - 0.2 - 0.1
+
+        // T2 : rapproché par position_id, net INCOMPLET (pas de fees/funding/slippage).
+        $t2 = $byTrade['T2'];
+        self::assertSame('matched', $t2['close_match_status']);
+        self::assertSame('matched_position_id', $t2['close_matched_by']);
+        self::assertSame('P2', $t2['position_id']);
+        self::assertEqualsWithDelta(-4.0, (float) $t2['recorded_pnl_usdt'], 1e-9);
+        self::assertFalse($this->asBool($t2['net_pnl_complete']));
+        self::assertNull($t2['net_pnl_usdt']);
+
+        // ETH : aucune clôture -> unmatched / ouvert, pas de PnL.
+        $eth = $byTrade['T3'];
+        self::assertSame('unmatched', $eth['close_match_status']);
+        self::assertSame('unmatched', $eth['close_matched_by']);
+        self::assertNull($eth['close_event_id']);
+        self::assertNull($eth['recorded_pnl_usdt']);
+    }
+
+    public function testCloseIsNotReusedAcrossEntriesSharingAPositionId(): void
+    {
+        $run = 'run_reuse';
+        // 2 entrées + 2 clôtures partageant le même position_id : appariement 1-pour-1
+        // par ROW_NUMBER, jamais de réutilisation ni de multiplication de lignes.
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['position_id' => 'PSHARED'], '2026-06-17 09:00:00+00', 300);
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['position_id' => 'PSHARED'], '2026-06-17 09:01:00+00', 301);
+        $this->close('BTCUSDT', $run, ['pnl' => 1.0], 'PSHARED', '2026-06-17 09:10:00+00', 400);
+        $this->close('BTCUSDT', $run, ['pnl' => 2.0], 'PSHARED', '2026-06-17 09:11:00+00', 401);
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT entry_event_id, close_event_id FROM position_trade_analysis WHERE run_id = ? ORDER BY entry_time',
+            [$run]
+        );
+
+        self::assertCount(2, $rows, 'exactement 2 lignes (pas de produit cartésien)');
+        $closeIds = array_column($rows, 'close_event_id');
+        self::assertNotContains(null, $closeIds, 'les deux entrées sont rapprochées');
+        self::assertSame($closeIds, array_unique($closeIds), 'chaque clôture sert une seule entrée');
+    }
+
+    private function createMinimalSchema(): void
+    {
+        $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
+        $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
+        $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
+
+        $this->conn->executeStatement(<<<'SQL'
+CREATE TABLE trade_lifecycle_event (
+    id BIGSERIAL PRIMARY KEY,
+    symbol VARCHAR(50) NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    run_id VARCHAR(64),
+    position_id VARCHAR(64),
+    timeframe VARCHAR(8),
+    config_profile VARCHAR(64),
+    exchange VARCHAR(32) DEFAULT 'bitmart',
+    market_type VARCHAR(32) DEFAULT 'perpetual',
+    extra JSONB,
+    happened_at TIMESTAMPTZ NOT NULL
+)
+SQL);
+
+        $this->conn->executeStatement(<<<'SQL'
+CREATE TABLE indicator_snapshots (
+    id BIGSERIAL PRIMARY KEY,
+    symbol VARCHAR(50) NOT NULL,
+    timeframe VARCHAR(8) NOT NULL,
+    kline_time TIMESTAMPTZ NOT NULL,
+    values JSONB
+)
+SQL);
+    }
+
+    private function applyViewMigration(): void
+    {
+        // Les migrations ne sont pas dans l'autoload Composer (chargées par Doctrine).
+        if (!class_exists(Version20260622000000::class, false)) {
+            require_once \dirname(__DIR__, 3) . '/migrations/Version20260622000000.php';
+        }
+
+        $migration = new Version20260622000000($this->conn, new NullLogger());
+        $migration->up(new Schema());
+        foreach ($migration->getSql() as $query) {
+            $this->conn->executeStatement($query->getStatement(), $query->getParameters(), $query->getTypes());
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    private function entry(
+        string $symbol,
+        string $runId,
+        string $setId,
+        string $profile,
+        string $exchange,
+        string $marketType,
+        array $extra,
+        string $happenedAt,
+        int $forcedId,
+    ): void {
+        $extra += [
+            'orchestration_run_id' => $runId,
+            'orchestration_dashboard_id' => 'dashA',
+            'orchestration_set_id' => $setId,
+        ];
+
+        $this->conn->executeStatement(
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, config_profile, exchange, market_type, extra, happened_at)
+             VALUES (?, ?, \'order_submitted\', ?, ?, ?, ?, ?::jsonb, ?)',
+            [$forcedId, $symbol, $runId, $profile, $exchange, $marketType, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    private function close(string $symbol, string $runId, array $extra, ?string $positionId, string $happenedAt, int $forcedId): void
+    {
+        $this->conn->executeStatement(
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, extra, happened_at)
+             VALUES (?, ?, \'position_closed\', ?, ?, ?::jsonb, ?)',
+            [$forcedId, $symbol, $runId, $positionId, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
+        );
+    }
+
+    private function asBool(mixed $value): bool
+    {
+        return $value === true || $value === 't' || $value === '1' || $value === 1;
+    }
+}

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -279,6 +279,44 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertEqualsWithDelta(8.0, (float) $byExchange['okx']['recorded_pnl_usdt'], 1e-9);
     }
 
+    public function testSameTradeIdAcrossVenuesMatchesEachOnItsOwnVenue(): void
+    {
+        $run = 'run_tid_venue';
+        // Même trade_id `TX` émis par DEUX venues (bitmart / okx) — possible car le
+        // trade_id n'est unique que par (exchange, market_type, trade_id). L'entrée
+        // bitmart est la première, mais la clôture OKX arrive AVANT la clôture bitmart :
+        // sans périmètre venue dans le passage trade_id, les rangs se croiseraient et
+        // l'entrée bitmart hériterait du PnL OKX (cross-venue swap).
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TX'], '2026-06-17 09:00:00+00', 1200);
+        $this->entry('BTCUSDT', $run, 's2', 'scalper', 'okx', 'perpetual', ['trade_id' => 'TX'], '2026-06-17 09:05:00+00', 1201);
+        $this->close('BTCUSDT', $run, ['trade_id' => 'TX', 'pnl' => 8.0], null, '2026-06-17 09:20:00+00', 1202, 'okx', 'perpetual');
+        $this->close('BTCUSDT', $run, ['trade_id' => 'TX', 'pnl' => 5.0], null, '2026-06-17 09:30:00+00', 1203, 'bitmart', 'perpetual');
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT exchange, trade_id, close_match_status, close_matched_by, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis_v2 WHERE run_id = ? ORDER BY exchange',
+            [$run]
+        );
+
+        self::assertCount(2, $rows);
+        $byExchange = [];
+        foreach ($rows as $r) {
+            $byExchange[$r['exchange']] = $r;
+        }
+
+        // Rapprochement PAR trade_id (pas position_id) mais borné à la venue : chaque
+        // entrée hérite du PnL de SA propre clôture, jamais en cross-venue.
+        self::assertSame('matched', $byExchange['bitmart']['close_match_status']);
+        self::assertSame('matched_trade_id', $byExchange['bitmart']['close_matched_by']);
+        self::assertSame(1203, (int) $byExchange['bitmart']['close_event_id']);
+        self::assertEqualsWithDelta(5.0, (float) $byExchange['bitmart']['recorded_pnl_usdt'], 1e-9);
+
+        self::assertSame('matched', $byExchange['okx']['close_match_status']);
+        self::assertSame('matched_trade_id', $byExchange['okx']['close_matched_by']);
+        self::assertSame(1202, (int) $byExchange['okx']['close_event_id']);
+        self::assertEqualsWithDelta(8.0, (float) $byExchange['okx']['recorded_pnl_usdt'], 1e-9);
+    }
+
     public function testStaleCloseDetectedViaRealCloseTimeNotLogTime(): void
     {
         $run = 'run_realtime';

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -279,6 +279,52 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertEqualsWithDelta(8.0, (float) $byExchange['okx']['recorded_pnl_usdt'], 1e-9);
     }
 
+    public function testStaleCloseDetectedViaRealCloseTimeNotLogTime(): void
+    {
+        $run = 'run_realtime';
+        // Entrée réelle à 09:00 (trade TCT, pont -> PCT).
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TCT'], '2026-06-17 09:00:00+00', 1000);
+        $this->opened('BTCUSDT', $run, 'TCT', 'PCT', '2026-06-17 09:00:30+00', 1001);
+        // Clôture périmée d'un ancien trade au MÊME position_id : LOGGÉE tardivement
+        // (happened_at 10:00, après l'entrée) mais close_time RÉEL à 08:00 (avant l'entrée).
+        // Le temps réel doit primer => non éligible => entrée unmatched, aucun PnL attribué.
+        $this->close('BTCUSDT', $run, ['pnl' => 999.0, 'close_time' => '2026-06-17 08:00:00'], 'PCT', '2026-06-17 10:00:00+00', 1002);
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT trade_id, close_match_status, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis_v2 WHERE run_id = ?',
+            [$run]
+        );
+
+        self::assertCount(1, $rows);
+        self::assertSame('TCT', $rows[0]['trade_id']);
+        self::assertSame('unmatched', $rows[0]['close_match_status']);
+        self::assertNull($rows[0]['close_event_id']);
+        self::assertNull($rows[0]['recorded_pnl_usdt'], 'aucun PnL périmé attribué via le log time');
+    }
+
+    public function testMatchedCloseExposesRealCloseTime(): void
+    {
+        $run = 'run_realtime_ok';
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TMC'], '2026-06-17 09:00:00+00', 1100);
+        $this->opened('BTCUSDT', $run, 'TMC', 'PMC', '2026-06-17 09:00:30+00', 1101);
+        // Clôture réelle à 10:00 mais loggée à 10:05 : effective_close_time = close_time réel.
+        $this->close('BTCUSDT', $run, ['pnl' => 5.0, 'close_time' => '2026-06-17 10:00:00'], 'PMC', '2026-06-17 10:05:00+00', 1102);
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT close_match_status, close_event_id, close_time, recorded_pnl_usdt
+             FROM position_trade_analysis_v2 WHERE run_id = ?',
+            [$run]
+        );
+
+        self::assertCount(1, $rows);
+        self::assertSame('matched', $rows[0]['close_match_status']);
+        self::assertSame(1102, (int) $rows[0]['close_event_id']);
+        self::assertEqualsWithDelta(5.0, (float) $rows[0]['recorded_pnl_usdt'], 1e-9);
+        // close_time exposé = heure RÉELLE de clôture (10:00), pas le log time (10:05).
+        self::assertStringContainsString('10:00:00', (string) $rows[0]['close_time']);
+    }
+
     private function createMinimalSchema(): void
     {
         $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis_v2');

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -251,9 +251,9 @@ final class PositionTradeAnalysisViewTest extends TestCase
         // Une clôture OKX ne doit pas être appariée à l'entrée bitmart (PnL au mauvais
         // bucket by_exchange) et inversement.
         $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TBB'], '2026-06-17 09:00:00+00', 920);
-        $this->opened('BTCUSDT', $run, 'TBB', 'PV', '2026-06-17 09:00:30+00', 921);
+        $this->opened('BTCUSDT', $run, 'TBB', 'PV', '2026-06-17 09:00:30+00', 921, 'bitmart', 'perpetual');
         $this->entry('BTCUSDT', $run, 's2', 'scalper', 'okx', 'perpetual', ['trade_id' => 'TBO'], '2026-06-17 09:05:00+00', 922);
-        $this->opened('BTCUSDT', $run, 'TBO', 'PV', '2026-06-17 09:05:30+00', 923);
+        $this->opened('BTCUSDT', $run, 'TBO', 'PV', '2026-06-17 09:05:30+00', 923, 'okx', 'perpetual');
         $this->close('BTCUSDT', $run, ['pnl' => 5.0], 'PV', '2026-06-17 09:30:00+00', 924, 'bitmart', 'perpetual');
         $this->close('BTCUSDT', $run, ['pnl' => 8.0], 'PV', '2026-06-17 09:35:00+00', 925, 'okx', 'perpetual');
 
@@ -314,6 +314,46 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertSame('matched', $byExchange['okx']['close_match_status']);
         self::assertSame('matched_trade_id', $byExchange['okx']['close_matched_by']);
         self::assertSame(1202, (int) $byExchange['okx']['close_event_id']);
+        self::assertEqualsWithDelta(8.0, (float) $byExchange['okx']['recorded_pnl_usdt'], 1e-9);
+    }
+
+    public function testOpenedBridgeIsScopedByVenue(): void
+    {
+        $run = 'run_bridge_venue';
+        // Même trade_id `TG` émis par DEUX venues, chacune avec son `position_opened`
+        // (le pont) résolvant un position_id DISTINCT, puis sa clôture par position_id.
+        // Sans périmètre venue dans le pont, l'entrée okx pourrait hériter du position_id
+        // bitmart (rang croisé) et matcher la mauvaise venue (mauvais bucket by_exchange).
+        $this->entry('BTCUSDT', $run, 's1', 'scalper', 'bitmart', 'perpetual', ['trade_id' => 'TG'], '2026-06-17 09:00:00+00', 1300);
+        $this->opened('BTCUSDT', $run, 'TG', 'PGB', '2026-06-17 09:00:30+00', 1301, 'bitmart', 'perpetual');
+        $this->entry('BTCUSDT', $run, 's2', 'scalper', 'okx', 'perpetual', ['trade_id' => 'TG'], '2026-06-17 09:05:00+00', 1302);
+        $this->opened('BTCUSDT', $run, 'TG', 'PGO', '2026-06-17 09:05:30+00', 1303, 'okx', 'perpetual');
+        $this->close('BTCUSDT', $run, ['pnl' => 8.0], 'PGO', '2026-06-17 09:20:00+00', 1304, 'okx', 'perpetual');
+        $this->close('BTCUSDT', $run, ['pnl' => 5.0], 'PGB', '2026-06-17 09:30:00+00', 1305, 'bitmart', 'perpetual');
+
+        $rows = $this->conn->fetchAllAssociative(
+            'SELECT exchange, position_id, close_match_status, close_matched_by, close_event_id, recorded_pnl_usdt
+             FROM position_trade_analysis_v2 WHERE run_id = ? ORDER BY exchange',
+            [$run]
+        );
+
+        self::assertCount(2, $rows);
+        $byExchange = [];
+        foreach ($rows as $r) {
+            $byExchange[$r['exchange']] = $r;
+        }
+
+        // Chaque entrée résout le position_id de SA venue via le pont, puis matche SA clôture.
+        self::assertSame('PGB', $byExchange['bitmart']['position_id']);
+        self::assertSame('matched', $byExchange['bitmart']['close_match_status']);
+        self::assertSame('matched_position_id', $byExchange['bitmart']['close_matched_by']);
+        self::assertSame(1305, (int) $byExchange['bitmart']['close_event_id']);
+        self::assertEqualsWithDelta(5.0, (float) $byExchange['bitmart']['recorded_pnl_usdt'], 1e-9);
+
+        self::assertSame('PGO', $byExchange['okx']['position_id']);
+        self::assertSame('matched', $byExchange['okx']['close_match_status']);
+        self::assertSame('matched_position_id', $byExchange['okx']['close_matched_by']);
+        self::assertSame(1304, (int) $byExchange['okx']['close_event_id']);
         self::assertEqualsWithDelta(8.0, (float) $byExchange['okx']['recorded_pnl_usdt'], 1e-9);
     }
 
@@ -441,12 +481,20 @@ SQL);
      * Événement `position_opened` du flux MTF : porte À LA FOIS le `trade_id` (contexte
      * lifecycle) et le `position_id` (métadonnée d'ordre) — c'est le pont OBS-003 v2.
      */
-    private function opened(string $symbol, string $runId, string $tradeId, string $positionId, string $happenedAt, int $forcedId): void
-    {
+    private function opened(
+        string $symbol,
+        string $runId,
+        string $tradeId,
+        string $positionId,
+        string $happenedAt,
+        int $forcedId,
+        string $exchange = 'bitmart',
+        string $marketType = 'perpetual',
+    ): void {
         $this->conn->executeStatement(
-            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, extra, happened_at)
-             VALUES (?, ?, \'position_opened\', ?, ?, ?::jsonb, ?)',
-            [$forcedId, $symbol, $runId, $positionId, json_encode(['trade_id' => $tradeId], JSON_THROW_ON_ERROR), $happenedAt]
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, exchange, market_type, extra, happened_at)
+             VALUES (?, ?, \'position_opened\', ?, ?, ?, ?, ?::jsonb, ?)',
+            [$forcedId, $symbol, $runId, $positionId, $exchange, $marketType, json_encode(['trade_id' => $tradeId], JSON_THROW_ON_ERROR), $happenedAt]
         );
     }
 


### PR DESCRIPTION
## Objectif

Surface OUTCOME read-only fiable : relier un run d'orchestration à ses trades résultants (`run → dashboard → set → profil/exchange → trade → outcome`), avec une corrélation déterministe, un rapprochement entrée/clôture par identifiants exacts et un contrat PnL **honnête**.

Priorité produit : *moins de mauvais trades → données fiables → expectancy nette fiable*, jamais « plus de trades ».

- **Part of #189** (lineage) — voir critères ci-dessous.
- **Part of #190** (vue `position_trade_analysis` + PnL net) — voir critères ci-dessous.
- **Related to #173** (roadmap, item A10 OBS-003).
- **Supersedes #181.**

> Cette PR ne **clôt** ni #189 ni #190 : elle en livre un sous-ensemble vérifiable. Les critères restants sont listés plus bas.

## Corrections principales

- **Corrélation déterministe sans troncature**, algorithme **strictement identique** Python (`app/services/correlation.py`) ↔ PHP (`RunCorrelationId`), *trim* compris, via vecteurs partagés `tests/fixtures/run_correlation_vectors.json` (préfixes + espaces couverts).
- **Propagation + validation fail-closed** du contexte : en-têtes `X-Run-Id` / `X-Run-Correlation-Id` / `X-Orchestration-Set-Id` / `X-Orchestration-Dashboard-Id` consommés par Symfony ; `OrchestrationContextValidator` refuse en **422** (codes `ORCHESTRATION_*_MISMATCH`) toute contradiction vérifiable. La corrélation est validée que les valeurs viennent des **en-têtes ou du corps** (chemin body-only : `run_id`/`correlation_run_id` du payload comparés). Limite documentée : la relation set⇄dashboard exige les données orchestrateur (non vérifiable côté Symfony).
- **Vue VERSIONNÉE `position_trade_analysis_v2`** (bascule progressive #190) : la v1 historique est **conservée intacte** (comparaison/rollback/consommateurs préservés). Rapprochement par identifiants **EXACTS** (`trade_id` puis `position_id`, **les deux bornés à la venue** symbole+exchange+market_type + garde temporel, jamais par symbole), pont `trade_id → position_id` via `position_opened` (lui aussi borné à la venue), `ROW_NUMBER` 1-pour-1 (aucune clôture réutilisée).
- **Contrat PnL honnête (jamais d'estimé certifié)** : `recorded_pnl_usdt` (ni brut ni net garantis), `estimated_net_pnl_usdt` (estimation best-effort) + `cost_completeness` (`complete` réservé au contrat #190, **jamais émis**). Pas de `net_pnl_usdt` certifié. Coûts absents → `NULL`, jamais `0`.
- **États distincts** : `matched_closed_count` / `unmatched_count` / `confirmed_open_count` (=0) / `unknown_state_count`. `unmatched` n'est **jamais** compté comme position ouverte confirmée. Winrate sur `matched_closed` avec PnL ; `data_complete` faux si unmatched/coûts incomplets.
- **Erreurs de source explicites** : source indisponible → **503** `source_available=false` (HTTP non-2xx Symfony jamais interprété comme « 0 trade ») ; run inconnu → **404** ; run sans trade → **200** agrégat vide. Agrégat borné (`rowCap`) avec détection de **troncature** (`truncated` + `row_cap` relayés ; `data_complete=false`).

### Surfaces
- Symfony (read-only) : `GET /api/positions/analysis?run_id=…[&set_id=…]`.
- Orchestrateur : `GET /runs/{run_id}/outcome`.

## Hors-scope (invariants respectés)

Aucun changement de stratégie / validations MTF / EntryZone / Risk-Leverage / SL-TP / trailing / fréquence / nombre de contrats-trades / **activation live** (OKX & Hyperliquid restent dry-run, Bitmart et Fake/Paper disponibles) / provider bundles / EffectiveConfig / frontend / auth. Vue jamais écrite ; `/orchestrator/run`, `last_json`/`RunSet`, `mtf:run` et l'appel HTTP legacy `/api/mtf/run` (sans en-têtes) inchangés.

## Critères #189 (lineage) — couverts

- Corrélation run_id déterministe, partagée Python/PHP, sans troncature (collisions de préfixe + espaces testés).
- Propagation `run_id` / `dashboard_id` / `set_id` / `exchange` / `market_type` / `profile` jusqu'à l'`extra` de `order_submitted` (séquentiel + worker parallèle ; alias longs du payload préservés).
- run_id de corrélation = `run_id` du run (chemins workers=1 et workers>1 cohérents).
- Validation fail-closed des contradictions de contexte (422, codes stables ; en-têtes **et** corps).

## Critères #189 — restant à traiter

- **Clé de rapprochement partagée sur le cycle de vie live → suivi #200** : les producteurs live n'émettent pas de clé commune des deux côtés (`order_submitted`=`trade_id`, `position_opened`/`closed`=`position_id`), donc un trade MTF réel ressort `unmatched` (honnête) tant que la clé n'est pas propagée. Limite **documentée** dans le docblock de la migration ; correctif hors périmètre de cette PR.
- `internal_trade_id` / `internal_position_id` **persistés** et indépendants des identifiants exchange (cette PR s'appuie sur le `trade_id` applicatif + `position_id` exchange existants, sans nouvelle colonne persistée).
- Audit exhaustif `event_type -> identifiers -> monetary fields -> source` (livrable #189/#190 étape 1).
- Garanties scale-in/scale-out, hedge long+short simultanés au niveau identifiants.

## Critères #190 (vue + PnL) — couverts

- Rapprochement par identifiants exacts, jamais par symbole ; aucune réutilisation de clôture ; pas de multiplication de lignes (tests PostgreSQL).
- `recorded_pnl_usdt` distinct d'un net ; estimation explicitement séparée (`estimated_net_pnl_usdt` + `cost_completeness`) ; coûts inconnus jamais transformés en 0.
- Lignes ambiguës visibles avec statut (`analysis_status`, `unmatched`) ; exclues des compteurs certifiés ; `data_complete` honnête.
- Vue **versionnée v2** sans destruction de la v1 (étape 8) ; `down()` sûr.
- Ventilation par set/profil/exchange/symbole ; choix du périmètre via `cost_completeness`/états.

## Critères #190 — restant à traiter

- Contrat de coûts **complet** : `gross_realized_pnl_usdt`, `entry_fee`/`exit_fee` séparés, `spread_cost`, `borrow_cost`, convention de signe funding documentée → tant qu'absents, `cost_completeness` reste `partial/unknown` et `net_pnl_usdt` certifié **non exposé**.
- `risk_usdt_at_entry` figé + `realized_net_pnl_R` ; MFE/MAE avec source de prix documentée (étapes 4 & 6).
- Partial fills / clôtures partielles / `remaining_qty` / `position_fully_closed` (le PnL agrégé actuel vient de l'événement de clôture, pas d'une agrégation de fills).
- Backfill idempotent + rapport de divergence v1/v2 + index dédiés (étapes 9 & 10).
- Bascule effective des consommateurs de v1 vers v2.

## Tests exécutés (localement)

- `php bin/phpunit tests/Trading tests/MtfRunner tests/Contract/MtfValidator/Dto` (PostgreSQL 16) → **95 passed**.
- `php bin/phpunit --fail-on-skipped tests/Trading/View/PositionTradeAnalysisViewTest.php` (PostgreSQL 16) → **11 passed** (matching exact, pont, anti-réutilisation, orphelin-avant/vraie-après, cross-symbole, cross-venue trade_id **et** position_id, pont borné venue, close_time réel vs log, recorded/estimated/cost_completeness).
- `pytest` (orchestrateur) → vert (corrélation partagée, client Symfony non-2xx → 503, `/runs/{id}/outcome` 404/200/503 + relai `truncated`/`row_cap`).
- `php bin/console lint:container` OK ; `php bin/console lint:yaml config` OK ; PHPStan (niveau 6) sur les fichiers OBS-003 → propre.

## Risques résiduels

- **Lineage live non rapproché tant que #200 n'est pas livré** : producteurs d'événements inchangés ; faute de clé partagée des deux côtés, la ligne reste `unmatched` (visible, jamais rapprochée par approximation, jamais de PnL inventé). Limite documentée dans le docblock de la migration ; suivi dédié **#200**.
- `estimated_net_pnl_usdt` reste une estimation (signe funding non garanti, spread absent) → jamais à utiliser comme mesure certifiée tant que #190 n'est pas complet.
- Doc de pilotage `docs/roadmap/tradingv3-roadmap-v2.md` (référencée par #189/#190 via #187) **absente du dépôt** — à créer hors de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)