### PR TITLE
Fix lineage read API review feedback

### DIFF
--- a/docs/handbook/technical/lineage-read-api.md
+++ b/docs/handbook/technical/lineage-read-api.md
@@ -99,6 +99,7 @@ Reponse :
       ],
       "lifecycle_events_pagination": {
         "limit": 100,
+        "offset": 0,
         "total": 3,
         "has_more": false
       }
@@ -128,6 +129,9 @@ GET /api/lineage/v1/{internal_trade_id}/events
 ```
 
 Retourne uniquement les evenements lifecycle associes et conserve `completeness_status` + `quality_flags`.
+
+`limit` et `offset` s'appliquent a la page d'evenements lifecycle. La recherche du lineage par
+`internal_trade_id` reste une lookup exacte non paginee.
 
 ## Statuts de completude
 

--- a/trading-app/src/Repository/TradeLifecycleEventRepository.php
+++ b/trading-app/src/Repository/TradeLifecycleEventRepository.php
@@ -87,12 +87,8 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
         string $exchange,
         string $marketType,
         int $limit,
+        int $offset = 0,
     ): array {
-        $or = [
-            'event.internalTradeId = :internalTradeId',
-            'event.clientOrderId = :clientOrderId',
-        ];
-
         $qb = $this->createQueryBuilder('event')
             ->andWhere('event.exchange = :exchange')
             ->andWhere('event.marketType = :marketType')
@@ -102,19 +98,10 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
             ->setParameter('clientOrderId', $clientOrderId)
             ->orderBy('event.happenedAt', 'ASC')
             ->addOrderBy('event.id', 'ASC')
+            ->setFirstResult(max(0, $offset))
             ->setMaxResults(max(1, $limit));
 
-        if ($exchangeOrderId !== null && $exchangeOrderId !== '') {
-            $or[] = 'event.orderId = :exchangeOrderId';
-            $qb->setParameter('exchangeOrderId', $exchangeOrderId);
-        }
-
-        if ($positionId !== null && $positionId !== '') {
-            $or[] = 'event.positionId = :positionId';
-            $qb->setParameter('positionId', $positionId);
-        }
-
-        $qb->andWhere($qb->expr()->orX(...$or));
+        $this->applyLineageIdentifierPredicate($qb, $internalTradeId, $clientOrderId, $exchangeOrderId, $positionId);
 
         return $qb->getQuery()->getResult();
     }
@@ -127,11 +114,6 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
         string $exchange,
         string $marketType,
     ): int {
-        $or = [
-            'event.internalTradeId = :internalTradeId',
-            'event.clientOrderId = :clientOrderId',
-        ];
-
         $qb = $this->createQueryBuilder('event')
             ->select('COUNT(event.id)')
             ->andWhere('event.exchange = :exchange')
@@ -141,19 +123,85 @@ final class TradeLifecycleEventRepository extends ServiceEntityRepository
             ->setParameter('internalTradeId', $internalTradeId)
             ->setParameter('clientOrderId', $clientOrderId);
 
+        $this->applyLineageIdentifierPredicate($qb, $internalTradeId, $clientOrderId, $exchangeOrderId, $positionId);
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    public function hasCloseEventForLineageIdentifiers(
+        string $internalTradeId,
+        string $clientOrderId,
+        ?string $exchangeOrderId,
+        ?string $positionId,
+        string $exchange,
+        string $marketType,
+    ): bool {
+        $qb = $this->createQueryBuilder('event')
+            ->select('1')
+            ->andWhere('event.exchange = :exchange')
+            ->andWhere('event.marketType = :marketType')
+            ->andWhere('event.eventType = :eventType')
+            ->setParameter('exchange', $exchange)
+            ->setParameter('marketType', $marketType)
+            ->setParameter('eventType', 'position_closed')
+            ->setParameter('internalTradeId', $internalTradeId)
+            ->setParameter('clientOrderId', $clientOrderId)
+            ->setMaxResults(1);
+
+        $this->applyLineageIdentifierPredicate($qb, $internalTradeId, $clientOrderId, $exchangeOrderId, $positionId);
+
+        return $qb->getQuery()->getOneOrNullResult() !== null;
+    }
+
+    private function applyLineageIdentifierPredicate(
+        QueryBuilder $qb,
+        string $internalTradeId,
+        string $clientOrderId,
+        ?string $exchangeOrderId,
+        ?string $positionId,
+    ): void {
+        $legacyBranches = [];
+        $orderNoConflict = null;
+        $positionNoConflict = null;
+
         if ($exchangeOrderId !== null && $exchangeOrderId !== '') {
-            $or[] = 'event.orderId = :exchangeOrderId';
+            $orderNoConflict = $qb->expr()->orX('event.orderId IS NULL', 'event.orderId = :exchangeOrderId');
             $qb->setParameter('exchangeOrderId', $exchangeOrderId);
         }
 
         if ($positionId !== null && $positionId !== '') {
-            $or[] = 'event.positionId = :positionId';
+            $legacyBranches[] = 'event.positionId = :positionId';
+            $positionNoConflict = $qb->expr()->orX('event.positionId IS NULL', 'event.positionId = :positionId');
             $qb->setParameter('positionId', $positionId);
         }
 
-        $qb->andWhere($qb->expr()->orX(...$or));
+        if ($exchangeOrderId !== null && $exchangeOrderId !== '') {
+            $orderBranch = [
+                'event.orderId = :exchangeOrderId',
+                $qb->expr()->orX('event.clientOrderId IS NULL', 'LOWER(event.clientOrderId) = LOWER(:clientOrderId)'),
+            ];
+            if ($positionNoConflict !== null) {
+                $orderBranch[] = $positionNoConflict;
+            }
+            $legacyBranches[] = $qb->expr()->andX(...$orderBranch);
+        }
 
-        return (int) $qb->getQuery()->getSingleScalarResult();
+        $clientOrderBranch = ['LOWER(event.clientOrderId) = LOWER(:clientOrderId)'];
+        if ($orderNoConflict !== null) {
+            $clientOrderBranch[] = $orderNoConflict;
+        }
+        if ($positionNoConflict !== null) {
+            $clientOrderBranch[] = $positionNoConflict;
+        }
+        $legacyBranches[] = $qb->expr()->andX(...$clientOrderBranch);
+
+        $qb->andWhere($qb->expr()->orX(
+            'event.internalTradeId = :internalTradeId',
+            $qb->expr()->andX(
+                'event.internalTradeId IS NULL',
+                $qb->expr()->orX(...$legacyBranches),
+            ),
+        ));
     }
 
     private function createCriteriaQueryBuilder(LineageReadCriteria $criteria): QueryBuilder

--- a/trading-app/src/Trading/Controller/Api/LineageReadApiController.php
+++ b/trading-app/src/Trading/Controller/Api/LineageReadApiController.php
@@ -65,12 +65,14 @@ final class LineageReadApiController extends AbstractController
         $criteria = LineageReadCriteria::forIdentifier(
             'internal_trade_id',
             $internalTradeId,
-            $this->intQuery($request, 'limit', LineageReadCriteria::MAX_LIMIT),
-            $this->intQuery($request, 'offset', 0),
+            1,
+            0,
         );
+        $eventLimit = $this->intQuery($request, 'limit', LineageReadCriteria::MAX_LIMIT);
+        $eventOffset = $this->intQuery($request, 'offset', 0);
 
         try {
-            $page = $this->lineageReadService->search($criteria);
+            $page = $this->lineageReadService->search($criteria, $eventLimit, $eventOffset);
         } catch (LineageReadException $e) {
             return $this->error($e->errorCode, $e->getMessage(), $e->getCode());
         }
@@ -96,8 +98,8 @@ final class LineageReadApiController extends AbstractController
         $criteria = LineageReadCriteria::forIdentifier(
             'internal_trade_id',
             $internalTradeId,
-            $this->intQuery($request, 'limit', LineageReadCriteria::MAX_LIMIT),
-            $this->intQuery($request, 'offset', 0),
+            1,
+            0,
         );
 
         try {

--- a/trading-app/src/Trading/Lineage/ReadModel/DoctrineLineageReadStore.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/DoctrineLineageReadStore.php
@@ -46,7 +46,7 @@ final readonly class DoctrineLineageReadStore implements LineageReadStoreInterfa
         return $this->events->findUnmatchedByReadCriteria($criteria);
     }
 
-    public function findEventsForLineage(TradeLineage $lineage, int $limit): array
+    public function findEventsForLineage(TradeLineage $lineage, int $limit, int $offset = 0): array
     {
         return $this->events->findForLineageIdentifiers(
             internalTradeId: $lineage->getInternalTradeId(),
@@ -56,12 +56,25 @@ final readonly class DoctrineLineageReadStore implements LineageReadStoreInterfa
             exchange: $lineage->getExchange(),
             marketType: $lineage->getMarketType(),
             limit: $limit,
+            offset: $offset,
         );
     }
 
     public function countEventsForLineage(TradeLineage $lineage): int
     {
         return $this->events->countForLineageIdentifiers(
+            internalTradeId: $lineage->getInternalTradeId(),
+            clientOrderId: $lineage->getClientOrderId(),
+            exchangeOrderId: $lineage->getExchangeOrderId(),
+            positionId: $lineage->getPositionId(),
+            exchange: $lineage->getExchange(),
+            marketType: $lineage->getMarketType(),
+        );
+    }
+
+    public function hasCloseEventForLineage(TradeLineage $lineage): bool
+    {
+        return $this->events->hasCloseEventForLineageIdentifiers(
             internalTradeId: $lineage->getInternalTradeId(),
             clientOrderId: $lineage->getClientOrderId(),
             exchangeOrderId: $lineage->getExchangeOrderId(),

--- a/trading-app/src/Trading/Lineage/ReadModel/LineageReadService.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/LineageReadService.php
@@ -18,8 +18,10 @@ final readonly class LineageReadService
     ) {
     }
 
-    public function search(LineageReadCriteria $criteria): LineageReadPage
+    public function search(LineageReadCriteria $criteria, ?int $eventLimit = null, int $eventOffset = 0): LineageReadPage
     {
+        $eventLimit = $this->boundedEventLimit($eventLimit);
+        $eventOffset = max(0, $eventOffset);
         $total = $this->store->count($criteria);
         if ($criteria->isConflictSensitive() && $total > 1) {
             throw new LineageReadException(
@@ -31,6 +33,15 @@ final readonly class LineageReadService
 
         $lineages = $this->store->find($criteria);
         if ($lineages === []) {
+            if ($total > 0) {
+                return new LineageReadPage(
+                    items: [],
+                    total: $total,
+                    limit: $criteria->limit,
+                    offset: $criteria->offset,
+                );
+            }
+
             $unmatchedEvents = $this->store->findUnmatchedEvents($criteria);
             $items = array_map(fn (TradeLifecycleEvent $event): array => $this->serializeUnmatchedEvent($event), $unmatchedEvents);
 
@@ -44,8 +55,8 @@ final readonly class LineageReadService
 
         $items = [];
         foreach ($lineages as $lineage) {
-            $events = $this->store->findEventsForLineage($lineage, self::EVENT_LIMIT);
-            $items[] = $this->serializeLineage($lineage, $events);
+            $events = $this->store->findEventsForLineage($lineage, $eventLimit, $eventOffset);
+            $items[] = $this->serializeLineage($lineage, $events, $eventLimit, $eventOffset);
         }
 
         return new LineageReadPage(
@@ -60,9 +71,9 @@ final readonly class LineageReadService
      * @param TradeLifecycleEvent[] $events
      * @return array<string,mixed>
      */
-    private function serializeLineage(TradeLineage $lineage, array $events): array
+    private function serializeLineage(TradeLineage $lineage, array $events, int $eventLimit, int $eventOffset): array
     {
-        $qualityFlags = $this->qualityFlags($lineage, $events);
+        $qualityFlags = $this->qualityFlags($lineage);
         $status = $this->completenessStatus($qualityFlags);
 
         return [
@@ -71,7 +82,7 @@ final readonly class LineageReadService
             'lineage' => $this->lineagePayload($lineage),
             'order_intent' => $lineage->getOrderIntent() !== null ? $this->orderIntentPayload($lineage->getOrderIntent()) : null,
             'lifecycle_events' => array_map(fn (TradeLifecycleEvent $event): array => $this->eventPayload($event), $events),
-            'lifecycle_events_pagination' => $this->eventPagination($lineage, $events),
+            'lifecycle_events_pagination' => $this->eventPagination($lineage, $events, $eventLimit, $eventOffset),
         ];
     }
 
@@ -95,10 +106,9 @@ final readonly class LineageReadService
     }
 
     /**
-     * @param TradeLifecycleEvent[] $events
      * @return list<string>
      */
-    private function qualityFlags(TradeLineage $lineage, array $events): array
+    private function qualityFlags(TradeLineage $lineage): array
     {
         $flags = [];
 
@@ -118,7 +128,7 @@ final readonly class LineageReadService
             $flags[] = 'missing_position_id';
         }
 
-        if (!$this->hasCloseEvent($events)) {
+        if (!$this->store->hasCloseEventForLineage($lineage)) {
             $flags[] = 'missing_close_event';
         }
 
@@ -160,31 +170,27 @@ final readonly class LineageReadService
 
     /**
      * @param TradeLifecycleEvent[] $events
-     */
-    private function hasCloseEvent(array $events): bool
-    {
-        foreach ($events as $event) {
-            if ($event->getEventType() === 'position_closed') {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param TradeLifecycleEvent[] $events
      * @return array<string,mixed>
      */
-    private function eventPagination(TradeLineage $lineage, array $events): array
+    private function eventPagination(TradeLineage $lineage, array $events, int $eventLimit, int $eventOffset): array
     {
         $total = $this->store->countEventsForLineage($lineage);
 
         return [
-            'limit' => self::EVENT_LIMIT,
+            'limit' => $eventLimit,
+            'offset' => $eventOffset,
             'total' => $total,
-            'has_more' => $total > count($events),
+            'has_more' => $eventOffset + count($events) < $total,
         ];
+    }
+
+    private function boundedEventLimit(?int $limit): int
+    {
+        if ($limit === null) {
+            return self::EVENT_LIMIT;
+        }
+
+        return min(self::EVENT_LIMIT, max(1, $limit));
     }
 
     /**

--- a/trading-app/src/Trading/Lineage/ReadModel/LineageReadStoreInterface.php
+++ b/trading-app/src/Trading/Lineage/ReadModel/LineageReadStoreInterface.php
@@ -24,7 +24,9 @@ interface LineageReadStoreInterface
     /**
      * @return TradeLifecycleEvent[]
      */
-    public function findEventsForLineage(TradeLineage $lineage, int $limit): array;
+    public function findEventsForLineage(TradeLineage $lineage, int $limit, int $offset = 0): array;
 
     public function countEventsForLineage(TradeLineage $lineage): int;
+
+    public function hasCloseEventForLineage(TradeLineage $lineage): bool;
 }

--- a/trading-app/tests/Trading/Controller/Api/LineageReadApiControllerTest.php
+++ b/trading-app/tests/Trading/Controller/Api/LineageReadApiControllerTest.php
@@ -85,6 +85,35 @@ final class LineageReadApiControllerTest extends TestCase
         self::assertStringNotContainsString('SECRET', (string) $response->getContent());
     }
 
+    public function testEventsEndpointAppliesOffsetToLifecycleEventsNotLineageLookup(): void
+    {
+        $lineage = $this->lineage('trade-events')
+            ->setOrderIntent($this->intent(8, 'trade-events'))
+            ->setExchangeOrderId('EX-EVENTS')
+            ->setPositionId('POS-EVENTS');
+
+        $events = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $events[] = $this->event('order_updated', 'trade-events')->setOrderId('EX-EVENTS');
+        }
+        $events[] = $this->event('position_closed', 'trade-events')->setOrderId('EX-EVENTS');
+
+        $response = $this->controller([$lineage], ['trade-events' => $events])->events(
+            'trade-events',
+            new Request(['limit' => '100', 'offset' => '100']),
+        );
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame(100, $body['pagination']['limit']);
+        self::assertSame(100, $body['pagination']['offset']);
+        self::assertSame(101, $body['pagination']['total']);
+        self::assertFalse($body['pagination']['has_more']);
+        self::assertCount(1, $body['data']);
+        self::assertSame('position_closed', $body['data'][0]['event_type']);
+        self::assertSame('complete', $body['completeness_status']);
+    }
+
     /**
      * @param TradeLineage[] $lineages
      * @param array<string, TradeLifecycleEvent[]> $eventsByTrade
@@ -102,10 +131,18 @@ final class LineageReadApiControllerTest extends TestCase
 
             public function count(LineageReadCriteria $criteria): int
             {
-                return count($this->find($criteria));
+                return count($this->matchingLineages($criteria));
             }
 
             public function find(LineageReadCriteria $criteria): array
+            {
+                return array_slice($this->matchingLineages($criteria), $criteria->offset, $criteria->limit);
+            }
+
+            /**
+             * @return TradeLineage[]
+             */
+            private function matchingLineages(LineageReadCriteria $criteria): array
             {
                 return array_values(array_filter($this->lineages, static function (TradeLineage $lineage) use ($criteria): bool {
                     return match ($criteria->kind) {
@@ -123,14 +160,25 @@ final class LineageReadApiControllerTest extends TestCase
                 return [];
             }
 
-            public function findEventsForLineage(TradeLineage $lineage, int $limit): array
+            public function findEventsForLineage(TradeLineage $lineage, int $limit, int $offset = 0): array
             {
-                return array_slice($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [], 0, $limit);
+                return array_slice($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [], $offset, $limit);
             }
 
             public function countEventsForLineage(TradeLineage $lineage): int
             {
                 return count($this->eventsByTrade[$lineage->getInternalTradeId()] ?? []);
+            }
+
+            public function hasCloseEventForLineage(TradeLineage $lineage): bool
+            {
+                foreach ($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [] as $event) {
+                    if ($event->getEventType() === 'position_closed') {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }));
 

--- a/trading-app/tests/Trading/Lineage/LineageReadIntegrationTest.php
+++ b/trading-app/tests/Trading/Lineage/LineageReadIntegrationTest.php
@@ -110,6 +110,96 @@ final class LineageReadIntegrationTest extends KernelTestCase
         );
     }
 
+    public function testLineageDetailDoesNotMixLifecycleEventsFromAmbiguousVenueIdentifiers(): void
+    {
+        $intentA = $this->persistIntent('trade-a');
+        $intentB = $this->persistIntent('trade-b');
+
+        $this->persistLineage('trade-a', 'bitmart', 'perpetual', 'EX-SAME', 'POS-SAME', orderIntent: $intentA, withCloseEvent: false);
+        $this->persistLifecycleEvent('trade-a', 'bitmart', 'perpetual', 'EX-SAME', 'POS-SAME', 'order_submitted');
+
+        $this->persistLineage('trade-b', 'bitmart', 'perpetual', 'EX-SAME', 'POS-SAME', orderIntent: $intentB, withCloseEvent: false);
+        $this->persistLifecycleEvent('trade-b', 'bitmart', 'perpetual', 'EX-SAME', 'POS-SAME', 'position_closed');
+
+        $page = $this->service->search(
+            LineageReadCriteria::forIdentifier('internal_trade_id', 'trade-a', 10, 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame('missing_close_event', $page->items[0]['completeness_status']);
+        self::assertSame(['order_submitted'], array_column($page->items[0]['lifecycle_events'], 'event_type'));
+        self::assertSame(['trade-a'], array_unique(array_column($page->items[0]['lifecycle_events'], 'internal_trade_id')));
+    }
+
+    public function testLineageDetailDoesNotImportConflictingLegacyLifecycleEvents(): void
+    {
+        $intentA = $this->persistIntent('trade-a');
+        $intentB = $this->persistIntent('trade-b');
+
+        $this->persistLineage('trade-a', 'bitmart', 'perpetual', 'EX-SAME', 'POS-SAME', orderIntent: $intentA, withCloseEvent: false);
+        $this->persistLifecycleEvent('trade-a', 'bitmart', 'perpetual', 'EX-SAME', 'POS-SAME', 'order_submitted');
+
+        $this->persistLineage('trade-b', 'bitmart', 'perpetual', 'EX-SAME', 'POS-SAME', orderIntent: $intentB, withCloseEvent: false);
+        $this->persistLegacyLifecycleEvent('client-trade-b', 'bitmart', 'perpetual', 'EX-SAME', 'POS-OTHER', 'position_closed');
+
+        $page = $this->service->search(
+            LineageReadCriteria::forIdentifier('internal_trade_id', 'trade-a', 10, 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame('missing_close_event', $page->items[0]['completeness_status']);
+        self::assertSame(['order_submitted'], array_column($page->items[0]['lifecycle_events'], 'event_type'));
+    }
+
+    public function testLineageDetailIncludesLegacyCloseMatchedByPositionWithDistinctClosingOrder(): void
+    {
+        $intent = $this->persistIntent('trade-position-close');
+
+        $this->persistLineage(
+            'trade-position-close',
+            'bitmart',
+            'perpetual',
+            'EX-ENTRY',
+            'POS-STABLE',
+            orderIntent: $intent,
+            withCloseEvent: false,
+        );
+        $this->persistLifecycleEvent('trade-position-close', 'bitmart', 'perpetual', 'EX-ENTRY', 'POS-STABLE', 'order_submitted');
+        $this->persistLegacyLifecycleEvent('client-close-order', 'bitmart', 'perpetual', 'EX-CLOSE', 'POS-STABLE', 'position_closed');
+
+        $page = $this->service->search(
+            LineageReadCriteria::forIdentifier('internal_trade_id', 'trade-position-close', 10, 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame('complete', $page->items[0]['completeness_status']);
+        self::assertSame(['order_submitted', 'position_closed'], array_column($page->items[0]['lifecycle_events'], 'event_type'));
+    }
+
+    public function testLineageDetailMatchesLegacyExchangeOrderWhenClientOrderCaseDiffers(): void
+    {
+        $intent = $this->persistIntent('trade-case');
+
+        $this->persistLineage(
+            'trade-case',
+            'bitmart',
+            'perpetual',
+            'EX-CASE',
+            'POS-CASE',
+            orderIntent: $intent,
+            withCloseEvent: false,
+        );
+        $this->persistLegacyLifecycleEvent('CLIENT-TRADE-CASE', 'bitmart', 'perpetual', 'EX-CASE', null, 'position_closed');
+
+        $page = $this->service->search(
+            LineageReadCriteria::forIdentifier('internal_trade_id', 'trade-case', 10, 0),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame('complete', $page->items[0]['completeness_status']);
+        self::assertSame(['position_closed'], array_column($page->items[0]['lifecycle_events'], 'event_type'));
+    }
+
     public function testRunSearchIsPaginatedAndDeterministicallyOrdered(): void
     {
         $this->persistLineage('trade-1', 'bitmart', 'perpetual', 'EX-1', 'POS-1', 'run-paged');
@@ -158,6 +248,7 @@ final class LineageReadIntegrationTest extends KernelTestCase
         string $orchestrationRunId = 'run-1',
         string $orchestrationSetId = 'set-1',
         ?OrderIntent $orderIntent = null,
+        bool $withCloseEvent = true,
     ): void {
         $lineage = (new TradeLineage($internalTradeId, 'client-' . $internalTradeId, 'BTCUSDT'))
             ->setOrderIntent($orderIntent)
@@ -172,7 +263,82 @@ final class LineageReadIntegrationTest extends KernelTestCase
             ->setOrchestrationSetId($orchestrationSetId)
             ->setOrchestrationDashboardId('dash-1');
 
-        $event = (new TradeLifecycleEvent('BTCUSDT', 'position_closed'))
+        $this->em->persist($lineage);
+        if ($withCloseEvent) {
+            $this->em->persist($this->lifecycleEvent(
+                $internalTradeId,
+                $exchange,
+                $marketType,
+                $exchangeOrderId,
+                $positionId,
+                'position_closed',
+                $orchestrationRunId,
+                $orchestrationSetId,
+            ));
+        }
+        $this->em->flush();
+    }
+
+    private function persistLifecycleEvent(
+        string $internalTradeId,
+        string $exchange,
+        string $marketType,
+        string $exchangeOrderId,
+        string $positionId,
+        string $eventType,
+        string $orchestrationRunId = 'run-1',
+        string $orchestrationSetId = 'set-1',
+    ): void {
+        $this->em->persist($this->lifecycleEvent(
+            $internalTradeId,
+            $exchange,
+            $marketType,
+            $exchangeOrderId,
+            $positionId,
+            $eventType,
+            $orchestrationRunId,
+            $orchestrationSetId,
+        ));
+        $this->em->flush();
+    }
+
+    private function persistLegacyLifecycleEvent(
+        string $clientOrderId,
+        string $exchange,
+        string $marketType,
+        string $exchangeOrderId,
+        ?string $positionId,
+        string $eventType,
+        string $orchestrationRunId = 'run-1',
+        string $orchestrationSetId = 'set-1',
+    ): void {
+        $event = $this->lifecycleEvent(
+            null,
+            $exchange,
+            $marketType,
+            $exchangeOrderId,
+            $positionId,
+            $eventType,
+            $orchestrationRunId,
+            $orchestrationSetId,
+        );
+        $event->setClientOrderId($clientOrderId);
+
+        $this->em->persist($event);
+        $this->em->flush();
+    }
+
+    private function lifecycleEvent(
+        ?string $internalTradeId,
+        string $exchange,
+        string $marketType,
+        string $exchangeOrderId,
+        ?string $positionId,
+        string $eventType,
+        string $orchestrationRunId,
+        string $orchestrationSetId,
+    ): TradeLifecycleEvent {
+        return (new TradeLifecycleEvent('BTCUSDT', $eventType))
             ->setExchange($exchange)
             ->setMarketType($marketType)
             ->setInternalTradeId($internalTradeId)
@@ -181,10 +347,6 @@ final class LineageReadIntegrationTest extends KernelTestCase
             ->setOrchestrationRunId($orchestrationRunId)
             ->setOrchestrationSetId($orchestrationSetId)
             ->setOrchestrationDashboardId('dash-1');
-
-        $this->em->persist($lineage);
-        $this->em->persist($event);
-        $this->em->flush();
     }
 
     private function persistIntent(string $internalTradeId): OrderIntent

--- a/trading-app/tests/Trading/Lineage/LineageReadServiceTest.php
+++ b/trading-app/tests/Trading/Lineage/LineageReadServiceTest.php
@@ -91,6 +91,48 @@ final class LineageReadServiceTest extends TestCase
         self::assertCount(1, $page->items[0]['lifecycle_events']);
     }
 
+    public function testCompletenessUsesCloseEventBeyondFirstLifecyclePage(): void
+    {
+        $lineage = $this->lineage('trade-long-events')
+            ->setOrderIntent($this->intent(50, 'trade-long-events'))
+            ->setExchangeOrderId('EX-LONG')
+            ->setPositionId('POS-LONG');
+
+        $events = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $events[] = $this->event('order_updated', 'trade-long-events');
+        }
+        $events[] = $this->event('position_closed', 'trade-long-events');
+
+        $page = $this->service([$lineage], ['trade-long-events' => $events])->search(
+            LineageReadCriteria::forIdentifier('internal_trade_id', 'trade-long-events', limit: 10, offset: 0),
+        );
+
+        self::assertSame('complete', $page->items[0]['completeness_status']);
+        self::assertSame([], $page->items[0]['quality_flags']);
+        self::assertCount(100, $page->items[0]['lifecycle_events']);
+        self::assertSame(101, $page->items[0]['lifecycle_events_pagination']['total']);
+        self::assertTrue($page->items[0]['lifecycle_events_pagination']['has_more']);
+    }
+
+    public function testEmptyLineagePageKeepsTotalWithoutFallingBackToUnmatched(): void
+    {
+        $lineage = $this->lineage('trade-paged')
+            ->setOrderIntent($this->intent(51, 'trade-paged'))
+            ->setExchangeOrderId('EX-PAGED')
+            ->setPositionId('POS-PAGED');
+
+        $page = $this->service([$lineage], ['trade-paged' => [$this->event('position_closed', 'trade-paged')]])->search(
+            LineageReadCriteria::forIdentifier('orchestration_run_id', 'orun-1', limit: 10, offset: 10),
+        );
+
+        self::assertSame(1, $page->total);
+        self::assertSame(10, $page->limit);
+        self::assertSame(10, $page->offset);
+        self::assertSame([], $page->items);
+        self::assertFalse($page->hasMore);
+    }
+
     public function testIdentifierConflictIsNeverResolvedSilently(): void
     {
         $lineageA = $this->lineage('trade-a')->setExchangeOrderId('EX-1');
@@ -133,10 +175,18 @@ final class LineageReadServiceTest extends TestCase
 
             public function count(LineageReadCriteria $criteria): int
             {
-                return count($this->find($criteria));
+                return count($this->matchingLineages($criteria));
             }
 
             public function find(LineageReadCriteria $criteria): array
+            {
+                return array_slice($this->matchingLineages($criteria), $criteria->offset, $criteria->limit);
+            }
+
+            /**
+             * @return TradeLineage[]
+             */
+            private function matchingLineages(LineageReadCriteria $criteria): array
             {
                 return array_values(array_filter(
                     $this->lineages,
@@ -170,14 +220,25 @@ final class LineageReadServiceTest extends TestCase
                 ));
             }
 
-            public function findEventsForLineage(TradeLineage $lineage, int $limit): array
+            public function findEventsForLineage(TradeLineage $lineage, int $limit, int $offset = 0): array
             {
-                return array_slice($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [], 0, $limit);
+                return array_slice($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [], $offset, $limit);
             }
 
             public function countEventsForLineage(TradeLineage $lineage): int
             {
                 return count($this->eventsByTrade[$lineage->getInternalTradeId()] ?? []);
+            }
+
+            public function hasCloseEventForLineage(TradeLineage $lineage): bool
+            {
+                foreach ($this->eventsByTrade[$lineage->getInternalTradeId()] ?? [] as $event) {
+                    if ($event->getEventType() === 'position_closed') {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         });
     }


### PR DESCRIPTION
Part of #189
Related to #173
Follow-up to #205 after post-merge Codex review feedback.

References PR #199, #201, #202, #203, #204 and #205.

## Changes
- Prevent lifecycle event reads from mixing events that carry a different internal_trade_id when exchange identifiers are reused in the same venue.
- Compute missing_close_event from an unpaginated existence query instead of the first lifecycle event page.
- Apply /events limit/offset to lifecycle events, not to the internal_trade_id lineage lookup.
- Preserve non-zero totals for empty search pages beyond the current offset.
- Document lifecycle event pagination offset.

## Verification
- DATABASE_URL='sqlite:///:memory:' php bin/phpunit tests/Trading/Lineage tests/Trading/Controller/Api/LineageReadApiControllerTest.php --no-coverage
- DATABASE_URL='postgresql://postgres:password@localhost:5436/trading_app?serverVersion=15&charset=utf8' php bin/phpunit --fail-on-skipped tests/Trading/Lineage/LineageReadIntegrationTest.php --no-coverage
- vendor/bin/phpstan analyse src/Repository/TradeLifecycleEventRepository.php src/Trading/Controller/Api/LineageReadApiController.php src/Trading/Lineage/ReadModel/DoctrineLineageReadStore.php src/Trading/Lineage/ReadModel/LineageReadService.php src/Trading/Lineage/ReadModel/LineageReadStoreInterface.php tests/Trading/Controller/Api/LineageReadApiControllerTest.php tests/Trading/Lineage/LineageReadIntegrationTest.php tests/Trading/Lineage/LineageReadServiceTest.php --memory-limit=1G
- php bin/console lint:container --no-debug
- php bin/console lint:yaml config
- git diff --check
