### PR TITLE
Add internal trade lineage mapping

### DIFF
--- a/docs/handbook/technical/internal-trade-lineage.md
+++ b/docs/handbook/technical/internal-trade-lineage.md
@@ -1,0 +1,45 @@
+# Contrat `internal_trade_id`
+
+`internal_trade_id` est la clé interne stable d'un trade logique. Elle est indépendante des identifiants exchange et sert à relier l'intention, l'ordre soumis, l'ouverture, la clôture et l'analyse outcome sans approximation par symbole ou horodatage.
+
+## Création
+
+- La clé est créée une seule fois lorsque le trade logique est matérialisé côté MTF.
+- Pour le flux MTF actuel, le `trade_id` interne existant devient aussi `internal_trade_id`.
+- La clé est persistée dans `trade_lineage` au moment de la réservation de `OrderIntent`, avant la soumission effective.
+- En compatibilité legacy, les champs restent nullable et aucun backfill heuristique n'est réalisé.
+
+## Persistance
+
+La table `trade_lineage` porte le mapping exact :
+
+- `internal_trade_id`
+- `order_intent_id`
+- `client_order_id`
+- `exchange_order_id`
+- `position_id`
+- `run_id`, `correlation_run_id`, `orchestration_run_id`, `orchestration_set_id`, `orchestration_dashboard_id`
+- `exchange`, `market_type`, `symbol`, `side`, `profile`, `origin`
+
+`trade_lifecycle_event.internal_trade_id` est une colonne additive indexée. La même valeur reste aussi dans `extra.internal_trade_id` pour les consommateurs existants ; `extra.trade_id` est conservé pour la vue `position_trade_analysis_v2`.
+
+## Résolution
+
+Ordre autorisé :
+
+1. clé interne déjà présente dans le message ou l'événement ;
+2. mapping exact par `client_order_id` dans la même venue ;
+3. mapping exact par `exchange_order_id` dans la même venue ;
+4. mapping exact par `position_id` dans la même venue, uniquement si ce `position_id` a déjà été persisté ;
+5. sinon `unmatched`.
+
+La venue est toujours `exchange + market_type`. Les résolutions par symbole seul, symbole + side, timestamp, ou première clôture suivante sont interdites.
+Si un identifiant exact non unique produit plusieurs mappings dans la même venue, la résolution reste `unmatched` : le système ne choisit jamais silencieusement un candidat.
+
+## Couverture actuelle
+
+- `order_submitted` reçoit `internal_trade_id`, `trade_id`, `run_id`, set/dashboard/profil et venue.
+- `LimitFillWatchMessage` conserve le contexte lifecycle pour les ordres LIMIT.
+- La synchronisation REST enrichit `position_opened` et `position_closed` uniquement si un identifiant exact est disponible dans le payload provider ou déjà persisté.
+- Fake/Paper expose `last_order_id`, ce qui permet la résolution exacte via `exchange_order_id`.
+- Bitmart conserve `client_order_id` côté ordre et les champs bruts de position sont préservés ; sans identifiant exact dans le payload position, l'événement reste volontairement `unmatched`.

--- a/trading-app/migrations/Version20260623000000.php
+++ b/trading-app/migrations/Version20260623000000.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260623000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add persistent internal trade lineage mapping for exact trade lifecycle correlation';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+CREATE TABLE IF NOT EXISTS trade_lineage (
+    id BIGSERIAL NOT NULL,
+    order_intent_id BIGINT DEFAULT NULL,
+    internal_trade_id VARCHAR(96) NOT NULL,
+    client_order_id VARCHAR(96) NOT NULL,
+    exchange_order_id VARCHAR(96) DEFAULT NULL,
+    position_id VARCHAR(96) DEFAULT NULL,
+    run_id VARCHAR(96) DEFAULT NULL,
+    correlation_run_id VARCHAR(96) DEFAULT NULL,
+    orchestration_run_id VARCHAR(96) DEFAULT NULL,
+    orchestration_set_id VARCHAR(96) DEFAULT NULL,
+    orchestration_dashboard_id VARCHAR(96) DEFAULT NULL,
+    exchange VARCHAR(32) DEFAULT 'bitmart' NOT NULL,
+    market_type VARCHAR(32) DEFAULT 'perpetual' NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side VARCHAR(16) DEFAULT NULL,
+    profile VARCHAR(80) DEFAULT NULL,
+    origin VARCHAR(24) DEFAULT 'runtime' NOT NULL,
+    created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    PRIMARY KEY(id)
+)
+SQL);
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_trade_lineage_internal_trade_id ON trade_lineage (internal_trade_id)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_trade_lineage_order_intent ON trade_lineage (order_intent_id)');
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_trade_lineage_venue_client_order ON trade_lineage (exchange, market_type, client_order_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lineage_venue_exchange_order ON trade_lineage (exchange, market_type, exchange_order_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lineage_venue_position ON trade_lineage (exchange, market_type, position_id)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lineage_run_set ON trade_lineage (run_id, orchestration_set_id)');
+        $this->addSql('ALTER TABLE trade_lineage ADD CONSTRAINT FK_TRADE_LINEAGE_ORDER_INTENT FOREIGN KEY (order_intent_id) REFERENCES order_intent (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE trade_lifecycle_event ADD COLUMN IF NOT EXISTS internal_trade_id VARCHAR(96) DEFAULT NULL');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_trade_lifecycle_internal_trade_id ON trade_lifecycle_event (internal_trade_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_trade_lifecycle_internal_trade_id');
+        $this->addSql('ALTER TABLE trade_lifecycle_event DROP COLUMN IF EXISTS internal_trade_id');
+        $this->addSql('DROP TABLE IF EXISTS trade_lineage');
+    }
+}

--- a/trading-app/src/Contract/Provider/Dto/PositionDto.php
+++ b/trading-app/src/Contract/Provider/Dto/PositionDto.php
@@ -87,9 +87,8 @@ final class PositionDto extends BaseDto
             leverage: BigDecimal::of($leverage),
             openedAt: $openedAt,
             closedAt: $closedAt,
-            metadata: $data['metadata'] ?? []
+            metadata: \is_array($data['metadata'] ?? null) ? array_replace($data, $data['metadata']) : $data
         );
     }
 }
-
 

--- a/trading-app/src/Entity/TradeLifecycleEvent.php
+++ b/trading-app/src/Entity/TradeLifecycleEvent.php
@@ -37,6 +37,9 @@ class TradeLifecycleEvent
     #[ORM\Column(length: 64, nullable: true)]
     private ?string $positionId = null;
 
+    #[ORM\Column(name: 'internal_trade_id', length: 96, nullable: true)]
+    private ?string $internalTradeId = null;
+
     #[ORM\Column(length: 16, nullable: true)]
     private ?string $side = null;
 
@@ -142,6 +145,20 @@ class TradeLifecycleEvent
     public function setPositionId(?string $positionId): self
     {
         $this->positionId = $positionId;
+
+        return $this;
+    }
+
+    public function getInternalTradeId(): ?string
+    {
+        return $this->internalTradeId;
+    }
+
+    public function setInternalTradeId(?string $internalTradeId): self
+    {
+        $this->internalTradeId = $internalTradeId !== null && trim($internalTradeId) !== ''
+            ? trim($internalTradeId)
+            : null;
 
         return $this;
     }

--- a/trading-app/src/Entity/TradeLineage.php
+++ b/trading-app/src/Entity/TradeLineage.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Repository\TradeLineageRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: TradeLineageRepository::class)]
+#[ORM\Table(name: 'trade_lineage')]
+#[ORM\UniqueConstraint(name: 'ux_trade_lineage_internal_trade_id', columns: ['internal_trade_id'])]
+#[ORM\UniqueConstraint(name: 'ux_trade_lineage_order_intent', columns: ['order_intent_id'])]
+#[ORM\UniqueConstraint(name: 'ux_trade_lineage_venue_client_order', columns: ['exchange', 'market_type', 'client_order_id'])]
+#[ORM\Index(name: 'idx_trade_lineage_venue_exchange_order', columns: ['exchange', 'market_type', 'exchange_order_id'])]
+#[ORM\Index(name: 'idx_trade_lineage_venue_position', columns: ['exchange', 'market_type', 'position_id'])]
+#[ORM\Index(name: 'idx_trade_lineage_run_set', columns: ['run_id', 'orchestration_set_id'])]
+final class TradeLineage
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'internal_trade_id', type: Types::STRING, length: 96)]
+    private string $internalTradeId;
+
+    #[ORM\OneToOne(targetEntity: OrderIntent::class)]
+    #[ORM\JoinColumn(name: 'order_intent_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?OrderIntent $orderIntent = null;
+
+    #[ORM\Column(name: 'client_order_id', type: Types::STRING, length: 96)]
+    private string $clientOrderId;
+
+    #[ORM\Column(name: 'exchange_order_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $exchangeOrderId = null;
+
+    #[ORM\Column(name: 'position_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $positionId = null;
+
+    #[ORM\Column(name: 'run_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $runId = null;
+
+    #[ORM\Column(name: 'correlation_run_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $correlationRunId = null;
+
+    #[ORM\Column(name: 'orchestration_run_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $orchestrationRunId = null;
+
+    #[ORM\Column(name: 'orchestration_set_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $orchestrationSetId = null;
+
+    #[ORM\Column(name: 'orchestration_dashboard_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $orchestrationDashboardId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32, options: ['default' => 'bitmart'])]
+    private string $exchange = 'bitmart';
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32, options: ['default' => 'perpetual'])]
+    private string $marketType = 'perpetual';
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::STRING, length: 16, nullable: true)]
+    private ?string $side = null;
+
+    #[ORM\Column(type: Types::STRING, length: 80, nullable: true)]
+    private ?string $profile = null;
+
+    #[ORM\Column(type: Types::STRING, length: 24, options: ['default' => 'runtime'])]
+    private string $origin = 'runtime';
+
+    #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(name: 'updated_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(string $internalTradeId, string $clientOrderId, string $symbol)
+    {
+        $this->internalTradeId = $internalTradeId;
+        $this->clientOrderId = $clientOrderId;
+        $this->symbol = strtoupper($symbol);
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getInternalTradeId(): string
+    {
+        return $this->internalTradeId;
+    }
+
+    public function getOrderIntent(): ?OrderIntent
+    {
+        return $this->orderIntent;
+    }
+
+    public function setOrderIntent(?OrderIntent $orderIntent): self
+    {
+        $this->orderIntent = $orderIntent;
+
+        return $this->touch();
+    }
+
+    public function getClientOrderId(): string
+    {
+        return $this->clientOrderId;
+    }
+
+    public function getExchangeOrderId(): ?string
+    {
+        return $this->exchangeOrderId;
+    }
+
+    public function setExchangeOrderId(?string $exchangeOrderId): self
+    {
+        $this->exchangeOrderId = self::blankToNull($exchangeOrderId);
+
+        return $this->touch();
+    }
+
+    public function getPositionId(): ?string
+    {
+        return $this->positionId;
+    }
+
+    public function setPositionId(?string $positionId): self
+    {
+        $this->positionId = self::blankToNull($positionId);
+
+        return $this->touch();
+    }
+
+    public function getRunId(): ?string
+    {
+        return $this->runId;
+    }
+
+    public function setRunId(?string $runId): self
+    {
+        $this->runId = self::blankToNull($runId);
+
+        return $this->touch();
+    }
+
+    public function getCorrelationRunId(): ?string
+    {
+        return $this->correlationRunId;
+    }
+
+    public function setCorrelationRunId(?string $correlationRunId): self
+    {
+        $this->correlationRunId = self::blankToNull($correlationRunId);
+
+        return $this->touch();
+    }
+
+    public function getOrchestrationRunId(): ?string
+    {
+        return $this->orchestrationRunId;
+    }
+
+    public function setOrchestrationRunId(?string $orchestrationRunId): self
+    {
+        $this->orchestrationRunId = self::blankToNull($orchestrationRunId);
+
+        return $this->touch();
+    }
+
+    public function getOrchestrationSetId(): ?string
+    {
+        return $this->orchestrationSetId;
+    }
+
+    public function setOrchestrationSetId(?string $orchestrationSetId): self
+    {
+        $this->orchestrationSetId = self::blankToNull($orchestrationSetId);
+
+        return $this->touch();
+    }
+
+    public function getOrchestrationDashboardId(): ?string
+    {
+        return $this->orchestrationDashboardId;
+    }
+
+    public function setOrchestrationDashboardId(?string $orchestrationDashboardId): self
+    {
+        $this->orchestrationDashboardId = self::blankToNull($orchestrationDashboardId);
+
+        return $this->touch();
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function setExchange(Exchange|string $exchange): self
+    {
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower($exchange);
+
+        return $this->touch();
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function setMarketType(MarketType|string $marketType): self
+    {
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower($marketType);
+
+        return $this->touch();
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function getSide(): ?string
+    {
+        return $this->side;
+    }
+
+    public function setSide(?string $side): self
+    {
+        $this->side = self::blankToNull($side !== null ? strtoupper($side) : null);
+
+        return $this->touch();
+    }
+
+    public function getProfile(): ?string
+    {
+        return $this->profile;
+    }
+
+    public function setProfile(?string $profile): self
+    {
+        $this->profile = self::blankToNull($profile);
+
+        return $this->touch();
+    }
+
+    public function getOrigin(): string
+    {
+        return $this->origin;
+    }
+
+    public function setOrigin(string $origin): self
+    {
+        $this->origin = strtolower(trim($origin)) !== '' ? strtolower(trim($origin)) : 'legacy';
+
+        return $this->touch();
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    private function touch(): self
+    {
+        $this->updatedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        return $this;
+    }
+
+    private static function blankToNull(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/trading-app/src/Logging/Dto/LifecycleContextBuilder.php
+++ b/trading-app/src/Logging/Dto/LifecycleContextBuilder.php
@@ -38,6 +38,11 @@ final class LifecycleContextBuilder
         return $this->set('trade_id', $tradeId);
     }
 
+    public function withInternalTradeId(?string $internalTradeId): self
+    {
+        return $this->set('internal_trade_id', $internalTradeId);
+    }
+
     public function withProfile(?string $profile): self
     {
         return $this->set('profile', $profile);

--- a/trading-app/src/Logging/TradeLifecycleLogger.php
+++ b/trading-app/src/Logging/TradeLifecycleLogger.php
@@ -178,6 +178,14 @@ final class TradeLifecycleLogger
 
     private function persist(TradeLifecycleEvent $event): void
     {
+        $extra = $event->getExtra();
+        if (\is_array($extra)) {
+            $internalTradeId = $extra['internal_trade_id'] ?? null;
+            if (\is_scalar($internalTradeId) && trim((string) $internalTradeId) !== '') {
+                $event->setInternalTradeId((string) $internalTradeId);
+            }
+        }
+
         $this->entityManager->persist($event);
         $this->entityManager->flush();
     }

--- a/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
+++ b/trading-app/src/MtfValidator/Service/TradingDecisionHandler.php
@@ -126,6 +126,7 @@ final class TradingDecisionHandler
 
         $lifecycleContext = $this->lifecycleContextFactory->create($symbolResult->symbol)
             ->withDecisionKey($decisionKey)
+            ->withInternalTradeId($tradeId)
             ->withTradeId($tradeId)
             ->withProfile($resolvedMode)
             ->withMtfContext($effectiveTf, $this->extractMtfContext($symbolResult), $symbolResult->blockingTf)

--- a/trading-app/src/Repository/TradeLineageRepository.php
+++ b/trading-app/src/Repository/TradeLineageRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\TradeLineage;
+use App\Provider\Context\ExchangeContext;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TradeLineage>
+ */
+final class TradeLineageRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TradeLineage::class);
+    }
+
+    public function findOneByInternalTradeId(string $internalTradeId): ?TradeLineage
+    {
+        return $this->findOneBy(['internalTradeId' => $internalTradeId]);
+    }
+
+    public function findOneByOrderIntentId(int $orderIntentId): ?TradeLineage
+    {
+        return $this->createQueryBuilder('lineage')
+            ->andWhere('IDENTITY(lineage.orderIntent) = :orderIntentId')
+            ->setParameter('orderIntentId', $orderIntentId)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findOneByClientOrderId(string $clientOrderId, ?ExchangeContext $context = null): ?TradeLineage
+    {
+        return $this->findOneBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            'clientOrderId' => $clientOrderId,
+        ]);
+    }
+
+    public function findOneByExchangeOrderId(string $exchangeOrderId, ?ExchangeContext $context = null): ?TradeLineage
+    {
+        return $this->findUniqueByVenueIdentifier('exchangeOrderId', $exchangeOrderId, $context);
+    }
+
+    public function findOneByPositionId(string $positionId, ?ExchangeContext $context = null): ?TradeLineage
+    {
+        return $this->findUniqueByVenueIdentifier('positionId', $positionId, $context);
+    }
+
+    private function findUniqueByVenueIdentifier(string $field, string $value, ?ExchangeContext $context): ?TradeLineage
+    {
+        $matches = $this->findBy([
+            'exchange' => ExchangeContext::exchangeValue($context),
+            'marketType' => ExchangeContext::marketTypeValue($context),
+            $field => $value,
+        ], null, 2);
+
+        return \count($matches) === 1 ? $matches[0] : null;
+    }
+}

--- a/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
@@ -12,6 +12,7 @@ use App\Logging\TradeLifecycleLogger;
 use App\Logging\TradeLifecycleReason;
 use App\Provider\Context\ExchangeContext;
 use App\TradeEntry\Message\LimitFillWatchMessage;
+use App\Trading\Lineage\TradeLineageManager;
 use Brick\Math\RoundingMode;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -32,6 +33,7 @@ final class LimitFillWatchMessageHandler
         private readonly LoggerInterface $positionsLogger,
         private readonly MessageBusInterface $bus,
         private readonly TradeLifecycleLogger $tradeLifecycleLogger,
+        private readonly ?TradeLineageManager $tradeLineageManager = null,
     ) {}
 
     public function __invoke(LimitFillWatchMessage $message): void
@@ -219,6 +221,18 @@ final class LimitFillWatchMessageHandler
                 'decision_key' => $message->decisionKey,
                 'source' => 'limit_watch',
             ]);
+            $context = $this->contextFromLifecycle($extra);
+            $lineage = $this->tradeLineageManager?->resolve(
+                $context,
+                internalTradeId: $this->stringValue($extra['internal_trade_id'] ?? null),
+                clientOrderId: $message->clientOrderId,
+                exchangeOrderId: $order->orderId,
+            );
+            if ($lineage !== null) {
+                $positionId = $this->stringValue($order->metadata['position_id'] ?? null);
+                $this->tradeLineageManager?->attachPositionId($lineage, $positionId);
+                $extra = array_merge($this->tradeLineageManager->lifecycleExtra($lineage), $extra);
+            }
 
             $this->tradeLifecycleLogger->logPositionOpened(
                 symbol: $order->symbol,
@@ -226,7 +240,11 @@ final class LimitFillWatchMessageHandler
                 side: $order->side->value,
                 qty: $filledQty->toScale(8, RoundingMode::DOWN)->__toString(),
                 entryPrice: $avgPrice?->toScale(8, RoundingMode::DOWN)->__toString(),
+                runId: $this->stringValue($extra['run_id'] ?? null),
+                exchange: $context->exchange->value,
+                accountId: null,
                 extra: $extra,
+                marketType: $context->marketType->value,
             );
         } catch (\Throwable $e) {
             $this->positionsLogger->warning('limit_watch.lifecycle_position_log_failed', [
@@ -248,6 +266,28 @@ final class LimitFillWatchMessageHandler
         }
 
         return array_merge($message->lifecycleContext, $extra);
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    private function contextFromLifecycle(array $extra): ExchangeContext
+    {
+        return ExchangeContext::fromValues(
+            $this->stringValue($extra['exchange'] ?? null),
+            $this->stringValue($extra['market_type'] ?? null),
+        );
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (!\is_scalar($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
     }
 
     private function rescheduleWatch(

--- a/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
+++ b/trading-app/src/TradeEntry/MessageHandler/LimitFillWatchMessageHandler.php
@@ -222,17 +222,7 @@ final class LimitFillWatchMessageHandler
                 'source' => 'limit_watch',
             ]);
             $context = $this->contextFromLifecycle($extra);
-            $lineage = $this->tradeLineageManager?->resolve(
-                $context,
-                internalTradeId: $this->stringValue($extra['internal_trade_id'] ?? null),
-                clientOrderId: $message->clientOrderId,
-                exchangeOrderId: $order->orderId,
-            );
-            if ($lineage !== null) {
-                $positionId = $this->stringValue($order->metadata['position_id'] ?? null);
-                $this->tradeLineageManager?->attachPositionId($lineage, $positionId);
-                $extra = array_merge($this->tradeLineageManager->lifecycleExtra($lineage), $extra);
-            }
+            $extra = $this->withBestEffortLineage($context, $message, $order, $extra);
 
             $this->tradeLifecycleLogger->logPositionOpened(
                 symbol: $order->symbol,
@@ -252,6 +242,47 @@ final class LimitFillWatchMessageHandler
                 'exchange_order_id' => $message->exchangeOrderId,
                 'error' => $e->getMessage(),
             ]);
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     * @return array<string,mixed>
+     */
+    private function withBestEffortLineage(
+        ExchangeContext $context,
+        LimitFillWatchMessage $message,
+        OrderDto $order,
+        array $extra,
+    ): array {
+        if ($this->tradeLineageManager === null) {
+            return $extra;
+        }
+
+        try {
+            $lineage = $this->tradeLineageManager->resolve(
+                $context,
+                internalTradeId: $this->stringValue($extra['internal_trade_id'] ?? null),
+                clientOrderId: $message->clientOrderId,
+                exchangeOrderId: $order->orderId,
+            );
+            if ($lineage === null) {
+                return $extra;
+            }
+
+            $positionId = $this->stringValue($order->metadata['position_id'] ?? null);
+            $this->tradeLineageManager->attachPositionId($lineage, $positionId);
+
+            return array_merge($this->tradeLineageManager->lifecycleExtra($lineage), $extra);
+        } catch (\Throwable $e) {
+            $this->positionsLogger->warning('limit_watch.lineage_sync_failed', [
+                'symbol' => $message->symbol,
+                'exchange_order_id' => $order->orderId,
+                'client_order_id' => $message->clientOrderId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return $extra;
         }
     }
 

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -251,10 +251,7 @@ final class ExecuteOrderPlan
         }
 
         try {
-            if ($this->tradeLineageManager !== null) {
-                $lineage = $this->tradeLineageManager->ensureForIntent($intent);
-                $this->tradeLineageManager->attachExchangeOrderId($lineage, $result->exchangeOrderId);
-            }
+            $this->syncLineageAfterExecution($intent, $result);
 
             if ($result->exchangeOrderId !== null && $this->shouldMarkIntentSent($result)) {
                 $this->orderIntentManager->markAsSent($intent, $result->exchangeOrderId);
@@ -276,6 +273,26 @@ final class ExecuteOrderPlan
             $this->positionsLogger->warning('execute_order_plan.intent_status_sync_failed', [
                 'order_intent_id' => $intent->getId(),
                 'client_order_id' => $intent->getClientOrderId(),
+                'status' => $result->status,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function syncLineageAfterExecution(OrderIntent $intent, ExecutionResult $result): void
+    {
+        if ($this->tradeLineageManager === null) {
+            return;
+        }
+
+        try {
+            $lineage = $this->tradeLineageManager->ensureForIntent($intent);
+            $this->tradeLineageManager->attachExchangeOrderId($lineage, $result->exchangeOrderId);
+        } catch (\Throwable $e) {
+            $this->positionsLogger->warning('execute_order_plan.lineage_sync_failed', [
+                'order_intent_id' => $intent->getId(),
+                'client_order_id' => $intent->getClientOrderId(),
+                'exchange_order_id' => $result->exchangeOrderId,
                 'status' => $result->status,
                 'error' => $e->getMessage(),
             ]);

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -102,10 +102,7 @@ final class ExecuteOrderPlan
                 }
 
                 $intent = $reservation->intent;
-                if ($this->tradeLineageManager !== null) {
-                    $lineage = $this->tradeLineageManager->ensureForIntent($intent, $contextBuilder?->toArray() ?? []);
-                    $contextBuilder?->merge($this->tradeLineageManager->lifecycleExtra($lineage));
-                }
+                $this->syncLineageBeforeExecution($intent, $contextBuilder);
 
                 $validationErrors = $this->orderIntentManager->validateOrderParams($this->intentOrderParams($executionPlan, $decisionKey, $clientOrderId));
                 if (!$this->orderIntentManager->validateIntent($intent, $validationErrors)) {
@@ -274,6 +271,24 @@ final class ExecuteOrderPlan
                 'order_intent_id' => $intent->getId(),
                 'client_order_id' => $intent->getClientOrderId(),
                 'status' => $result->status,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    private function syncLineageBeforeExecution(OrderIntent $intent, ?LifecycleContextBuilder $contextBuilder): void
+    {
+        if ($this->tradeLineageManager === null) {
+            return;
+        }
+
+        try {
+            $lineage = $this->tradeLineageManager->ensureForIntent($intent, $contextBuilder?->toArray() ?? []);
+            $contextBuilder?->merge($this->tradeLineageManager->lifecycleExtra($lineage));
+        } catch (\Throwable $e) {
+            $this->positionsLogger->warning('execute_order_plan.lineage_pre_submit_sync_failed', [
+                'order_intent_id' => $intent->getId(),
+                'client_order_id' => $intent->getClientOrderId(),
                 'error' => $e->getMessage(),
             ]);
         }

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -102,7 +102,6 @@ final class ExecuteOrderPlan
                 }
 
                 $intent = $reservation->intent;
-                $this->syncLineageBeforeExecution($intent, $contextBuilder);
 
                 $validationErrors = $this->orderIntentManager->validateOrderParams($this->intentOrderParams($executionPlan, $decisionKey, $clientOrderId));
                 if (!$this->orderIntentManager->validateIntent($intent, $validationErrors)) {
@@ -120,6 +119,7 @@ final class ExecuteOrderPlan
                 }
 
                 $this->orderIntentManager->markReadyToSend($intent);
+                $this->syncLineageBeforeExecution($intent, $contextBuilder);
             }
 
             $result = $useApiFirstExecution

--- a/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
+++ b/trading-app/src/TradeEntry/Workflow/ExecuteOrderPlan.php
@@ -6,6 +6,7 @@ namespace App\TradeEntry\Workflow;
 use App\Entity\OrderIntent;
 use App\Exchange\Adapter\BitmartLegacyOrderMapper;
 use App\Service\OrderIntentManager;
+use App\Trading\Lineage\TradeLineageManager;
 use App\TradeEntry\Dto\ExecutionResult;
 use App\TradeEntry\Execution\ExchangeExecutionService;
 use App\TradeEntry\Execution\ExecutionBox;
@@ -26,6 +27,7 @@ final class ExecuteOrderPlan
         #[Autowire(service: 'monolog.logger.positions')] private readonly LoggerInterface $positionsLogger,
         private readonly ?OrderIntentManager $orderIntentManager = null,
         private readonly ?IdempotencyPolicy $idempotency = null,
+        private readonly ?TradeLineageManager $tradeLineageManager = null,
         ?BitmartLegacyOrderMapper $bitmartOrders = null,
     ) {
         $this->bitmartOrders = $bitmartOrders ?? new BitmartLegacyOrderMapper();
@@ -100,6 +102,11 @@ final class ExecuteOrderPlan
                 }
 
                 $intent = $reservation->intent;
+                if ($this->tradeLineageManager !== null) {
+                    $lineage = $this->tradeLineageManager->ensureForIntent($intent, $contextBuilder?->toArray() ?? []);
+                    $contextBuilder?->merge($this->tradeLineageManager->lifecycleExtra($lineage));
+                }
+
                 $validationErrors = $this->orderIntentManager->validateOrderParams($this->intentOrderParams($executionPlan, $decisionKey, $clientOrderId));
                 if (!$this->orderIntentManager->validateIntent($intent, $validationErrors)) {
                     return new ExecutionResult(
@@ -244,6 +251,11 @@ final class ExecuteOrderPlan
         }
 
         try {
+            if ($this->tradeLineageManager !== null) {
+                $lineage = $this->tradeLineageManager->ensureForIntent($intent);
+                $this->tradeLineageManager->attachExchangeOrderId($lineage, $result->exchangeOrderId);
+            }
+
             if ($result->exchangeOrderId !== null && $this->shouldMarkIntentSent($result)) {
                 $this->orderIntentManager->markAsSent($intent, $result->exchangeOrderId);
                 return;

--- a/trading-app/src/Trading/Lineage/TradeLineageManager.php
+++ b/trading-app/src/Trading/Lineage/TradeLineageManager.php
@@ -46,8 +46,8 @@ final class TradeLineageManager
             return $existingByClient;
         }
 
-        $internalTradeId = $this->contextString($context, 'internal_trade_id')
-            ?? $this->contextString($context, 'trade_id')
+        $internalTradeId = $this->contextString($context, 'internal_trade_id', 96)
+            ?? $this->contextString($context, 'trade_id', 96)
             ?? $this->generateInternalTradeId();
 
         $lineage = (new TradeLineage($internalTradeId, $intent->getClientOrderId(), $intent->getSymbol()))
@@ -55,13 +55,13 @@ final class TradeLineageManager
             ->setExchange($intent->getExchange())
             ->setMarketType($intent->getMarketType())
             ->setSide($this->sideFromIntent($intent))
-            ->setProfile($this->contextString($context, 'profile') ?? $intent->getStrategyProfile())
-            ->setRunId($this->contextString($context, 'run_id'))
-            ->setCorrelationRunId($this->contextString($context, 'correlation_run_id'))
-            ->setOrchestrationRunId($this->contextString($context, 'orchestration_run_id'))
-            ->setOrchestrationSetId($this->contextString($context, 'orchestration_set_id'))
-            ->setOrchestrationDashboardId($this->contextString($context, 'orchestration_dashboard_id'))
-            ->setOrigin($this->contextString($context, 'origin') ?? 'runtime');
+            ->setProfile($this->contextString($context, 'profile', 80) ?? $this->limitString($intent->getStrategyProfile(), 80))
+            ->setRunId($this->contextString($context, 'run_id', 96))
+            ->setCorrelationRunId($this->contextString($context, 'correlation_run_id', 96))
+            ->setOrchestrationRunId($this->contextString($context, 'orchestration_run_id', 96))
+            ->setOrchestrationSetId($this->contextString($context, 'orchestration_set_id', 96))
+            ->setOrchestrationDashboardId($this->contextString($context, 'orchestration_dashboard_id', 96))
+            ->setOrigin($this->contextString($context, 'origin', 24) ?? 'runtime');
 
         $this->entityManager->persist($lineage);
         $this->entityManager->flush();
@@ -88,7 +88,7 @@ final class TradeLineageManager
             return;
         }
 
-        $lineage->setExchangeOrderId($exchangeOrderId);
+        $lineage->setExchangeOrderId($this->limitString($exchangeOrderId, 96));
         $this->entityManager->flush();
     }
 
@@ -102,7 +102,7 @@ final class TradeLineageManager
             return;
         }
 
-        $lineage->setPositionId($positionId);
+        $lineage->setPositionId($this->limitString($positionId, 96));
         $this->entityManager->flush();
     }
 
@@ -161,9 +161,9 @@ final class TradeLineageManager
     /**
      * @param array<string,mixed> $context
      */
-    private function contextString(array $context, string $key): ?string
+    private function contextString(array $context, string $key, ?int $maxLength = null): ?string
     {
-        return $this->normalize($context[$key] ?? null);
+        return $this->limitString($this->normalize($context[$key] ?? null), $maxLength);
     }
 
     private function normalize(mixed $value): ?string
@@ -175,6 +175,15 @@ final class TradeLineageManager
         $normalized = trim((string) $value);
 
         return $normalized !== '' ? $normalized : null;
+    }
+
+    private function limitString(?string $value, ?int $maxLength): ?string
+    {
+        if ($value === null || $maxLength === null || strlen($value) <= $maxLength) {
+            return $value;
+        }
+
+        return substr($value, 0, $maxLength);
     }
 
     private function generateInternalTradeId(): string

--- a/trading-app/src/Trading/Lineage/TradeLineageManager.php
+++ b/trading-app/src/Trading/Lineage/TradeLineageManager.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Lineage;
+
+use App\Entity\OrderIntent;
+use App\Entity\TradeLineage;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\TradeLineageRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+
+final class TradeLineageManager
+{
+    public function __construct(
+        private readonly TradeLineageRepository $repository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     */
+    public function ensureForIntent(OrderIntent $intent, array $context = []): TradeLineage
+    {
+        $intentId = $intent->getId();
+        if ($intentId !== null) {
+            $existing = $this->repository->findOneByOrderIntentId($intentId);
+            if ($existing instanceof TradeLineage) {
+                return $existing;
+            }
+        }
+
+        $existingByClient = $this->repository->findOneByClientOrderId(
+            $intent->getClientOrderId(),
+            ExchangeContext::fromValues($intent->getExchange(), $intent->getMarketType()),
+        );
+        if ($existingByClient instanceof TradeLineage) {
+            if ($existingByClient->getOrderIntent() === null) {
+                $existingByClient->setOrderIntent($intent);
+                $this->entityManager->flush();
+            }
+
+            return $existingByClient;
+        }
+
+        $internalTradeId = $this->contextString($context, 'internal_trade_id')
+            ?? $this->contextString($context, 'trade_id')
+            ?? $this->generateInternalTradeId();
+
+        $lineage = (new TradeLineage($internalTradeId, $intent->getClientOrderId(), $intent->getSymbol()))
+            ->setOrderIntent($intent)
+            ->setExchange($intent->getExchange())
+            ->setMarketType($intent->getMarketType())
+            ->setSide($this->sideFromIntent($intent))
+            ->setProfile($this->contextString($context, 'profile') ?? $intent->getStrategyProfile())
+            ->setRunId($this->contextString($context, 'run_id'))
+            ->setCorrelationRunId($this->contextString($context, 'correlation_run_id'))
+            ->setOrchestrationRunId($this->contextString($context, 'orchestration_run_id'))
+            ->setOrchestrationSetId($this->contextString($context, 'orchestration_set_id'))
+            ->setOrchestrationDashboardId($this->contextString($context, 'orchestration_dashboard_id'))
+            ->setOrigin($this->contextString($context, 'origin') ?? 'runtime');
+
+        $this->entityManager->persist($lineage);
+        $this->entityManager->flush();
+
+        $this->logger->debug('[TradeLineage] Created lineage mapping', [
+            'internal_trade_id' => $lineage->getInternalTradeId(),
+            'order_intent_id' => $intent->getId(),
+            'client_order_id' => $lineage->getClientOrderId(),
+            'exchange' => $lineage->getExchange(),
+            'market_type' => $lineage->getMarketType(),
+            'symbol' => $lineage->getSymbol(),
+        ]);
+
+        return $lineage;
+    }
+
+    public function attachExchangeOrderId(TradeLineage $lineage, ?string $exchangeOrderId): void
+    {
+        if ($exchangeOrderId === null || trim($exchangeOrderId) === '') {
+            return;
+        }
+
+        if ($lineage->getExchangeOrderId() === $exchangeOrderId) {
+            return;
+        }
+
+        $lineage->setExchangeOrderId($exchangeOrderId);
+        $this->entityManager->flush();
+    }
+
+    public function attachPositionId(TradeLineage $lineage, ?string $positionId): void
+    {
+        if ($positionId === null || trim($positionId) === '') {
+            return;
+        }
+
+        if ($lineage->getPositionId() === $positionId) {
+            return;
+        }
+
+        $lineage->setPositionId($positionId);
+        $this->entityManager->flush();
+    }
+
+    public function resolve(
+        ?ExchangeContext $context,
+        ?string $internalTradeId = null,
+        ?string $clientOrderId = null,
+        ?string $exchangeOrderId = null,
+        ?string $positionId = null,
+        ?string $symbol = null,
+        ?string $side = null,
+    ): ?TradeLineage {
+        unset($symbol, $side);
+
+        $internalTradeId = $this->normalize($internalTradeId);
+        if ($internalTradeId !== null) {
+            return $this->repository->findOneByInternalTradeId($internalTradeId);
+        }
+
+        $clientOrderId = $this->normalize($clientOrderId);
+        if ($clientOrderId !== null) {
+            return $this->repository->findOneByClientOrderId($clientOrderId, $context);
+        }
+
+        $exchangeOrderId = $this->normalize($exchangeOrderId);
+        if ($exchangeOrderId !== null) {
+            return $this->repository->findOneByExchangeOrderId($exchangeOrderId, $context);
+        }
+
+        $positionId = $this->normalize($positionId);
+        if ($positionId !== null) {
+            return $this->repository->findOneByPositionId($positionId, $context);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function lifecycleExtra(TradeLineage $lineage): array
+    {
+        return array_filter([
+            'internal_trade_id' => $lineage->getInternalTradeId(),
+            'trade_id' => $lineage->getInternalTradeId(),
+            'run_id' => $lineage->getRunId(),
+            'correlation_run_id' => $lineage->getCorrelationRunId(),
+            'orchestration_run_id' => $lineage->getOrchestrationRunId(),
+            'orchestration_set_id' => $lineage->getOrchestrationSetId(),
+            'orchestration_dashboard_id' => $lineage->getOrchestrationDashboardId(),
+            'profile' => $lineage->getProfile(),
+            'origin' => $lineage->getOrigin(),
+        ], static fn (mixed $value): bool => $value !== null && $value !== '');
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     */
+    private function contextString(array $context, string $key): ?string
+    {
+        return $this->normalize($context[$key] ?? null);
+    }
+
+    private function normalize(mixed $value): ?string
+    {
+        if (!\is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function generateInternalTradeId(): string
+    {
+        try {
+            return 'itd:' . bin2hex(random_bytes(16));
+        } catch (\Throwable) {
+            return 'itd:' . str_replace('.', '', uniqid('', true));
+        }
+    }
+
+    private function sideFromIntent(OrderIntent $intent): ?string
+    {
+        return match ($intent->getSide()) {
+            1, 3 => 'LONG',
+            2, 4 => 'SHORT',
+            default => null,
+        };
+    }
+}

--- a/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
+++ b/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
@@ -33,9 +33,7 @@ final class TradeLifecycleLoggerListener
         $position = $event->position;
         $marketType = $this->marketTypeFromExtra($event->extra);
 
-        $rawPositionId = $position->raw['position_id']
-            ?? $position->raw['positionId']
-            ?? null;
+        $rawPositionId = $this->positionIdFromRaw($position->raw);
         $positionId = $rawPositionId
             ?? sprintf('%s:%s:%s', $position->symbol, strtolower($position->side->value), $position->openedAt->format('U'));
         $lineage = $this->safeResolveLineageFromPositionPayload($position->raw, $event->extra, $marketType, $rawPositionId);
@@ -71,9 +69,7 @@ final class TradeLifecycleLoggerListener
         $history = $event->positionHistory;
         $marketType = $this->marketTypeFromExtra($event->extra);
 
-        $rawPositionId = $history->raw['position_id']
-            ?? $history->raw['positionId']
-            ?? null;
+        $rawPositionId = $this->positionIdFromRaw($history->raw);
         $positionId = $rawPositionId
             ?? sprintf('%s:%s:%s', $history->symbol, strtolower($history->side->value), $history->closedAt->format('U'));
         $lineage = $this->safeResolveLineageFromPositionPayload($history->raw, $event->extra, $marketType, $rawPositionId);
@@ -355,6 +351,29 @@ final class TradeLifecycleLoggerListener
         } catch (\Throwable) {
             // Le lifecycle reste prioritaire; le lineage sera récupéré par un identifiant exact ultérieur.
         }
+    }
+
+    /**
+     * @param array<string,mixed> $raw
+     */
+    private function positionIdFromRaw(array $raw): mixed
+    {
+        return $raw['position_id']
+            ?? $raw['positionId']
+            ?? $this->positionIdFromNestedRaw($raw['raw_history'] ?? null)
+            ?? $this->positionIdFromNestedRaw($raw['raw_snapshot'] ?? null)
+            ?? null;
+    }
+
+    private function positionIdFromNestedRaw(mixed $raw): mixed
+    {
+        if (!\is_array($raw)) {
+            return null;
+        }
+
+        return $raw['position_id']
+            ?? $raw['positionId']
+            ?? null;
     }
 
     private function stringValue(mixed $value): ?string

--- a/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
+++ b/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
@@ -110,6 +110,9 @@ final class TradeLifecycleLoggerListener
             if ($marketType !== null) {
                 $criteria['marketType'] = $marketType;
             }
+            if ($lineage !== null) {
+                $criteria['internalTradeId'] = $lineage->getInternalTradeId();
+            }
             $recent = $this->tradeLifecycleRepository->findRecentBy($criteria, 10);
             foreach ($recent as $lifecycleEvent) {
                 $extra = $lifecycleEvent->getExtra();

--- a/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
+++ b/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
@@ -38,10 +38,8 @@ final class TradeLifecycleLoggerListener
             ?? null;
         $positionId = $rawPositionId
             ?? sprintf('%s:%s:%s', $position->symbol, strtolower($position->side->value), $position->openedAt->format('U'));
-        $lineage = $this->resolveLineageFromPositionPayload($position->raw, $event->extra, $marketType, $rawPositionId);
-        if ($lineage !== null && $rawPositionId !== null) {
-            $this->tradeLineageManager?->attachPositionId($lineage, (string) $rawPositionId);
-        }
+        $lineage = $this->safeResolveLineageFromPositionPayload($position->raw, $event->extra, $marketType, $rawPositionId);
+        $this->safeAttachPositionId($lineage, $rawPositionId);
         $extra = array_merge(
             $lineage !== null ? $this->tradeLineageManager?->lifecycleExtra($lineage) ?? [] : [],
             [
@@ -78,10 +76,8 @@ final class TradeLifecycleLoggerListener
             ?? null;
         $positionId = $rawPositionId
             ?? sprintf('%s:%s:%s', $history->symbol, strtolower($history->side->value), $history->closedAt->format('U'));
-        $lineage = $this->resolveLineageFromPositionPayload($history->raw, $event->extra, $marketType, $rawPositionId);
-        if ($lineage !== null && $rawPositionId !== null) {
-            $this->tradeLineageManager?->attachPositionId($lineage, (string) $rawPositionId);
-        }
+        $lineage = $this->safeResolveLineageFromPositionPayload($history->raw, $event->extra, $marketType, $rawPositionId);
+        $this->safeAttachPositionId($lineage, $rawPositionId);
 
         // Déterminer le reasonCode si non fourni
         $reasonCode = $event->reasonCode;
@@ -328,6 +324,37 @@ final class TradeLifecycleLoggerListener
             ),
             positionId: $this->stringValue($positionId),
         );
+    }
+
+    /**
+     * @param array<string,mixed> $raw
+     * @param array<string,mixed> $extra
+     */
+    private function safeResolveLineageFromPositionPayload(
+        array $raw,
+        array $extra,
+        ?string $marketType,
+        mixed $positionId,
+    ): ?\App\Entity\TradeLineage {
+        try {
+            return $this->resolveLineageFromPositionPayload($raw, $extra, $marketType, $positionId);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function safeAttachPositionId(?\App\Entity\TradeLineage $lineage, mixed $positionId): void
+    {
+        $positionId = $this->stringValue($positionId);
+        if ($lineage === null || $positionId === null) {
+            return;
+        }
+
+        try {
+            $this->tradeLineageManager?->attachPositionId($lineage, $positionId);
+        } catch (\Throwable) {
+            // Le lifecycle reste prioritaire; le lineage sera récupéré par un identifiant exact ultérieur.
+        }
     }
 
     private function stringValue(mixed $value): ?string

--- a/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
+++ b/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
@@ -100,6 +100,7 @@ final class TradeLifecycleLoggerListener
         $pnlFloat = (float)$history->realizedPnl->__toString();
         $pnlPct = $notional !== null && $notional > 0.0 ? $pnlFloat / $notional : null;
         $holdingTimeSec = $history->closedAt->getTimestamp() - $history->openedAt->getTimestamp();
+        $effectiveRunId = $event->runId ?? $lineage?->getRunId();
 
         // Approximate initial risk in USDT from the most recent ORDER_SUBMITTED lifecycle event
         $pnlR = null;
@@ -108,8 +109,8 @@ final class TradeLifecycleLoggerListener
                 'symbol' => strtoupper($history->symbol),
                 'eventType' => 'order_submitted',
             ];
-            if ($event->runId !== null) {
-                $criteria['runId'] = $event->runId;
+            if ($effectiveRunId !== null) {
+                $criteria['runId'] = $effectiveRunId;
             }
             if ($event->exchange !== null) {
                 $criteria['exchange'] = $event->exchange;
@@ -200,7 +201,7 @@ final class TradeLifecycleLoggerListener
             symbol: $history->symbol,
             positionId: (string) $positionId,
             side: strtoupper($history->side->value),
-            runId: $event->runId ?? $lineage?->getRunId(),
+            runId: $effectiveRunId,
             exchange: $event->exchange,
             accountId: $event->accountId,
             reasonCode: $reasonCode,

--- a/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
+++ b/trading-app/src/Trading/Listener/TradeLifecycleLoggerListener.php
@@ -9,6 +9,7 @@ use App\Contract\Provider\MainProviderInterface;
 use App\Logging\TradeLifecycleLogger;
 use App\Provider\Context\ExchangeContext;
 use App\Repository\TradeLifecycleEventRepository;
+use App\Trading\Lineage\TradeLineageManager;
 use App\Trading\Event\OrderStateChangedEvent;
 use App\Trading\Event\PositionClosedEvent;
 use App\Trading\Event\PositionOpenedEvent;
@@ -21,6 +22,7 @@ final class TradeLifecycleLoggerListener
         private readonly TradeLifecycleLogger $tradeLifecycleLogger,
         private readonly TradeLifecycleEventRepository $tradeLifecycleRepository,
         private readonly ?MainProviderInterface $mainProvider = null,
+        private readonly ?TradeLineageManager $tradeLineageManager = null,
     ) {}
 
     // --- POSITION OUVERTE ----------------------------------------------------
@@ -31,9 +33,23 @@ final class TradeLifecycleLoggerListener
         $position = $event->position;
         $marketType = $this->marketTypeFromExtra($event->extra);
 
-        $positionId = $position->raw['position_id']
+        $rawPositionId = $position->raw['position_id']
             ?? $position->raw['positionId']
+            ?? null;
+        $positionId = $rawPositionId
             ?? sprintf('%s:%s:%s', $position->symbol, strtolower($position->side->value), $position->openedAt->format('U'));
+        $lineage = $this->resolveLineageFromPositionPayload($position->raw, $event->extra, $marketType, $rawPositionId);
+        if ($lineage !== null && $rawPositionId !== null) {
+            $this->tradeLineageManager?->attachPositionId($lineage, (string) $rawPositionId);
+        }
+        $extra = array_merge(
+            $lineage !== null ? $this->tradeLineageManager?->lifecycleExtra($lineage) ?? [] : [],
+            [
+                'source' => 'trading_state_sync',
+                'raw'    => $position->raw,
+            ],
+            $event->extra,
+        );
 
         $this->tradeLifecycleLogger->logPositionOpened(
             symbol: $position->symbol,
@@ -41,13 +57,10 @@ final class TradeLifecycleLoggerListener
             side: strtoupper($position->side->value),
             qty: $position->size->__toString(),
             entryPrice: $position->entryPrice->__toString(),
-            runId: $event->runId,
+            runId: $event->runId ?? $lineage?->getRunId(),
             exchange: $event->exchange,
             accountId: $event->accountId,
-            extra: array_merge([
-                'source' => 'trading_state_sync',
-                'raw'    => $position->raw,
-            ], $event->extra),
+            extra: $extra,
             marketType: $marketType,
         );
     }
@@ -60,9 +73,15 @@ final class TradeLifecycleLoggerListener
         $history = $event->positionHistory;
         $marketType = $this->marketTypeFromExtra($event->extra);
 
-        $positionId = $history->raw['position_id']
+        $rawPositionId = $history->raw['position_id']
             ?? $history->raw['positionId']
+            ?? null;
+        $positionId = $rawPositionId
             ?? sprintf('%s:%s:%s', $history->symbol, strtolower($history->side->value), $history->closedAt->format('U'));
+        $lineage = $this->resolveLineageFromPositionPayload($history->raw, $event->extra, $marketType, $rawPositionId);
+        if ($lineage !== null && $rawPositionId !== null) {
+            $this->tradeLineageManager?->attachPositionId($lineage, (string) $rawPositionId);
+        }
 
         // Déterminer le reasonCode si non fourni
         $reasonCode = $event->reasonCode;
@@ -181,27 +200,31 @@ final class TradeLifecycleLoggerListener
             symbol: $history->symbol,
             positionId: (string) $positionId,
             side: strtoupper($history->side->value),
-            runId: $event->runId,
+            runId: $event->runId ?? $lineage?->getRunId(),
             exchange: $event->exchange,
             accountId: $event->accountId,
             reasonCode: $reasonCode,
-            extra: array_merge([
-                'pnl'  => $history->realizedPnl->__toString(),
-                'pnl_pct' => $pnlPct,
-                'pnl_R' => $pnlR,
-                'notional_usdt' => $notional,
-                'entry_price' => $history->entryPrice->__toString(),
-                'exit_price' => $history->exitPrice->__toString(),
-                'entry_time' => $history->openedAt->format('Y-m-d H:i:s'),
-                'close_time' => $history->closedAt->format('Y-m-d H:i:s'),
-                'holding_time_sec' => $holdingTimeSec,
-                'max_favorable_price' => $mfePrice,
-                'max_adverse_price' => $maePrice,
-                'mfe_pct' => $mfePct,
-                'mae_pct' => $maePct,
-                'fees' => $history->fees?->__toString(),
-                'raw'  => $history->raw,
-            ], $event->extra),
+            extra: array_merge(
+                $lineage !== null ? $this->tradeLineageManager?->lifecycleExtra($lineage) ?? [] : [],
+                [
+                    'pnl'  => $history->realizedPnl->__toString(),
+                    'pnl_pct' => $pnlPct,
+                    'pnl_R' => $pnlR,
+                    'notional_usdt' => $notional,
+                    'entry_price' => $history->entryPrice->__toString(),
+                    'exit_price' => $history->exitPrice->__toString(),
+                    'entry_time' => $history->openedAt->format('Y-m-d H:i:s'),
+                    'close_time' => $history->closedAt->format('Y-m-d H:i:s'),
+                    'holding_time_sec' => $holdingTimeSec,
+                    'max_favorable_price' => $mfePrice,
+                    'max_adverse_price' => $maePrice,
+                    'mfe_pct' => $mfePct,
+                    'mae_pct' => $maePct,
+                    'fees' => $history->fees?->__toString(),
+                    'raw'  => $history->raw,
+                ],
+                $event->extra,
+            ),
             marketType: $marketType,
         );
     }
@@ -270,5 +293,50 @@ final class TradeLifecycleLoggerListener
         $marketType = $extra['market_type'] ?? $extra['marketType'] ?? null;
 
         return \is_string($marketType) && $marketType !== '' ? $marketType : null;
+    }
+
+    /**
+     * @param array<string,mixed> $raw
+     * @param array<string,mixed> $extra
+     */
+    private function resolveLineageFromPositionPayload(
+        array $raw,
+        array $extra,
+        ?string $marketType,
+        mixed $positionId,
+    ): ?\App\Entity\TradeLineage {
+        if ($this->tradeLineageManager === null) {
+            return null;
+        }
+
+        $context = ExchangeContext::fromValues(
+            $this->stringValue($raw['exchange'] ?? $extra['exchange'] ?? null),
+            $marketType ?? $this->stringValue($raw['market_type'] ?? $extra['market_type'] ?? null),
+        );
+
+        return $this->tradeLineageManager->resolve(
+            $context,
+            internalTradeId: $this->stringValue($extra['internal_trade_id'] ?? $raw['internal_trade_id'] ?? null),
+            clientOrderId: $this->stringValue($extra['client_order_id'] ?? $raw['client_order_id'] ?? null),
+            exchangeOrderId: $this->stringValue(
+                $extra['exchange_order_id']
+                    ?? $raw['exchange_order_id']
+                    ?? $raw['order_id']
+                    ?? $raw['last_order_id']
+                    ?? null
+            ),
+            positionId: $this->stringValue($positionId),
+        );
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (!\is_scalar($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
     }
 }

--- a/trading-app/tests/Trading/Lineage/ExecuteOrderPlanLineageSyncTest.php
+++ b/trading-app/tests/Trading/Lineage/ExecuteOrderPlanLineageSyncTest.php
@@ -11,6 +11,7 @@ use App\Entity\TradeLineage;
 use App\Repository\OrderIntentRepository;
 use App\Repository\TradeLineageRepository;
 use App\Service\OrderIntentManager;
+use App\Logging\Dto\LifecycleContextBuilder;
 use App\TradeEntry\Dto\ExecutionResult;
 use App\TradeEntry\Execution\ExchangeExecutionService;
 use App\TradeEntry\Execution\ExecutionBox;
@@ -82,6 +83,27 @@ final class ExecuteOrderPlanLineageSyncTest extends KernelTestCase
 
         self::assertSame(OrderIntent::STATUS_SENT, $intent->getStatus());
         self::assertSame('exchange-accepted-1', $intent->getExchangeOrderId());
+    }
+
+    public function testPreSubmitLineageSyncIsBestEffortWhenLineageTableIsMissing(): void
+    {
+        $intent = $this->persistReadyIntent();
+        $contextBuilder = (new LifecycleContextBuilder('BTCUSDT'))
+            ->withInternalTradeId('itd-from-mtf')
+            ->withTradeId('itd-from-mtf');
+
+        $workflow = new ExecuteOrderPlan(
+            $this->uninitialized(ExecutionBox::class),
+            $this->uninitialized(ExchangeExecutionService::class),
+            new NullLogger(),
+            $this->orderIntentManager(),
+            null,
+            $this->tradeLineageManager(),
+        );
+        $method = new \ReflectionMethod(ExecuteOrderPlan::class, 'syncLineageBeforeExecution');
+        $method->invoke($workflow, $intent, $contextBuilder);
+
+        self::assertSame('itd-from-mtf', $contextBuilder->toArray()['internal_trade_id'] ?? null);
     }
 
     private function persistReadyIntent(): OrderIntent

--- a/trading-app/tests/Trading/Lineage/ExecuteOrderPlanLineageSyncTest.php
+++ b/trading-app/tests/Trading/Lineage/ExecuteOrderPlanLineageSyncTest.php
@@ -106,6 +106,50 @@ final class ExecuteOrderPlanLineageSyncTest extends KernelTestCase
         self::assertSame('itd-from-mtf', $contextBuilder->toArray()['internal_trade_id'] ?? null);
     }
 
+    public function testPreSubmitLineageSyncNormalizesOverlongOrchestrationIds(): void
+    {
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema([
+            $this->em->getClassMetadata(OrderIntent::class),
+            $this->em->getClassMetadata(TradeLineage::class),
+        ]);
+        $schemaTool->createSchema([
+            $this->em->getClassMetadata(OrderIntent::class),
+            $this->em->getClassMetadata(TradeLineage::class),
+        ]);
+
+        $intent = $this->persistReadyIntent();
+        $contextBuilder = (new LifecycleContextBuilder('BTCUSDT'))
+            ->withInternalTradeId('itd-from-mtf')
+            ->withTradeId('itd-from-mtf')
+            ->merge([
+                'orchestration_run_id' => str_repeat('r', 140),
+                'orchestration_set_id' => str_repeat('s', 140),
+                'orchestration_dashboard_id' => str_repeat('d', 140),
+            ]);
+
+        $workflow = new ExecuteOrderPlan(
+            $this->uninitialized(ExecutionBox::class),
+            $this->uninitialized(ExchangeExecutionService::class),
+            new NullLogger(),
+            $this->orderIntentManager(),
+            null,
+            $this->tradeLineageManager(),
+        );
+        $method = new \ReflectionMethod(ExecuteOrderPlan::class, 'syncLineageBeforeExecution');
+        $method->invoke($workflow, $intent, $contextBuilder);
+
+        /** @var TradeLineage $lineage */
+        $lineage = $this->em->getRepository(TradeLineage::class)->findOneBy([
+            'internalTradeId' => 'itd-from-mtf',
+        ]);
+
+        self::assertNotNull($lineage);
+        self::assertLessThanOrEqual(96, strlen($lineage->getOrchestrationRunId() ?? ''));
+        self::assertLessThanOrEqual(96, strlen($lineage->getOrchestrationSetId() ?? ''));
+        self::assertLessThanOrEqual(96, strlen($lineage->getOrchestrationDashboardId() ?? ''));
+    }
+
     private function persistReadyIntent(): OrderIntent
     {
         $intent = (new OrderIntent())

--- a/trading-app/tests/Trading/Lineage/ExecuteOrderPlanLineageSyncTest.php
+++ b/trading-app/tests/Trading/Lineage/ExecuteOrderPlanLineageSyncTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Lineage;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Entity\OrderIntent;
+use App\Entity\TradeLineage;
+use App\Repository\OrderIntentRepository;
+use App\Repository\TradeLineageRepository;
+use App\Service\OrderIntentManager;
+use App\TradeEntry\Dto\ExecutionResult;
+use App\TradeEntry\Execution\ExchangeExecutionService;
+use App\TradeEntry\Execution\ExecutionBox;
+use App\TradeEntry\Idempotency\DecisionKeyFactory;
+use App\TradeEntry\Workflow\ExecuteOrderPlan;
+use App\Trading\Lineage\TradeLineageManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(ExecuteOrderPlan::class)]
+final class ExecuteOrderPlanLineageSyncTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema([
+            $this->em->getClassMetadata(OrderIntent::class),
+            $this->em->getClassMetadata(TradeLineage::class),
+        ]);
+        $schemaTool->createSchema([
+            $this->em->getClassMetadata(OrderIntent::class),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            (new SchemaTool($this->em))->dropSchema([
+                $this->em->getClassMetadata(OrderIntent::class),
+            ]);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testIntentStatusSyncContinuesWhenLineageTableIsMissing(): void
+    {
+        $intent = $this->persistReadyIntent();
+        $result = new ExecutionResult(
+            clientOrderId: $intent->getClientOrderId(),
+            exchangeOrderId: 'exchange-accepted-1',
+            status: ExecutionResult::STATUS_SUBMITTED,
+        );
+
+        $workflow = new ExecuteOrderPlan(
+            $this->uninitialized(ExecutionBox::class),
+            $this->uninitialized(ExchangeExecutionService::class),
+            new NullLogger(),
+            $this->orderIntentManager(),
+            null,
+            $this->tradeLineageManager(),
+        );
+        $method = new \ReflectionMethod(ExecuteOrderPlan::class, 'syncIntentAfterExecution');
+        $method->invoke($workflow, $intent, $result);
+
+        self::assertSame(OrderIntent::STATUS_SENT, $intent->getStatus());
+        self::assertSame('exchange-accepted-1', $intent->getExchangeOrderId());
+    }
+
+    private function persistReadyIntent(): OrderIntent
+    {
+        $intent = (new OrderIntent())
+            ->setExchange(Exchange::BITMART)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setSize(1)
+            ->setClientOrderId('cid-lineage-missing')
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setDecisionKey('bitmart:perpetual:BTCUSDT:1m:1764161200:long:scalper:v1')
+            ->markAsReadyToSend();
+
+        $this->em->persist($intent);
+        $this->em->flush();
+
+        return $intent;
+    }
+
+    private function orderIntentManager(): OrderIntentManager
+    {
+        /** @var OrderIntentRepository $repository */
+        $repository = $this->em->getRepository(OrderIntent::class);
+
+        return new OrderIntentManager($repository, $this->em, new NullLogger(), new DecisionKeyFactory());
+    }
+
+    private function tradeLineageManager(): TradeLineageManager
+    {
+        /** @var TradeLineageRepository $repository */
+        $repository = $this->em->getRepository(TradeLineage::class);
+
+        return new TradeLineageManager($repository, $this->em, new NullLogger());
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $className
+     * @return T
+     */
+    private function uninitialized(string $className): object
+    {
+        return (new \ReflectionClass($className))->newInstanceWithoutConstructor();
+    }
+}

--- a/trading-app/tests/Trading/Lineage/LimitFillWatchMessageHandlerLineageTest.php
+++ b/trading-app/tests/Trading/Lineage/LimitFillWatchMessageHandlerLineageTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Lineage;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderStatus;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\ContractProviderInterface;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Contract\Provider\MainProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Contract\Provider\SystemProviderInterface;
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+use App\Logging\TradeLifecycleLogger;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\TradeLineageRepository;
+use App\TradeEntry\Message\LimitFillWatchMessage;
+use App\TradeEntry\MessageHandler\LimitFillWatchMessageHandler;
+use App\Trading\Lineage\TradeLineageManager;
+use Brick\Math\BigDecimal;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Clock\ClockInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[CoversClass(LimitFillWatchMessageHandler::class)]
+final class LimitFillWatchMessageHandlerLineageTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadata = [
+            $this->em->getClassMetadata(TradeLifecycleEvent::class),
+            $this->em->getClassMetadata(TradeLineage::class),
+        ];
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema([
+            $this->em->getClassMetadata(TradeLifecycleEvent::class),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            (new SchemaTool($this->em))->dropSchema([
+                $this->em->getClassMetadata(TradeLifecycleEvent::class),
+            ]);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testLimitFillLifecycleIsLoggedWhenLineageTableIsMissing(): void
+    {
+        $handler = new LimitFillWatchMessageHandler(
+            $this->mainProvider(),
+            new NullLogger(),
+            $this->messageBus(),
+            new TradeLifecycleLogger($this->em, $this->fixedClock()),
+            $this->tradeLineageManager(),
+        );
+
+        $method = new \ReflectionMethod(LimitFillWatchMessageHandler::class, 'logPositionOpenedLifecycle');
+        $method->invoke(
+            $handler,
+            new LimitFillWatchMessage(
+                symbol: 'BTCUSDT',
+                exchangeOrderId: 'exchange-limit-1',
+                clientOrderId: 'client-limit-1',
+                side: 'BUY',
+                cancelAfterSec: 30,
+                decisionKey: 'bitmart:perpetual:BTCUSDT:1m:1764161200:long:scalper:v1',
+                lifecycleContext: [
+                    'exchange' => 'bitmart',
+                    'market_type' => 'perpetual',
+                    'run_id' => 'run-limit',
+                ],
+            ),
+            new OrderDto(
+                orderId: 'exchange-limit-1',
+                symbol: 'BTCUSDT',
+                side: OrderSide::BUY,
+                type: OrderType::LIMIT,
+                status: OrderStatus::FILLED,
+                quantity: BigDecimal::of('3'),
+                price: BigDecimal::of('100'),
+                stopPrice: null,
+                filledQuantity: BigDecimal::of('3'),
+                remainingQuantity: BigDecimal::of('0'),
+                averagePrice: BigDecimal::of('101'),
+                createdAt: new \DateTimeImmutable('2026-06-23 12:00:00 UTC'),
+                metadata: ['position_id' => 'pos-limit-1'],
+            ),
+        );
+
+        /** @var TradeLifecycleEvent|null $opened */
+        $opened = $this->em->getRepository(TradeLifecycleEvent::class)->findOneBy([
+            'eventType' => 'position_opened',
+            'positionId' => 'pos-limit-1',
+        ]);
+
+        self::assertNotNull($opened);
+        self::assertSame('run-limit', $opened->getRunId());
+    }
+
+    private function tradeLineageManager(): TradeLineageManager
+    {
+        /** @var TradeLineageRepository $repository */
+        $repository = $this->em->getRepository(TradeLineage::class);
+
+        return new TradeLineageManager($repository, $this->em, new NullLogger());
+    }
+
+    private function mainProvider(): MainProviderInterface
+    {
+        return new class implements MainProviderInterface {
+            public function getKlineProvider(): KlineProviderInterface { throw new \LogicException('unused'); }
+            public function getContractProvider(): ContractProviderInterface { throw new \LogicException('unused'); }
+            public function getOrderProvider(): ?OrderProviderInterface { throw new \LogicException('unused'); }
+            public function getAccountProvider(): ?AccountProviderInterface { throw new \LogicException('unused'); }
+            public function getSystemProvider(): SystemProviderInterface { throw new \LogicException('unused'); }
+            public function forContext(?ExchangeContext $context = null): self { return $this; }
+        };
+    }
+
+    private function messageBus(): MessageBusInterface
+    {
+        return new class implements MessageBusInterface {
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                return new Envelope($message, $stamps);
+            }
+        };
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-06-23 12:01:00 UTC');
+            }
+        };
+    }
+}

--- a/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerLineageTest.php
+++ b/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerLineageTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Lineage;
+
+use App\Entity\TradeLifecycleEvent;
+use App\Logging\TradeLifecycleLogger;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Clock\ClockInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(TradeLifecycleLogger::class)]
+final class TradeLifecycleLoggerLineageTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadata = [$this->em->getClassMetadata(TradeLifecycleEvent::class)];
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            (new SchemaTool($this->em))->dropSchema([$this->em->getClassMetadata(TradeLifecycleEvent::class)]);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testOrderSubmittedPersistsInternalTradeIdColumn(): void
+    {
+        $logger = new TradeLifecycleLogger($this->em, $this->fixedClock());
+
+        $logger->logOrderSubmitted(
+            symbol: 'BTCUSDT',
+            orderId: 'ex-1',
+            clientOrderId: 'cid-1',
+            side: 'BUY',
+            qty: '1',
+            price: '100',
+            runId: 'run-1',
+            exchange: 'bitmart',
+            extra: [
+                'internal_trade_id' => 'itd-logger-1',
+                'trade_id' => 'itd-logger-1',
+            ],
+            marketType: 'perpetual',
+        );
+
+        /** @var TradeLifecycleEvent $event */
+        $event = $this->em->getRepository(TradeLifecycleEvent::class)->findOneBy([
+            'clientOrderId' => 'CID-1',
+        ]);
+
+        self::assertNotNull($event);
+        self::assertSame('itd-logger-1', $event->getInternalTradeId());
+        self::assertSame('itd-logger-1', $event->getExtra()['internal_trade_id'] ?? null);
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-06-23 10:00:00 UTC');
+            }
+        };
+    }
+}

--- a/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
+++ b/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Lineage;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\PositionSide;
+use App\Entity\OrderIntent;
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+use App\Logging\TradeLifecycleLogger;
+use App\Repository\TradeLifecycleEventRepository;
+use App\Repository\TradeLineageRepository;
+use App\Trading\Dto\PositionHistoryEntryDto;
+use App\Trading\Event\PositionClosedEvent;
+use App\Trading\Lineage\TradeLineageManager;
+use App\Trading\Listener\TradeLifecycleLoggerListener;
+use Brick\Math\BigDecimal;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Clock\ClockInterface;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(TradeLifecycleLoggerListener::class)]
+final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadata = array_map(
+            fn (string $class) => $this->em->getClassMetadata($class),
+            [OrderIntent::class, TradeLineage::class, TradeLifecycleEvent::class],
+        );
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            $metadata = array_map(
+                fn (string $class) => $this->em->getClassMetadata($class),
+                [OrderIntent::class, TradeLineage::class, TradeLifecycleEvent::class],
+            );
+            (new SchemaTool($this->em))->dropSchema($metadata);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testClosedPositionRiskLookupUsesResolvedLineageRunId(): void
+    {
+        $lineage = $this->persistLineageWithPosition();
+        $this->persistOrderSubmitted('run-other', '1', new \DateTimeImmutable('2026-06-23 10:02:00 UTC'));
+        $this->persistOrderSubmitted($lineage->getRunId(), '50', new \DateTimeImmutable('2026-06-23 10:01:00 UTC'));
+
+        /** @var TradeLifecycleEventRepository $tradeLifecycleRepository */
+        $tradeLifecycleRepository = $this->em->getRepository(TradeLifecycleEvent::class);
+
+        $listener = new TradeLifecycleLoggerListener(
+            new TradeLifecycleLogger($this->em, $this->fixedClock()),
+            $tradeLifecycleRepository,
+            null,
+            $this->tradeLineageManager(),
+        );
+
+        $listener->onPositionClosed(new PositionClosedEvent(
+            positionHistory: new PositionHistoryEntryDto(
+                symbol: 'BTCUSDT',
+                side: PositionSide::LONG,
+                size: BigDecimal::of('1'),
+                entryPrice: BigDecimal::of('100'),
+                exitPrice: BigDecimal::of('200'),
+                realizedPnl: BigDecimal::of('100'),
+                fees: null,
+                openedAt: new \DateTimeImmutable('2026-06-23 10:00:00 UTC'),
+                closedAt: new \DateTimeImmutable('2026-06-23 10:05:00 UTC'),
+                raw: ['position_id' => 'pos-real'],
+            ),
+            runId: null,
+            exchange: Exchange::BITMART->value,
+            extra: ['market_type' => MarketType::PERPETUAL->value],
+        ));
+
+        /** @var TradeLifecycleEvent $closed */
+        $closed = $this->em->getRepository(TradeLifecycleEvent::class)->findOneBy([
+            'eventType' => 'position_closed',
+            'positionId' => 'pos-real',
+        ]);
+
+        self::assertNotNull($closed);
+        self::assertSame('run-real', $closed->getRunId());
+        self::assertSame(2.0, $closed->getExtra()['pnl_R'] ?? null);
+    }
+
+    private function persistLineageWithPosition(): TradeLineage
+    {
+        $intent = (new OrderIntent())
+            ->setExchange(Exchange::BITMART)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setSize(1)
+            ->setClientOrderId('cid-real')
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setDecisionKey('bitmart:perpetual:BTCUSDT:1m:1764161200:long:scalper:v1');
+
+        $this->em->persist($intent);
+        $this->em->flush();
+
+        $lineage = $this->tradeLineageManager()->ensureForIntent($intent, [
+            'internal_trade_id' => 'itd-real',
+            'run_id' => 'run-real',
+        ]);
+        $this->tradeLineageManager()->attachPositionId($lineage, 'pos-real');
+
+        return $lineage;
+    }
+
+    private function persistOrderSubmitted(string $runId, string $riskUsdt, \DateTimeImmutable $happenedAt): void
+    {
+        $event = (new TradeLifecycleEvent('BTCUSDT', 'order_submitted', $happenedAt))
+            ->setRunId($runId)
+            ->setExchange(Exchange::BITMART)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setExtra(['risk_usdt' => $riskUsdt]);
+
+        $this->em->persist($event);
+        $this->em->flush();
+    }
+
+    private function tradeLineageManager(): TradeLineageManager
+    {
+        /** @var TradeLineageRepository $repository */
+        $repository = $this->em->getRepository(TradeLineage::class);
+
+        return new TradeLineageManager($repository, $this->em, new NullLogger());
+    }
+
+    private function fixedClock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-06-23 10:06:00 UTC');
+            }
+        };
+    }
+}

--- a/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
+++ b/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
@@ -68,8 +68,8 @@ final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
     public function testClosedPositionRiskLookupUsesResolvedLineageRunId(): void
     {
         $lineage = $this->persistLineageWithPosition();
-        $this->persistOrderSubmitted('run-other', '1', new \DateTimeImmutable('2026-06-23 10:02:00 UTC'));
-        $this->persistOrderSubmitted($lineage->getRunId(), '50', new \DateTimeImmutable('2026-06-23 10:01:00 UTC'));
+        $this->persistOrderSubmitted($lineage->getRunId(), '1', new \DateTimeImmutable('2026-06-23 10:02:00 UTC'), 'itd-other');
+        $this->persistOrderSubmitted($lineage->getRunId(), '50', new \DateTimeImmutable('2026-06-23 10:01:00 UTC'), $lineage->getInternalTradeId());
 
         $listener = new TradeLifecycleLoggerListener(
             new TradeLifecycleLogger($this->em, $this->fixedClock()),
@@ -110,7 +110,7 @@ final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
     public function testClosedPositionResolvesLineageFromNestedRawHistoryPositionId(): void
     {
         $lineage = $this->persistLineageWithPosition();
-        $this->persistOrderSubmitted($lineage->getRunId(), '25', new \DateTimeImmutable('2026-06-23 10:01:00 UTC'));
+        $this->persistOrderSubmitted($lineage->getRunId(), '25', new \DateTimeImmutable('2026-06-23 10:01:00 UTC'), $lineage->getInternalTradeId());
 
         $listener = new TradeLifecycleLoggerListener(
             new TradeLifecycleLogger($this->em, $this->fixedClock()),
@@ -214,13 +214,17 @@ final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
         return $lineage;
     }
 
-    private function persistOrderSubmitted(string $runId, string $riskUsdt, \DateTimeImmutable $happenedAt): void
+    private function persistOrderSubmitted(string $runId, string $riskUsdt, \DateTimeImmutable $happenedAt, ?string $internalTradeId = null): void
     {
         $event = (new TradeLifecycleEvent('BTCUSDT', 'order_submitted', $happenedAt))
             ->setRunId($runId)
             ->setExchange(Exchange::BITMART)
             ->setMarketType(MarketType::PERPETUAL)
-            ->setExtra(['risk_usdt' => $riskUsdt]);
+            ->setInternalTradeId($internalTradeId)
+            ->setExtra(array_filter([
+                'risk_usdt' => $riskUsdt,
+                'internal_trade_id' => $internalTradeId,
+            ], static fn (mixed $value): bool => $value !== null));
 
         $this->em->persist($event);
         $this->em->flush();

--- a/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
+++ b/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
@@ -107,6 +107,47 @@ final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
         self::assertSame(2.0, $closed->getExtra()['pnl_R'] ?? null);
     }
 
+    public function testClosedPositionResolvesLineageFromNestedRawHistoryPositionId(): void
+    {
+        $lineage = $this->persistLineageWithPosition();
+        $this->persistOrderSubmitted($lineage->getRunId(), '25', new \DateTimeImmutable('2026-06-23 10:01:00 UTC'));
+
+        $listener = new TradeLifecycleLoggerListener(
+            new TradeLifecycleLogger($this->em, $this->fixedClock()),
+            $this->tradeLifecycleRepository(),
+            null,
+            $this->tradeLineageManager(),
+        );
+
+        $listener->onPositionClosed(new PositionClosedEvent(
+            positionHistory: new PositionHistoryEntryDto(
+                symbol: 'BTCUSDT',
+                side: PositionSide::LONG,
+                size: BigDecimal::of('1'),
+                entryPrice: BigDecimal::of('100'),
+                exitPrice: BigDecimal::of('150'),
+                realizedPnl: BigDecimal::of('50'),
+                fees: null,
+                openedAt: new \DateTimeImmutable('2026-06-23 10:00:00 UTC'),
+                closedAt: new \DateTimeImmutable('2026-06-23 10:05:00 UTC'),
+                raw: ['raw_history' => ['position_id' => 'pos-real']],
+            ),
+            runId: null,
+            exchange: Exchange::BITMART->value,
+            extra: ['market_type' => MarketType::PERPETUAL->value],
+        ));
+
+        /** @var TradeLifecycleEvent|null $closed */
+        $closed = $this->em->getRepository(TradeLifecycleEvent::class)->findOneBy([
+            'eventType' => 'position_closed',
+            'positionId' => 'pos-real',
+        ]);
+
+        self::assertNotNull($closed);
+        self::assertSame('run-real', $closed->getRunId());
+        self::assertSame(2.0, $closed->getExtra()['pnl_R'] ?? null);
+    }
+
     public function testOpenedPositionLifecycleIsLoggedWhenLineageTableIsMissing(): void
     {
         (new SchemaTool($this->em))->dropSchema([

--- a/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
+++ b/trading-app/tests/Trading/Lineage/TradeLifecycleLoggerListenerLineageTest.php
@@ -14,7 +14,9 @@ use App\Logging\TradeLifecycleLogger;
 use App\Repository\TradeLifecycleEventRepository;
 use App\Repository\TradeLineageRepository;
 use App\Trading\Dto\PositionHistoryEntryDto;
+use App\Trading\Dto\PositionDto;
 use App\Trading\Event\PositionClosedEvent;
+use App\Trading\Event\PositionOpenedEvent;
 use App\Trading\Lineage\TradeLineageManager;
 use App\Trading\Listener\TradeLifecycleLoggerListener;
 use Brick\Math\BigDecimal;
@@ -69,12 +71,9 @@ final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
         $this->persistOrderSubmitted('run-other', '1', new \DateTimeImmutable('2026-06-23 10:02:00 UTC'));
         $this->persistOrderSubmitted($lineage->getRunId(), '50', new \DateTimeImmutable('2026-06-23 10:01:00 UTC'));
 
-        /** @var TradeLifecycleEventRepository $tradeLifecycleRepository */
-        $tradeLifecycleRepository = $this->em->getRepository(TradeLifecycleEvent::class);
-
         $listener = new TradeLifecycleLoggerListener(
             new TradeLifecycleLogger($this->em, $this->fixedClock()),
-            $tradeLifecycleRepository,
+            $this->tradeLifecycleRepository(),
             null,
             $this->tradeLineageManager(),
         );
@@ -106,6 +105,45 @@ final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
         self::assertNotNull($closed);
         self::assertSame('run-real', $closed->getRunId());
         self::assertSame(2.0, $closed->getExtra()['pnl_R'] ?? null);
+    }
+
+    public function testOpenedPositionLifecycleIsLoggedWhenLineageTableIsMissing(): void
+    {
+        (new SchemaTool($this->em))->dropSchema([
+            $this->em->getClassMetadata(TradeLineage::class),
+        ]);
+
+        $listener = new TradeLifecycleLoggerListener(
+            new TradeLifecycleLogger($this->em, $this->fixedClock()),
+            $this->tradeLifecycleRepository(),
+            null,
+            $this->tradeLineageManager(),
+        );
+
+        $listener->onPositionOpened(new PositionOpenedEvent(
+            position: new PositionDto(
+                symbol: 'ETHUSDT',
+                side: PositionSide::LONG,
+                size: BigDecimal::of('2'),
+                entryPrice: BigDecimal::of('1000'),
+                markPrice: BigDecimal::of('1001'),
+                unrealizedPnl: BigDecimal::of('0'),
+                leverage: BigDecimal::of('5'),
+                openedAt: new \DateTimeImmutable('2026-06-23 11:00:00 UTC'),
+                raw: ['position_id' => 'pos-missing-lineage'],
+            ),
+            exchange: Exchange::BITMART->value,
+            extra: ['market_type' => MarketType::PERPETUAL->value],
+        ));
+
+        /** @var TradeLifecycleEvent|null $opened */
+        $opened = $this->em->getRepository(TradeLifecycleEvent::class)->findOneBy([
+            'eventType' => 'position_opened',
+            'positionId' => 'pos-missing-lineage',
+        ]);
+
+        self::assertNotNull($opened);
+        self::assertSame('ETHUSDT', $opened->getSymbol());
     }
 
     private function persistLineageWithPosition(): TradeLineage
@@ -153,6 +191,14 @@ final class TradeLifecycleLoggerListenerLineageTest extends KernelTestCase
         $repository = $this->em->getRepository(TradeLineage::class);
 
         return new TradeLineageManager($repository, $this->em, new NullLogger());
+    }
+
+    private function tradeLifecycleRepository(): TradeLifecycleEventRepository
+    {
+        /** @var TradeLifecycleEventRepository $repository */
+        $repository = $this->em->getRepository(TradeLifecycleEvent::class);
+
+        return $repository;
     }
 
     private function fixedClock(): ClockInterface

--- a/trading-app/tests/Trading/Lineage/TradeLineageManagerTest.php
+++ b/trading-app/tests/Trading/Lineage/TradeLineageManagerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Lineage;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Entity\OrderIntent;
+use App\Entity\TradeLineage;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\TradeLineageRepository;
+use App\Trading\Lineage\TradeLineageManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(TradeLineageManager::class)]
+#[CoversClass(TradeLineageRepository::class)]
+final class TradeLineageManagerTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private TradeLineageManager $manager;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $metadata = array_map(
+            fn (string $class) => $this->em->getClassMetadata($class),
+            [OrderIntent::class, TradeLineage::class],
+        );
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+
+        /** @var TradeLineageRepository $repository */
+        $repository = $this->em->getRepository(TradeLineage::class);
+        $this->manager = new TradeLineageManager($repository, $this->em, new NullLogger());
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            $metadata = array_map(
+                fn (string $class) => $this->em->getClassMetadata($class),
+                [OrderIntent::class, TradeLineage::class],
+            );
+            (new SchemaTool($this->em))->dropSchema($metadata);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testCreatesOneStableInternalTradeIdForAnOrderIntent(): void
+    {
+        $intent = $this->persistIntent('cid-1', 'BTCUSDT', Exchange::BITMART, MarketType::PERPETUAL);
+
+        $lineage = $this->manager->ensureForIntent($intent, [
+            'internal_trade_id' => 'itd-stable-1',
+            'trade_id' => 'legacy-trade-ignored',
+            'run_id' => 'run-1',
+            'orchestration_set_id' => 'set-1',
+            'orchestration_dashboard_id' => 'dash-1',
+            'profile' => 'scalper_micro',
+        ]);
+        $again = $this->manager->ensureForIntent($intent, [
+            'internal_trade_id' => 'itd-would-be-wrong',
+        ]);
+
+        self::assertSame('itd-stable-1', $lineage->getInternalTradeId());
+        self::assertSame($lineage->getId(), $again->getId());
+        self::assertSame('itd-stable-1', $again->getInternalTradeId());
+        self::assertSame('run-1', $again->getRunId());
+        self::assertSame('set-1', $again->getOrchestrationSetId());
+        self::assertSame('dash-1', $again->getOrchestrationDashboardId());
+        self::assertSame('scalper_micro', $again->getProfile());
+    }
+
+    public function testResolvesOnlyByExactPersistedIdentifiersWithinVenue(): void
+    {
+        $bitmart = $this->persistIntent('shared-cid', 'BTCUSDT', Exchange::BITMART, MarketType::PERPETUAL);
+        $okx = $this->persistIntent('shared-cid', 'BTCUSDT', Exchange::OKX, MarketType::PERPETUAL);
+
+        $bitmartLineage = $this->manager->ensureForIntent($bitmart, ['internal_trade_id' => 'itd-bitmart']);
+        $okxLineage = $this->manager->ensureForIntent($okx, ['internal_trade_id' => 'itd-okx']);
+
+        $this->manager->attachExchangeOrderId($bitmartLineage, 'ex-shared');
+        $this->manager->attachExchangeOrderId($okxLineage, 'ex-shared');
+        $this->manager->attachPositionId($bitmartLineage, 'pos-shared');
+        $this->manager->attachPositionId($okxLineage, 'pos-shared');
+
+        self::assertSame(
+            'itd-bitmart',
+            $this->manager->resolve(
+                new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+                clientOrderId: 'shared-cid',
+            )?->getInternalTradeId(),
+        );
+        self::assertSame(
+            'itd-okx',
+            $this->manager->resolve(
+                new ExchangeContext(Exchange::OKX, MarketType::PERPETUAL),
+                exchangeOrderId: 'ex-shared',
+            )?->getInternalTradeId(),
+        );
+        self::assertSame(
+            'itd-bitmart',
+            $this->manager->resolve(
+                new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+                positionId: 'pos-shared',
+            )?->getInternalTradeId(),
+        );
+    }
+
+    public function testDoesNotResolveFromSymbolSideOrTimestamp(): void
+    {
+        $intent = $this->persistIntent('cid-a', 'SOLUSDT', Exchange::BITMART, MarketType::PERPETUAL);
+        $this->manager->ensureForIntent($intent, ['internal_trade_id' => 'itd-sol']);
+
+        $resolved = $this->manager->resolve(
+            new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+            symbol: 'SOLUSDT',
+            side: 'LONG',
+        );
+
+        self::assertNull($resolved);
+    }
+
+    public function testAmbiguousExchangeOrPositionIdentifierStaysUnmatched(): void
+    {
+        $first = $this->persistIntent('cid-first', 'BTCUSDT', Exchange::BITMART, MarketType::PERPETUAL);
+        $second = $this->persistIntent('cid-second', 'BTCUSDT', Exchange::BITMART, MarketType::PERPETUAL);
+
+        $firstLineage = $this->manager->ensureForIntent($first, ['internal_trade_id' => 'itd-first']);
+        $secondLineage = $this->manager->ensureForIntent($second, ['internal_trade_id' => 'itd-second']);
+
+        $this->manager->attachExchangeOrderId($firstLineage, 'ambiguous-order');
+        $this->manager->attachExchangeOrderId($secondLineage, 'ambiguous-order');
+        $this->manager->attachPositionId($firstLineage, 'ambiguous-position');
+        $this->manager->attachPositionId($secondLineage, 'ambiguous-position');
+
+        $context = new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL);
+
+        self::assertNull($this->manager->resolve($context, exchangeOrderId: 'ambiguous-order'));
+        self::assertNull($this->manager->resolve($context, positionId: 'ambiguous-position'));
+        self::assertSame('itd-first', $this->manager->resolve($context, clientOrderId: 'cid-first')?->getInternalTradeId());
+    }
+
+    private function persistIntent(
+        string $clientOrderId,
+        string $symbol,
+        Exchange $exchange,
+        MarketType $marketType,
+    ): OrderIntent {
+        $intent = (new OrderIntent())
+            ->setExchange($exchange)
+            ->setMarketType($marketType)
+            ->setSymbol($symbol)
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setSize(1)
+            ->setClientOrderId($clientOrderId)
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setDecisionKey(sprintf('%s:%s:%s:%s:1m:1764161200:long:scalper:v1', $exchange->value, $marketType->value, $symbol, $clientOrderId));
+
+        $this->em->persist($intent);
+        $this->em->flush();
+
+        return $intent;
+    }
+}


### PR DESCRIPTION
## Contexte

Part of #200
Part of #189
Related to #173
Related to #190
Référence: #199

#199 a rendu `position_trade_analysis_v2` exploitable en lecture, mais les événements runtime réels restent souvent `unmatched` car `order_submitted`, `position_opened` et `position_closed` ne partagent pas toujours une clé interne stable. Cette PR ajoute ce chaînage sans modifier les règles de stratégie, MTF, EntryZone, Risk/Leverage, SL/TP, fréquence, ni les modes live/dry-run.

## Décision d'architecture

Ajout d'un mapping persistant `TradeLineage` piloté par `internal_trade_id`. La clé est créée une seule fois quand le trade logique est matérialisé via `OrderIntent`, puis réutilisée dans les événements lifecycle. La résolution respecte strictement l'ordre autorisé :

1. `internal_trade_id` déjà présent ;
2. `client_order_id` exact dans la même venue ;
3. `exchange_order_id` exact dans la même venue ;
4. `position_id` exact dans la même venue uniquement s'il a déjà été persisté ;
5. sinon `unmatched`.

Aucun rapprochement par symbole, side ou timestamp n'est introduit. Si un identifiant exact produit plusieurs mappings dans la même venue, la résolution reste `unmatched`.

## Modèle de persistance

- Nouvelle table additive `trade_lineage` : `internal_trade_id`, `order_intent_id`, `client_order_id`, `exchange_order_id`, `position_id`, run/set/dashboard/profile, `exchange`, `market_type`, `symbol`, `side`, `origin`.
- Nouvelle colonne nullable et indexée `trade_lifecycle_event.internal_trade_id`.
- Pas de suppression de colonne existante.
- Pas de backfill heuristique.
- Compatibilité legacy : champs nullable côté événements existants, `origin` permet de distinguer la provenance runtime/legacy.

## Chemins couverts

- MTF `TradingDecisionHandler` ajoute `internal_trade_id` au contexte lifecycle, aligné sur le `trade_id` interne existant.
- `ExecuteOrderPlan` crée ou relit le mapping avant soumission, puis attache `exchange_order_id` dès qu'il est connu.
- `LimitFillWatchMessageHandler` propage la clé sur les LIMIT fills/partials via contexte, client order id ou exchange order id exact.
- `TradeLifecycleLoggerListener` enrichit les événements issus de la sync REST uniquement avec des identifiants exacts.
- `PositionDto` conserve le payload provider brut en metadata pour ne pas perdre les identifiants utilisables après restart/sync.
- Bitmart et Fake/Paper restent disponibles ; OKX/Hyperliquid ne sont pas activés en live.

## Chemins non couverts

- Aucun backfill historique.
- Aucun rapprochement d'événements legacy sans identifiant exact.
- Si Bitmart ne fournit pas d'identifiant exact dans le payload position REST/WebSocket, l'événement reste volontairement `unmatched`.

## Tests exécutés

- `php bin/phpunit tests/Trading/Lineage`
- `php bin/phpunit tests/Trading/Lineage tests/TradeEntry/Execution/ExchangeExecutionServiceTest.php tests/Exchange/Adapter/FakeExchangeAdapterTest.php tests/Exchange/Adapter/BitmartExchangeAdapterTest.php tests/Trading/View/PositionTradeAnalysisViewTest.php tests/MtfRunner`
- `DATABASE_URL=... vendor/bin/phpunit --bootstrap vendor/autoload.php --fail-on-skipped tests/Trading/View/PositionTradeAnalysisViewTest.php`
- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Trading tests/MtfRunner`
- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Contract/MtfValidator/Dto`
- `vendor/bin/phpstan analyse --no-progress src/Trading/Lineage/TradeLineageManager.php src/Repository/TradeLineageRepository.php src/Entity/TradeLineage.php tests/Trading/Lineage --memory-limit=1G`
- `vendor/bin/phpstan analyse --no-progress src/Trading/Service/RunTradeOutcomeService.php src/Trading/Service/PositionTradeOutcomeSourceException.php src/Trading/Service/PositionTradeAnalysisReaderInterface.php src/Trading/Service/RunCorrelationId.php src/Trading/Orchestration/OrchestrationContextValidator.php src/Trading/Orchestration/OrchestrationContextException.php src/Trading/Controller/Api/PositionAnalysisApiController.php`
- `php bin/console lint:container --no-debug`
- `php bin/console lint:yaml config`
- `php -l` sur les nouveaux fichiers PHP principaux/tests/migration
- `git diff --check`

Note : `tests/Trading` conserve les skips existants quand `DATABASE_URL` n'est pas exportée ; le test PostgreSQL dédié a été relancé séparément avec `--fail-on-skipped` et une vraie connexion.

## Compatibilité legacy

`internal_trade_id` reste nullable sur `trade_lifecycle_event`. Les événements sans mapping exact restent exploitables comme `unmatched`; la PR n'invente pas de PnL ni d'association financière.

## Risques

- Un provider peut ne pas exposer d'identifiant exact sur certains événements position : ces événements resteront `unmatched` jusqu'à ce que le payload fournisse `client_order_id`, `exchange_order_id` ou un `position_id` déjà persisté.
- Les événements historiques ne sont pas corrigés par cette migration.

## Rollback

Rollback applicatif : revenir le commit.
Rollback base : migration down supprime `trade_lineage` et la colonne additive `trade_lifecycle_event.internal_trade_id`. Aucun champ existant n'est supprimé par la migration up.