### PR TITLE
Issue 190 - Bitmart fill ledger ingestion

### DIFF
--- a/docs/handbook/technical/bitmart-ledger-ingestion.md
+++ b/docs/handbook/technical/bitmart-ledger-ingestion.md
@@ -1,0 +1,42 @@
+# Bitmart Fill Ledger Ingestion v1
+
+This document records the first Bitmart-specific ingestion path into the exchange-neutral `fill_cost_ledger`.
+
+## Scope
+
+Bitmart REST trade rows from `GET /contract/private/trades` are normalized into `ExchangeFillDto` through `BitmartExchangeAdapter::getFillsSnapshot()`. `ExchangeReconciliationService` can then publish `ExchangeFillReceived`, and the existing ledger ingestion persists those fills idempotently.
+
+This PR does not certify Bitmart net PnL. It imports fill facts and preserves available fee fields, while incomplete or ambiguous costs remain visible through ledger quality flags.
+
+## Source Matrix
+
+| Source field | Endpoint/topic | Ledger mapping | Currency | Sign | Quality | Certification |
+|---|---|---|---|---|---|---|
+| `trade_id` / `id` | `/contract/private/trades` | `exchange_fill_id` | n/a | n/a | exact when present | usable for idempotency |
+| `order_id` | `/contract/private/trades` | `exchange_order_id` | n/a | n/a | required | usable for lineage fallback |
+| `client_order_id` | `/contract/private/trades` when present | `client_order_id` | n/a | n/a | optional | usable for lineage fallback |
+| `position_id` / `exchange_position_id` | `/contract/private/trades` when present | metadata `position_id` | n/a | n/a | optional | usable for lineage fallback |
+| `side` | `/contract/private/trades` | side + position side | n/a | n/a | exact for numeric Bitmart side codes `1..4`; string side has unknown position side | partial |
+| `price` | `/contract/private/trades` | fill price | USDT quote implied by symbol | positive | required | fill fact only |
+| `vol` / `size` / `deal_size` / `filled_size` | `/contract/private/trades` | fill quantity | contract/base quantity | positive | required | fill fact only |
+| `fee` / `fees` / `commission` | `/contract/private/trades` | `fee_amount` | provider field | provider sign preserved | partial | `fee_usdt` only when currency is USDT or explicit conversion exists |
+| `fee_currency` / variants | `/contract/private/trades` | `fee_currency` | source value | n/a | optional | missing currency leaves `fee_usdt=NULL` |
+| `exec_type` / liquidity variants | `/contract/private/trades` | `liquidity_role` | n/a | n/a | maker/taker if explicit, otherwise unknown | informational |
+| `create_time` / `trade_time` / timestamp variants | `/contract/private/trades` | `occurred_at` | n/a | n/a | source timestamp, seconds or milliseconds | ordering only |
+| `flow_type=3` funding | `/contract/private/transaction-history` | not ingested in v1 | provider | not proven here | audited but inactive | not certified |
+| `flow_type=2` realized PnL | `/contract/private/transaction-history` | not ingested in v1 | provider | not proven gross/net | audited but inactive | not certified |
+
+## Runtime Behavior
+
+- `BitmartExchangeAdapter` now implements `ExchangeRestSnapshotProviderInterface`.
+- `getFillsSnapshot()` reads up to 200 recent trades from `BitmartAccountProvider::getTrades()` and maps only rows with symbol, order ID, positive quantity and positive price.
+- `getOrdersSnapshot()` keeps the existing open-order snapshot behavior.
+- `hasAuthoritativePositionSnapshot()` returns `false`: current Bitmart position reads can return an empty array on provider errors, so reconciliation must not close local positions from absence in this PR.
+- Duplicate REST/WS projection is delegated to the ledger idempotency key: `bitmart:perpetual:exchange_fill:{trade_id}` when Bitmart provides `trade_id`, otherwise the ledger deterministic fallback.
+
+## Limits
+
+- Funding is intentionally not persisted from Bitmart transactions until the sign and exact linkage to an internal trade are demonstrated by fixtures or runtime audit.
+- Non-USDT fees require an explicit conversion in event metadata; otherwise `fee_usdt` remains `NULL`.
+- Missing lineage does not block persistence, but the row is not considered certified net PnL.
+- No Bitmart live behavior, strategy, SL/TP, risk or guard logic changes are included.

--- a/docs/handbook/technical/fill-cost-ledger.md
+++ b/docs/handbook/technical/fill-cost-ledger.md
@@ -6,7 +6,7 @@ This document describes the first persistent ledger for exchange-neutral fills a
 
 The ledger persists normalized fill and cost facts in `fill_cost_ledger`. It is append-only for normal ingestion: a repeated event with the same idempotency key is treated as a replay, while the same key with a different payload is rejected as a conflict.
 
-This first version uses Fake/Paper as the deterministic reference source. Real exchanges may produce normalized `ExchangeFillReceived` events, but this PR does not certify Bitmart, OKX, or Hyperliquid net PnL.
+The first version uses Fake/Paper as the deterministic reference source. Bitmart can now project audited REST trade fills into the ledger; the Bitmart-specific coverage and remaining certification limits are documented in `docs/handbook/technical/bitmart-ledger-ingestion.md`. This does not certify Bitmart, OKX, or Hyperliquid net PnL.
 
 ## Stored Fields
 

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -306,7 +306,7 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface, Exchange
             positionSide: $positionSide,
             quantity: $quantity,
             price: $price,
-            fee: $this->floatOrNull($row['fee'] ?? $row['fees'] ?? $row['commission'] ?? null),
+            fee: $this->floatOrNull($row['paid_fees'] ?? $row['fee'] ?? $row['fees'] ?? $row['commission'] ?? null),
             feeCurrency: $this->stringValue($row['fee_currency'] ?? $row['feeCurrency'] ?? $row['fee_ccy'] ?? $row['feeCcy'] ?? null),
             filledAt: $this->tradeTime($row['trade_time'] ?? $row['tradeTime'] ?? $row['create_time'] ?? $row['timestamp'] ?? $row['time'] ?? null),
             metadata: $metadata,

--- a/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/BitmartExchangeAdapter.php
@@ -21,6 +21,7 @@ use App\Exchange\Dto\CancelOrderRequest;
 use App\Exchange\Dto\CancelOrderResult;
 use App\Exchange\Dto\ExchangeBalanceDto;
 use App\Exchange\Dto\ExchangeCapabilities;
+use App\Exchange\Dto\ExchangeFillDto;
 use App\Exchange\Dto\ExchangeOrderDto;
 use App\Exchange\Dto\ExchangePositionDto;
 use App\Exchange\Dto\ExchangeReconciliationResult;
@@ -32,11 +33,12 @@ use App\Exchange\Enum\ExchangeOrderType;
 use App\Exchange\Enum\ExchangePositionSide;
 use App\Exchange\Enum\ExchangeTimeInForce;
 use App\Provider\Context\ExchangeContext;
+use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
 use Psr\Clock\ClockInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 
 #[AutoconfigureTag('app.exchange_adapter')]
-final class BitmartExchangeAdapter implements ExchangeAdapterInterface
+final class BitmartExchangeAdapter implements ExchangeAdapterInterface, ExchangeRestSnapshotProviderInterface
 {
     private readonly ExchangeContext $context;
 
@@ -233,6 +235,157 @@ final class BitmartExchangeAdapter implements ExchangeAdapterInterface
             completedAt: $now,
             metadata: ['reason' => 'legacy_bitmart_reconciliation_not_wired_yet'],
         );
+    }
+
+    public function getOrdersSnapshot(?string $symbol = null): array
+    {
+        return $this->getOpenOrders($symbol);
+    }
+
+    public function getFillsSnapshot(?string $symbol = null): array
+    {
+        $fills = [];
+        foreach ($this->bundle()->account()->getTrades($symbol, 200) as $row) {
+            if (!\is_array($row)) {
+                continue;
+            }
+
+            $fill = $this->mapTradeFill($row);
+            if ($fill instanceof ExchangeFillDto) {
+                $fills[] = $fill;
+            }
+        }
+
+        usort($fills, static function (ExchangeFillDto $left, ExchangeFillDto $right): int {
+            return [$left->filledAt->getTimestamp(), $left->fillId ?? '', $left->exchangeOrderId]
+                <=> [$right->filledAt->getTimestamp(), $right->fillId ?? '', $right->exchangeOrderId];
+        });
+
+        return $fills;
+    }
+
+    public function hasAuthoritativePositionSnapshot(?string $symbol = null): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function mapTradeFill(array $row): ?ExchangeFillDto
+    {
+        $symbol = strtoupper((string) ($row['symbol'] ?? ''));
+        $exchangeOrderId = $this->stringValue($row['order_id'] ?? $row['orderId'] ?? null);
+        $quantity = $this->positiveFloat($row['vol'] ?? $row['size'] ?? $row['deal_size'] ?? $row['filled_size'] ?? $row['quantity'] ?? null);
+        $price = $this->positiveFloat($row['price'] ?? $row['deal_price'] ?? $row['exec_price'] ?? $row['execution_price'] ?? null);
+        if ($symbol === '' || $exchangeOrderId === null || $quantity === null || $price === null) {
+            return null;
+        }
+
+        [$side, $positionSide] = $this->tradeSide($row['side'] ?? null);
+        $metadata = $row + [
+            'source' => 'bitmart_rest_trades',
+            'source_version' => 'bitmart_ledger_ingestion_v1',
+            'pnl_source' => 'bitmart_rest_trades',
+            'liquidity_role' => $this->liquidityRoleFromTrade($row['exec_type'] ?? $row['liquidity_role'] ?? $row['liquidity'] ?? null),
+        ];
+        $positionId = $this->stringValue($row['position_id'] ?? $row['positionId'] ?? $row['exchange_position_id'] ?? null);
+        if ($positionId !== null) {
+            $metadata['position_id'] = $positionId;
+            $metadata['exchange_position_id'] = $positionId;
+        }
+
+        return new ExchangeFillDto(
+            exchange: $this->exchange(),
+            marketType: $this->marketType(),
+            symbol: $symbol,
+            exchangeOrderId: $exchangeOrderId,
+            clientOrderId: $this->stringValue($row['client_order_id'] ?? $row['clientOrderId'] ?? null),
+            fillId: $this->stringValue($row['trade_id'] ?? $row['tradeId'] ?? $row['id'] ?? null),
+            side: $side,
+            positionSide: $positionSide,
+            quantity: $quantity,
+            price: $price,
+            fee: $this->floatOrNull($row['fee'] ?? $row['fees'] ?? $row['commission'] ?? null),
+            feeCurrency: $this->stringValue($row['fee_currency'] ?? $row['feeCurrency'] ?? $row['fee_ccy'] ?? $row['feeCcy'] ?? null),
+            filledAt: $this->tradeTime($row['trade_time'] ?? $row['tradeTime'] ?? $row['create_time'] ?? $row['timestamp'] ?? $row['time'] ?? null),
+            metadata: $metadata,
+        );
+    }
+
+    /**
+     * @return array{0: ExchangeOrderSide, 1: ?ExchangePositionSide}
+     */
+    private function tradeSide(mixed $value): array
+    {
+        if (\is_numeric($value)) {
+            return match ((int) $value) {
+                1 => [ExchangeOrderSide::BUY, ExchangePositionSide::LONG],
+                2 => [ExchangeOrderSide::BUY, ExchangePositionSide::SHORT],
+                3 => [ExchangeOrderSide::SELL, ExchangePositionSide::LONG],
+                4 => [ExchangeOrderSide::SELL, ExchangePositionSide::SHORT],
+                default => [ExchangeOrderSide::BUY, null],
+            };
+        }
+
+        $side = strtolower((string) $value);
+
+        return match ($side) {
+            'sell', 'ask' => [ExchangeOrderSide::SELL, null],
+            default => [ExchangeOrderSide::BUY, null],
+        };
+    }
+
+    private function tradeTime(mixed $value): \DateTimeImmutable
+    {
+        if (\is_numeric($value)) {
+            $timestamp = (float) $value;
+            if ($timestamp > 9999999999) {
+                $timestamp /= 1000;
+            }
+
+            return (new \DateTimeImmutable('@' . (int) floor($timestamp)))->setTimezone(new \DateTimeZone('UTC'));
+        }
+
+        if (\is_string($value) && trim($value) !== '') {
+            return new \DateTimeImmutable($value);
+        }
+
+        return $this->clock->now();
+    }
+
+    private function positiveFloat(mixed $value): ?float
+    {
+        if (!\is_numeric($value)) {
+            return null;
+        }
+
+        $float = (float) $value;
+
+        return $float > 0.0 ? $float : null;
+    }
+
+    private function floatOrNull(mixed $value): ?float
+    {
+        return \is_numeric($value) ? (float) $value : null;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (!\is_scalar($value)) {
+            return null;
+        }
+
+        $string = trim((string) $value);
+
+        return $string !== '' ? $string : null;
+    }
+
+    private function liquidityRoleFromTrade(mixed $value): string
+    {
+        $role = strtolower((string) $value);
+
+        return \in_array($role, ['maker', 'taker'], true) ? $role : 'unknown';
     }
 
     private function bundle(): \App\Provider\Registry\ExchangeProviderBundle

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -421,7 +421,7 @@ final class BitmartExchangeAdapterTest extends TestCase
                 'side' => 1,
                 'price' => '25000.5',
                 'vol' => '0.25',
-                'fee' => '-0.0123',
+                'paid_fees' => '-0.0123',
                 'fee_currency' => 'USDT',
                 'exec_type' => 'maker',
                 'create_time' => 1767225601123,

--- a/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/BitmartExchangeAdapterTest.php
@@ -19,12 +19,14 @@ use App\Contract\Provider\OrderProviderInterface;
 use App\Contract\Provider\SystemProviderInterface;
 use App\Exchange\Adapter\BitmartExchangeAdapter;
 use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\ExchangeFillDto;
 use App\Exchange\Dto\PlaceOrderRequest;
 use App\Exchange\Enum\ExchangeOrderSide;
 use App\Exchange\Enum\ExchangeOrderStatus;
 use App\Exchange\Enum\ExchangeOrderType;
 use App\Exchange\Enum\ExchangePositionSide;
 use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Registry\ExchangeProviderBundle;
 use Brick\Math\BigDecimal;
@@ -262,9 +264,9 @@ final class BitmartExchangeAdapterTest extends TestCase
 
         $result = $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::SHORT, ExchangeOrderSide::SELL));
 
-        self::assertSame(ExchangeOrderSide::SELL, $result->order?->side);
-        self::assertSame(ExchangePositionSide::SHORT, $result->order?->positionSide);
-        self::assertFalse($result->order?->reduceOnly);
+        self::assertSame(ExchangeOrderSide::SELL, $result->order->side);
+        self::assertSame(ExchangePositionSide::SHORT, $result->order->positionSide);
+        self::assertFalse($result->order->reduceOnly);
     }
 
     public function testMapsReturnedLongExitFromRawBitmartSideCode(): void
@@ -286,10 +288,10 @@ final class BitmartExchangeAdapterTest extends TestCase
             postOnly: false,
         ));
 
-        self::assertSame(ExchangeOrderSide::SELL, $result->order?->side);
-        self::assertSame(ExchangePositionSide::LONG, $result->order?->positionSide);
-        self::assertTrue($result->order?->reduceOnly);
-        self::assertSame(ExchangeTimeInForce::IOC, $result->order?->timeInForce);
+        self::assertSame(ExchangeOrderSide::SELL, $result->order->side);
+        self::assertSame(ExchangePositionSide::LONG, $result->order->positionSide);
+        self::assertTrue($result->order->reduceOnly);
+        self::assertSame(ExchangeTimeInForce::IOC, $result->order->timeInForce);
     }
 
     public function testMapsReturnedGtcMode(): void
@@ -306,7 +308,7 @@ final class BitmartExchangeAdapterTest extends TestCase
 
         $result = $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::LONG, ExchangeOrderSide::BUY));
 
-        self::assertSame(ExchangeTimeInForce::GTC, $result->order?->timeInForce);
+        self::assertSame(ExchangeTimeInForce::GTC, $result->order->timeInForce);
     }
 
     public function testMapsReturnedPostOnlyModeAsGtc(): void
@@ -323,8 +325,8 @@ final class BitmartExchangeAdapterTest extends TestCase
 
         $result = $adapter->placeOrder($this->placeOrderRequest(ExchangePositionSide::LONG, ExchangeOrderSide::BUY));
 
-        self::assertTrue($result->order?->postOnly);
-        self::assertSame(ExchangeTimeInForce::GTC, $result->order?->timeInForce);
+        self::assertTrue($result->order->postOnly);
+        self::assertSame(ExchangeTimeInForce::GTC, $result->order->timeInForce);
     }
 
     public function testFallbackSubmitOnlyOrderPreservesSubmittedIntent(): void
@@ -346,13 +348,13 @@ final class BitmartExchangeAdapterTest extends TestCase
             postOnly: false,
         ));
 
-        self::assertSame('cid-1', $result->order?->clientOrderId);
-        self::assertSame(ExchangeOrderSide::SELL, $result->order?->side);
-        self::assertSame(ExchangePositionSide::LONG, $result->order?->positionSide);
-        self::assertTrue($result->order?->reduceOnly);
-        self::assertSame(ExchangeTimeInForce::IOC, $result->order?->timeInForce);
-        self::assertSame(3, $result->order?->metadata['side'] ?? null);
-        self::assertTrue($result->order?->metadata['submit_only'] ?? false);
+        self::assertSame('cid-1', $result->order->clientOrderId);
+        self::assertSame(ExchangeOrderSide::SELL, $result->order->side);
+        self::assertSame(ExchangePositionSide::LONG, $result->order->positionSide);
+        self::assertTrue($result->order->reduceOnly);
+        self::assertSame(ExchangeTimeInForce::IOC, $result->order->timeInForce);
+        self::assertSame(3, $result->order->metadata['side'] ?? null);
+        self::assertTrue($result->order->metadata['submit_only'] ?? false);
     }
 
     public function testGetOpenOrdersIncludesBitmartPlanOrders(): void
@@ -404,6 +406,82 @@ final class BitmartExchangeAdapterTest extends TestCase
         self::assertSame('exchange_order_cancel_failed', $result->metadata['reason'] ?? null);
     }
 
+    public function testExposesBitmartRestFillSnapshotsWithoutAuthoritativePositionClosure(): void
+    {
+        $accountProvider = $this->createMock(AccountProviderInterface::class);
+        $accountProvider
+            ->expects($this->once())
+            ->method('getTrades')
+            ->with('BTCUSDT', 200, null, null)
+            ->willReturn([[
+                'symbol' => 'BTCUSDT',
+                'order_id' => 'ex-fill-1',
+                'client_order_id' => 'cid-fill-1',
+                'trade_id' => 'trade-1',
+                'side' => 1,
+                'price' => '25000.5',
+                'vol' => '0.25',
+                'fee' => '-0.0123',
+                'fee_currency' => 'USDT',
+                'exec_type' => 'maker',
+                'create_time' => 1767225601123,
+                'position_id' => 'pos-1',
+            ]]);
+
+        $adapter = $this->createAdapterWithOrderProvider($this->createNoopOrderProvider(), $accountProvider);
+
+        self::assertInstanceOf(ExchangeRestSnapshotProviderInterface::class, $adapter);
+        self::assertFalse($adapter->hasAuthoritativePositionSnapshot('BTCUSDT'));
+
+        $fills = $adapter->getFillsSnapshot('BTCUSDT');
+
+        self::assertCount(1, $fills);
+        self::assertInstanceOf(ExchangeFillDto::class, $fills[0]);
+        self::assertSame('BTCUSDT', $fills[0]->symbol);
+        self::assertSame('ex-fill-1', $fills[0]->exchangeOrderId);
+        self::assertSame('cid-fill-1', $fills[0]->clientOrderId);
+        self::assertSame('trade-1', $fills[0]->fillId);
+        self::assertSame(ExchangeOrderSide::BUY, $fills[0]->side);
+        self::assertSame(ExchangePositionSide::LONG, $fills[0]->positionSide);
+        self::assertEqualsWithDelta(0.25, $fills[0]->quantity, 0.000001);
+        self::assertEqualsWithDelta(25000.5, $fills[0]->price, 0.000001);
+        self::assertEqualsWithDelta(-0.0123, $fills[0]->fee ?? 0.0, 0.000001);
+        self::assertSame('USDT', $fills[0]->feeCurrency);
+        self::assertSame('2026-01-01T00:00:01+00:00', $fills[0]->filledAt->format(\DateTimeInterface::ATOM));
+        self::assertSame('bitmart_rest_trades', $fills[0]->metadata['source'] ?? null);
+        self::assertSame('bitmart_ledger_ingestion_v1', $fills[0]->metadata['source_version'] ?? null);
+        self::assertSame('maker', $fills[0]->metadata['liquidity_role'] ?? null);
+        self::assertSame('pos-1', $fills[0]->metadata['position_id'] ?? null);
+    }
+
+    public function testBitmartRestFillSnapshotKeepsUnknownFeeCurrencyUncertified(): void
+    {
+        $accountProvider = $this->createMock(AccountProviderInterface::class);
+        $accountProvider
+            ->expects($this->once())
+            ->method('getTrades')
+            ->willReturn([[
+                'symbol' => 'BTCUSDT',
+                'order_id' => 'ex-fill-2',
+                'trade_id' => 'trade-2',
+                'side' => 2,
+                'price' => '24900',
+                'size' => '1',
+                'fee' => '0.01',
+                'create_time' => 1767225602000,
+            ]]);
+
+        $adapter = $this->createAdapterWithOrderProvider($this->createNoopOrderProvider(), $accountProvider);
+        $fills = $adapter->getFillsSnapshot('BTCUSDT');
+
+        self::assertCount(1, $fills);
+        self::assertSame(ExchangeOrderSide::BUY, $fills[0]->side);
+        self::assertSame(ExchangePositionSide::SHORT, $fills[0]->positionSide);
+        self::assertEqualsWithDelta(0.01, $fills[0]->fee ?? 0.0, 0.000001);
+        self::assertNull($fills[0]->feeCurrency);
+        self::assertSame('unknown', $fills[0]->metadata['liquidity_role'] ?? null);
+    }
+
     /**
      * @param callable(array<string,mixed>): void $captureOptions
      */
@@ -431,14 +509,17 @@ final class BitmartExchangeAdapterTest extends TestCase
         return $this->createAdapterWithOrderProvider($orderProvider);
     }
 
-    private function createAdapterWithOrderProvider(OrderProviderInterface $orderProvider): BitmartExchangeAdapter
+    private function createAdapterWithOrderProvider(
+        OrderProviderInterface $orderProvider,
+        ?AccountProviderInterface $accountProvider = null,
+    ): BitmartExchangeAdapter
     {
         $bundle = new ExchangeProviderBundle(
             new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
             $this->createMock(KlineProviderInterface::class),
             $this->createMock(ContractProviderInterface::class),
             $orderProvider,
-            $this->createMock(AccountProviderInterface::class),
+            $accountProvider ?? $this->createMock(AccountProviderInterface::class),
             $this->createMock(SystemProviderInterface::class),
         );
 
@@ -446,6 +527,14 @@ final class BitmartExchangeAdapterTest extends TestCase
         $registry->method('get')->willReturn($bundle);
 
         return new BitmartExchangeAdapter($registry, $this->fixedClock());
+    }
+
+    private function createNoopOrderProvider(): OrderProviderInterface
+    {
+        $orderProvider = $this->createMock(OrderProviderInterface::class);
+        $orderProvider->method('getOpenOrders')->willReturn([]);
+
+        return $orderProvider;
     }
 
     private function placeOrderRequest(
@@ -522,6 +611,9 @@ final readonly class PlanOrderProviderStub implements OrderProviderInterface
     {
     }
 
+    /**
+     * @param array<string,mixed> $options
+     */
     public function placeOrder(
         string $symbol,
         OrderSide $side,
@@ -544,6 +636,9 @@ final readonly class PlanOrderProviderStub implements OrderProviderInterface
         return null;
     }
 
+    /**
+     * @return OrderDto[]
+     */
     public function getOpenOrders(?string $symbol = null): array
     {
         return [];
@@ -554,6 +649,9 @@ final readonly class PlanOrderProviderStub implements OrderProviderInterface
         return [];
     }
 
+    /**
+     * @return OrderDto[]
+     */
     public function getOrderHistory(string $symbol, int $limit = 100): array
     {
         return [];


### PR DESCRIPTION
## Context

Part of #190
Related to #195
Related to #173
Related to #207

This PR adds the first conservative Bitmart ingestion path into the persistent fill/cost ledger. It uses audited REST trade rows from `/contract/private/trades` and does not certify Bitmart net PnL.

## Changes

- `BitmartExchangeAdapter` now implements `ExchangeRestSnapshotProviderInterface`.
- `getFillsSnapshot()` maps Bitmart trade rows into `ExchangeFillDto` with exact venue identifiers when present: `trade_id`, `order_id`, `client_order_id`, and `position_id`.
- Bitmart REST fills can now be published by `ExchangeReconciliationService` as `ExchangeFillReceived`, then persisted by the existing idempotent ledger service.
- Bitmart position snapshots are intentionally non-authoritative in this PR to avoid closing local positions from a provider error that returns an empty list.
- Added Bitmart ledger ingestion documentation and a source-field matrix.

## Certification limits

- No Bitmart net PnL certification in this PR.
- Funding from transaction history is documented but not ingested because source sign/linkage is not proven by fixture/runtime audit here.
- Missing fee currency or non-USDT fees remain incomplete unless an explicit conversion is supplied by the event metadata.
- No live strategy, SL/TP, risk, leverage, or guard behavior is changed.

## Tests

- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL=sqlite:///:memory: php bin/phpunit tests/Exchange/Adapter/BitmartExchangeAdapterTest.php --no-coverage` -> OK, 22 tests / 186 assertions.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL=sqlite:///:memory: php bin/phpunit tests/Exchange/Adapter/BitmartExchangeAdapterTest.php tests/Exchange/Contract/BitmartExchangeAdapterContractTest.php tests/Exchange/Reconciliation/ExchangeReconciliationServiceTest.php tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php --no-coverage` -> OK, 74 tests / 347 assertions, 9 skipped contract cases.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL=sqlite:///:memory: vendor/bin/phpstan analyse --no-progress src/Exchange/Adapter/BitmartExchangeAdapter.php tests/Exchange/Adapter/BitmartExchangeAdapterTest.php --memory-limit=1G` -> OK.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL=sqlite:///:memory: php bin/console lint:yaml config` -> OK.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL=sqlite:///:memory: php bin/console lint:container --no-debug` -> OK, with pre-existing PHP 8.4 deprecation in `EntryZoneStatsCommand`.
- `git diff --check` -> OK.