### PR TITLE
Issue 190 - Fill cost ledger core

### DIFF
--- a/docs/handbook/technical/certified-net-pnl-contract.md
+++ b/docs/handbook/technical/certified-net-pnl-contract.md
@@ -59,6 +59,14 @@ Les valeurs numeriques legacy ou provider qui ne sont pas parseables sont traite
 
 Conclusion : seul Fake/Paper peut servir de reference complete dans ce lot. Les providers reels restent `partial` ou `unknown` tant qu'un ledger fill/cout persistant et relie au trade logique n'est pas livre.
 
+## Ledger fills/couts
+
+Le ledger persistant v1 est documente dans `docs/handbook/technical/fill-cost-ledger.md`.
+
+Il introduit la table `fill_cost_ledger`, reliee au trade logique par `internal_trade_id` lorsque le lineage exact est disponible. L'idempotence est portee par `exchange + market_type + exchange_fill_id` quand l'exchange fournit un identifiant de fill, sinon par un identifiant interne deterministe documente.
+
+Les couts absents restent `NULL`. Les rows sans lineage exact restent visibles avec `quality_flags=["missing_lineage"]` et ne doivent pas etre considerees comme net PnL certifie.
+
 ## MFE / MAE
 
 La vue conserve les champs historiques `mfe_pct` et `mae_pct` provenant du listener lifecycle. Leur source actuelle est best-effort via klines 1m (`high/low`) entre ouverture et cloture. Cette source n'est pas une certification microstructure : gaps, donnees manquantes, mark/mid/last et scale-in restent a versionner separement.

--- a/docs/handbook/technical/fill-cost-ledger.md
+++ b/docs/handbook/technical/fill-cost-ledger.md
@@ -63,7 +63,7 @@ If no exchange fill ID exists, the fallback is:
 
 The deterministic fill ID is derived from venue, market type, symbol, order ID, client order ID, fill timestamp, quantity, price, order side, and position side. It never uses symbol and timestamp alone.
 
-Replays with the same payload hash are ignored. A different payload for the same idempotency key raises a conflict and does not update the existing row.
+Replays with the same canonical fill/cost payload hash are ignored. Mutable projection source and late lineage enrichment do not change that canonical hash. If both the existing row and the replay provide non-null lineage identifiers and they differ, ingestion raises a conflict instead of silently moving the fill to another trade. A different payload for the same idempotency key raises a conflict and does not update the existing row.
 
 ## Lineage Resolution
 
@@ -90,4 +90,4 @@ The conversion rate must be finite and strictly positive. If the conversion is m
 
 ## Raw Reference Redaction
 
-`raw_reference` is a compact reference, not a raw provider payload. It may include IDs such as `exchange_fill_id`, `exchange_order_id`, `client_order_id`, or a fixture event ID. Sensitive keys such as `api_key`, `secret`, `token`, `password`, `memo`, and `credentials` are removed.
+`raw_reference` is a compact reference, not a raw provider payload. It may include IDs such as `exchange_fill_id`, `exchange_order_id`, `client_order_id`, or a fixture event ID. Sensitive key variants containing markers such as `apikey`, `secret`, `token`, `password`, `memo`, or `credential` are removed recursively.

--- a/docs/handbook/technical/fill-cost-ledger.md
+++ b/docs/handbook/technical/fill-cost-ledger.md
@@ -86,7 +86,7 @@ A non-USDT fee is converted only when the event metadata or payload includes an 
 {"fee_conversion": {"currency": "BNB", "usdt_rate": 600.0}}
 ```
 
-If the conversion is missing, `fee_usdt` remains `NULL` and `fee_conversion_missing` is added to `quality_flags`.
+The conversion rate must be finite and strictly positive. If the conversion is missing, `fee_usdt` remains `NULL` and `fee_conversion_missing` is added to `quality_flags`. If the conversion rate is invalid, `fee_usdt` remains `NULL` and `fee_conversion_invalid` is added.
 
 ## Raw Reference Redaction
 

--- a/docs/handbook/technical/fill-cost-ledger.md
+++ b/docs/handbook/technical/fill-cost-ledger.md
@@ -1,0 +1,93 @@
+# Fill and Cost Ledger v1
+
+This document describes the first persistent ledger for exchange-neutral fills and costs. It is part of #190 and depends on the certified net PnL contract delivered before it.
+
+## Scope
+
+The ledger persists normalized fill and cost facts in `fill_cost_ledger`. It is append-only for normal ingestion: a repeated event with the same idempotency key is treated as a replay, while the same key with a different payload is rejected as a conflict.
+
+This first version uses Fake/Paper as the deterministic reference source. Real exchanges may produce normalized `ExchangeFillReceived` events, but this PR does not certify Bitmart, OKX, or Hyperliquid net PnL.
+
+## Stored Fields
+
+Each row stores the exact identifiers available at ingestion time:
+
+- `internal_trade_id`
+- `internal_position_id`
+- `position_id`
+- `exchange`
+- `market_type`
+- `symbol`
+- `side`
+- `fill_id`
+- `exchange_fill_id`
+- `exchange_order_id`
+- `client_order_id`
+- `order_intent_id`
+- `fill_role`
+- `liquidity_role`
+- `price`
+- `quantity`
+- `notional`
+- `fee_amount`
+- `fee_currency`
+- `fee_usdt`
+- `funding_usdt`
+- `spread_cost_usdt`
+- `slippage_cost_usdt`
+- `borrow_cost_usdt`
+- `liquidation_fee_usdt`
+- `occurred_at`
+- `source`
+- `source_version`
+- `quality_flags`
+- `raw_reference`
+
+Unknown costs remain `NULL`. They are not converted to zero unless the source explicitly reports zero or a deterministic fixture states that the cost is not applicable.
+
+## Idempotency
+
+The exact idempotency key is:
+
+```text
+{exchange}:{market_type}:exchange_fill:{exchange_fill_id}
+```
+
+when `exchange_fill_id` is present.
+
+If no exchange fill ID exists, the fallback is:
+
+```text
+{exchange}:{market_type}:internal:{deterministic_fill_id}
+```
+
+The deterministic fill ID is derived from venue, market type, symbol, order ID, client order ID, fill timestamp, quantity, price, order side, and position side. It never uses symbol and timestamp alone.
+
+Replays with the same payload hash are ignored. A different payload for the same idempotency key raises a conflict and does not update the existing row.
+
+## Lineage Resolution
+
+`FillCostLedgerIngestionService` resolves lineage in this order:
+
+1. `internal_trade_id` from normalized fill metadata or event payload;
+2. exact `client_order_id` in the same `exchange + market_type`;
+3. exact `exchange_order_id` in the same `exchange + market_type`;
+4. exact `position_id` in the same `exchange + market_type` when present.
+
+There is no fallback by symbol alone and no timestamp-window matching. If no lineage is found, the row is still persisted with `quality_flags=["missing_lineage"]`.
+
+## Fee Conversion
+
+USDT fees are copied to `fee_usdt`.
+
+A non-USDT fee is converted only when the event metadata or payload includes an explicit conversion:
+
+```json
+{"fee_conversion": {"currency": "BNB", "usdt_rate": 600.0}}
+```
+
+If the conversion is missing, `fee_usdt` remains `NULL` and `fee_conversion_missing` is added to `quality_flags`.
+
+## Raw Reference Redaction
+
+`raw_reference` is a compact reference, not a raw provider payload. It may include IDs such as `exchange_fill_id`, `exchange_order_id`, `client_order_id`, or a fixture event ID. Sensitive keys such as `api_key`, `secret`, `token`, `password`, `memo`, and `credentials` are removed.

--- a/docs/handbook/technical/fill-cost-ledger.md
+++ b/docs/handbook/technical/fill-cost-ledger.md
@@ -78,7 +78,7 @@ There is no fallback by symbol alone and no timestamp-window matching. If no lin
 
 ## Fee Conversion
 
-USDT fees are copied to `fee_usdt`.
+`fee_amount` preserves the provider-reported amount for audit, including provider sign conventions. `fee_usdt` stores the normalized USDT cost used by certification and is non-negative; provider-signed charged fees such as `-0.02 USDT` are stored as `fee_amount=-0.020000000000` and `fee_usdt=0.020000000000`.
 
 A non-USDT fee is converted only when the event metadata or payload includes an explicit conversion:
 

--- a/docs/handbook/technical/fill-cost-ledger.md
+++ b/docs/handbook/technical/fill-cost-ledger.md
@@ -74,7 +74,7 @@ Replays with the same canonical fill/cost payload hash are ignored. Mutable proj
 3. exact `exchange_order_id` in the same `exchange + market_type`;
 4. exact `position_id` in the same `exchange + market_type` when present.
 
-There is no fallback by symbol alone and no timestamp-window matching. If no lineage is found, the row is still persisted with `quality_flags=["missing_lineage"]`.
+When a higher-priority identifier is present but unmatched, the resolver continues to the next exact identifier. There is no fallback by symbol alone and no timestamp-window matching. If no lineage is found, the row is still persisted with `quality_flags=["missing_lineage"]`.
 
 ## Fee Conversion
 

--- a/trading-app/migrations/Version20260625010000.php
+++ b/trading-app/migrations/Version20260625010000.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260625010000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'DATA-002: create exchange-neutral fill and cost ledger';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+CREATE TABLE fill_cost_ledger (
+    id BIGSERIAL NOT NULL,
+    idempotency_key VARCHAR(255) NOT NULL,
+    payload_hash VARCHAR(64) NOT NULL,
+    internal_trade_id VARCHAR(96) DEFAULT NULL,
+    internal_position_id VARCHAR(96) DEFAULT NULL,
+    position_id VARCHAR(96) DEFAULT NULL,
+    exchange VARCHAR(32) NOT NULL,
+    market_type VARCHAR(32) NOT NULL,
+    symbol VARCHAR(50) NOT NULL,
+    side VARCHAR(16) DEFAULT NULL,
+    fill_id VARCHAR(128) NOT NULL,
+    exchange_fill_id VARCHAR(128) DEFAULT NULL,
+    exchange_order_id VARCHAR(96) DEFAULT NULL,
+    client_order_id VARCHAR(96) DEFAULT NULL,
+    order_intent_id BIGINT DEFAULT NULL,
+    fill_role VARCHAR(24) NOT NULL,
+    liquidity_role VARCHAR(24) NOT NULL,
+    price NUMERIC(30, 12) DEFAULT NULL,
+    quantity NUMERIC(30, 12) DEFAULT NULL,
+    notional NUMERIC(30, 12) DEFAULT NULL,
+    fee_amount NUMERIC(30, 12) DEFAULT NULL,
+    fee_currency VARCHAR(20) DEFAULT NULL,
+    fee_usdt NUMERIC(30, 12) DEFAULT NULL,
+    funding_usdt NUMERIC(30, 12) DEFAULT NULL,
+    spread_cost_usdt NUMERIC(30, 12) DEFAULT NULL,
+    slippage_cost_usdt NUMERIC(30, 12) DEFAULT NULL,
+    borrow_cost_usdt NUMERIC(30, 12) DEFAULT NULL,
+    liquidation_fee_usdt NUMERIC(30, 12) DEFAULT NULL,
+    occurred_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    source VARCHAR(64) NOT NULL,
+    source_version VARCHAR(64) NOT NULL,
+    quality_flags JSONB NOT NULL,
+    raw_reference JSONB NOT NULL,
+    created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+    PRIMARY KEY(id)
+)
+SQL);
+        $this->addSql('CREATE UNIQUE INDEX ux_fill_cost_ledger_idempotency ON fill_cost_ledger (idempotency_key)');
+        $this->addSql('CREATE INDEX idx_fill_cost_ledger_internal_trade ON fill_cost_ledger (internal_trade_id, occurred_at, id)');
+        $this->addSql('CREATE INDEX idx_fill_cost_ledger_internal_position ON fill_cost_ledger (internal_position_id)');
+        $this->addSql('CREATE INDEX idx_fill_cost_ledger_position ON fill_cost_ledger (exchange, market_type, position_id)');
+        $this->addSql('CREATE INDEX idx_fill_cost_ledger_venue_fill ON fill_cost_ledger (exchange, market_type, exchange_fill_id)');
+        $this->addSql('CREATE INDEX idx_fill_cost_ledger_venue_order ON fill_cost_ledger (exchange, market_type, exchange_order_id)');
+        $this->addSql('CREATE INDEX idx_fill_cost_ledger_client_order ON fill_cost_ledger (exchange, market_type, client_order_id)');
+        $this->addSql('CREATE INDEX idx_fill_cost_ledger_order_intent ON fill_cost_ledger (order_intent_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS fill_cost_ledger');
+    }
+}

--- a/trading-app/src/Entity/FillCostLedgerEntry.php
+++ b/trading-app/src/Entity/FillCostLedgerEntry.php
@@ -1,0 +1,520 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Repository\FillCostLedgerEntryRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: FillCostLedgerEntryRepository::class)]
+#[ORM\Table(name: 'fill_cost_ledger')]
+#[ORM\UniqueConstraint(name: 'ux_fill_cost_ledger_idempotency', columns: ['idempotency_key'])]
+#[ORM\Index(name: 'idx_fill_cost_ledger_internal_trade', columns: ['internal_trade_id', 'occurred_at', 'id'])]
+#[ORM\Index(name: 'idx_fill_cost_ledger_internal_position', columns: ['internal_position_id'])]
+#[ORM\Index(name: 'idx_fill_cost_ledger_position', columns: ['exchange', 'market_type', 'position_id'])]
+#[ORM\Index(name: 'idx_fill_cost_ledger_venue_fill', columns: ['exchange', 'market_type', 'exchange_fill_id'])]
+#[ORM\Index(name: 'idx_fill_cost_ledger_venue_order', columns: ['exchange', 'market_type', 'exchange_order_id'])]
+#[ORM\Index(name: 'idx_fill_cost_ledger_client_order', columns: ['exchange', 'market_type', 'client_order_id'])]
+#[ORM\Index(name: 'idx_fill_cost_ledger_order_intent', columns: ['order_intent_id'])]
+final class FillCostLedgerEntry
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'idempotency_key', type: Types::STRING, length: 255)]
+    private string $idempotencyKey;
+
+    #[ORM\Column(name: 'payload_hash', type: Types::STRING, length: 64)]
+    private string $payloadHash;
+
+    #[ORM\Column(name: 'internal_trade_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $internalTradeId = null;
+
+    #[ORM\Column(name: 'internal_position_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $internalPositionId = null;
+
+    #[ORM\Column(name: 'position_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $positionId = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32)]
+    private string $exchange;
+
+    #[ORM\Column(name: 'market_type', type: Types::STRING, length: 32)]
+    private string $marketType;
+
+    #[ORM\Column(type: Types::STRING, length: 50)]
+    private string $symbol;
+
+    #[ORM\Column(type: Types::STRING, length: 16, nullable: true)]
+    private ?string $side = null;
+
+    #[ORM\Column(name: 'fill_id', type: Types::STRING, length: 128)]
+    private string $fillId;
+
+    #[ORM\Column(name: 'exchange_fill_id', type: Types::STRING, length: 128, nullable: true)]
+    private ?string $exchangeFillId = null;
+
+    #[ORM\Column(name: 'exchange_order_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $exchangeOrderId = null;
+
+    #[ORM\Column(name: 'client_order_id', type: Types::STRING, length: 96, nullable: true)]
+    private ?string $clientOrderId = null;
+
+    #[ORM\Column(name: 'order_intent_id', type: Types::BIGINT, nullable: true)]
+    private ?int $orderIntentId = null;
+
+    #[ORM\Column(name: 'fill_role', type: Types::STRING, length: 24)]
+    private string $fillRole;
+
+    #[ORM\Column(name: 'liquidity_role', type: Types::STRING, length: 24)]
+    private string $liquidityRole = 'unknown';
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $price = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $quantity = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $notional = null;
+
+    #[ORM\Column(name: 'fee_amount', type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $feeAmount = null;
+
+    #[ORM\Column(name: 'fee_currency', type: Types::STRING, length: 20, nullable: true)]
+    private ?string $feeCurrency = null;
+
+    #[ORM\Column(name: 'fee_usdt', type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $feeUsdt = null;
+
+    #[ORM\Column(name: 'funding_usdt', type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $fundingUsdt = null;
+
+    #[ORM\Column(name: 'spread_cost_usdt', type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $spreadCostUsdt = null;
+
+    #[ORM\Column(name: 'slippage_cost_usdt', type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $slippageCostUsdt = null;
+
+    #[ORM\Column(name: 'borrow_cost_usdt', type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $borrowCostUsdt = null;
+
+    #[ORM\Column(name: 'liquidation_fee_usdt', type: Types::DECIMAL, precision: 30, scale: 12, nullable: true)]
+    private ?string $liquidationFeeUsdt = null;
+
+    #[ORM\Column(name: 'occurred_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $occurredAt;
+
+    #[ORM\Column(type: Types::STRING, length: 64)]
+    private string $source;
+
+    #[ORM\Column(name: 'source_version', type: Types::STRING, length: 64)]
+    private string $sourceVersion;
+
+    /** @var list<string> */
+    #[ORM\Column(name: 'quality_flags', type: Types::JSON, options: ['jsonb' => true])]
+    private array $qualityFlags = [];
+
+    /** @var array<string,mixed> */
+    #[ORM\Column(name: 'raw_reference', type: Types::JSON, options: ['jsonb' => true])]
+    private array $rawReference = [];
+
+    #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(
+        string $idempotencyKey,
+        string $payloadHash,
+        Exchange|string $exchange,
+        MarketType|string $marketType,
+        string $symbol,
+        string $fillId,
+        string $fillRole,
+        \DateTimeImmutable $occurredAt,
+        string $source,
+        string $sourceVersion,
+    ) {
+        $this->idempotencyKey = self::requireNonBlank($idempotencyKey, 'idempotencyKey');
+        $this->payloadHash = self::requireNonBlank($payloadHash, 'payloadHash');
+        $this->exchange = $exchange instanceof Exchange ? $exchange->value : strtolower(self::requireNonBlank($exchange, 'exchange'));
+        $this->marketType = $marketType instanceof MarketType ? $marketType->value : strtolower(self::requireNonBlank($marketType, 'marketType'));
+        $this->symbol = strtoupper(self::requireNonBlank($symbol, 'symbol'));
+        $this->fillId = self::requireNonBlank($fillId, 'fillId');
+        $this->fillRole = strtolower(self::requireNonBlank($fillRole, 'fillRole'));
+        $this->occurredAt = $occurredAt;
+        $this->source = self::requireNonBlank($source, 'source');
+        $this->sourceVersion = self::requireNonBlank($sourceVersion, 'sourceVersion');
+        $this->createdAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getIdempotencyKey(): string
+    {
+        return $this->idempotencyKey;
+    }
+
+    public function getPayloadHash(): string
+    {
+        return $this->payloadHash;
+    }
+
+    public function getInternalTradeId(): ?string
+    {
+        return $this->internalTradeId;
+    }
+
+    public function setInternalTradeId(?string $internalTradeId): self
+    {
+        $this->internalTradeId = self::blankToNull($internalTradeId);
+
+        return $this;
+    }
+
+    public function getInternalPositionId(): ?string
+    {
+        return $this->internalPositionId;
+    }
+
+    public function setInternalPositionId(?string $internalPositionId): self
+    {
+        $this->internalPositionId = self::blankToNull($internalPositionId);
+
+        return $this;
+    }
+
+    public function getPositionId(): ?string
+    {
+        return $this->positionId;
+    }
+
+    public function setPositionId(?string $positionId): self
+    {
+        $this->positionId = self::blankToNull($positionId);
+
+        return $this;
+    }
+
+    public function getExchange(): string
+    {
+        return $this->exchange;
+    }
+
+    public function getMarketType(): string
+    {
+        return $this->marketType;
+    }
+
+    public function getSymbol(): string
+    {
+        return $this->symbol;
+    }
+
+    public function getSide(): ?string
+    {
+        return $this->side;
+    }
+
+    public function setSide(?string $side): self
+    {
+        $this->side = self::blankToNull($side !== null ? strtoupper($side) : null);
+
+        return $this;
+    }
+
+    public function getFillId(): string
+    {
+        return $this->fillId;
+    }
+
+    public function getExchangeFillId(): ?string
+    {
+        return $this->exchangeFillId;
+    }
+
+    public function setExchangeFillId(?string $exchangeFillId): self
+    {
+        $this->exchangeFillId = self::blankToNull($exchangeFillId);
+
+        return $this;
+    }
+
+    public function getExchangeOrderId(): ?string
+    {
+        return $this->exchangeOrderId;
+    }
+
+    public function setExchangeOrderId(?string $exchangeOrderId): self
+    {
+        $this->exchangeOrderId = self::blankToNull($exchangeOrderId);
+
+        return $this;
+    }
+
+    public function getClientOrderId(): ?string
+    {
+        return $this->clientOrderId;
+    }
+
+    public function setClientOrderId(?string $clientOrderId): self
+    {
+        $this->clientOrderId = self::blankToNull($clientOrderId);
+
+        return $this;
+    }
+
+    public function getOrderIntentId(): ?int
+    {
+        return $this->orderIntentId;
+    }
+
+    public function setOrderIntentId(?int $orderIntentId): self
+    {
+        $this->orderIntentId = $orderIntentId;
+
+        return $this;
+    }
+
+    public function getFillRole(): string
+    {
+        return $this->fillRole;
+    }
+
+    public function getLiquidityRole(): string
+    {
+        return $this->liquidityRole;
+    }
+
+    public function setLiquidityRole(string $liquidityRole): self
+    {
+        $role = strtolower(trim($liquidityRole));
+        $this->liquidityRole = \in_array($role, ['maker', 'taker', 'unknown'], true) ? $role : 'unknown';
+
+        return $this;
+    }
+
+    public function getPrice(): ?string
+    {
+        return $this->price;
+    }
+
+    public function setPrice(?string $price): self
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    public function getQuantity(): ?string
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(?string $quantity): self
+    {
+        $this->quantity = $quantity;
+
+        return $this;
+    }
+
+    public function getNotional(): ?string
+    {
+        return $this->notional;
+    }
+
+    public function setNotional(?string $notional): self
+    {
+        $this->notional = $notional;
+
+        return $this;
+    }
+
+    public function getFeeAmount(): ?string
+    {
+        return $this->feeAmount;
+    }
+
+    public function setFeeAmount(?string $feeAmount): self
+    {
+        $this->feeAmount = $feeAmount;
+
+        return $this;
+    }
+
+    public function getFeeCurrency(): ?string
+    {
+        return $this->feeCurrency;
+    }
+
+    public function setFeeCurrency(?string $feeCurrency): self
+    {
+        $this->feeCurrency = self::blankToNull($feeCurrency !== null ? strtoupper($feeCurrency) : null);
+
+        return $this;
+    }
+
+    public function getFeeUsdt(): ?string
+    {
+        return $this->feeUsdt;
+    }
+
+    public function setFeeUsdt(?string $feeUsdt): self
+    {
+        $this->feeUsdt = $feeUsdt;
+
+        return $this;
+    }
+
+    public function getFundingUsdt(): ?string
+    {
+        return $this->fundingUsdt;
+    }
+
+    public function setFundingUsdt(?string $fundingUsdt): self
+    {
+        $this->fundingUsdt = $fundingUsdt;
+
+        return $this;
+    }
+
+    public function getSpreadCostUsdt(): ?string
+    {
+        return $this->spreadCostUsdt;
+    }
+
+    public function setSpreadCostUsdt(?string $spreadCostUsdt): self
+    {
+        $this->spreadCostUsdt = $spreadCostUsdt;
+
+        return $this;
+    }
+
+    public function getSlippageCostUsdt(): ?string
+    {
+        return $this->slippageCostUsdt;
+    }
+
+    public function setSlippageCostUsdt(?string $slippageCostUsdt): self
+    {
+        $this->slippageCostUsdt = $slippageCostUsdt;
+
+        return $this;
+    }
+
+    public function getBorrowCostUsdt(): ?string
+    {
+        return $this->borrowCostUsdt;
+    }
+
+    public function setBorrowCostUsdt(?string $borrowCostUsdt): self
+    {
+        $this->borrowCostUsdt = $borrowCostUsdt;
+
+        return $this;
+    }
+
+    public function getLiquidationFeeUsdt(): ?string
+    {
+        return $this->liquidationFeeUsdt;
+    }
+
+    public function setLiquidationFeeUsdt(?string $liquidationFeeUsdt): self
+    {
+        $this->liquidationFeeUsdt = $liquidationFeeUsdt;
+
+        return $this;
+    }
+
+    public function getOccurredAt(): \DateTimeImmutable
+    {
+        return $this->occurredAt;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function getSourceVersion(): string
+    {
+        return $this->sourceVersion;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getQualityFlags(): array
+    {
+        return $this->qualityFlags;
+    }
+
+    /**
+     * @param list<string> $qualityFlags
+     */
+    public function setQualityFlags(array $qualityFlags): self
+    {
+        $flags = [];
+        foreach ($qualityFlags as $flag) {
+            if (\is_string($flag) && trim($flag) !== '') {
+                $flags[] = strtolower(trim($flag));
+            }
+        }
+
+        $this->qualityFlags = array_values(array_unique($flags));
+
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getRawReference(): array
+    {
+        return $this->rawReference;
+    }
+
+    /**
+     * @param array<string,mixed> $rawReference
+     */
+    public function setRawReference(array $rawReference): self
+    {
+        $this->rawReference = $rawReference;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    private static function requireNonBlank(string $value, string $field): string
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            throw new \InvalidArgumentException(sprintf('%s is required.', $field));
+        }
+
+        return $trimmed;
+    }
+
+    private static function blankToNull(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
+++ b/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
@@ -16,6 +16,7 @@ use App\MtfRunner\Service\FuturesOrderSyncService;
 use App\Provider\Context\ExchangeContext;
 use App\Repository\FuturesOrderRepository;
 use App\Repository\PositionRepository;
+use App\Trading\Pnl\FillCostLedgerIngestionService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 
@@ -27,6 +28,7 @@ final readonly class DoctrineExchangeLocalProjectionStore implements ExchangeLoc
         private FuturesOrderRepository $orders,
         private PositionRepository $positions,
         private EntityManagerInterface $entityManager,
+        private FillCostLedgerIngestionService $fillCostLedger,
     ) {
     }
 
@@ -78,6 +80,7 @@ final readonly class DoctrineExchangeLocalProjectionStore implements ExchangeLoc
 
         if ($event instanceof ExchangeFillReceived) {
             $this->orderSync->syncTradeFromApi($this->fillPayload($event->fill(), $event));
+            $this->fillCostLedger->ingestExchangeFill($event);
             return;
         }
 

--- a/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
+++ b/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
@@ -79,8 +79,8 @@ final readonly class DoctrineExchangeLocalProjectionStore implements ExchangeLoc
         }
 
         if ($event instanceof ExchangeFillReceived) {
-            $this->orderSync->syncTradeFromApi($this->fillPayload($event->fill(), $event));
             $this->fillCostLedger->ingestExchangeFill($event);
+            $this->orderSync->syncTradeFromApi($this->fillPayload($event->fill(), $event));
             return;
         }
 

--- a/trading-app/src/Repository/FillCostLedgerEntryRepository.php
+++ b/trading-app/src/Repository/FillCostLedgerEntryRepository.php
@@ -11,7 +11,7 @@ use Doctrine\Persistence\ManagerRegistry;
 /**
  * @extends ServiceEntityRepository<FillCostLedgerEntry>
  */
-final class FillCostLedgerEntryRepository extends ServiceEntityRepository
+class FillCostLedgerEntryRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {

--- a/trading-app/src/Repository/FillCostLedgerEntryRepository.php
+++ b/trading-app/src/Repository/FillCostLedgerEntryRepository.php
@@ -6,21 +6,41 @@ namespace App\Repository;
 
 use App\Entity\FillCostLedgerEntry;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use RuntimeException;
 
 /**
  * @extends ServiceEntityRepository<FillCostLedgerEntry>
  */
 class FillCostLedgerEntryRepository extends ServiceEntityRepository
 {
-    public function __construct(ManagerRegistry $registry)
+    public function __construct(private ManagerRegistry $registry)
     {
-        parent::__construct($registry, FillCostLedgerEntry::class);
+        parent::__construct($this->registry, FillCostLedgerEntry::class);
     }
 
     public function findOneByIdempotencyKey(string $idempotencyKey): ?FillCostLedgerEntry
     {
         return $this->findOneBy(['idempotencyKey' => $idempotencyKey]);
+    }
+
+    public function resetManagerAndFindOneByIdempotencyKey(string $idempotencyKey): ?FillCostLedgerEntry
+    {
+        $this->registry->resetManager();
+        $manager = $this->registry->getManagerForClass(FillCostLedgerEntry::class);
+        if (!$manager instanceof EntityManagerInterface) {
+            throw new RuntimeException('Could not reset the fill-cost ledger entity manager.');
+        }
+
+        return $manager->createQueryBuilder()
+            ->select('entry')
+            ->from(FillCostLedgerEntry::class, 'entry')
+            ->andWhere('entry.idempotencyKey = :idempotencyKey')
+            ->setParameter('idempotencyKey', $idempotencyKey)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
     /**

--- a/trading-app/src/Repository/FillCostLedgerEntryRepository.php
+++ b/trading-app/src/Repository/FillCostLedgerEntryRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\FillCostLedgerEntry;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FillCostLedgerEntry>
+ */
+final class FillCostLedgerEntryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FillCostLedgerEntry::class);
+    }
+
+    public function findOneByIdempotencyKey(string $idempotencyKey): ?FillCostLedgerEntry
+    {
+        return $this->findOneBy(['idempotencyKey' => $idempotencyKey]);
+    }
+
+    /**
+     * @return FillCostLedgerEntry[]
+     */
+    public function findByInternalTradeId(string $internalTradeId): array
+    {
+        return $this->createQueryBuilder('entry')
+            ->andWhere('entry.internalTradeId = :internalTradeId')
+            ->setParameter('internalTradeId', $internalTradeId)
+            ->orderBy('entry.occurredAt', 'ASC')
+            ->addOrderBy('entry.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function save(FillCostLedgerEntry $entry): void
+    {
+        $this->getEntityManager()->persist($entry);
+        $this->getEntityManager()->flush();
+    }
+}

--- a/trading-app/src/Trading/Lineage/TradeLineageManager.php
+++ b/trading-app/src/Trading/Lineage/TradeLineageManager.php
@@ -126,22 +126,34 @@ final class TradeLineageManager
 
         $internalTradeId = $this->normalize($internalTradeId);
         if ($internalTradeId !== null) {
-            return $this->repository->findOneByInternalTradeId($internalTradeId);
+            $lineage = $this->repository->findOneByInternalTradeId($internalTradeId);
+            if ($lineage instanceof TradeLineage) {
+                return $lineage;
+            }
         }
 
         $clientOrderId = $this->normalize($clientOrderId);
         if ($clientOrderId !== null) {
-            return $this->repository->findOneByClientOrderId($clientOrderId, $context);
+            $lineage = $this->repository->findOneByClientOrderId($clientOrderId, $context);
+            if ($lineage instanceof TradeLineage) {
+                return $lineage;
+            }
         }
 
         $exchangeOrderId = $this->normalize($exchangeOrderId);
         if ($exchangeOrderId !== null) {
-            return $this->repository->findOneByExchangeOrderId($exchangeOrderId, $context);
+            $lineage = $this->repository->findOneByExchangeOrderId($exchangeOrderId, $context);
+            if ($lineage instanceof TradeLineage) {
+                return $lineage;
+            }
         }
 
         $positionId = $this->normalize($positionId);
         if ($positionId !== null) {
-            return $this->repository->findOneByPositionId($positionId, $context);
+            $lineage = $this->repository->findOneByPositionId($positionId, $context);
+            if ($lineage instanceof TradeLineage) {
+                return $lineage;
+            }
         }
 
         return null;

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionConflict.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionConflict.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Pnl;
+
+final class FillCostLedgerIngestionConflict extends \RuntimeException
+{
+}

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionResult.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Pnl;
+
+use App\Entity\FillCostLedgerEntry;
+
+final readonly class FillCostLedgerIngestionResult
+{
+    public function __construct(
+        public FillCostLedgerEntry $entry,
+        public bool $inserted,
+        public bool $replayed,
+        public ?string $conflictReason = null,
+    ) {
+    }
+}

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
@@ -212,7 +212,7 @@ final readonly class FillCostLedgerIngestionService
         try {
             $this->ledger->save($entry);
         } catch (UniqueConstraintViolationException) {
-            $concurrent = $this->ledger->findOneByIdempotencyKey($idempotencyKey);
+            $concurrent = $this->ledger->resetManagerAndFindOneByIdempotencyKey($idempotencyKey);
             if ($concurrent instanceof FillCostLedgerEntry && $concurrent->getPayloadHash() === $payloadHash) {
                 return new FillCostLedgerIngestionResult($concurrent, inserted: false, replayed: true);
             }

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
@@ -20,7 +20,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 final readonly class FillCostLedgerIngestionService
 {
     private const SOURCE_VERSION = 'fill_cost_ledger_v1';
-    private const SENSITIVE_KEYS = ['api_key', 'apikey', 'secret', 'token', 'password', 'memo', 'credentials'];
+    private const SENSITIVE_KEY_MARKERS = ['apikey', 'secret', 'token', 'password', 'memo', 'credential'];
 
     public function __construct(
         private FillCostLedgerEntryRepository $ledger,
@@ -165,6 +165,13 @@ final readonly class FillCostLedgerIngestionService
         $existing = $this->ledger->findOneByIdempotencyKey($idempotencyKey);
         if ($existing instanceof FillCostLedgerEntry) {
             if ($existing->getPayloadHash() === $payloadHash) {
+                if ($this->lineageConflicts($existing, $snapshot)) {
+                    throw new FillCostLedgerIngestionConflict(sprintf(
+                        'Conflicting fill-cost ledger lineage for idempotency key "%s".',
+                        $idempotencyKey,
+                    ));
+                }
+
                 return new FillCostLedgerIngestionResult($existing, inserted: false, replayed: true);
             }
 
@@ -214,6 +221,13 @@ final readonly class FillCostLedgerIngestionService
         } catch (UniqueConstraintViolationException) {
             $concurrent = $this->ledger->resetManagerAndFindOneByIdempotencyKey($idempotencyKey);
             if ($concurrent instanceof FillCostLedgerEntry && $concurrent->getPayloadHash() === $payloadHash) {
+                if ($this->lineageConflicts($concurrent, $snapshot)) {
+                    throw new FillCostLedgerIngestionConflict(sprintf(
+                        'Conflicting fill-cost ledger lineage for idempotency key "%s".',
+                        $idempotencyKey,
+                    ));
+                }
+
                 return new FillCostLedgerIngestionResult($concurrent, inserted: false, replayed: true);
             }
 
@@ -343,8 +357,7 @@ final readonly class FillCostLedgerIngestionService
     {
         $redacted = [];
         foreach ($reference as $key => $value) {
-            $normalized = strtolower((string) $key);
-            if (\in_array($normalized, self::SENSITIVE_KEYS, true)) {
+            if ($this->isSensitiveReferenceKey((string) $key)) {
                 continue;
             }
             if (\is_array($value)) {
@@ -355,6 +368,44 @@ final readonly class FillCostLedgerIngestionService
         }
 
         return $redacted;
+    }
+
+    private function isSensitiveReferenceKey(string $key): bool
+    {
+        $normalized = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '', $key));
+        foreach (self::SENSITIVE_KEY_MARKERS as $marker) {
+            if (str_contains($normalized, $marker)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    private function lineageConflicts(FillCostLedgerEntry $existing, array $snapshot): bool
+    {
+        $pairs = [
+            [$existing->getInternalTradeId(), $this->string($snapshot['internal_trade_id'] ?? null)],
+            [$existing->getInternalPositionId(), $this->string($snapshot['internal_position_id'] ?? null)],
+            [$existing->getPositionId(), $this->string($snapshot['position_id'] ?? null)],
+            [
+                $existing->getOrderIntentId() !== null ? (string) $existing->getOrderIntentId() : null,
+                isset($snapshot['order_intent_id']) && \is_scalar($snapshot['order_intent_id'])
+                    ? $this->string($snapshot['order_intent_id'])
+                    : null,
+            ],
+        ];
+
+        foreach ($pairs as [$existingValue, $incomingValue]) {
+            if ($existingValue !== null && $incomingValue !== null && $existingValue !== $incomingValue) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
@@ -285,14 +285,14 @@ final readonly class FillCostLedgerIngestionService
         }
 
         if (strtoupper($currency) === 'USDT') {
-            return $this->decimal($fill->fee);
+            return $this->decimal(abs($fill->fee));
         }
 
         $conversion = $metadata['fee_conversion'] ?? $payload['fee_conversion'] ?? null;
         if (\is_array($conversion) && isset($conversion['usdt_rate']) && is_numeric($conversion['usdt_rate'])) {
             $conversionCurrency = $this->string($conversion['currency'] ?? null);
             if ($conversionCurrency === null || strtoupper($conversionCurrency) === strtoupper($currency)) {
-                return $this->decimal($fill->fee * (float) $conversion['usdt_rate']);
+                return $this->decimal(abs($fill->fee) * (float) $conversion['usdt_rate']);
             }
         }
 

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Pnl;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Entity\FillCostLedgerEntry;
+use App\Entity\TradeLineage;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Provider\Context\ExchangeContext;
+use App\Repository\FillCostLedgerEntryRepository;
+use App\Trading\Lineage\TradeLineageManager;
+
+final readonly class FillCostLedgerIngestionService
+{
+    private const SOURCE_VERSION = 'fill_cost_ledger_v1';
+    private const SENSITIVE_KEYS = ['api_key', 'apikey', 'secret', 'token', 'password', 'memo', 'credentials'];
+
+    public function __construct(
+        private FillCostLedgerEntryRepository $ledger,
+        private TradeLineageManager $lineageManager,
+    ) {
+    }
+
+    public function ingestExchangeFill(ExchangeFillReceived $event): FillCostLedgerIngestionResult
+    {
+        $fill = $event->fill();
+        $metadata = $fill->metadata;
+        $payload = $event->payload();
+        $exchangeFillId = $this->string($fill->fillId);
+        $fillId = $exchangeFillId ?? $this->deterministicFillId($fill);
+        $idempotencyKey = $exchangeFillId !== null
+            ? sprintf('%s:%s:exchange_fill:%s', $fill->exchange->value, $fill->marketType->value, $exchangeFillId)
+            : sprintf('%s:%s:internal:%s', $fill->exchange->value, $fill->marketType->value, $fillId);
+
+        $lineage = $this->resolveLineage($fill, $metadata, $payload);
+        $qualityFlags = [];
+        $internalTradeId = $lineage?->getInternalTradeId() ?? $this->string($metadata['internal_trade_id'] ?? $payload['internal_trade_id'] ?? null);
+        if (!$lineage instanceof TradeLineage) {
+            $qualityFlags[] = 'missing_lineage';
+        }
+
+        $fee = $fill->fee !== null ? $this->decimal($fill->fee) : null;
+        $feeCurrency = $this->string($fill->feeCurrency);
+        $feeCurrency = $feeCurrency !== null ? strtoupper($feeCurrency) : null;
+        $feeUsdt = $this->feeUsdt($fill, $metadata, $payload, $qualityFlags);
+        $source = $this->source($metadata, $payload);
+        $sourceVersion = $this->string($metadata['source_version'] ?? $payload['source_version'] ?? null)
+            ?? $this->string($metadata['pnl_source'] ?? $payload['pnl_source'] ?? null)
+            ?? self::SOURCE_VERSION;
+
+        $snapshot = [
+            'internal_trade_id' => $internalTradeId,
+            'internal_position_id' => $lineage?->getInternalPositionId() ?? $this->string($metadata['internal_position_id'] ?? $payload['internal_position_id'] ?? null),
+            'position_id' => $lineage?->getPositionId() ?? $this->string($metadata['position_id'] ?? $payload['position_id'] ?? $metadata['exchange_position_id'] ?? $payload['exchange_position_id'] ?? null),
+            'exchange' => $fill->exchange->value,
+            'market_type' => $fill->marketType->value,
+            'symbol' => strtoupper($fill->symbol),
+            'side' => strtoupper($fill->side->name),
+            'fill_id' => $fillId,
+            'exchange_fill_id' => $exchangeFillId,
+            'exchange_order_id' => $fill->exchangeOrderId,
+            'client_order_id' => $fill->clientOrderId,
+            'order_intent_id' => $lineage?->getOrderIntent()?->getId(),
+            'fill_role' => $this->fillRole($fill),
+            'liquidity_role' => $this->liquidityRole($metadata, $payload),
+            'price' => $this->decimal($fill->price),
+            'quantity' => $this->decimal($fill->quantity),
+            'notional' => $this->decimal($fill->price * $fill->quantity),
+            'fee_amount' => $fee,
+            'fee_currency' => $feeCurrency,
+            'fee_usdt' => $feeUsdt,
+            'funding_usdt' => null,
+            'spread_cost_usdt' => null,
+            'slippage_cost_usdt' => null,
+            'borrow_cost_usdt' => null,
+            'liquidation_fee_usdt' => null,
+            'occurred_at' => $fill->filledAt->format(\DateTimeInterface::ATOM),
+            'source' => $source,
+            'source_version' => $sourceVersion,
+            'quality_flags' => array_values(array_unique($qualityFlags)),
+            'raw_reference' => $this->rawReference($event->eventType(), $source, $exchangeFillId, $fill->exchangeOrderId, $fill->clientOrderId),
+        ];
+
+        return $this->persistSnapshot($idempotencyKey, $snapshot);
+    }
+
+    /**
+     * @param array<string,mixed> $rawReference
+     */
+    public function ingestFundingAdjustment(
+        string $internalTradeId,
+        Exchange $exchange,
+        MarketType $marketType,
+        string $symbol,
+        float $fundingUsdt,
+        \DateTimeImmutable $occurredAt,
+        string $source,
+        string $sourceVersion,
+        array $rawReference,
+    ): FillCostLedgerIngestionResult {
+        $fundingEventId = $this->string($rawReference['funding_event_id'] ?? null);
+        $idempotencyKey = $fundingEventId !== null
+            ? sprintf('%s:%s:funding:%s', $exchange->value, $marketType->value, $fundingEventId)
+            : sprintf('%s:%s:funding:%s', $exchange->value, $marketType->value, substr(hash('sha256', implode(':', [
+                $internalTradeId,
+                $symbol,
+                $occurredAt->format('U.u'),
+                $this->decimal($fundingUsdt),
+            ])), 0, 48));
+        $lineage = $this->lineageManager->resolve(
+            new ExchangeContext($exchange, $marketType),
+            internalTradeId: $internalTradeId,
+        );
+        $flags = $lineage instanceof TradeLineage ? [] : ['missing_lineage'];
+
+        $snapshot = [
+            'internal_trade_id' => $internalTradeId,
+            'internal_position_id' => $lineage?->getInternalPositionId(),
+            'position_id' => $lineage?->getPositionId(),
+            'exchange' => $exchange->value,
+            'market_type' => $marketType->value,
+            'symbol' => strtoupper($symbol),
+            'side' => $lineage?->getSide(),
+            'fill_id' => $idempotencyKey,
+            'exchange_fill_id' => null,
+            'exchange_order_id' => null,
+            'client_order_id' => $lineage?->getClientOrderId(),
+            'order_intent_id' => $lineage?->getOrderIntent()?->getId(),
+            'fill_role' => 'funding',
+            'liquidity_role' => 'unknown',
+            'price' => null,
+            'quantity' => null,
+            'notional' => null,
+            'fee_amount' => null,
+            'fee_currency' => null,
+            'fee_usdt' => null,
+            'funding_usdt' => $this->decimal($fundingUsdt),
+            'spread_cost_usdt' => null,
+            'slippage_cost_usdt' => null,
+            'borrow_cost_usdt' => null,
+            'liquidation_fee_usdt' => null,
+            'occurred_at' => $occurredAt->format(\DateTimeInterface::ATOM),
+            'source' => $source,
+            'source_version' => $sourceVersion,
+            'quality_flags' => $flags,
+            'raw_reference' => $this->redactReference($rawReference + ['source' => $source]),
+        ];
+
+        return $this->persistSnapshot($idempotencyKey, $snapshot);
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    private function persistSnapshot(string $idempotencyKey, array $snapshot): FillCostLedgerIngestionResult
+    {
+        $payloadHash = $this->payloadHash($snapshot);
+        $existing = $this->ledger->findOneByIdempotencyKey($idempotencyKey);
+        if ($existing instanceof FillCostLedgerEntry) {
+            if ($existing->getPayloadHash() === $payloadHash) {
+                return new FillCostLedgerIngestionResult($existing, inserted: false, replayed: true);
+            }
+
+            throw new FillCostLedgerIngestionConflict(sprintf(
+                'Conflicting fill-cost ledger payload for idempotency key "%s".',
+                $idempotencyKey,
+            ));
+        }
+
+        $entry = (new FillCostLedgerEntry(
+            idempotencyKey: $idempotencyKey,
+            payloadHash: $payloadHash,
+            exchange: (string) $snapshot['exchange'],
+            marketType: (string) $snapshot['market_type'],
+            symbol: (string) $snapshot['symbol'],
+            fillId: (string) $snapshot['fill_id'],
+            fillRole: (string) $snapshot['fill_role'],
+            occurredAt: new \DateTimeImmutable((string) $snapshot['occurred_at']),
+            source: (string) $snapshot['source'],
+            sourceVersion: (string) $snapshot['source_version'],
+        ))
+            ->setInternalTradeId($this->string($snapshot['internal_trade_id'] ?? null))
+            ->setInternalPositionId($this->string($snapshot['internal_position_id'] ?? null))
+            ->setPositionId($this->string($snapshot['position_id'] ?? null))
+            ->setSide($this->string($snapshot['side'] ?? null))
+            ->setExchangeFillId($this->string($snapshot['exchange_fill_id'] ?? null))
+            ->setExchangeOrderId($this->string($snapshot['exchange_order_id'] ?? null))
+            ->setClientOrderId($this->string($snapshot['client_order_id'] ?? null))
+            ->setOrderIntentId(\is_int($snapshot['order_intent_id'] ?? null) ? $snapshot['order_intent_id'] : null)
+            ->setLiquidityRole((string) $snapshot['liquidity_role'])
+            ->setPrice($this->string($snapshot['price'] ?? null))
+            ->setQuantity($this->string($snapshot['quantity'] ?? null))
+            ->setNotional($this->string($snapshot['notional'] ?? null))
+            ->setFeeAmount($this->string($snapshot['fee_amount'] ?? null))
+            ->setFeeCurrency($this->string($snapshot['fee_currency'] ?? null))
+            ->setFeeUsdt($this->string($snapshot['fee_usdt'] ?? null))
+            ->setFundingUsdt($this->string($snapshot['funding_usdt'] ?? null))
+            ->setSpreadCostUsdt($this->string($snapshot['spread_cost_usdt'] ?? null))
+            ->setSlippageCostUsdt($this->string($snapshot['slippage_cost_usdt'] ?? null))
+            ->setBorrowCostUsdt($this->string($snapshot['borrow_cost_usdt'] ?? null))
+            ->setLiquidationFeeUsdt($this->string($snapshot['liquidation_fee_usdt'] ?? null))
+            ->setQualityFlags(\is_array($snapshot['quality_flags']) ? $snapshot['quality_flags'] : [])
+            ->setRawReference(\is_array($snapshot['raw_reference']) ? $snapshot['raw_reference'] : []);
+
+        $this->ledger->save($entry);
+
+        return new FillCostLedgerIngestionResult($entry, inserted: true, replayed: false);
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     * @param array<string,mixed> $payload
+     */
+    private function resolveLineage(ExchangeFillDto $fill, array $metadata, array $payload): ?TradeLineage
+    {
+        return $this->lineageManager->resolve(
+            new ExchangeContext($fill->exchange, $fill->marketType),
+            internalTradeId: $this->string($metadata['internal_trade_id'] ?? $payload['internal_trade_id'] ?? null),
+            clientOrderId: $fill->clientOrderId,
+            exchangeOrderId: $fill->exchangeOrderId,
+            positionId: $this->string($metadata['position_id'] ?? $payload['position_id'] ?? $metadata['exchange_position_id'] ?? $payload['exchange_position_id'] ?? null),
+        );
+    }
+
+    private function fillRole(ExchangeFillDto $fill): string
+    {
+        return match ([$fill->positionSide, $fill->side]) {
+            [ExchangePositionSide::LONG, ExchangeOrderSide::BUY],
+            [ExchangePositionSide::SHORT, ExchangeOrderSide::SELL] => 'entry',
+            [ExchangePositionSide::LONG, ExchangeOrderSide::SELL],
+            [ExchangePositionSide::SHORT, ExchangeOrderSide::BUY] => 'exit',
+            default => 'adjustment',
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     * @param array<string,mixed> $payload
+     */
+    private function liquidityRole(array $metadata, array $payload): string
+    {
+        $role = strtolower((string) ($metadata['liquidity_role'] ?? $metadata['liquidity'] ?? $payload['liquidity_role'] ?? $payload['liquidity'] ?? 'unknown'));
+
+        return \in_array($role, ['maker', 'taker'], true) ? $role : 'unknown';
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     * @param array<string,mixed> $payload
+     * @param list<string> $qualityFlags
+     */
+    private function feeUsdt(ExchangeFillDto $fill, array $metadata, array $payload, array &$qualityFlags): ?string
+    {
+        if ($fill->fee === null) {
+            $qualityFlags[] = 'fee_missing';
+            return null;
+        }
+
+        $currency = $this->string($fill->feeCurrency);
+        if ($currency === null) {
+            $qualityFlags[] = 'fee_currency_missing';
+            return null;
+        }
+
+        if (strtoupper($currency) === 'USDT') {
+            return $this->decimal($fill->fee);
+        }
+
+        $conversion = $metadata['fee_conversion'] ?? $payload['fee_conversion'] ?? null;
+        if (\is_array($conversion) && isset($conversion['usdt_rate']) && is_numeric($conversion['usdt_rate'])) {
+            $conversionCurrency = $this->string($conversion['currency'] ?? null);
+            if ($conversionCurrency === null || strtoupper($conversionCurrency) === strtoupper($currency)) {
+                return $this->decimal($fill->fee * (float) $conversion['usdt_rate']);
+            }
+        }
+
+        $qualityFlags[] = 'fee_conversion_missing';
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     * @param array<string,mixed> $payload
+     */
+    private function source(array $metadata, array $payload): string
+    {
+        return $this->string($metadata['source'] ?? $payload['source'] ?? null) ?? 'exchange_event';
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function rawReference(
+        string $eventType,
+        string $source,
+        ?string $exchangeFillId,
+        ?string $exchangeOrderId,
+        ?string $clientOrderId,
+    ): array {
+        return array_filter([
+            'source' => $source,
+            'event_type' => $eventType,
+            'exchange_fill_id' => $exchangeFillId,
+            'exchange_order_id' => $exchangeOrderId,
+            'client_order_id' => $clientOrderId,
+        ], static fn (mixed $value): bool => $value !== null && $value !== '');
+    }
+
+    /**
+     * @param array<string,mixed> $reference
+     * @return array<string,mixed>
+     */
+    private function redactReference(array $reference): array
+    {
+        $redacted = [];
+        foreach ($reference as $key => $value) {
+            $normalized = strtolower((string) $key);
+            if (\in_array($normalized, self::SENSITIVE_KEYS, true)) {
+                continue;
+            }
+            if (\is_array($value)) {
+                $redacted[$key] = $this->redactReference($value);
+            } elseif ($value === null || \is_scalar($value)) {
+                $redacted[$key] = $value;
+            }
+        }
+
+        return $redacted;
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    private function payloadHash(array $snapshot): string
+    {
+        ksort($snapshot);
+
+        return hash('sha256', json_encode($snapshot, JSON_THROW_ON_ERROR));
+    }
+
+    private function deterministicFillId(ExchangeFillDto $fill): string
+    {
+        return 'fill-' . substr(hash('sha256', implode(':', [
+            $fill->exchange->value,
+            $fill->marketType->value,
+            $fill->symbol,
+            $fill->exchangeOrderId,
+            $fill->clientOrderId ?? '',
+            $fill->filledAt->format('U.u'),
+            (string) $fill->quantity,
+            (string) $fill->price,
+            $fill->side->value,
+            $fill->positionSide?->value ?? '',
+        ])), 0, 48);
+    }
+
+    private function decimal(float $value): string
+    {
+        return number_format($value, 12, '.', '');
+    }
+
+    private function string(mixed $value): ?string
+    {
+        if (!\is_scalar($value)) {
+            return null;
+        }
+
+        $string = trim((string) $value);
+
+        return $string !== '' ? $string : null;
+    }
+}

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
@@ -290,9 +290,15 @@ final readonly class FillCostLedgerIngestionService
 
         $conversion = $metadata['fee_conversion'] ?? $payload['fee_conversion'] ?? null;
         if (\is_array($conversion) && isset($conversion['usdt_rate']) && is_numeric($conversion['usdt_rate'])) {
+            $rate = (float) $conversion['usdt_rate'];
+            if (!\is_finite($rate) || $rate <= 0.0) {
+                $qualityFlags[] = 'fee_conversion_invalid';
+                return null;
+            }
+
             $conversionCurrency = $this->string($conversion['currency'] ?? null);
             if ($conversionCurrency === null || strtoupper($conversionCurrency) === strtoupper($currency)) {
-                return $this->decimal(abs($fill->fee) * (float) $conversion['usdt_rate']);
+                return $this->decimal(abs($fill->fee) * $rate);
             }
         }
 

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
@@ -15,6 +15,7 @@ use App\Exchange\Event\ExchangeFillReceived;
 use App\Provider\Context\ExchangeContext;
 use App\Repository\FillCostLedgerEntryRepository;
 use App\Trading\Lineage\TradeLineageManager;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 
 final readonly class FillCostLedgerIngestionService
 {
@@ -160,7 +161,7 @@ final readonly class FillCostLedgerIngestionService
      */
     private function persistSnapshot(string $idempotencyKey, array $snapshot): FillCostLedgerIngestionResult
     {
-        $payloadHash = $this->payloadHash($snapshot);
+        $payloadHash = $this->conflictHash($snapshot);
         $existing = $this->ledger->findOneByIdempotencyKey($idempotencyKey);
         if ($existing instanceof FillCostLedgerEntry) {
             if ($existing->getPayloadHash() === $payloadHash) {
@@ -208,7 +209,19 @@ final readonly class FillCostLedgerIngestionService
             ->setQualityFlags(\is_array($snapshot['quality_flags']) ? $snapshot['quality_flags'] : [])
             ->setRawReference(\is_array($snapshot['raw_reference']) ? $snapshot['raw_reference'] : []);
 
-        $this->ledger->save($entry);
+        try {
+            $this->ledger->save($entry);
+        } catch (UniqueConstraintViolationException) {
+            $concurrent = $this->ledger->findOneByIdempotencyKey($idempotencyKey);
+            if ($concurrent instanceof FillCostLedgerEntry && $concurrent->getPayloadHash() === $payloadHash) {
+                return new FillCostLedgerIngestionResult($concurrent, inserted: false, replayed: true);
+            }
+
+            throw new FillCostLedgerIngestionConflict(sprintf(
+                'Conflicting fill-cost ledger payload for idempotency key "%s".',
+                $idempotencyKey,
+            ));
+        }
 
         return new FillCostLedgerIngestionResult($entry, inserted: true, replayed: false);
     }
@@ -260,6 +273,9 @@ final readonly class FillCostLedgerIngestionService
         if ($fill->fee === null) {
             $qualityFlags[] = 'fee_missing';
             return null;
+        }
+        if (abs($fill->fee) <= 0.000000000001) {
+            return $this->decimal(0.0);
         }
 
         $currency = $this->string($fill->feeCurrency);
@@ -338,11 +354,37 @@ final readonly class FillCostLedgerIngestionService
     /**
      * @param array<string,mixed> $snapshot
      */
-    private function payloadHash(array $snapshot): string
+    private function conflictHash(array $snapshot): string
     {
-        ksort($snapshot);
+        $canonical = [];
+        foreach ([
+            'exchange',
+            'market_type',
+            'symbol',
+            'side',
+            'fill_id',
+            'exchange_fill_id',
+            'exchange_order_id',
+            'client_order_id',
+            'fill_role',
+            'liquidity_role',
+            'price',
+            'quantity',
+            'notional',
+            'fee_amount',
+            'fee_currency',
+            'fee_usdt',
+            'funding_usdt',
+            'spread_cost_usdt',
+            'slippage_cost_usdt',
+            'borrow_cost_usdt',
+            'liquidation_fee_usdt',
+            'occurred_at',
+        ] as $key) {
+            $canonical[$key] = $snapshot[$key] ?? null;
+        }
 
-        return hash('sha256', json_encode($snapshot, JSON_THROW_ON_ERROR));
+        return hash('sha256', json_encode($canonical, JSON_THROW_ON_ERROR));
     }
 
     private function deterministicFillId(ExchangeFillDto $fill): string

--- a/trading-app/tests/Exchange/Event/DoctrineExchangeLocalProjectionStoreTest.php
+++ b/trading-app/tests/Exchange/Event/DoctrineExchangeLocalProjectionStoreTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Event;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Entity\FillCostLedgerEntry;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Event\DoctrineExchangeLocalProjectionStore;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\MtfRunner\Service\FuturesOrderSyncService;
+use App\Repository\FillCostLedgerEntryRepository;
+use App\Repository\FuturesOrderRepository;
+use App\Repository\PositionRepository;
+use App\Repository\TradeLineageRepository;
+use App\Trading\Lineage\TradeLineageManager;
+use App\Trading\Pnl\FillCostLedgerIngestionConflict;
+use App\Trading\Pnl\FillCostLedgerIngestionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(DoctrineExchangeLocalProjectionStore::class)]
+final class DoctrineExchangeLocalProjectionStoreTest extends TestCase
+{
+    public function testFillLedgerConflictPreventsLegacyTradeSync(): void
+    {
+        $orderSync = $this->createMock(FuturesOrderSyncService::class);
+        $orderSync->expects(self::never())->method('syncTradeFromApi');
+
+        $ledgerRepository = $this->createMock(FillCostLedgerEntryRepository::class);
+        $ledgerRepository->expects(self::once())
+            ->method('findOneByIdempotencyKey')
+            ->with('fake:perpetual:exchange_fill:fill-conflict')
+            ->willReturn(new FillCostLedgerEntry(
+                idempotencyKey: 'fake:perpetual:exchange_fill:fill-conflict',
+                payloadHash: str_repeat('0', 64),
+                exchange: 'fake',
+                marketType: 'perpetual',
+                symbol: 'BTCUSDT',
+                fillId: 'fill-conflict',
+                fillRole: 'entry',
+                occurredAt: new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
+                source: 'test',
+                sourceVersion: 'test_v1',
+            ));
+
+        $registry = $this->createStub(ManagerRegistry::class);
+        $lineage = new TradeLineageManager(
+            new TradeLineageRepository($registry),
+            $this->createStub(EntityManagerInterface::class),
+            new NullLogger(),
+        );
+        $store = new DoctrineExchangeLocalProjectionStore(
+            $orderSync,
+            new FuturesOrderRepository($registry),
+            $this->createStub(PositionRepository::class),
+            $this->createStub(EntityManagerInterface::class),
+            new FillCostLedgerIngestionService($ledgerRepository, $lineage),
+        );
+
+        $this->expectException(FillCostLedgerIngestionConflict::class);
+
+        $store->project(new ExchangeFillReceived(new ExchangeFillDto(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: '',
+            clientOrderId: null,
+            fillId: 'fill-conflict',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            quantity: 1.0,
+            price: 100.0,
+            fee: 0.01,
+            feeCurrency: 'USDT',
+            filledAt: new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
+        )));
+    }
+}

--- a/trading-app/tests/Trading/Lineage/TradeLineageManagerTest.php
+++ b/trading-app/tests/Trading/Lineage/TradeLineageManagerTest.php
@@ -171,6 +171,21 @@ final class TradeLineageManagerTest extends KernelTestCase
         self::assertNull($resolved);
     }
 
+    public function testResolveFallsBackAfterUnmatchedHigherPriorityIdentifier(): void
+    {
+        $intent = $this->persistIntent('cid-real', 'BTCUSDT', Exchange::BITMART, MarketType::PERPETUAL);
+        $lineage = $this->manager->ensureForIntent($intent, ['internal_trade_id' => 'itd-fallback']);
+        $this->manager->attachExchangeOrderId($lineage, 'ex-fallback');
+
+        $resolved = $this->manager->resolve(
+            new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+            clientOrderId: 'stale-client-id',
+            exchangeOrderId: 'ex-fallback',
+        );
+
+        self::assertSame('itd-fallback', $resolved?->getInternalTradeId());
+    }
+
     public function testAmbiguousExchangeOrPositionIdentifierStaysUnmatched(): void
     {
         $first = $this->persistIntent('cid-first', 'BTCUSDT', Exchange::BITMART, MarketType::PERPETUAL);

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -170,6 +170,27 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         self::assertContains('missing_lineage', $entry->getQualityFlags());
     }
 
+    public function testReplayWithDifferentResolvedLineageIsRejectedAsConflict(): void
+    {
+        $this->persistLineage('itd-ledger-lineage-a', 'cid-lineage-a', 'EX-LINEAGE-CONFLICT', null);
+        $this->persistLineage('itd-ledger-lineage-b', 'cid-lineage-b', 'EX-LINEAGE-OTHER', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-LINEAGE-CONFLICT',
+            clientOrderId: 'cid-lineage-a',
+            fillId: 'fill-lineage-conflict',
+        )));
+
+        $this->expectException(FillCostLedgerIngestionConflict::class);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-LINEAGE-CONFLICT',
+            clientOrderId: 'cid-lineage-a',
+            fillId: 'fill-lineage-conflict',
+            metadata: ['internal_trade_id' => 'itd-ledger-lineage-b'],
+        )));
+    }
+
     public function testConcurrentDuplicateInsertIsReturnedAsReplayWhenStoredPayloadMatches(): void
     {
         $existing = null;
@@ -587,6 +608,38 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         self::assertStringNotContainsString('SECRET', $encoded);
         self::assertArrayNotHasKey('api_key', $entry->getRawReference());
         self::assertArrayNotHasKey('token', $entry->getRawReference());
+    }
+
+    public function testFundingRawReferenceRedactsCommonSecretKeyVariants(): void
+    {
+        $this->persistLineage('itd-ledger-funding-redacted', 'cid-funding-redacted', 'EX-FUNDING-REDACTED', null);
+
+        $this->service->ingestFundingAdjustment(
+            internalTradeId: 'itd-ledger-funding-redacted',
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            fundingUsdt: 0.25,
+            occurredAt: new \DateTimeImmutable('2026-01-01 00:12:00 UTC'),
+            source: 'fake_fixture',
+            sourceVersion: 'v1',
+            rawReference: [
+                'funding_event_id' => 'funding-redacted',
+                'access_token' => 'SECRET',
+                'secret_key' => 'SECRET',
+                'nested' => [
+                    'refreshToken' => 'SECRET',
+                    'public_reference' => 'visible',
+                ],
+            ],
+        );
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-funding-redacted')[0];
+        $encoded = json_encode($entry->getRawReference(), JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('SECRET', $encoded);
+        self::assertSame('visible', $entry->getRawReference()['nested']['public_reference'] ?? null);
+        self::assertArrayNotHasKey('access_token', $entry->getRawReference());
+        self::assertArrayNotHasKey('secret_key', $entry->getRawReference());
     }
 
     private function persistLineage(

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -1,0 +1,502 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Pnl;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Entity\OrderIntent;
+use App\Entity\TradeLineage;
+use App\Entity\FillCostLedgerEntry;
+use App\Exchange\Dto\ExchangeFillDto;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Event\ExchangeFillReceived;
+use App\Repository\FillCostLedgerEntryRepository;
+use App\Repository\TradeLineageRepository;
+use App\Trading\Lineage\TradeLineageManager;
+use App\Trading\Pnl\FillCostLedgerIngestionConflict;
+use App\Trading\Pnl\FillCostLedgerIngestionService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Log\NullLogger;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[CoversClass(FillCostLedgerIngestionService::class)]
+#[CoversClass(FillCostLedgerEntry::class)]
+final class FillCostLedgerIngestionServiceTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private FillCostLedgerIngestionService $service;
+    private FillCostLedgerEntryRepository $ledger;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+
+        $tool = new SchemaTool($this->em);
+        $classes = [
+            $this->em->getClassMetadata(OrderIntent::class),
+            $this->em->getClassMetadata(TradeLineage::class),
+            $this->em->getClassMetadata(FillCostLedgerEntry::class),
+        ];
+        $tool->dropSchema($classes);
+        $tool->createSchema($classes);
+
+        /** @var FillCostLedgerEntryRepository $ledger */
+        $ledger = $this->em->getRepository(FillCostLedgerEntry::class);
+        /** @var TradeLineageRepository $lineages */
+        $lineages = $this->em->getRepository(TradeLineage::class);
+
+        $this->ledger = $ledger;
+        $this->service = new FillCostLedgerIngestionService(
+            $ledger,
+            new TradeLineageManager($lineages, $this->em, new NullLogger()),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            (new SchemaTool($this->em))->dropSchema([
+                $this->em->getClassMetadata(OrderIntent::class),
+                $this->em->getClassMetadata(TradeLineage::class),
+                $this->em->getClassMetadata(FillCostLedgerEntry::class),
+            ]);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testPersistsFakeEntryFillWithExactLineageAndKnownUsdtFee(): void
+    {
+        $this->persistLineage('itd-ledger-1', 'cid-ledger-1', 'EX-LEDGER-1', 'ipos-ledger-1');
+
+        $result = $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-LEDGER-1',
+            clientOrderId: 'cid-ledger-1',
+            fillId: 'fake-fill-entry-maker',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            quantity: 2.5,
+            price: 100.0,
+            fee: 0.125,
+            feeCurrency: 'USDT',
+            metadata: ['liquidity_role' => 'maker', 'source' => 'fake_exchange_ws'],
+        )));
+
+        self::assertTrue($result->inserted);
+        self::assertFalse($result->replayed);
+        self::assertNull($result->conflictReason);
+
+        $entries = $this->ledger->findByInternalTradeId('itd-ledger-1');
+        self::assertCount(1, $entries);
+        $entry = $entries[0];
+        self::assertSame('itd-ledger-1', $entry->getInternalTradeId());
+        self::assertSame('ipos-ledger-1', $entry->getInternalPositionId());
+        self::assertSame('fake', $entry->getExchange());
+        self::assertSame('perpetual', $entry->getMarketType());
+        self::assertSame('BTCUSDT', $entry->getSymbol());
+        self::assertSame('BUY', $entry->getSide());
+        self::assertSame('entry', $entry->getFillRole());
+        self::assertSame('maker', $entry->getLiquidityRole());
+        self::assertSame('250.000000000000', $entry->getNotional());
+        self::assertSame('0.125000000000', $entry->getFeeAmount());
+        self::assertSame('USDT', $entry->getFeeCurrency());
+        self::assertSame('0.125000000000', $entry->getFeeUsdt());
+        self::assertSame([], $entry->getQualityFlags());
+        self::assertSame([
+            'source' => 'fake_exchange_ws',
+            'event_type' => 'exchange.fill.received',
+            'exchange_fill_id' => 'fake-fill-entry-maker',
+            'exchange_order_id' => 'EX-LEDGER-1',
+            'client_order_id' => 'cid-ledger-1',
+        ], $entry->getRawReference());
+    }
+
+    public function testReplayOfSameExchangeFillIsIdempotent(): void
+    {
+        $this->persistLineage('itd-ledger-replay', 'cid-replay', 'EX-REPLAY', null);
+        $event = new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-REPLAY',
+            clientOrderId: 'cid-replay',
+            fillId: 'fake-fill-replay',
+        ));
+
+        $first = $this->service->ingestExchangeFill($event);
+        $second = $this->service->ingestExchangeFill($event);
+
+        self::assertTrue($first->inserted);
+        self::assertTrue($second->replayed);
+        self::assertFalse($second->inserted);
+        self::assertSame(1, $this->ledger->count([]));
+    }
+
+    public function testSameExchangeFillIdWithDifferentPayloadIsRejectedAsConflict(): void
+    {
+        $this->persistLineage('itd-ledger-conflict', 'cid-conflict', 'EX-CONFLICT', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-CONFLICT',
+            clientOrderId: 'cid-conflict',
+            fillId: 'fake-fill-conflict',
+            price: 100.0,
+        )));
+
+        $this->expectException(FillCostLedgerIngestionConflict::class);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-CONFLICT',
+            clientOrderId: 'cid-conflict',
+            fillId: 'fake-fill-conflict',
+            price: 101.0,
+        )));
+    }
+
+    public function testVenueScopedExchangeFillIdsCanBeReusedAcrossExchanges(): void
+    {
+        $this->persistLineage('itd-fake-shared', 'cid-fake-shared', 'EX-SHARED-FILL', null, exchange: Exchange::FAKE);
+        $this->persistLineage('itd-okx-shared', 'cid-okx-shared', 'OKX-ORDER-SHARED', null, exchange: Exchange::OKX);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchange: Exchange::FAKE,
+            exchangeOrderId: 'EX-SHARED-FILL',
+            clientOrderId: 'cid-fake-shared',
+            fillId: 'venue-reused-fill-id',
+        )));
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchange: Exchange::OKX,
+            exchangeOrderId: 'OKX-ORDER-SHARED',
+            clientOrderId: 'cid-okx-shared',
+            fillId: 'venue-reused-fill-id',
+        )));
+
+        self::assertCount(1, $this->ledger->findByInternalTradeId('itd-fake-shared'));
+        self::assertCount(1, $this->ledger->findByInternalTradeId('itd-okx-shared'));
+    }
+
+    public function testMissingLineageIsPersistedWithQualityFlagWithoutSymbolTimeFallback(): void
+    {
+        $result = $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-NO-LINEAGE',
+            clientOrderId: 'cid-no-lineage',
+            fillId: 'fake-fill-no-lineage',
+        )));
+
+        self::assertTrue($result->inserted);
+        $entry = $this->ledger->findOneByIdempotencyKey('fake:perpetual:exchange_fill:fake-fill-no-lineage');
+        self::assertInstanceOf(FillCostLedgerEntry::class, $entry);
+        self::assertNull($entry->getInternalTradeId());
+        self::assertContains('missing_lineage', $entry->getQualityFlags());
+    }
+
+    public function testPartialFillsCreateSeparateLedgerRowsForSameTrade(): void
+    {
+        $this->persistLineage('itd-ledger-partial', 'cid-partial', 'EX-PARTIAL', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-PARTIAL',
+            clientOrderId: 'cid-partial',
+            fillId: 'fill-partial-1',
+            quantity: 0.4,
+            price: 100.0,
+        )));
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-PARTIAL',
+            clientOrderId: 'cid-partial',
+            fillId: 'fill-partial-2',
+            quantity: 0.6,
+            price: 101.0,
+        )));
+
+        $entries = $this->ledger->findByInternalTradeId('itd-ledger-partial');
+        self::assertCount(2, $entries);
+        self::assertSame(['0.400000000000', '0.600000000000'], array_map(
+            static fn (FillCostLedgerEntry $entry): ?string => $entry->getQuantity(),
+            $entries,
+        ));
+    }
+
+    public function testExitTakerFillIsClassifiedWithoutChangingCosts(): void
+    {
+        $this->persistLineage('itd-ledger-exit', 'cid-exit', 'EX-EXIT', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-EXIT',
+            clientOrderId: 'cid-exit',
+            fillId: 'fill-exit-taker',
+            side: ExchangeOrderSide::SELL,
+            positionSide: ExchangePositionSide::LONG,
+            quantity: 1.0,
+            price: 110.0,
+            fee: 0.055,
+            feeCurrency: 'USDT',
+            metadata: ['liquidity_role' => 'taker'],
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-exit')[0];
+        self::assertSame('exit', $entry->getFillRole());
+        self::assertSame('taker', $entry->getLiquidityRole());
+        self::assertSame('0.055000000000', $entry->getFeeUsdt());
+    }
+
+    public function testLedgerCanBeReadAfterEntityManagerClear(): void
+    {
+        $this->persistLineage('itd-ledger-reread', 'cid-reread', 'EX-REREAD', null);
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-REREAD',
+            clientOrderId: 'cid-reread',
+            fillId: 'fill-reread',
+        )));
+
+        $this->em->clear();
+
+        /** @var FillCostLedgerEntryRepository $freshRepository */
+        $freshRepository = $this->em->getRepository(FillCostLedgerEntry::class);
+        $entries = $freshRepository->findByInternalTradeId('itd-ledger-reread');
+        self::assertCount(1, $entries);
+        self::assertSame('fill-reread', $entries[0]->getFillId());
+    }
+
+    public function testOutOfOrderEventsAreStoredAndReadDeterministicallyByOccurrenceTime(): void
+    {
+        $this->persistLineage('itd-ledger-ordered', 'cid-ordered', 'EX-ORDERED', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-ORDERED',
+            clientOrderId: 'cid-ordered',
+            fillId: 'fill-late',
+            metadata: ['filled_at_override' => 'ignored'],
+            filledAt: new \DateTimeImmutable('2026-01-01 00:02:00 UTC'),
+        )));
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-ORDERED',
+            clientOrderId: 'cid-ordered',
+            fillId: 'fill-early',
+            filledAt: new \DateTimeImmutable('2026-01-01 00:01:00 UTC'),
+        )));
+
+        $entries = $this->ledger->findByInternalTradeId('itd-ledger-ordered');
+        self::assertSame(['fill-early', 'fill-late'], array_map(
+            static fn (FillCostLedgerEntry $entry): string => $entry->getFillId(),
+            $entries,
+        ));
+    }
+
+    public function testWrongVenueDoesNotAttachLineageWithSameClientOrderId(): void
+    {
+        $this->persistLineage('itd-ledger-wrong-venue', 'cid-same-venue-test', 'EX-FAKE-VENUE', null, exchange: Exchange::FAKE);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchange: Exchange::OKX,
+            exchangeOrderId: 'OKX-ORDER-VENUE',
+            clientOrderId: 'cid-same-venue-test',
+            fillId: 'okx-fill-wrong-venue',
+        )));
+
+        $entry = $this->ledger->findOneByIdempotencyKey('okx:perpetual:exchange_fill:okx-fill-wrong-venue');
+        self::assertInstanceOf(FillCostLedgerEntry::class, $entry);
+        self::assertNull($entry->getInternalTradeId());
+        self::assertContains('missing_lineage', $entry->getQualityFlags());
+    }
+
+    public function testKnownNonUsdtFeeRequiresExplicitConversionRate(): void
+    {
+        $this->persistLineage('itd-ledger-bnb-fee', 'cid-bnb-fee', 'EX-BNB-FEE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-BNB-FEE',
+            clientOrderId: 'cid-bnb-fee',
+            fillId: 'fill-bnb-fee',
+            fee: 0.01,
+            feeCurrency: 'BNB',
+            metadata: ['fee_conversion' => ['currency' => 'BNB', 'usdt_rate' => 600.0]],
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-bnb-fee')[0];
+        self::assertSame('BNB', $entry->getFeeCurrency());
+        self::assertSame('6.000000000000', $entry->getFeeUsdt());
+        self::assertSame([], $entry->getQualityFlags());
+    }
+
+    public function testUnknownNonUsdtFeeDoesNotBecomeZero(): void
+    {
+        $this->persistLineage('itd-ledger-unknown-fee', 'cid-unknown-fee', 'EX-UNKNOWN-FEE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-UNKNOWN-FEE',
+            clientOrderId: 'cid-unknown-fee',
+            fillId: 'fill-unknown-fee',
+            fee: 0.01,
+            feeCurrency: 'BNB',
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-unknown-fee')[0];
+        self::assertSame('0.010000000000', $entry->getFeeAmount());
+        self::assertSame('BNB', $entry->getFeeCurrency());
+        self::assertNull($entry->getFeeUsdt());
+        self::assertContains('fee_conversion_missing', $entry->getQualityFlags());
+    }
+
+    public function testAbsentFeeRemainsNullAndIsFlagged(): void
+    {
+        $this->persistLineage('itd-ledger-no-fee', 'cid-no-fee', 'EX-NO-FEE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-NO-FEE',
+            clientOrderId: 'cid-no-fee',
+            fillId: 'fill-no-fee',
+            fee: null,
+            feeCurrency: null,
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-no-fee')[0];
+        self::assertNull($entry->getFeeAmount());
+        self::assertNull($entry->getFeeCurrency());
+        self::assertNull($entry->getFeeUsdt());
+        self::assertContains('fee_missing', $entry->getQualityFlags());
+    }
+
+    public function testFundingAdjustmentsCanBePersistedWithPositiveAndNegativeSigns(): void
+    {
+        $this->persistLineage('itd-ledger-funding', 'cid-funding', 'EX-FUNDING', null);
+
+        $positive = $this->service->ingestFundingAdjustment(
+            internalTradeId: 'itd-ledger-funding',
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            fundingUsdt: 1.25,
+            occurredAt: new \DateTimeImmutable('2026-01-01 00:10:00 UTC'),
+            source: 'fake_fixture',
+            sourceVersion: 'v1',
+            rawReference: ['funding_event_id' => 'funding-positive'],
+        );
+        $negative = $this->service->ingestFundingAdjustment(
+            internalTradeId: 'itd-ledger-funding',
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            fundingUsdt: -0.75,
+            occurredAt: new \DateTimeImmutable('2026-01-01 00:11:00 UTC'),
+            source: 'fake_fixture',
+            sourceVersion: 'v1',
+            rawReference: ['funding_event_id' => 'funding-negative'],
+        );
+
+        self::assertTrue($positive->inserted);
+        self::assertTrue($negative->inserted);
+        $entries = $this->ledger->findByInternalTradeId('itd-ledger-funding');
+        self::assertSame(['1.250000000000', '-0.750000000000'], array_map(
+            static fn (FillCostLedgerEntry $entry): ?string => $entry->getFundingUsdt(),
+            $entries,
+        ));
+    }
+
+    public function testRawReferenceIsRedacted(): void
+    {
+        $this->persistLineage('itd-ledger-redacted', 'cid-redacted', 'EX-REDACTED', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-REDACTED',
+            clientOrderId: 'cid-redacted',
+            fillId: 'fill-redacted',
+            metadata: [
+                'source' => 'fake_exchange_ws',
+                'api_key' => 'SECRET',
+                'token' => 'SECRET',
+                'nested' => ['secret' => 'SECRET'],
+            ],
+        ), [
+            'secret' => 'SECRET',
+            'api_key' => 'SECRET',
+        ]));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-redacted')[0];
+        $encoded = json_encode($entry->getRawReference(), JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('SECRET', $encoded);
+        self::assertArrayNotHasKey('api_key', $entry->getRawReference());
+        self::assertArrayNotHasKey('token', $entry->getRawReference());
+    }
+
+    private function persistLineage(
+        string $internalTradeId,
+        string $clientOrderId,
+        string $exchangeOrderId,
+        ?string $internalPositionId,
+        Exchange $exchange = Exchange::FAKE,
+    ): void {
+        $intent = (new OrderIntent())
+            ->setExchange($exchange)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSymbol('BTCUSDT')
+            ->setSide(1)
+            ->setType(OrderIntent::TYPE_LIMIT)
+            ->setOpenType(OrderIntent::OPEN_TYPE_ISOLATED)
+            ->setPositionMode(OrderIntent::POSITION_MODE_HEDGE)
+            ->setSize(1)
+            ->setClientOrderId($clientOrderId)
+            ->setPresetMode(OrderIntent::PRESET_MODE_NONE)
+            ->setStatus(OrderIntent::STATUS_SENT)
+            ->setExchangeOrderId($exchangeOrderId)
+            ->setInternalTradeId($internalTradeId)
+            ->setInternalPositionId($internalPositionId);
+
+        $lineage = (new TradeLineage($internalTradeId, $clientOrderId, 'BTCUSDT'))
+            ->setOrderIntent($intent)
+            ->setExchange($exchange)
+            ->setMarketType(MarketType::PERPETUAL)
+            ->setSide('LONG')
+            ->setOrigin('orchestrator')
+            ->setExchangeOrderId($exchangeOrderId)
+            ->setInternalPositionId($internalPositionId);
+
+        $this->em->persist($intent);
+        $this->em->persist($lineage);
+        $this->em->flush();
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function fill(
+        Exchange $exchange = Exchange::FAKE,
+        string $exchangeOrderId = 'EX-FILL',
+        ?string $clientOrderId = 'cid-fill',
+        ?string $fillId = 'fill-id',
+        ExchangeOrderSide $side = ExchangeOrderSide::BUY,
+        ExchangePositionSide $positionSide = ExchangePositionSide::LONG,
+        float $quantity = 1.0,
+        float $price = 100.0,
+        ?float $fee = 0.05,
+        ?string $feeCurrency = 'USDT',
+        array $metadata = [],
+        ?\DateTimeImmutable $filledAt = null,
+    ): ExchangeFillDto {
+        return new ExchangeFillDto(
+            exchange: $exchange,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: $exchangeOrderId,
+            clientOrderId: $clientOrderId,
+            fillId: $fillId,
+            side: $side,
+            positionSide: $positionSide,
+            quantity: $quantity,
+            price: $price,
+            fee: $fee,
+            feeCurrency: $feeCurrency,
+            filledAt: $filledAt ?? new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
+            metadata: $metadata,
+        );
+    }
+}

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -411,6 +411,45 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         self::assertSame([], $entry->getQualityFlags());
     }
 
+    public function testProviderSignedUsdtFeeIsNormalizedAsPositiveCost(): void
+    {
+        $this->persistLineage('itd-ledger-negative-usdt-fee', 'cid-negative-usdt-fee', 'EX-NEG-USDT-FEE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-NEG-USDT-FEE',
+            clientOrderId: 'cid-negative-usdt-fee',
+            fillId: 'fill-negative-usdt-fee',
+            fee: -0.02,
+            feeCurrency: 'USDT',
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-negative-usdt-fee')[0];
+        self::assertSame('-0.020000000000', $entry->getFeeAmount());
+        self::assertSame('USDT', $entry->getFeeCurrency());
+        self::assertSame('0.020000000000', $entry->getFeeUsdt());
+        self::assertSame([], $entry->getQualityFlags());
+    }
+
+    public function testProviderSignedNonUsdtFeeIsNormalizedAfterExplicitConversion(): void
+    {
+        $this->persistLineage('itd-ledger-negative-bnb-fee', 'cid-negative-bnb-fee', 'EX-NEG-BNB-FEE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-NEG-BNB-FEE',
+            clientOrderId: 'cid-negative-bnb-fee',
+            fillId: 'fill-negative-bnb-fee',
+            fee: -0.01,
+            feeCurrency: 'BNB',
+            metadata: ['fee_conversion' => ['currency' => 'BNB', 'usdt_rate' => 600.0]],
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-negative-bnb-fee')[0];
+        self::assertSame('-0.010000000000', $entry->getFeeAmount());
+        self::assertSame('BNB', $entry->getFeeCurrency());
+        self::assertSame('6.000000000000', $entry->getFeeUsdt());
+        self::assertSame([], $entry->getQualityFlags());
+    }
+
     public function testExplicitZeroFeeIsKnownEvenWhenCurrencyIsMissing(): void
     {
         $this->persistLineage('itd-ledger-zero-fee', 'cid-zero-fee', 'EX-ZERO-FEE', null);

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -17,7 +17,9 @@ use App\Repository\FillCostLedgerEntryRepository;
 use App\Repository\TradeLineageRepository;
 use App\Trading\Lineage\TradeLineageManager;
 use App\Trading\Pnl\FillCostLedgerIngestionConflict;
+use App\Trading\Pnl\FillCostLedgerIngestionResult;
 use App\Trading\Pnl\FillCostLedgerIngestionService;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\SchemaTool;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -139,6 +141,86 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         self::assertTrue($second->replayed);
         self::assertFalse($second->inserted);
         self::assertSame(1, $this->ledger->count([]));
+    }
+
+    public function testReplayIgnoresMutableProjectionSourceAndLateLineageEnrichment(): void
+    {
+        $event = new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-LATE-LINEAGE',
+            clientOrderId: 'cid-late-lineage',
+            fillId: 'fake-fill-late-lineage',
+            metadata: ['source' => 'rest_reconciliation'],
+        ));
+        $this->service->ingestExchangeFill($event);
+
+        $this->persistLineage('itd-late-lineage', 'cid-late-lineage', 'EX-LATE-LINEAGE', null);
+        $replay = $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-LATE-LINEAGE',
+            clientOrderId: 'cid-late-lineage',
+            fillId: 'fake-fill-late-lineage',
+            metadata: ['source' => 'fake_exchange_ws'],
+        )));
+
+        self::assertTrue($replay->replayed);
+        self::assertFalse($replay->inserted);
+        self::assertSame(1, $this->ledger->count([]));
+        $entry = $this->ledger->findOneByIdempotencyKey('fake:perpetual:exchange_fill:fake-fill-late-lineage');
+        self::assertInstanceOf(FillCostLedgerEntry::class, $entry);
+        self::assertNull($entry->getInternalTradeId());
+        self::assertContains('missing_lineage', $entry->getQualityFlags());
+    }
+
+    public function testConcurrentDuplicateInsertIsReturnedAsReplayWhenStoredPayloadMatches(): void
+    {
+        $existing = null;
+        $findCalls = 0;
+
+        $repository = $this->createMock(FillCostLedgerEntryRepository::class);
+        $repository->expects(self::exactly(2))
+            ->method('findOneByIdempotencyKey')
+            ->with('fake:perpetual:exchange_fill:fill-concurrent')
+            ->willReturnCallback(static function () use (&$findCalls, &$existing): ?FillCostLedgerEntry {
+                ++$findCalls;
+
+                return $findCalls === 1 ? null : $existing;
+            });
+        $repository->expects(self::once())
+            ->method('save')
+            ->willReturnCallback(static function (FillCostLedgerEntry $entry) use (&$existing): void {
+                $existing = new FillCostLedgerEntry(
+                    idempotencyKey: $entry->getIdempotencyKey(),
+                    payloadHash: $entry->getPayloadHash(),
+                    exchange: $entry->getExchange(),
+                    marketType: $entry->getMarketType(),
+                    symbol: $entry->getSymbol(),
+                    fillId: $entry->getFillId(),
+                    fillRole: $entry->getFillRole(),
+                    occurredAt: $entry->getOccurredAt(),
+                    source: $entry->getSource(),
+                    sourceVersion: $entry->getSourceVersion(),
+                );
+
+                throw new UniqueConstraintViolationException(new class('duplicate') extends \Exception implements \Doctrine\DBAL\Driver\Exception {
+                    public function getSQLState(): ?string
+                    {
+                        return '23505';
+                    }
+                }, null);
+            });
+
+        /** @var TradeLineageRepository $lineages */
+        $lineages = $this->em->getRepository(TradeLineage::class);
+        $service = new FillCostLedgerIngestionService(
+            $repository,
+            new TradeLineageManager($lineages, $this->em, new NullLogger()),
+        );
+
+        $event = new ExchangeFillReceived($this->fill(fillId: 'fill-concurrent'));
+        $expected = $service->ingestExchangeFill($event);
+
+        self::assertInstanceOf(FillCostLedgerIngestionResult::class, $expected);
+        self::assertTrue($expected->replayed);
+        self::assertFalse($expected->inserted);
     }
 
     public function testSameExchangeFillIdWithDifferentPayloadIsRejectedAsConflict(): void
@@ -325,6 +407,25 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         $entry = $this->ledger->findByInternalTradeId('itd-ledger-bnb-fee')[0];
         self::assertSame('BNB', $entry->getFeeCurrency());
         self::assertSame('6.000000000000', $entry->getFeeUsdt());
+        self::assertSame([], $entry->getQualityFlags());
+    }
+
+    public function testExplicitZeroFeeIsKnownEvenWhenCurrencyIsMissing(): void
+    {
+        $this->persistLineage('itd-ledger-zero-fee', 'cid-zero-fee', 'EX-ZERO-FEE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-ZERO-FEE',
+            clientOrderId: 'cid-zero-fee',
+            fillId: 'fill-zero-fee',
+            fee: 0.0,
+            feeCurrency: null,
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-zero-fee')[0];
+        self::assertSame('0.000000000000', $entry->getFeeAmount());
+        self::assertNull($entry->getFeeCurrency());
+        self::assertSame('0.000000000000', $entry->getFeeUsdt());
         self::assertSame([], $entry->getQualityFlags());
     }
 

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -488,6 +488,26 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         self::assertContains('fee_conversion_missing', $entry->getQualityFlags());
     }
 
+    public function testInvalidNonUsdtFeeConversionRateIsRejected(): void
+    {
+        $this->persistLineage('itd-ledger-invalid-fee-rate', 'cid-invalid-fee-rate', 'EX-INVALID-FEE-RATE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-INVALID-FEE-RATE',
+            clientOrderId: 'cid-invalid-fee-rate',
+            fillId: 'fill-invalid-fee-rate',
+            fee: 0.01,
+            feeCurrency: 'BNB',
+            metadata: ['fee_conversion' => ['currency' => 'BNB', 'usdt_rate' => 0.0]],
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-invalid-fee-rate')[0];
+        self::assertSame('0.010000000000', $entry->getFeeAmount());
+        self::assertSame('BNB', $entry->getFeeCurrency());
+        self::assertNull($entry->getFeeUsdt());
+        self::assertContains('fee_conversion_invalid', $entry->getQualityFlags());
+    }
+
     public function testAbsentFeeRemainsNullAndIsFlagged(): void
     {
         $this->persistLineage('itd-ledger-no-fee', 'cid-no-fee', 'EX-NO-FEE', null);

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -173,17 +173,12 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
     public function testConcurrentDuplicateInsertIsReturnedAsReplayWhenStoredPayloadMatches(): void
     {
         $existing = null;
-        $findCalls = 0;
 
         $repository = $this->createMock(FillCostLedgerEntryRepository::class);
-        $repository->expects(self::exactly(2))
+        $repository->expects(self::once())
             ->method('findOneByIdempotencyKey')
             ->with('fake:perpetual:exchange_fill:fill-concurrent')
-            ->willReturnCallback(static function () use (&$findCalls, &$existing): ?FillCostLedgerEntry {
-                ++$findCalls;
-
-                return $findCalls === 1 ? null : $existing;
-            });
+            ->willReturn(null);
         $repository->expects(self::once())
             ->method('save')
             ->willReturnCallback(static function (FillCostLedgerEntry $entry) use (&$existing): void {
@@ -206,6 +201,12 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
                         return '23505';
                     }
                 }, null);
+            });
+        $repository->expects(self::once())
+            ->method('resetManagerAndFindOneByIdempotencyKey')
+            ->with('fake:perpetual:exchange_fill:fill-concurrent')
+            ->willReturnCallback(static function () use (&$existing): ?FillCostLedgerEntry {
+                return $existing;
             });
 
         /** @var TradeLineageRepository $lineages */

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -170,6 +170,22 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         self::assertContains('missing_lineage', $entry->getQualityFlags());
     }
 
+    public function testLineageFallsBackToExchangeOrderIdWhenClientOrderIdIsUnknown(): void
+    {
+        $this->persistLineage('itd-ledger-fallback', 'cid-ledger-fallback-real', 'EX-FALLBACK-LINEAGE', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-FALLBACK-LINEAGE',
+            clientOrderId: 'stale-client-id',
+            fillId: 'fill-fallback-lineage',
+        )));
+
+        $entry = $this->ledger->findOneByIdempotencyKey('fake:perpetual:exchange_fill:fill-fallback-lineage');
+        self::assertInstanceOf(FillCostLedgerEntry::class, $entry);
+        self::assertSame('itd-ledger-fallback', $entry->getInternalTradeId());
+        self::assertSame([], $entry->getQualityFlags());
+    }
+
     public function testReplayWithDifferentResolvedLineageIsRejectedAsConflict(): void
     {
         $this->persistLineage('itd-ledger-lineage-a', 'cid-lineage-a', 'EX-LINEAGE-CONFLICT', null);


### PR DESCRIPTION
Part of #190
Related to #189
Related to #173
Related to #204

## Summary

Adds the first persistent, exchange-neutral fill and cost ledger linked to logical trades by exact lineage identifiers when available.

This PR starts with Fake/Paper as the deterministic reference source and does not certify Bitmart, OKX, or Hyperliquid net PnL.

## Delivered

- New additive table/entity `fill_cost_ledger` with indexes for exact lineage and venue identifiers.
- `FillCostLedgerIngestionService` for idempotent ingestion from normalized `ExchangeFillReceived` events.
- Exact idempotency key:
  - `exchange:market_type:exchange_fill:{exchange_fill_id}` when available;
  - `exchange:market_type:internal:{deterministic_fill_id}` otherwise.
- Conflict detection for replayed idempotency keys with different payloads.
- Exact lineage resolution by `internal_trade_id`, then same-venue `client_order_id`, `exchange_order_id`, or `position_id`; no symbol-only or time-window fallback.
- Missing lineage remains visible through `quality_flags=["missing_lineage"]`.
- Fee handling that keeps absent/unknown costs as `NULL`, converts USDT directly, and converts non-USDT only with an explicit fixture conversion rate.
- Funding adjustment ingestion with positive/negative sign preservation.
- Redacted `raw_reference`; no raw provider payload or secrets stored.
- Fake/Paper fill projection wired through `DoctrineExchangeLocalProjectionStore` after the existing `FuturesOrderTrade` projection.
- Documentation in `docs/handbook/technical/fill-cost-ledger.md` and a link from `certified-net-pnl-contract.md`.

## Out of scope

- No Bitmart/OKX/Hyperliquid certification.
- No strategy, MTF, EntryZone, Risk/Leverage, SL/TP, or live guard changes.
- No heuristic backfill.
- No merge/closure of #190 in this PR.

## Verification

Executed locally:

- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/phpunit tests/Trading/Pnl tests/Exchange/Event/ExchangeWsIngestionServiceTest.php tests/Exchange/Event/FakeExchangeEventNormalizerTest.php tests/Exchange/Adapter/FakeExchangeAdapterTest.php --no-coverage` -> OK, 62 tests / 299 assertions.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' vendor/bin/phpstan analyse --no-progress src/Entity/FillCostLedgerEntry.php src/Repository/FillCostLedgerEntryRepository.php src/Trading/Pnl/FillCostLedgerIngestionService.php src/Trading/Pnl/FillCostLedgerIngestionResult.php src/Trading/Pnl/FillCostLedgerIngestionConflict.php src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php migrations/Version20260625010000.php tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php --memory-limit=1G` -> OK.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/console lint:yaml config` -> OK.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/console lint:container --no-debug` -> OK, with pre-existing PHP 8.4 deprecation in `EntryZoneStatsCommand`.
- `git diff --check` -> OK.

PostgreSQL note:

- Direct SQL validation with `psql` against `localhost:5436` is blocked locally: connection refused.
- Docker is also unavailable locally (`~/.docker/run/docker.sock` missing), so full migration execution should be covered by CI/PostgreSQL environment.

## #190 remaining after this PR

This is a core ledger slice only. #190 should remain open after merge. Remaining work includes at least real exchange certification, broader backfill/divergence reporting, and downstream consumer gating on certified rows.