### PR TITLE
Issue 189 - Lineage read API

### DIFF
--- a/docs/handbook/technical/interfaces.md
+++ b/docs/handbook/technical/interfaces.md
@@ -12,6 +12,9 @@
 | `GET /api/mtf/switches` | `MtfController` | Switches MTF. |
 | `GET /api/mtf-audits` | `MtfAuditController` | Audits MTF JSON. |
 | `GET /api/mtf-audits?runId={runId}` | `MtfAuditController` | Lecture des audits d'un run. |
+| `GET /api/lineage/v1/search` | `LineageReadApiController` | Lecture read-only du lineage persistant par identifiants exacts. |
+| `GET /api/lineage/v1/{internal_trade_id}` | `LineageReadApiController` | Detail complet d'un lineage. |
+| `GET /api/lineage/v1/{internal_trade_id}/events` | `LineageReadApiController` | Evenements lifecycle associes au lineage. |
 | `GET /api/indicators/available` | `IndicatorApiController` | Conditions/indicateurs disponibles. |
 | `GET /api/indicators/pivots` | `IndicatorApiController` | Pivots. |
 | `GET /api/indicators/values` | `IndicatorApiController` | Valeurs indicateurs. |

--- a/docs/handbook/technical/internal-trade-lineage.md
+++ b/docs/handbook/technical/internal-trade-lineage.md
@@ -39,6 +39,8 @@ Ordre autorisé :
 La venue est toujours `exchange + market_type`. Les résolutions par symbole seul, symbole + side, timestamp, ou première clôture suivante sont interdites.
 Si un identifiant exact non unique produit plusieurs mappings dans la même venue, la résolution reste `unmatched` : le système ne choisit jamais silencieusement un candidat.
 
+L'API read-only `GET /api/lineage/v1/search` expose ce comportement aux clients : une ambiguite persistante dans une meme venue retourne `identifier_conflict`, tandis que deux venues differentes peuvent reutiliser le meme identifiant si `exchange + market_type` sont fournis explicitement. Voir [API read-only de lineage](lineage-read-api.md).
+
 ## Couverture actuelle
 
 - `order_submitted` reçoit `internal_trade_id`, `trade_id`, `run_id`, set/dashboard/profil et venue.

--- a/docs/handbook/technical/lineage-read-api.md
+++ b/docs/handbook/technical/lineage-read-api.md
@@ -1,0 +1,179 @@
+# API read-only de lineage
+
+Cette surface permet de naviguer dans le lineage persistant sans reconstruire les relations par symbole, side ou fenetre temporelle.
+
+Controleur Symfony : `App\Trading\Controller\Api\LineageReadApiController`.
+
+## Principes
+
+- Lecture seule uniquement.
+- Un seul identifiant exact par requete.
+- Aucun fallback par symbole seul.
+- Aucun rapprochement par fenetre temporelle.
+- `client_order_id`, `exchange_order_id` et `position_id` exigent toujours `exchange` et `market_type`.
+- Les identifiants ambigus dans une meme venue retournent `409 identifier_conflict`.
+- Les reponses n'exposent pas `extra`, `raw_inputs`, `validation_errors` ni payload provider brut.
+- Chaque item expose toujours `completeness_status` et `quality_flags`.
+- Pagination bornee : `limit` est force entre 1 et 100, `offset >= 0`.
+
+## Endpoints
+
+### Recherche
+
+```text
+GET /api/lineage/v1/search
+```
+
+Parametres acceptes, un seul a la fois :
+
+- `orchestration_run_id`
+- `correlation_run_id`
+- `orchestration_set_id`
+- `orchestration_dashboard_id`
+- `internal_trade_id`
+- `internal_position_id`
+- `order_intent_id`
+- `client_order_id` avec `exchange` + `market_type`
+- `exchange_order_id` avec `exchange` + `market_type`
+- `position_id` avec `exchange` + `market_type`
+
+Parametres de pagination :
+
+- `limit` : defaut 100, maximum 100.
+- `offset` : defaut 0.
+
+Exemples :
+
+```bash
+curl -s 'http://localhost:8082/api/lineage/v1/search?orchestration_run_id=run_dashA_20260617T083000Z&limit=50' | jq .
+curl -s 'http://localhost:8082/api/lineage/v1/search?orchestration_set_id=set-scalper-micro-bitmart&limit=25&offset=0' | jq .
+curl -s 'http://localhost:8082/api/lineage/v1/search?internal_trade_id=trade_01HZ...' | jq .
+curl -s 'http://localhost:8082/api/lineage/v1/search?order_intent_id=12345' | jq .
+curl -s 'http://localhost:8082/api/lineage/v1/search?position_id=987654&exchange=bitmart&market_type=perpetual' | jq .
+curl -s 'http://localhost:8082/api/lineage/v1/search?exchange_order_id=abc123&exchange=okx&market_type=perpetual' | jq .
+```
+
+Reponse :
+
+```json
+{
+  "pagination": {
+    "limit": 50,
+    "offset": 0,
+    "total": 1,
+    "has_more": false
+  },
+  "data": [
+    {
+      "completeness_status": "complete",
+      "quality_flags": [],
+      "lineage": {
+        "internal_trade_id": "trade_01HZ...",
+        "order_intent_id": 12345,
+        "client_order_id": "cid-...",
+        "exchange_order_id": "abc123",
+        "position_id": "987654",
+        "orchestration_run_id": "run_dashA_20260617T083000Z",
+        "correlation_run_id": "run_dashA_20260617T083000Z",
+        "orchestration_set_id": "set-scalper-micro-bitmart",
+        "orchestration_dashboard_id": "dash-main",
+        "exchange": "bitmart",
+        "market_type": "perpetual",
+        "symbol": "BTCUSDT",
+        "origin": "orchestrator"
+      },
+      "order_intent": {
+        "id": 12345,
+        "status": "SENT",
+        "client_order_id": "cid-...",
+        "exchange_order_id": "abc123"
+      },
+      "lifecycle_events": [
+        {
+          "event_type": "position_closed",
+          "internal_trade_id": "trade_01HZ...",
+          "exchange_order_id": "abc123",
+          "position_id": "987654",
+          "happened_at": "2026-06-25T10:00:00+00:00"
+        }
+      ],
+      "lifecycle_events_pagination": {
+        "limit": 100,
+        "total": 3,
+        "has_more": false
+      }
+    }
+  ],
+  "filters": {
+    "identifier": "internal_trade_id",
+    "value": "trade_01HZ...",
+    "exchange": null,
+    "market_type": null
+  }
+}
+```
+
+### Detail complet
+
+```text
+GET /api/lineage/v1/{internal_trade_id}
+```
+
+Retourne le premier item de la recherche par `internal_trade_id`.
+
+### Evenements lifecycle
+
+```text
+GET /api/lineage/v1/{internal_trade_id}/events
+```
+
+Retourne uniquement les evenements lifecycle associes et conserve `completeness_status` + `quality_flags`.
+
+## Statuts de completude
+
+Priorite de calcul :
+
+| Statut | Signification |
+| --- | --- |
+| `identifier_conflict` | L'identifiant exact correspond a plusieurs lineages dans la meme venue. |
+| `legacy` | Origine legacy, sans contexte orchestrateur complet invente artificiellement. |
+| `missing_order_intent` | Aucun `OrderIntent` persistant n'est lie au lineage. |
+| `missing_exchange_order_id` | Aucun identifiant d'ordre exchange n'est persiste. |
+| `missing_position_id` | Aucun identifiant de position interne ou exchange n'est persiste. |
+| `missing_close_event` | Aucun evenement `position_closed` associe n'est visible. |
+| `partial` | Le lineage existe mais un champ structurant de contexte est absent. |
+| `unmatched` | Un evenement exact existe mais aucun `trade_lineage` persistant ne le relie. |
+| `complete` | OrderIntent, ordre exchange, position et cloture sont tous relies par identifiants exacts. |
+
+`quality_flags` contient le ou les marqueurs qui expliquent le statut.
+
+## Erreurs
+
+```json
+{
+  "error": {
+    "code": "missing_identifier",
+    "message": "Provide exactly one lineage identifier query parameter."
+  }
+}
+```
+
+Codes principaux :
+
+- `400 missing_identifier`
+- `400 multiple_identifiers`
+- `400 missing_venue`
+- `404 lineage_not_found`
+- `409 identifier_conflict` avec `completeness_status=identifier_conflict` et `quality_flags=["identifier_conflict"]`
+
+## Redaction
+
+Les reponses ne serialisent jamais :
+
+- `trade_lifecycle_event.extra`
+- `order_intent.raw_inputs`
+- `order_intent.validation_errors`
+- payload provider brut
+- secret ou credential exchange
+
+Les evenements lifecycle sont exposes via une whitelist de champs structurants seulement.

--- a/docs/handbook/technical/persistent-lineage-context.md
+++ b/docs/handbook/technical/persistent-lineage-context.md
@@ -37,6 +37,19 @@ Les champs utilisés pour filtrer, joindre ou auditer sont persistés en colonne
 
 Le contexte refuse les contradictions vérifiables entre alias (`set_id` vs `orchestration_set_id`, `profile` vs `mtf_profile`, etc.). Symfony ne valide pas la relation set/dashboard contre la base orchestrateur tant qu'elle n'est pas accessible localement.
 
-## Limites du lot
+## API de lecture
 
-Ce lot ne livre pas encore l'API complète de lecture par lineage. Les index et colonnes rendent possibles les lectures par `run_id`, `set_id`, `internal_trade_id`, `order_intent_id`, `position_id`, origin et replay sans reconstruire par symbole.
+La surface read-only `GET /api/lineage/v1/search` permet maintenant de lire le lineage par :
+
+- `orchestration_run_id`
+- `correlation_run_id`
+- `orchestration_set_id`
+- `orchestration_dashboard_id`
+- `internal_trade_id`
+- `internal_position_id`
+- `order_intent_id`
+- `client_order_id`
+- `exchange_order_id`
+- `position_id`
+
+Les identifiants de venue exigent `exchange + market_type`. Les reponses exposent `completeness_status` et `quality_flags`, sans payload brut. Voir [API read-only de lineage](lineage-read-api.md).

--- a/docs/superpowers/plans/2026-06-25-lineage-read-api.md
+++ b/docs/superpowers/plans/2026-06-25-lineage-read-api.md
@@ -1,0 +1,191 @@
+# Lineage Read API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only API to navigate persistent lineage by exact identifiers without symbol-only or time-window reconstruction.
+
+**Architecture:** Add a small Symfony read model under `App\Trading\Lineage\ReadModel` backed by explicit Doctrine queries on `trade_lineage`, `order_intent`, and `trade_lifecycle_event`. The controller exposes versioned `/api/lineage/v1` endpoints, enforces bounded pagination and venue requirements for exchange identifiers, and serializes only whitelisted fields.
+
+**Tech Stack:** Symfony 7 controllers, Doctrine ORM repositories, PHPUnit 11, PHPStan, Markdown docs.
+
+---
+
+## File Structure
+
+- Create `trading-app/src/Trading/Lineage/ReadModel/LineageReadCriteria.php`: immutable criteria object for search inputs, pagination, and venue.
+- Create `trading-app/src/Trading/Lineage/ReadModel/LineageReadPage.php`: typed page wrapper with `items`, `total`, `limit`, `offset`, `has_more`.
+- Create `trading-app/src/Trading/Lineage/ReadModel/LineageReadService.php`: read-only orchestration, completeness/quality evaluation, redacted response mapping.
+- Create `trading-app/src/Trading/Lineage/ReadModel/LineageReadException.php`: stable API error codes and HTTP status mapping.
+- Create `trading-app/src/Trading/Controller/Api/LineageReadApiController.php`: `/api/lineage/v1` routes only.
+- Modify `trading-app/src/Repository/TradeLineageRepository.php`: add bounded search and conflict-aware identifier queries.
+- Modify `trading-app/src/Repository/OrderIntentRepository.php`: add read helpers for lineage by exact fields.
+- Modify `trading-app/src/Repository/TradeLifecycleEventRepository.php`: add read helpers ordered by `happened_at, id`.
+- Create `trading-app/tests/Trading/Lineage/LineageReadServiceTest.php`: unit tests for completeness, conflicts, pagination, redaction.
+- Create `trading-app/tests/Trading/Controller/Api/LineageReadApiControllerTest.php`: controller tests for validation and response shape.
+- Create `trading-app/tests/Trading/Lineage/LineageReadIntegrationTest.php`: Doctrine-backed tests for venue conflicts on reused `position_id` and `exchange_order_id`.
+- Create `docs/handbook/technical/lineage-read-api.md`: endpoint contract and examples.
+- Modify `docs/handbook/technical/internal-trade-lineage.md`: link the read API.
+- Modify `docs/handbook/technical/persistent-lineage-context.md`: replace the "API missing" note with the delivered surface.
+
+## Endpoints
+
+- `GET /api/lineage/v1/search?orchestration_run_id=...`
+- `GET /api/lineage/v1/search?correlation_run_id=...`
+- `GET /api/lineage/v1/search?orchestration_set_id=...`
+- `GET /api/lineage/v1/search?orchestration_dashboard_id=...`
+- `GET /api/lineage/v1/search?internal_trade_id=...`
+- `GET /api/lineage/v1/search?internal_position_id=...`
+- `GET /api/lineage/v1/search?order_intent_id=...`
+- `GET /api/lineage/v1/search?client_order_id=...&exchange=...&market_type=...`
+- `GET /api/lineage/v1/search?exchange_order_id=...&exchange=...&market_type=...`
+- `GET /api/lineage/v1/search?position_id=...&exchange=...&market_type=...`
+- `GET /api/lineage/v1/{internal_trade_id}`
+- `GET /api/lineage/v1/{internal_trade_id}/events`
+
+All endpoints are read-only, require at least one exact identifier, use deterministic ordering, and apply `limit <= 100`.
+
+## Task 1: Failing Unit Tests for Read Service
+
+- [ ] **Step 1: Add service tests first**
+
+Write tests that create `TradeLineage`, `OrderIntent`, and `TradeLifecycleEvent` objects in memory and assert:
+
+- complete lineage returns `completeness_status=complete`;
+- missing order intent returns `missing_order_intent`;
+- legacy origin returns `legacy`;
+- missing exchange order returns `missing_exchange_order_id`;
+- missing position returns `missing_position_id`;
+- unmatched/no close event returns `missing_close_event` or `unmatched`;
+- conflict candidates return `identifier_conflict`;
+- raw `extra`, `rawInputs`, and `validationErrors` never appear in response arrays.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+DEFAULT_URI=http://localhost APP_ENV=test php bin/phpunit tests/Trading/Lineage/LineageReadServiceTest.php
+```
+
+Expected: FAIL because read model classes do not exist.
+
+- [ ] **Step 3: Implement minimal read model**
+
+Create criteria/page/exception/service classes and whitelist serializers.
+
+- [ ] **Step 4: Run service tests to verify GREEN**
+
+Run the same PHPUnit command and expect PASS.
+
+## Task 2: Repository Queries and Integration Conflict Tests
+
+- [ ] **Step 1: Add repository integration tests first**
+
+Write Doctrine-backed tests proving:
+
+- search by run/set/internal trade/order intent returns deterministic rows;
+- `position_id=POS-1` reused by Bitmart and OKX only returns matches when `exchange + market_type` are supplied;
+- `exchange_order_id=EX-1` reused by two venues behaves the same;
+- same venue duplicate identifier produces `identifier_conflict`;
+- pagination returns `limit`, `offset`, `total`, and `has_more`.
+
+- [ ] **Step 2: Run integration tests to verify RED**
+
+Run:
+
+```bash
+DEFAULT_URI=http://localhost APP_ENV=test php bin/phpunit tests/Trading/Lineage/LineageReadIntegrationTest.php
+```
+
+Expected: FAIL because repository helpers do not exist.
+
+- [ ] **Step 3: Implement repository helpers**
+
+Add bounded, parameterized query builders. Do not add symbol-only matching or timestamp-window matching.
+
+- [ ] **Step 4: Run integration tests to verify GREEN**
+
+Run the same PHPUnit command and expect PASS, or document PostgreSQL unavailability if the local DB is absent.
+
+## Task 3: Controller API Tests and Endpoints
+
+- [ ] **Step 1: Add controller tests first**
+
+Test:
+
+- missing identifier returns 400 with structured error;
+- exchange identifier without `exchange` or `market_type` returns 400;
+- unknown identifier returns 404;
+- conflict returns 409 with `identifier_conflict`;
+- `limit` above max is capped;
+- responses always include `completeness_status` and `quality_flags`;
+- responses never include raw payload fields.
+
+- [ ] **Step 2: Run controller tests to verify RED**
+
+Run:
+
+```bash
+DEFAULT_URI=http://localhost APP_ENV=test php bin/phpunit tests/Trading/Controller/Api/LineageReadApiControllerTest.php
+```
+
+Expected: FAIL because controller does not exist.
+
+- [ ] **Step 3: Implement controller**
+
+Add versioned routes, query parsing, venue validation, pagination cap, and structured error responses.
+
+- [ ] **Step 4: Run controller tests to verify GREEN**
+
+Run the same PHPUnit command and expect PASS.
+
+## Task 4: Documentation
+
+- [ ] **Step 1: Add API docs**
+
+Document endpoints, required venue parameters, examples, pagination, status codes, completeness statuses, quality flags, and redaction guarantees.
+
+- [ ] **Step 2: Update lineage docs**
+
+Link the API from existing lineage docs and remove the stale "API missing" statement.
+
+- [ ] **Step 3: Run docs diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+## Task 5: Final Verification and PR
+
+- [ ] **Step 1: Run targeted PHPUnit**
+
+```bash
+DEFAULT_URI=http://localhost APP_ENV=test php bin/phpunit tests/Trading/Lineage tests/Trading/Controller/Api/LineageReadApiControllerTest.php
+```
+
+- [ ] **Step 2: Run PHPStan on touched files**
+
+```bash
+DEFAULT_URI=http://localhost APP_ENV=test vendor/bin/phpstan analyse --no-progress src/Trading/Lineage/ReadModel src/Trading/Controller/Api/LineageReadApiController.php src/Repository/TradeLineageRepository.php src/Repository/OrderIntentRepository.php src/Repository/TradeLifecycleEventRepository.php tests/Trading/Lineage tests/Trading/Controller/Api/LineageReadApiControllerTest.php --memory-limit=1G
+```
+
+- [ ] **Step 3: Run Symfony and YAML lints**
+
+```bash
+DEFAULT_URI=http://localhost APP_ENV=test php bin/console lint:container --no-debug
+DEFAULT_URI=http://localhost APP_ENV=test php bin/console lint:yaml config
+```
+
+- [ ] **Step 4: Run whitespace check**
+
+```bash
+git diff --check
+```
+
+- [ ] **Step 5: Commit, push, and open PR**
+
+PR body must include `Part of #189`, `Related to #173`, and references to #199, #201, #202, #203, #204. Do not write `Closes #189` unless the final audit proves all remaining #189 criteria are covered.

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -97,6 +97,9 @@ services:
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
 
+    App\Trading\Lineage\ReadModel\LineageReadStoreInterface:
+        alias: App\Trading\Lineage\ReadModel\DoctrineLineageReadStore
+
 
 
     # MTF Services

--- a/trading-app/src/Repository/OrderIntentRepository.php
+++ b/trading-app/src/Repository/OrderIntentRepository.php
@@ -6,7 +6,9 @@ namespace App\Repository;
 
 use App\Entity\OrderIntent;
 use App\Provider\Context\ExchangeContext;
+use App\Trading\Lineage\ReadModel\LineageReadCriteria;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -14,6 +16,17 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class OrderIntentRepository extends ServiceEntityRepository
 {
+    private const CRITERIA_FIELD_MAP = [
+        'orchestration_run_id' => 'orchestrationRunId',
+        'correlation_run_id' => 'correlationRunId',
+        'orchestration_set_id' => 'orchestrationSetId',
+        'orchestration_dashboard_id' => 'orchestrationDashboardId',
+        'internal_trade_id' => 'internalTradeId',
+        'internal_position_id' => 'internalPositionId',
+        'client_order_id' => 'clientOrderId',
+        'exchange_order_id' => 'exchangeOrderId',
+    ];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, OrderIntent::class);
@@ -54,6 +67,47 @@ final class OrderIntentRepository extends ServiceEntityRepository
     public function findOneById(int $id): ?OrderIntent
     {
         return $this->find($id);
+    }
+
+    /**
+     * @return OrderIntent[]
+     */
+    public function findPageByReadCriteria(LineageReadCriteria $criteria): array
+    {
+        if ($criteria->kind === 'order_intent_id') {
+            $intent = $this->find((int) $criteria->value);
+
+            return $intent instanceof OrderIntent ? [$intent] : [];
+        }
+
+        return $this->createCriteriaQueryBuilder($criteria)
+            ->orderBy('intent.createdAt', 'ASC')
+            ->addOrderBy('intent.id', 'ASC')
+            ->setFirstResult($criteria->offset)
+            ->setMaxResults($criteria->limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    private function createCriteriaQueryBuilder(LineageReadCriteria $criteria): QueryBuilder
+    {
+        $field = self::CRITERIA_FIELD_MAP[$criteria->kind] ?? null;
+        if ($field === null) {
+            throw new \InvalidArgumentException(sprintf('Unsupported order intent read criteria "%s".', $criteria->kind));
+        }
+
+        $qb = $this->createQueryBuilder('intent')
+            ->andWhere(sprintf('intent.%s = :value', $field))
+            ->setParameter('value', $criteria->value);
+
+        if ($criteria->requiresVenue()) {
+            $qb->andWhere('intent.exchange = :exchange')
+                ->andWhere('intent.marketType = :marketType')
+                ->setParameter('exchange', $criteria->exchange)
+                ->setParameter('marketType', $criteria->marketType);
+        }
+
+        return $qb;
     }
 
     /**

--- a/trading-app/src/Repository/TradeLifecycleEventRepository.php
+++ b/trading-app/src/Repository/TradeLifecycleEventRepository.php
@@ -6,7 +6,9 @@ namespace App\Repository;
 
 use App\Entity\TradeLifecycleEvent;
 use App\Provider\Context\ExchangeContext;
+use App\Trading\Lineage\ReadModel\LineageReadCriteria;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -14,6 +16,18 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class TradeLifecycleEventRepository extends ServiceEntityRepository
 {
+    private const CRITERIA_FIELD_MAP = [
+        'orchestration_run_id' => 'orchestrationRunId',
+        'correlation_run_id' => 'correlationRunId',
+        'orchestration_set_id' => 'orchestrationSetId',
+        'orchestration_dashboard_id' => 'orchestrationDashboardId',
+        'internal_trade_id' => 'internalTradeId',
+        'internal_position_id' => 'internalPositionId',
+        'client_order_id' => 'clientOrderId',
+        'exchange_order_id' => 'orderId',
+        'position_id' => 'positionId',
+    ];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, TradeLifecycleEvent::class);
@@ -41,6 +55,126 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
         }
 
         return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @return TradeLifecycleEvent[]
+     */
+    public function findUnmatchedByReadCriteria(LineageReadCriteria $criteria): array
+    {
+        if (!in_array($criteria->kind, ['client_order_id', 'exchange_order_id', 'position_id'], true)) {
+            return [];
+        }
+
+        return $this->createCriteriaQueryBuilder($criteria)
+            ->andWhere('event.internalTradeId IS NULL')
+            ->orderBy('event.happenedAt', 'ASC')
+            ->addOrderBy('event.id', 'ASC')
+            ->setFirstResult($criteria->offset)
+            ->setMaxResults($criteria->limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return TradeLifecycleEvent[]
+     */
+    public function findForLineageIdentifiers(
+        string $internalTradeId,
+        string $clientOrderId,
+        ?string $exchangeOrderId,
+        ?string $positionId,
+        string $exchange,
+        string $marketType,
+        int $limit,
+    ): array {
+        $or = [
+            'event.internalTradeId = :internalTradeId',
+            'event.clientOrderId = :clientOrderId',
+        ];
+
+        $qb = $this->createQueryBuilder('event')
+            ->andWhere('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
+            ->setParameter('exchange', $exchange)
+            ->setParameter('marketType', $marketType)
+            ->setParameter('internalTradeId', $internalTradeId)
+            ->setParameter('clientOrderId', $clientOrderId)
+            ->orderBy('event.happenedAt', 'ASC')
+            ->addOrderBy('event.id', 'ASC')
+            ->setMaxResults(max(1, $limit));
+
+        if ($exchangeOrderId !== null && $exchangeOrderId !== '') {
+            $or[] = 'event.orderId = :exchangeOrderId';
+            $qb->setParameter('exchangeOrderId', $exchangeOrderId);
+        }
+
+        if ($positionId !== null && $positionId !== '') {
+            $or[] = 'event.positionId = :positionId';
+            $qb->setParameter('positionId', $positionId);
+        }
+
+        $qb->andWhere($qb->expr()->orX(...$or));
+
+        return $qb->getQuery()->getResult();
+    }
+
+    public function countForLineageIdentifiers(
+        string $internalTradeId,
+        string $clientOrderId,
+        ?string $exchangeOrderId,
+        ?string $positionId,
+        string $exchange,
+        string $marketType,
+    ): int {
+        $or = [
+            'event.internalTradeId = :internalTradeId',
+            'event.clientOrderId = :clientOrderId',
+        ];
+
+        $qb = $this->createQueryBuilder('event')
+            ->select('COUNT(event.id)')
+            ->andWhere('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
+            ->setParameter('exchange', $exchange)
+            ->setParameter('marketType', $marketType)
+            ->setParameter('internalTradeId', $internalTradeId)
+            ->setParameter('clientOrderId', $clientOrderId);
+
+        if ($exchangeOrderId !== null && $exchangeOrderId !== '') {
+            $or[] = 'event.orderId = :exchangeOrderId';
+            $qb->setParameter('exchangeOrderId', $exchangeOrderId);
+        }
+
+        if ($positionId !== null && $positionId !== '') {
+            $or[] = 'event.positionId = :positionId';
+            $qb->setParameter('positionId', $positionId);
+        }
+
+        $qb->andWhere($qb->expr()->orX(...$or));
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    private function createCriteriaQueryBuilder(LineageReadCriteria $criteria): QueryBuilder
+    {
+        $field = self::CRITERIA_FIELD_MAP[$criteria->kind] ?? null;
+        if ($field === null) {
+            throw new \InvalidArgumentException(sprintf('Unsupported lifecycle read criteria "%s".', $criteria->kind));
+        }
+
+        $qb = $this->createQueryBuilder('event')
+            ->andWhere(sprintf('event.%s = :value', $field))
+            ->setParameter('value', $criteria->value);
+
+        if ($criteria->requiresVenue()) {
+            $qb->andWhere('event.exchange = :exchange')
+                ->andWhere('event.marketType = :marketType')
+                ->setParameter('exchange', $criteria->exchange)
+                ->setParameter('marketType', $criteria->marketType);
+        }
+
+        return $qb;
     }
 
     /**

--- a/trading-app/src/Repository/TradeLineageRepository.php
+++ b/trading-app/src/Repository/TradeLineageRepository.php
@@ -6,7 +6,9 @@ namespace App\Repository;
 
 use App\Entity\TradeLineage;
 use App\Provider\Context\ExchangeContext;
+use App\Trading\Lineage\ReadModel\LineageReadCriteria;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -14,6 +16,18 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 final class TradeLineageRepository extends ServiceEntityRepository
 {
+    private const CRITERIA_FIELD_MAP = [
+        'orchestration_run_id' => 'orchestrationRunId',
+        'correlation_run_id' => 'correlationRunId',
+        'orchestration_set_id' => 'orchestrationSetId',
+        'orchestration_dashboard_id' => 'orchestrationDashboardId',
+        'internal_trade_id' => 'internalTradeId',
+        'internal_position_id' => 'internalPositionId',
+        'client_order_id' => 'clientOrderId',
+        'exchange_order_id' => 'exchangeOrderId',
+        'position_id' => 'positionId',
+    ];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, TradeLineage::class);
@@ -53,6 +67,28 @@ final class TradeLineageRepository extends ServiceEntityRepository
         return $this->findUniqueByVenueIdentifier('positionId', $positionId, $context);
     }
 
+    /**
+     * @return TradeLineage[]
+     */
+    public function findPageByReadCriteria(LineageReadCriteria $criteria): array
+    {
+        return $this->createCriteriaQueryBuilder($criteria)
+            ->orderBy('lineage.createdAt', 'ASC')
+            ->addOrderBy('lineage.id', 'ASC')
+            ->setFirstResult($criteria->offset)
+            ->setMaxResults($criteria->limit)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function countByReadCriteria(LineageReadCriteria $criteria): int
+    {
+        return (int) $this->createCriteriaQueryBuilder($criteria)
+            ->select('COUNT(lineage.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
     private function findUniqueByVenueIdentifier(string $field, string $value, ?ExchangeContext $context): ?TradeLineage
     {
         $matches = $this->findBy([
@@ -62,5 +98,26 @@ final class TradeLineageRepository extends ServiceEntityRepository
         ], null, 2);
 
         return \count($matches) === 1 ? $matches[0] : null;
+    }
+
+    private function createCriteriaQueryBuilder(LineageReadCriteria $criteria): QueryBuilder
+    {
+        $field = self::CRITERIA_FIELD_MAP[$criteria->kind] ?? null;
+        if ($field === null) {
+            throw new \InvalidArgumentException(sprintf('Unsupported lineage read criteria "%s".', $criteria->kind));
+        }
+
+        $qb = $this->createQueryBuilder('lineage')
+            ->andWhere(sprintf('lineage.%s = :value', $field))
+            ->setParameter('value', $criteria->value);
+
+        if ($criteria->requiresVenue()) {
+            $qb->andWhere('lineage.exchange = :exchange')
+                ->andWhere('lineage.marketType = :marketType')
+                ->setParameter('exchange', $criteria->exchange)
+                ->setParameter('marketType', $criteria->marketType);
+        }
+
+        return $qb;
     }
 }

--- a/trading-app/src/Trading/Controller/Api/LineageReadApiController.php
+++ b/trading-app/src/Trading/Controller/Api/LineageReadApiController.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Controller\Api;
+
+use App\Trading\Lineage\ReadModel\LineageReadCriteria;
+use App\Trading\Lineage\ReadModel\LineageReadException;
+use App\Trading\Lineage\ReadModel\LineageReadPage;
+use App\Trading\Lineage\ReadModel\LineageReadService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * DATA-001 #189 — read-only persistent lineage navigation.
+ *
+ * This API never reconstructs relations by symbol-only or timestamp windows. Venue-scoped
+ * identifiers require `exchange + market_type`; ambiguous exact identifiers return
+ * `identifier_conflict` instead of choosing an arbitrary lineage.
+ */
+#[Route('/api/lineage/v1', name: 'api_lineage_v1_')]
+final class LineageReadApiController extends AbstractController
+{
+    private const IDENTIFIER_PARAMS = [
+        'orchestration_run_id',
+        'correlation_run_id',
+        'orchestration_set_id',
+        'orchestration_dashboard_id',
+        'internal_trade_id',
+        'internal_position_id',
+        'order_intent_id',
+        'client_order_id',
+        'exchange_order_id',
+        'position_id',
+    ];
+
+    private const VENUE_REQUIRED = [
+        'client_order_id' => true,
+        'exchange_order_id' => true,
+        'position_id' => true,
+    ];
+
+    public function __construct(
+        private readonly LineageReadService $lineageReadService,
+    ) {
+    }
+
+    #[Route('/search', name: 'search', methods: ['GET'])]
+    public function search(Request $request): JsonResponse
+    {
+        $criteria = $this->criteriaFromRequest($request);
+        if ($criteria instanceof JsonResponse) {
+            return $criteria;
+        }
+
+        return $this->pageResponse($criteria);
+    }
+
+    #[Route('/{internalTradeId}/events', name: 'events', methods: ['GET'])]
+    public function events(string $internalTradeId, Request $request): JsonResponse
+    {
+        $criteria = LineageReadCriteria::forIdentifier(
+            'internal_trade_id',
+            $internalTradeId,
+            $this->intQuery($request, 'limit', LineageReadCriteria::MAX_LIMIT),
+            $this->intQuery($request, 'offset', 0),
+        );
+
+        try {
+            $page = $this->lineageReadService->search($criteria);
+        } catch (LineageReadException $e) {
+            return $this->error($e->errorCode, $e->getMessage(), $e->getCode());
+        }
+
+        if ($page->total === 0 || $page->items === []) {
+            return $this->error('lineage_not_found', 'No lineage was found for the requested identifier.', Response::HTTP_NOT_FOUND);
+        }
+
+        $item = $page->items[0];
+
+        return $this->json([
+            'internal_trade_id' => $internalTradeId,
+            'completeness_status' => $item['completeness_status'],
+            'quality_flags' => $item['quality_flags'],
+            'pagination' => $item['lifecycle_events_pagination'],
+            'data' => $item['lifecycle_events'],
+        ]);
+    }
+
+    #[Route('/{internalTradeId}', name: 'detail', methods: ['GET'])]
+    public function detail(string $internalTradeId, Request $request): JsonResponse
+    {
+        $criteria = LineageReadCriteria::forIdentifier(
+            'internal_trade_id',
+            $internalTradeId,
+            $this->intQuery($request, 'limit', LineageReadCriteria::MAX_LIMIT),
+            $this->intQuery($request, 'offset', 0),
+        );
+
+        try {
+            $page = $this->lineageReadService->search($criteria);
+        } catch (LineageReadException $e) {
+            return $this->error($e->errorCode, $e->getMessage(), $e->getCode());
+        }
+
+        if ($page->total === 0 || $page->items === []) {
+            return $this->error('lineage_not_found', 'No lineage was found for the requested identifier.', Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json($page->items[0]);
+    }
+
+    private function pageResponse(LineageReadCriteria $criteria): JsonResponse
+    {
+        try {
+            $page = $this->lineageReadService->search($criteria);
+        } catch (LineageReadException $e) {
+            return $this->error($e->errorCode, $e->getMessage(), $e->getCode());
+        }
+
+        if ($page->total === 0) {
+            return $this->error('lineage_not_found', 'No lineage was found for the requested identifier.', Response::HTTP_NOT_FOUND);
+        }
+
+        return $this->json($this->withFilters($page, $criteria));
+    }
+
+    private function criteriaFromRequest(Request $request): LineageReadCriteria|JsonResponse
+    {
+        $present = [];
+        foreach (self::IDENTIFIER_PARAMS as $param) {
+            $value = trim((string) $request->query->get($param, ''));
+            if ($value !== '') {
+                $present[$param] = $value;
+            }
+        }
+
+        if ($present === []) {
+            return $this->error(
+                'missing_identifier',
+                'Provide exactly one lineage identifier query parameter.',
+                Response::HTTP_BAD_REQUEST,
+            );
+        }
+
+        if (count($present) > 1) {
+            return $this->error(
+                'multiple_identifiers',
+                'Provide only one lineage identifier query parameter per request.',
+                Response::HTTP_BAD_REQUEST,
+            );
+        }
+
+        $kind = (string) array_key_first($present);
+        $value = $present[$kind];
+        $limit = $this->intQuery($request, 'limit', LineageReadCriteria::MAX_LIMIT);
+        $offset = $this->intQuery($request, 'offset', 0);
+
+        if (isset(self::VENUE_REQUIRED[$kind])) {
+            $exchange = trim((string) $request->query->get('exchange', ''));
+            $marketType = trim((string) $request->query->get('market_type', ''));
+            if ($exchange === '' || $marketType === '') {
+                return $this->error(
+                    'missing_venue',
+                    'exchange and market_type are required for venue-scoped identifiers.',
+                    Response::HTTP_BAD_REQUEST,
+                );
+            }
+
+            return LineageReadCriteria::forVenueIdentifier($kind, $value, $exchange, $marketType, $limit, $offset);
+        }
+
+        return LineageReadCriteria::forIdentifier($kind, $value, $limit, $offset);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function withFilters(LineageReadPage $page, LineageReadCriteria $criteria): array
+    {
+        $payload = $page->toArray();
+        $payload['filters'] = [
+            'identifier' => $criteria->kind,
+            'value' => $criteria->value,
+            'exchange' => $criteria->exchange,
+            'market_type' => $criteria->marketType,
+        ];
+
+        return $payload;
+    }
+
+    private function error(string $code, string $message, int $status): JsonResponse
+    {
+        $payload = [
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+            ],
+        ];
+
+        if ($code === 'identifier_conflict') {
+            $payload['completeness_status'] = 'identifier_conflict';
+            $payload['quality_flags'] = ['identifier_conflict'];
+        }
+
+        return $this->json($payload, $status);
+    }
+
+    private function intQuery(Request $request, string $key, int $default): int
+    {
+        $raw = $request->query->get($key);
+        if ($raw === null || $raw === '') {
+            return $default;
+        }
+
+        return (int) $raw;
+    }
+}

--- a/trading-app/src/Trading/Lineage/ReadModel/DoctrineLineageReadStore.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/DoctrineLineageReadStore.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Lineage\ReadModel;
+
+use App\Entity\OrderIntent;
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+use App\Repository\OrderIntentRepository;
+use App\Repository\TradeLifecycleEventRepository;
+use App\Repository\TradeLineageRepository;
+
+final readonly class DoctrineLineageReadStore implements LineageReadStoreInterface
+{
+    public function __construct(
+        private TradeLineageRepository $lineages,
+        private OrderIntentRepository $orderIntents,
+        private TradeLifecycleEventRepository $events,
+    ) {
+    }
+
+    public function count(LineageReadCriteria $criteria): int
+    {
+        if ($criteria->kind === 'order_intent_id') {
+            return count($this->find($criteria));
+        }
+
+        return $this->lineages->countByReadCriteria($criteria);
+    }
+
+    public function find(LineageReadCriteria $criteria): array
+    {
+        if ($criteria->kind === 'order_intent_id') {
+            $orderIntentId = (int) $criteria->value;
+            $lineage = $this->lineages->findOneByOrderIntentId($orderIntentId);
+
+            return $lineage instanceof TradeLineage ? [$lineage] : $this->lineagesFromOrderIntents($criteria);
+        }
+
+        return $this->lineages->findPageByReadCriteria($criteria);
+    }
+
+    public function findUnmatchedEvents(LineageReadCriteria $criteria): array
+    {
+        return $this->events->findUnmatchedByReadCriteria($criteria);
+    }
+
+    public function findEventsForLineage(TradeLineage $lineage, int $limit): array
+    {
+        return $this->events->findForLineageIdentifiers(
+            internalTradeId: $lineage->getInternalTradeId(),
+            clientOrderId: $lineage->getClientOrderId(),
+            exchangeOrderId: $lineage->getExchangeOrderId(),
+            positionId: $lineage->getPositionId(),
+            exchange: $lineage->getExchange(),
+            marketType: $lineage->getMarketType(),
+            limit: $limit,
+        );
+    }
+
+    public function countEventsForLineage(TradeLineage $lineage): int
+    {
+        return $this->events->countForLineageIdentifiers(
+            internalTradeId: $lineage->getInternalTradeId(),
+            clientOrderId: $lineage->getClientOrderId(),
+            exchangeOrderId: $lineage->getExchangeOrderId(),
+            positionId: $lineage->getPositionId(),
+            exchange: $lineage->getExchange(),
+            marketType: $lineage->getMarketType(),
+        );
+    }
+
+    /**
+     * @return TradeLineage[]
+     */
+    private function lineagesFromOrderIntents(LineageReadCriteria $criteria): array
+    {
+        $lineages = [];
+        foreach ($this->orderIntents->findPageByReadCriteria($criteria) as $intent) {
+            if (!$intent instanceof OrderIntent || $intent->getInternalTradeId() === null) {
+                continue;
+            }
+            $lineage = $this->lineages->findOneByInternalTradeId($intent->getInternalTradeId());
+            if ($lineage instanceof TradeLineage) {
+                $lineages[] = $lineage;
+            }
+        }
+
+        return $lineages;
+    }
+}

--- a/trading-app/src/Trading/Lineage/ReadModel/LineageReadCriteria.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/LineageReadCriteria.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Lineage\ReadModel;
+
+final readonly class LineageReadCriteria
+{
+    public const MAX_LIMIT = 100;
+
+    private const VENUE_IDENTIFIER_KINDS = [
+        'client_order_id' => true,
+        'exchange_order_id' => true,
+        'position_id' => true,
+    ];
+
+    private function __construct(
+        public string $kind,
+        public string $value,
+        public ?string $exchange,
+        public ?string $marketType,
+        public int $limit,
+        public int $offset,
+    ) {
+    }
+
+    public static function forIdentifier(string $kind, string $value, int $limit, int $offset): self
+    {
+        return new self(
+            kind: strtolower(trim($kind)),
+            value: trim($value),
+            exchange: null,
+            marketType: null,
+            limit: self::normalizeLimit($limit),
+            offset: max(0, $offset),
+        );
+    }
+
+    public static function forVenueIdentifier(
+        string $kind,
+        string $value,
+        string $exchange,
+        string $marketType,
+        int $limit,
+        int $offset,
+    ): self {
+        return new self(
+            kind: strtolower(trim($kind)),
+            value: trim($value),
+            exchange: strtolower(trim($exchange)),
+            marketType: strtolower(trim($marketType)),
+            limit: self::normalizeLimit($limit),
+            offset: max(0, $offset),
+        );
+    }
+
+    public function requiresVenue(): bool
+    {
+        return isset(self::VENUE_IDENTIFIER_KINDS[$this->kind]);
+    }
+
+    public function isConflictSensitive(): bool
+    {
+        return isset(self::VENUE_IDENTIFIER_KINDS[$this->kind]);
+    }
+
+    private static function normalizeLimit(int $limit): int
+    {
+        return min(self::MAX_LIMIT, max(1, $limit));
+    }
+}

--- a/trading-app/src/Trading/Lineage/ReadModel/LineageReadException.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/LineageReadException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Lineage\ReadModel;
+
+final class LineageReadException extends \RuntimeException
+{
+    public function __construct(
+        public readonly string $errorCode,
+        string $message,
+        int $httpStatus,
+    ) {
+        parent::__construct($message, $httpStatus);
+    }
+}

--- a/trading-app/src/Trading/Lineage/ReadModel/LineageReadPage.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/LineageReadPage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Lineage\ReadModel;
+
+final readonly class LineageReadPage
+{
+    public bool $hasMore;
+
+    /**
+     * @param list<array<string,mixed>> $items
+     */
+    public function __construct(
+        public array $items,
+        public int $total,
+        public int $limit,
+        public int $offset,
+    ) {
+        $this->hasMore = $this->offset + count($this->items) < $this->total;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'pagination' => [
+                'limit' => $this->limit,
+                'offset' => $this->offset,
+                'total' => $this->total,
+                'has_more' => $this->hasMore,
+            ],
+            'data' => $this->items,
+        ];
+    }
+}

--- a/trading-app/src/Trading/Lineage/ReadModel/LineageReadService.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/LineageReadService.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Lineage\ReadModel;
+
+use App\Entity\OrderIntent;
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+use Symfony\Component\HttpFoundation\Response;
+
+final readonly class LineageReadService
+{
+    private const EVENT_LIMIT = 100;
+
+    public function __construct(
+        private LineageReadStoreInterface $store,
+    ) {
+    }
+
+    public function search(LineageReadCriteria $criteria): LineageReadPage
+    {
+        $total = $this->store->count($criteria);
+        if ($criteria->isConflictSensitive() && $total > 1) {
+            throw new LineageReadException(
+                'identifier_conflict',
+                'The identifier matches more than one lineage in the requested venue.',
+                Response::HTTP_CONFLICT,
+            );
+        }
+
+        $lineages = $this->store->find($criteria);
+        if ($lineages === []) {
+            $unmatchedEvents = $this->store->findUnmatchedEvents($criteria);
+            $items = array_map(fn (TradeLifecycleEvent $event): array => $this->serializeUnmatchedEvent($event), $unmatchedEvents);
+
+            return new LineageReadPage(
+                items: $items,
+                total: count($items),
+                limit: $criteria->limit,
+                offset: $criteria->offset,
+            );
+        }
+
+        $items = [];
+        foreach ($lineages as $lineage) {
+            $events = $this->store->findEventsForLineage($lineage, self::EVENT_LIMIT);
+            $items[] = $this->serializeLineage($lineage, $events);
+        }
+
+        return new LineageReadPage(
+            items: $items,
+            total: $total,
+            limit: $criteria->limit,
+            offset: $criteria->offset,
+        );
+    }
+
+    /**
+     * @param TradeLifecycleEvent[] $events
+     * @return array<string,mixed>
+     */
+    private function serializeLineage(TradeLineage $lineage, array $events): array
+    {
+        $qualityFlags = $this->qualityFlags($lineage, $events);
+        $status = $this->completenessStatus($qualityFlags);
+
+        return [
+            'completeness_status' => $status,
+            'quality_flags' => $qualityFlags,
+            'lineage' => $this->lineagePayload($lineage),
+            'order_intent' => $lineage->getOrderIntent() !== null ? $this->orderIntentPayload($lineage->getOrderIntent()) : null,
+            'lifecycle_events' => array_map(fn (TradeLifecycleEvent $event): array => $this->eventPayload($event), $events),
+            'lifecycle_events_pagination' => $this->eventPagination($lineage, $events),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function serializeUnmatchedEvent(TradeLifecycleEvent $event): array
+    {
+        return [
+            'completeness_status' => 'unmatched',
+            'quality_flags' => ['unmatched'],
+            'lineage' => null,
+            'order_intent' => null,
+            'lifecycle_events' => [$this->eventPayload($event)],
+            'lifecycle_events_pagination' => [
+                'limit' => self::EVENT_LIMIT,
+                'total' => 1,
+                'has_more' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param TradeLifecycleEvent[] $events
+     * @return list<string>
+     */
+    private function qualityFlags(TradeLineage $lineage, array $events): array
+    {
+        $flags = [];
+
+        if ($lineage->getOrigin() === 'legacy') {
+            $flags[] = 'legacy';
+        }
+
+        if ($lineage->getOrderIntent() === null) {
+            $flags[] = 'missing_order_intent';
+        }
+
+        if ($lineage->getExchangeOrderId() === null) {
+            $flags[] = 'missing_exchange_order_id';
+        }
+
+        if ($lineage->getPositionId() === null && $lineage->getInternalPositionId() === null) {
+            $flags[] = 'missing_position_id';
+        }
+
+        if (!$this->hasCloseEvent($events)) {
+            $flags[] = 'missing_close_event';
+        }
+
+        if (
+            $lineage->getOrigin() !== 'legacy'
+            && (
+                $lineage->getOrchestrationRunId() === null
+                || $lineage->getCorrelationRunId() === null
+                || $lineage->getOrchestrationSetId() === null
+                || $lineage->getOrchestrationDashboardId() === null
+            )
+        ) {
+            $flags[] = 'partial';
+        }
+
+        return array_values(array_unique($flags));
+    }
+
+    /**
+     * @param list<string> $qualityFlags
+     */
+    private function completenessStatus(array $qualityFlags): string
+    {
+        foreach ([
+            'legacy',
+            'missing_order_intent',
+            'missing_exchange_order_id',
+            'missing_position_id',
+            'missing_close_event',
+            'partial',
+        ] as $status) {
+            if (in_array($status, $qualityFlags, true)) {
+                return $status;
+            }
+        }
+
+        return 'complete';
+    }
+
+    /**
+     * @param TradeLifecycleEvent[] $events
+     */
+    private function hasCloseEvent(array $events): bool
+    {
+        foreach ($events as $event) {
+            if ($event->getEventType() === 'position_closed') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param TradeLifecycleEvent[] $events
+     * @return array<string,mixed>
+     */
+    private function eventPagination(TradeLineage $lineage, array $events): array
+    {
+        $total = $this->store->countEventsForLineage($lineage);
+
+        return [
+            'limit' => self::EVENT_LIMIT,
+            'total' => $total,
+            'has_more' => $total > count($events),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function lineagePayload(TradeLineage $lineage): array
+    {
+        return [
+            'id' => $lineage->getId(),
+            'internal_trade_id' => $lineage->getInternalTradeId(),
+            'internal_position_id' => $lineage->getInternalPositionId(),
+            'order_intent_id' => $lineage->getOrderIntent()?->getId(),
+            'client_order_id' => $lineage->getClientOrderId(),
+            'exchange_order_id' => $lineage->getExchangeOrderId(),
+            'position_id' => $lineage->getPositionId(),
+            'run_id' => $lineage->getRunId(),
+            'correlation_run_id' => $lineage->getCorrelationRunId(),
+            'orchestration_run_id' => $lineage->getOrchestrationRunId(),
+            'orchestration_set_id' => $lineage->getOrchestrationSetId(),
+            'orchestration_dashboard_id' => $lineage->getOrchestrationDashboardId(),
+            'exchange' => $lineage->getExchange(),
+            'market_type' => $lineage->getMarketType(),
+            'symbol' => $lineage->getSymbol(),
+            'side' => $lineage->getSide(),
+            'profile' => $lineage->getProfile(),
+            'origin' => $lineage->getOrigin(),
+            'replay_of_run_id' => $lineage->getReplayOfRunId(),
+            'replay_of_correlation_id' => $lineage->getReplayOfCorrelationId(),
+            'attempt_number' => $lineage->getAttemptNumber(),
+            'config_hash' => $lineage->getConfigHash(),
+            'created_at' => $this->formatDate($lineage->getCreatedAt()),
+            'updated_at' => $this->formatDate($lineage->getUpdatedAt()),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function orderIntentPayload(OrderIntent $intent): array
+    {
+        return [
+            'id' => $intent->getId(),
+            'exchange' => $intent->getExchange(),
+            'market_type' => $intent->getMarketType(),
+            'symbol' => $intent->getSymbol(),
+            'side' => $intent->getSide(),
+            'status' => $intent->getStatus(),
+            'client_order_id' => $intent->getClientOrderId(),
+            'order_id' => $intent->getOrderId(),
+            'exchange_order_id' => $intent->getExchangeOrderId(),
+            'internal_trade_id' => $intent->getInternalTradeId(),
+            'internal_position_id' => $intent->getInternalPositionId(),
+            'correlation_run_id' => $intent->getCorrelationRunId(),
+            'orchestration_run_id' => $intent->getOrchestrationRunId(),
+            'orchestration_set_id' => $intent->getOrchestrationSetId(),
+            'orchestration_dashboard_id' => $intent->getOrchestrationDashboardId(),
+            'origin' => $intent->getOrigin(),
+            'created_at' => $this->formatDate($intent->getCreatedAt()),
+            'updated_at' => $this->formatDate($intent->getUpdatedAt()),
+            'sent_at' => $this->formatDate($intent->getSentAt()),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function eventPayload(TradeLifecycleEvent $event): array
+    {
+        return [
+            'id' => $event->getId(),
+            'event_type' => $event->getEventType(),
+            'symbol' => $event->getSymbol(),
+            'run_id' => $event->getRunId(),
+            'client_order_id' => $event->getClientOrderId(),
+            'exchange_order_id' => $event->getOrderId(),
+            'position_id' => $event->getPositionId(),
+            'internal_trade_id' => $event->getInternalTradeId(),
+            'internal_position_id' => $event->getInternalPositionId(),
+            'correlation_run_id' => $event->getCorrelationRunId(),
+            'orchestration_run_id' => $event->getOrchestrationRunId(),
+            'orchestration_set_id' => $event->getOrchestrationSetId(),
+            'orchestration_dashboard_id' => $event->getOrchestrationDashboardId(),
+            'origin' => $event->getOrigin(),
+            'exchange' => $event->getExchange(),
+            'market_type' => $event->getMarketType(),
+            'side' => $event->getSide(),
+            'qty' => $event->getQty(),
+            'price' => $event->getPrice(),
+            'reason_code' => $event->getReasonCode(),
+            'happened_at' => $this->formatDate($event->getHappenedAt()),
+        ];
+    }
+
+    private function formatDate(?\DateTimeInterface $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return \DateTimeImmutable::createFromInterface($value)
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->format(\DateTimeInterface::ATOM);
+    }
+}

--- a/trading-app/src/Trading/Lineage/ReadModel/LineageReadStoreInterface.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/LineageReadStoreInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Lineage\ReadModel;
+
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+
+interface LineageReadStoreInterface
+{
+    public function count(LineageReadCriteria $criteria): int;
+
+    /**
+     * @return TradeLineage[]
+     */
+    public function find(LineageReadCriteria $criteria): array;
+
+    /**
+     * @return TradeLifecycleEvent[]
+     */
+    public function findUnmatchedEvents(LineageReadCriteria $criteria): array;
+
+    /**
+     * @return TradeLifecycleEvent[]
+     */
+    public function findEventsForLineage(TradeLineage $lineage, int $limit): array;
+
+    public function countEventsForLineage(TradeLineage $lineage): int;
+}

--- a/trading-app/tests/Trading/Controller/Api/LineageReadApiControllerTest.php
+++ b/trading-app/tests/Trading/Controller/Api/LineageReadApiControllerTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Controller\Api;
+
+use App\Entity\OrderIntent;
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+use App\Trading\Controller\Api\LineageReadApiController;
+use App\Trading\Lineage\ReadModel\LineageReadCriteria;
+use App\Trading\Lineage\ReadModel\LineageReadService;
+use App\Trading\Lineage\ReadModel\LineageReadStoreInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(LineageReadApiController::class)]
+final class LineageReadApiControllerTest extends TestCase
+{
+    public function testMissingIdentifierReturnsStructured400(): void
+    {
+        $response = $this->controller([])->search(new Request());
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertSame('missing_identifier', $this->json($response)['error']['code']);
+    }
+
+    public function testVenueIdentifierRequiresExchangeAndMarketType(): void
+    {
+        $response = $this->controller([])->search(new Request(['position_id' => 'POS-1', 'exchange' => 'bitmart']));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        self::assertSame('missing_venue', $this->json($response)['error']['code']);
+    }
+
+    public function testUnknownIdentifierReturns404(): void
+    {
+        $response = $this->controller([])->search(new Request(['internal_trade_id' => 'missing']));
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        self::assertSame('lineage_not_found', $this->json($response)['error']['code']);
+    }
+
+    public function testConflictReturns409(): void
+    {
+        $lineageA = $this->lineage('trade-a')->setExchangeOrderId('EX-DUP');
+        $lineageB = $this->lineage('trade-b')->setExchangeOrderId('EX-DUP');
+
+        $response = $this->controller([$lineageA, $lineageB])->search(new Request([
+            'exchange_order_id' => 'EX-DUP',
+            'exchange' => 'bitmart',
+            'market_type' => 'perpetual',
+        ]));
+
+        self::assertSame(Response::HTTP_CONFLICT, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('identifier_conflict', $body['error']['code']);
+        self::assertSame('identifier_conflict', $body['completeness_status']);
+        self::assertSame(['identifier_conflict'], $body['quality_flags']);
+    }
+
+    public function testSearchCapsLimitAndReturnsRedactedItems(): void
+    {
+        $lineage = $this->lineage('trade-1')
+            ->setOrderIntent($this->intent(7, 'trade-1'))
+            ->setExchangeOrderId('EX-1')
+            ->setPositionId('POS-1');
+
+        $response = $this->controller([$lineage], [
+            'trade-1' => [$this->event('position_closed', 'trade-1')],
+        ])->search(new Request([
+            'internal_trade_id' => 'trade-1',
+            'limit' => '500',
+        ]));
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame(100, $body['pagination']['limit']);
+        self::assertSame('complete', $body['data'][0]['completeness_status']);
+        self::assertSame([], $body['data'][0]['quality_flags']);
+        self::assertArrayNotHasKey('extra', $body['data'][0]['lifecycle_events'][0]);
+        self::assertStringNotContainsString('SECRET', (string) $response->getContent());
+    }
+
+    /**
+     * @param TradeLineage[] $lineages
+     * @param array<string, TradeLifecycleEvent[]> $eventsByTrade
+     */
+    private function controller(array $lineages, array $eventsByTrade = []): LineageReadApiController
+    {
+        $controller = new LineageReadApiController(new LineageReadService(new class($lineages, $eventsByTrade) implements LineageReadStoreInterface {
+            /**
+             * @param TradeLineage[] $lineages
+             * @param array<string, TradeLifecycleEvent[]> $eventsByTrade
+             */
+            public function __construct(private readonly array $lineages, private readonly array $eventsByTrade)
+            {
+            }
+
+            public function count(LineageReadCriteria $criteria): int
+            {
+                return count($this->find($criteria));
+            }
+
+            public function find(LineageReadCriteria $criteria): array
+            {
+                return array_values(array_filter($this->lineages, static function (TradeLineage $lineage) use ($criteria): bool {
+                    return match ($criteria->kind) {
+                        'internal_trade_id' => $lineage->getInternalTradeId() === $criteria->value,
+                        'exchange_order_id' => $lineage->getExchangeOrderId() === $criteria->value
+                            && $lineage->getExchange() === $criteria->exchange
+                            && $lineage->getMarketType() === $criteria->marketType,
+                        default => false,
+                    };
+                }));
+            }
+
+            public function findUnmatchedEvents(LineageReadCriteria $criteria): array
+            {
+                return [];
+            }
+
+            public function findEventsForLineage(TradeLineage $lineage, int $limit): array
+            {
+                return array_slice($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [], 0, $limit);
+            }
+
+            public function countEventsForLineage(TradeLineage $lineage): int
+            {
+                return count($this->eventsByTrade[$lineage->getInternalTradeId()] ?? []);
+            }
+        }));
+
+        $controller->setContainer(new class implements ContainerInterface {
+            public function get(string $id): mixed
+            {
+                throw new \RuntimeException('not available: ' . $id);
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        });
+
+        return $controller;
+    }
+
+    private function lineage(string $internalTradeId): TradeLineage
+    {
+        return (new TradeLineage($internalTradeId, 'client-' . $internalTradeId, 'BTCUSDT'))
+            ->setExchange('bitmart')
+            ->setMarketType('perpetual')
+            ->setOrigin('orchestrator')
+            ->setRunId('run-1')
+            ->setCorrelationRunId('run-1')
+            ->setOrchestrationRunId('orun-1')
+            ->setOrchestrationSetId('set-1')
+            ->setOrchestrationDashboardId('dash-1');
+    }
+
+    private function intent(int $id, string $internalTradeId): OrderIntent
+    {
+        $intent = (new OrderIntent())
+            ->setExchange('bitmart')
+            ->setMarketType('perpetual')
+            ->setSymbol('BTCUSDT')
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setSize(1)
+            ->setClientOrderId('client-' . $internalTradeId)
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setInternalTradeId($internalTradeId)
+            ->setRawInputs(['secret' => 'SECRET']);
+
+        $property = new \ReflectionProperty($intent, 'id');
+        $property->setAccessible(true);
+        $property->setValue($intent, $id);
+
+        return $intent;
+    }
+
+    private function event(string $type, string $internalTradeId): TradeLifecycleEvent
+    {
+        return (new TradeLifecycleEvent('BTCUSDT', $type, new \DateTimeImmutable('2026-06-25T10:00:00+00:00')))
+            ->setExchange('bitmart')
+            ->setMarketType('perpetual')
+            ->setInternalTradeId($internalTradeId)
+            ->setOrderId('EX-1')
+            ->setExtra(['provider_payload' => 'SECRET']);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function json(Response $response): array
+    {
+        return json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/trading-app/tests/Trading/Lineage/LineageReadIntegrationTest.php
+++ b/trading-app/tests/Trading/Lineage/LineageReadIntegrationTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Lineage;
+
+use App\Entity\OrderIntent;
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+use App\Repository\OrderIntentRepository;
+use App\Repository\TradeLifecycleEventRepository;
+use App\Repository\TradeLineageRepository;
+use App\Trading\Lineage\ReadModel\DoctrineLineageReadStore;
+use App\Trading\Lineage\ReadModel\LineageReadCriteria;
+use App\Trading\Lineage\ReadModel\LineageReadException;
+use App\Trading\Lineage\ReadModel\LineageReadService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(DoctrineLineageReadStore::class)]
+final class LineageReadIntegrationTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private LineageReadService $service;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $tool = new SchemaTool($this->em);
+        $classes = [
+            $this->em->getClassMetadata(OrderIntent::class),
+            $this->em->getClassMetadata(TradeLineage::class),
+            $this->em->getClassMetadata(TradeLifecycleEvent::class),
+        ];
+        $tool->dropSchema($classes);
+        $tool->createSchema($classes);
+
+        /** @var TradeLineageRepository $lineages */
+        $lineages = $this->em->getRepository(TradeLineage::class);
+        /** @var OrderIntentRepository $orderIntents */
+        $orderIntents = $this->em->getRepository(OrderIntent::class);
+        /** @var TradeLifecycleEventRepository $events */
+        $events = $this->em->getRepository(TradeLifecycleEvent::class);
+        $store = new DoctrineLineageReadStore($lineages, $orderIntents, $events);
+        $this->service = new LineageReadService($store);
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            $tool = new SchemaTool($this->em);
+            $tool->dropSchema([
+                $this->em->getClassMetadata(OrderIntent::class),
+                $this->em->getClassMetadata(TradeLineage::class),
+                $this->em->getClassMetadata(TradeLifecycleEvent::class),
+            ]);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testPositionIdCanBeReusedAcrossVenuesWhenVenueIsExplicit(): void
+    {
+        $this->persistLineage('trade-bitmart', 'bitmart', 'perpetual', 'EX-SHARED', 'POS-SHARED');
+        $this->persistLineage('trade-okx', 'okx', 'perpetual', 'EX-SHARED', 'POS-SHARED');
+
+        $page = $this->service->search(
+            LineageReadCriteria::forVenueIdentifier('position_id', 'POS-SHARED', 'okx', 'perpetual', 10, 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame('trade-okx', $page->items[0]['lineage']['internal_trade_id']);
+        self::assertSame('okx', $page->items[0]['lineage']['exchange']);
+    }
+
+    public function testExchangeOrderIdCanBeReusedAcrossVenuesWhenVenueIsExplicit(): void
+    {
+        $this->persistLineage('trade-bitmart', 'bitmart', 'perpetual', 'EX-SHARED', 'POS-BM');
+        $this->persistLineage('trade-okx', 'okx', 'perpetual', 'EX-SHARED', 'POS-OKX');
+
+        $page = $this->service->search(
+            LineageReadCriteria::forVenueIdentifier('exchange_order_id', 'EX-SHARED', 'bitmart', 'perpetual', 10, 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame('trade-bitmart', $page->items[0]['lineage']['internal_trade_id']);
+        self::assertSame('bitmart', $page->items[0]['lineage']['exchange']);
+    }
+
+    public function testSameVenueDuplicateExchangeIdentifierReturnsConflict(): void
+    {
+        $this->persistLineage('trade-a', 'bitmart', 'perpetual', 'EX-DUP', 'POS-A');
+        $this->persistLineage('trade-b', 'bitmart', 'perpetual', 'EX-DUP', 'POS-B');
+
+        $this->expectException(LineageReadException::class);
+        $this->expectExceptionCode(409);
+
+        $this->service->search(
+            LineageReadCriteria::forVenueIdentifier('exchange_order_id', 'EX-DUP', 'bitmart', 'perpetual', 10, 0),
+        );
+    }
+
+    public function testRunSearchIsPaginatedAndDeterministicallyOrdered(): void
+    {
+        $this->persistLineage('trade-1', 'bitmart', 'perpetual', 'EX-1', 'POS-1', 'run-paged');
+        $this->persistLineage('trade-2', 'bitmart', 'perpetual', 'EX-2', 'POS-2', 'run-paged');
+        $this->persistLineage('trade-3', 'bitmart', 'perpetual', 'EX-3', 'POS-3', 'run-paged');
+
+        $page = $this->service->search(
+            LineageReadCriteria::forIdentifier('orchestration_run_id', 'run-paged', 2, 0),
+        );
+
+        self::assertSame(3, $page->total);
+        self::assertSame(2, $page->limit);
+        self::assertSame(0, $page->offset);
+        self::assertTrue($page->hasMore);
+        self::assertSame(['trade-1', 'trade-2'], array_column(array_column($page->items, 'lineage'), 'internal_trade_id'));
+    }
+
+    public function testSearchBySetAndOrderIntentId(): void
+    {
+        $intent = $this->persistIntent('trade-intent');
+        $this->persistLineage('trade-intent', 'bitmart', 'perpetual', 'EX-INTENT', 'POS-INTENT', 'run-intent', 'set-a', $intent);
+        $this->persistLineage('trade-set-peer', 'bitmart', 'perpetual', 'EX-PEER', 'POS-PEER', 'run-intent', 'set-a');
+        $this->persistLineage('trade-other-set', 'bitmart', 'perpetual', 'EX-OTHER', 'POS-OTHER', 'run-intent', 'set-b');
+
+        $setPage = $this->service->search(
+            LineageReadCriteria::forIdentifier('orchestration_set_id', 'set-a', 10, 0),
+        );
+        self::assertSame(2, $setPage->total);
+        self::assertSame(['trade-intent', 'trade-set-peer'], array_column(array_column($setPage->items, 'lineage'), 'internal_trade_id'));
+
+        self::assertNotNull($intent->getId());
+        $intentPage = $this->service->search(
+            LineageReadCriteria::forIdentifier('order_intent_id', (string) $intent->getId(), 10, 0),
+        );
+        self::assertSame(1, $intentPage->total);
+        self::assertSame('trade-intent', $intentPage->items[0]['lineage']['internal_trade_id']);
+        self::assertSame($intent->getId(), $intentPage->items[0]['order_intent']['id']);
+    }
+
+    private function persistLineage(
+        string $internalTradeId,
+        string $exchange,
+        string $marketType,
+        string $exchangeOrderId,
+        string $positionId,
+        string $orchestrationRunId = 'run-1',
+        string $orchestrationSetId = 'set-1',
+        ?OrderIntent $orderIntent = null,
+    ): void {
+        $lineage = (new TradeLineage($internalTradeId, 'client-' . $internalTradeId, 'BTCUSDT'))
+            ->setOrderIntent($orderIntent)
+            ->setExchange($exchange)
+            ->setMarketType($marketType)
+            ->setExchangeOrderId($exchangeOrderId)
+            ->setPositionId($positionId)
+            ->setOrigin('orchestrator')
+            ->setRunId($orchestrationRunId)
+            ->setCorrelationRunId($orchestrationRunId)
+            ->setOrchestrationRunId($orchestrationRunId)
+            ->setOrchestrationSetId($orchestrationSetId)
+            ->setOrchestrationDashboardId('dash-1');
+
+        $event = (new TradeLifecycleEvent('BTCUSDT', 'position_closed'))
+            ->setExchange($exchange)
+            ->setMarketType($marketType)
+            ->setInternalTradeId($internalTradeId)
+            ->setOrderId($exchangeOrderId)
+            ->setPositionId($positionId)
+            ->setOrchestrationRunId($orchestrationRunId)
+            ->setOrchestrationSetId($orchestrationSetId)
+            ->setOrchestrationDashboardId('dash-1');
+
+        $this->em->persist($lineage);
+        $this->em->persist($event);
+        $this->em->flush();
+    }
+
+    private function persistIntent(string $internalTradeId): OrderIntent
+    {
+        $intent = (new OrderIntent())
+            ->setExchange('bitmart')
+            ->setMarketType('perpetual')
+            ->setSymbol('BTCUSDT')
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setSize(1)
+            ->setClientOrderId('client-' . $internalTradeId)
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setInternalTradeId($internalTradeId);
+
+        $this->em->persist($intent);
+        $this->em->flush();
+
+        return $intent;
+    }
+}

--- a/trading-app/tests/Trading/Lineage/LineageReadServiceTest.php
+++ b/trading-app/tests/Trading/Lineage/LineageReadServiceTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Lineage;
+
+use App\Entity\OrderIntent;
+use App\Entity\TradeLifecycleEvent;
+use App\Entity\TradeLineage;
+use App\Trading\Lineage\ReadModel\LineageReadCriteria;
+use App\Trading\Lineage\ReadModel\LineageReadException;
+use App\Trading\Lineage\ReadModel\LineageReadService;
+use App\Trading\Lineage\ReadModel\LineageReadStoreInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LineageReadService::class)]
+final class LineageReadServiceTest extends TestCase
+{
+    public function testCompleteLineageReturnsWhitelistedPayload(): void
+    {
+        $lineage = $this->lineage('trade-1')
+            ->setOrderIntent($this->intent(42, 'trade-1'))
+            ->setExchangeOrderId('EX-1')
+            ->setPositionId('POS-1');
+
+        $events = [
+            $this->event('order_submitted', 'trade-1'),
+            $this->event('position_opened', 'trade-1'),
+            $this->event('position_closed', 'trade-1'),
+        ];
+
+        $page = $this->service([$lineage], ['trade-1' => $events])->search(
+            LineageReadCriteria::forIdentifier('internal_trade_id', 'trade-1', limit: 10, offset: 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertFalse($page->hasMore);
+        self::assertSame(10, $page->limit);
+        self::assertSame(0, $page->offset);
+
+        $item = $page->items[0];
+        self::assertSame('complete', $item['completeness_status']);
+        self::assertSame([], $item['quality_flags']);
+        self::assertSame('trade-1', $item['lineage']['internal_trade_id']);
+        self::assertSame(42, $item['order_intent']['id']);
+        self::assertCount(3, $item['lifecycle_events']);
+        self::assertArrayNotHasKey('extra', $item['lifecycle_events'][0]);
+        self::assertArrayNotHasKey('raw_inputs', $item['order_intent']);
+        self::assertArrayNotHasKey('validation_errors', $item['order_intent']);
+        self::assertStringNotContainsString('SECRET', json_encode($item, JSON_THROW_ON_ERROR));
+    }
+
+    public function testCompletenessStatusesExposeSpecificPartialReasons(): void
+    {
+        $cases = [
+            'legacy' => $this->lineage('legacy')->setOrigin('legacy'),
+            'missing_order_intent' => $this->lineage('missing-intent')->setExchangeOrderId('EX-1')->setPositionId('POS-1')->setOrigin('orchestrator'),
+            'missing_exchange_order_id' => $this->lineage('missing-exchange')->setOrderIntent($this->intent(1, 'missing-exchange'))->setPositionId('POS-1'),
+            'missing_position_id' => $this->lineage('missing-position')->setOrderIntent($this->intent(2, 'missing-position'))->setExchangeOrderId('EX-1'),
+            'missing_close_event' => $this->lineage('missing-close')->setOrderIntent($this->intent(3, 'missing-close'))->setExchangeOrderId('EX-1')->setPositionId('POS-1'),
+            'partial' => $this->lineage('partial')->setOrderIntent($this->intent(4, 'partial'))->setExchangeOrderId('EX-1')->setPositionId('POS-1')->setOrchestrationDashboardId(null),
+        ];
+
+        foreach ($cases as $expectedStatus => $lineage) {
+            $events = $expectedStatus === 'missing_close_event'
+                ? [$this->event('order_submitted', $lineage->getInternalTradeId())]
+                : [$this->event('position_closed', $lineage->getInternalTradeId())];
+
+            $page = $this->service([$lineage], [$lineage->getInternalTradeId() => $events])->search(
+                LineageReadCriteria::forIdentifier('internal_trade_id', $lineage->getInternalTradeId(), limit: 10, offset: 0),
+            );
+
+            self::assertSame($expectedStatus, $page->items[0]['completeness_status'], $expectedStatus);
+            self::assertContains($expectedStatus, $page->items[0]['quality_flags'], $expectedStatus);
+        }
+    }
+
+    public function testUnmatchedEventWithoutPersistentLineageIsVisible(): void
+    {
+        $event = $this->event('position_closed', null)->setPositionId('POS-404');
+
+        $page = $this->service([], [], [$event])->search(
+            LineageReadCriteria::forVenueIdentifier('position_id', 'POS-404', 'okx', 'perpetual', limit: 10, offset: 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame('unmatched', $page->items[0]['completeness_status']);
+        self::assertContains('unmatched', $page->items[0]['quality_flags']);
+        self::assertNull($page->items[0]['lineage']);
+        self::assertCount(1, $page->items[0]['lifecycle_events']);
+    }
+
+    public function testIdentifierConflictIsNeverResolvedSilently(): void
+    {
+        $lineageA = $this->lineage('trade-a')->setExchangeOrderId('EX-1');
+        $lineageB = $this->lineage('trade-b')->setExchangeOrderId('EX-1');
+
+        $this->expectException(LineageReadException::class);
+        $this->expectExceptionCode(409);
+
+        $this->service([$lineageA, $lineageB])->search(
+            LineageReadCriteria::forVenueIdentifier('exchange_order_id', 'EX-1', 'bitmart', 'perpetual', limit: 10, offset: 0),
+        );
+    }
+
+    public function testLimitIsCappedAtOneHundred(): void
+    {
+        $criteria = LineageReadCriteria::forIdentifier('orchestration_run_id', 'run-1', limit: 500, offset: 0);
+
+        self::assertSame(100, $criteria->limit);
+    }
+
+    /**
+     * @param TradeLineage[] $lineages
+     * @param array<string, TradeLifecycleEvent[]> $eventsByTrade
+     * @param TradeLifecycleEvent[] $unmatchedEvents
+     */
+    private function service(array $lineages, array $eventsByTrade = [], array $unmatchedEvents = []): LineageReadService
+    {
+        return new LineageReadService(new class($lineages, $eventsByTrade, $unmatchedEvents) implements LineageReadStoreInterface {
+            /**
+             * @param TradeLineage[] $lineages
+             * @param array<string, TradeLifecycleEvent[]> $eventsByTrade
+             * @param TradeLifecycleEvent[] $unmatchedEvents
+             */
+            public function __construct(
+                private readonly array $lineages,
+                private readonly array $eventsByTrade,
+                private readonly array $unmatchedEvents,
+            ) {
+            }
+
+            public function count(LineageReadCriteria $criteria): int
+            {
+                return count($this->find($criteria));
+            }
+
+            public function find(LineageReadCriteria $criteria): array
+            {
+                return array_values(array_filter(
+                    $this->lineages,
+                    static fn (TradeLineage $lineage): bool => match ($criteria->kind) {
+                        'internal_trade_id' => $lineage->getInternalTradeId() === $criteria->value,
+                        'orchestration_run_id' => $lineage->getOrchestrationRunId() === $criteria->value,
+                        'exchange_order_id' => $lineage->getExchangeOrderId() === $criteria->value
+                            && $lineage->getExchange() === $criteria->exchange
+                            && $lineage->getMarketType() === $criteria->marketType,
+                        'position_id' => $lineage->getPositionId() === $criteria->value
+                            && $lineage->getExchange() === $criteria->exchange
+                            && $lineage->getMarketType() === $criteria->marketType,
+                        default => false,
+                    },
+                ));
+            }
+
+            public function findUnmatchedEvents(LineageReadCriteria $criteria): array
+            {
+                if (!in_array($criteria->kind, ['position_id', 'exchange_order_id', 'client_order_id'], true)) {
+                    return [];
+                }
+
+                return array_values(array_filter(
+                    $this->unmatchedEvents,
+                    static fn (TradeLifecycleEvent $event): bool => match ($criteria->kind) {
+                        'position_id' => $event->getPositionId() === $criteria->value,
+                        'exchange_order_id' => $event->getOrderId() === $criteria->value,
+                        'client_order_id' => $event->getClientOrderId() === $criteria->value,
+                    },
+                ));
+            }
+
+            public function findEventsForLineage(TradeLineage $lineage, int $limit): array
+            {
+                return array_slice($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [], 0, $limit);
+            }
+
+            public function countEventsForLineage(TradeLineage $lineage): int
+            {
+                return count($this->eventsByTrade[$lineage->getInternalTradeId()] ?? []);
+            }
+        });
+    }
+
+    private function lineage(string $internalTradeId): TradeLineage
+    {
+        return (new TradeLineage($internalTradeId, 'client-' . $internalTradeId, 'BTCUSDT'))
+            ->setExchange('bitmart')
+            ->setMarketType('perpetual')
+            ->setOrigin('orchestrator')
+            ->setRunId('run-1')
+            ->setCorrelationRunId('run-1')
+            ->setOrchestrationRunId('orun-1')
+            ->setOrchestrationSetId('set-1')
+            ->setOrchestrationDashboardId('dash-1')
+            ->setProfile('scalper_micro');
+    }
+
+    private function intent(int $id, string $internalTradeId): OrderIntent
+    {
+        $intent = (new OrderIntent())
+            ->setExchange('bitmart')
+            ->setMarketType('perpetual')
+            ->setSymbol('BTCUSDT')
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_ONE_WAY)
+            ->setSize(1)
+            ->setClientOrderId('client-' . $internalTradeId)
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setInternalTradeId($internalTradeId)
+            ->setRawInputs(['secret' => 'SECRET'])
+            ->setValidationErrors(['provider_payload' => 'SECRET']);
+
+        $this->setId($intent, $id);
+
+        return $intent;
+    }
+
+    private function event(string $type, ?string $internalTradeId): TradeLifecycleEvent
+    {
+        return (new TradeLifecycleEvent('BTCUSDT', $type, new \DateTimeImmutable('2026-06-25T10:00:00+00:00')))
+            ->setExchange('bitmart')
+            ->setMarketType('perpetual')
+            ->setInternalTradeId($internalTradeId)
+            ->setOrderId('EX-1')
+            ->setClientOrderId('client-' . ($internalTradeId ?? 'none'))
+            ->setExtra(['provider_payload' => 'SECRET']);
+    }
+
+    private function setId(object $entity, int $id): void
+    {
+        $property = new \ReflectionProperty($entity, 'id');
+        $property->setAccessible(true);
+        $property->setValue($entity, $id);
+    }
+}


### PR DESCRIPTION
## Summary

Part of #189  
Related to #173  
References #199, #201, #202, #203, #204

Adds a versioned, read-only Symfony API for navigating persistent trade lineage by exact identifiers, without reconstructing relationships by symbol, side, or timestamp windows.

## API surface

- `GET /api/lineage/v1/search`
  - supports `orchestration_run_id`, `correlation_run_id`, `orchestration_set_id`, `orchestration_dashboard_id`, `internal_trade_id`, `internal_position_id`, `order_intent_id`, `client_order_id`, `exchange_order_id`, `position_id`
  - requires `exchange + market_type` for `client_order_id`, `exchange_order_id`, and `position_id`
  - applies bounded pagination with `limit <= 100`
- `GET /api/lineage/v1/{internal_trade_id}`
- `GET /api/lineage/v1/{internal_trade_id}/events`

## Behavior

- Read-only only; no trading, MTF, EntryZone, risk/leverage, SL/TP, live guard, or strategy changes.
- No symbol-only fallback and no time-window matching.
- Ambiguous exact identifiers in the same venue return `409 identifier_conflict` and include `completeness_status=identifier_conflict` plus `quality_flags`.
- Every lineage item includes `completeness_status` and `quality_flags`.
- Responses are redacted by whitelist and do not expose lifecycle `extra`, `OrderIntent.rawInputs`, validation errors, provider raw payloads, or secrets.

## Completeness statuses

The read model distinguishes:

- `complete`
- `partial`
- `legacy`
- `unmatched`
- `identifier_conflict`
- `missing_order_intent`
- `missing_exchange_order_id`
- `missing_position_id`
- `missing_close_event`

## Tests

Executed locally:

- `DEFAULT_URI=http://localhost APP_ENV=test php bin/phpunit tests/Trading/Lineage/LineageContextTest.php --no-coverage` -> OK, 5 tests / 31 assertions.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/phpunit tests/Trading/Lineage tests/Trading/Controller/Api/LineageReadApiControllerTest.php --no-coverage` -> OK, 36 tests / 178 assertions.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='postgresql://postgres:password@localhost:5436/trading_app?serverVersion=15&charset=utf8' php bin/phpunit --fail-on-skipped tests/Trading/Lineage/LineageReadIntegrationTest.php --no-coverage` -> OK, 5 tests / 19 assertions.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' vendor/bin/phpstan analyse --no-progress src/Trading/Lineage/ReadModel src/Trading/Controller/Api/LineageReadApiController.php src/Repository/TradeLineageRepository.php src/Repository/OrderIntentRepository.php src/Repository/TradeLifecycleEventRepository.php tests/Trading/Lineage/LineageReadServiceTest.php tests/Trading/Lineage/LineageReadIntegrationTest.php tests/Trading/Controller/Api/LineageReadApiControllerTest.php --memory-limit=1G` -> OK.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/console lint:container --no-debug` -> OK, with pre-existing PHP 8.4 deprecation in `EntryZoneStatsCommand`.
- `DEFAULT_URI=http://localhost APP_ENV=test php bin/console lint:yaml config` -> OK.
- `git diff --check` -> OK.

## Remaining #189 audit

This PR is `Part of #189`, not `Closes #189`. It delivers the read API requested after #199/#201/#202/#203/#204. After merge, #189 should be re-evaluated against any remaining criteria such as broader cockpit integration or additional lineage propagation/backfill work that may still be outside this read-only surface.
