### PR TITLE
Issue 190 - Partial fill quantity aggregation

### DIFF
--- a/docs/handbook/technical/certified-net-pnl-contract.md
+++ b/docs/handbook/technical/certified-net-pnl-contract.md
@@ -30,12 +30,16 @@ net_pnl_usdt =
 - les montants sont normalises en USDT ;
 - les fills d'entree et de sortie sont complets ;
 - `entry_qty = exit_qty`, `remaining_qty = 0`, et `position_fully_closed=true` ;
+- `quantity_status=complete` dans l'agregat `FillQuantityAggregationService` ;
+- aucun `quantity_quality_flags` bloquant (`fill_conflict`, `exit_qty_exceeds_entry_qty`, `missing_entry_fill`, `missing_exit_fill`, `position_not_fully_closed`) ;
 - aucun `identifier_conflict` ;
 - le lineage est suffisant.
 
 Sinon `cost_completeness` vaut `partial` ou `unknown`, `net_pnl_usdt` vaut `NULL`, et `pnl_quality_flags` liste les raisons (`missing_entry_fee`, `quantity_mismatch`, `position_not_fully_closed`, etc.).
 
 Les valeurs numeriques legacy ou provider qui ne sont pas parseables sont traitees comme inconnues. Elles ne doivent jamais faire echouer la lecture de `position_trade_analysis_v2` et ne peuvent pas produire un PnL net certifie.
+
+Aucun flag provider du type `quantity_coherent=true` ne remplace cette preuve quantitative. Les TP1, trailing du reliquat, scale-out, partial stop et partial entry fills doivent etre reduits au meme triplet `entry_qty`, `exit_qty`, `remaining_qty` avant certification.
 
 ## Audit des sources
 
@@ -46,7 +50,7 @@ Les valeurs numeriques legacy ou provider qui ne sont pas parseables sont traite
 | Fake/Paper | fee par fill/devise | fee deterministe `notional * 0.0005`, `USDT` | cout explicite | positif | au fill | fill | complet | non | fill fee USDT | `testFakeFillsExpose...` |
 | Fake/Paper | funding/spread/slippage/borrow/liquidation | lifecycle `extra` explicite fixture | couts normalises | funding credit positif/debit negatif | a la cloture | trade | complet si fourni | non pour certification | `position_trade_analysis_v2` fixture | PostgreSQL view test |
 | Bitmart | order fill price/qty | `OrderDto` / `/contract/private/order*` (`deal_avg_price`, `deal_size`) | brut order | positif | apres fill/order history | ordre | partiel | oui | payload brut metadata | adapter tests existants |
-| Bitmart | fee par fill/devise | `/contract/private/trades` (`fee`, `fee_currency`) | cout fill | provider brut, non normalise garanti | apres REST sync | fill | partiel, pas relie au trade logique complet | oui | `FuturesOrderTrade` | projection tests partiels |
+| Bitmart | fee par fill/devise | `/contract/private/trades` (`paid_fees`, `fee_currency`) | cout fill | provider brut, non normalise garanti | apres REST sync | fill | partiel, pas relie au trade logique complet | oui | `FuturesOrderTrade` | projection tests partiels |
 | Bitmart | realized PnL provider | `/contract/private/transaction-history` flow_type=2 | inconnu brut/net | montant provider | apres cloture | transaction | non certifie | oui | transaction raw | sync tests existants |
 | Bitmart | funding | `/contract/private/transaction-history` flow_type=3, contract funding metadata | funding provider | non certifie ici | apres transaction | transaction | partiel | oui | raw transaction | aucun contrat net |
 | Bitmart | spread/slippage/borrow/liquidation | logs/config ou absent | absent | n/a | n/a | n/a | non disponible | oui | aucun | aucun |
@@ -66,6 +70,8 @@ Le ledger persistant v1 est documente dans `docs/handbook/technical/fill-cost-le
 Il introduit la table `fill_cost_ledger`, reliee au trade logique par `internal_trade_id` lorsque le lineage exact est disponible. L'idempotence est portee par `exchange + market_type + exchange_fill_id` quand l'exchange fournit un identifiant de fill, sinon par un identifiant interne deterministe documente.
 
 Les couts absents restent `NULL`. Les rows sans lineage exact restent visibles avec `quality_flags=["missing_lineage"]` et ne doivent pas etre considerees comme net PnL certifie.
+
+La quantite residuelle est calculee par `FillQuantityAggregationService` sur `internal_trade_id + exchange + market_type`. Le certificateur peut consommer le resultat via `certifyWithQuantityAggregation(...)`; si l'agregat n'autorise pas la certification, `net_pnl_usdt` et `realized_net_pnl_R` restent `NULL` meme lorsque les listes de fills passees au calcul semblent equilibrees.
 
 ## MFE / MAE
 

--- a/docs/handbook/technical/certified-net-pnl-contract.md
+++ b/docs/handbook/technical/certified-net-pnl-contract.md
@@ -73,6 +73,8 @@ Les couts absents restent `NULL`. Les rows sans lineage exact restent visibles a
 
 La quantite residuelle est calculee par `FillQuantityAggregationService` sur `internal_trade_id + exchange + market_type`. Le certificateur peut consommer le resultat via `certifyWithQuantityAggregation(...)`; si l'agregat n'autorise pas la certification, `net_pnl_usdt` et `realized_net_pnl_R` restent `NULL` meme lorsque les listes de fills passees au calcul semblent equilibrees.
 
+`position_trade_analysis_v2` ne certifie plus le net a partir des seuls extras `position_closed`. Tant que la vue SQL ne consomme pas directement l'agregat ledger persistant, elle ajoute `ledger_quantity_aggregate_missing`, garde `cost_completeness=partial` pour les lignes autrement completes et laisse `net_pnl_usdt`/`realized_net_pnl_R` a `NULL`.
+
 ## MFE / MAE
 
 La vue conserve les champs historiques `mfe_pct` et `mae_pct` provenant du listener lifecycle. Leur source actuelle est best-effort via klines 1m (`high/low`) entre ouverture et cloture. Cette source n'est pas une certification microstructure : gaps, donnees manquantes, mark/mid/last et scale-in restent a versionner separement.

--- a/docs/handbook/technical/fill-cost-ledger.md
+++ b/docs/handbook/technical/fill-cost-ledger.md
@@ -76,6 +76,47 @@ Replays with the same canonical fill/cost payload hash are ignored. Mutable proj
 
 When a higher-priority identifier is present but unmatched, the resolver continues to the next exact identifier. There is no fallback by symbol alone and no timestamp-window matching. If no lineage is found, the row is still persisted with `quality_flags=["missing_lineage"]`.
 
+## Quantity Aggregation
+
+`FillQuantityAggregationService` builds the deterministic quantity state for one logical trade and one venue. The input scope is exactly:
+
+```text
+internal_trade_id + exchange + market_type
+```
+
+It does not match by symbol, timestamp, profile, or "next close" ordering. The repository query orders by `occurred_at, id`, and the service recomputes quantities from persisted ledger facts.
+
+The aggregation exposes:
+
+- `entry_first_fill_at`
+- `entry_last_fill_at`
+- `entry_qty`
+- `entry_vwap`
+- `exit_first_fill_at`
+- `exit_last_fill_at`
+- `exit_qty`
+- `exit_vwap`
+- `remaining_qty`
+- `position_fully_closed`
+- `quantity_status`
+- `quantity_quality_flags`
+
+`entry_vwap` and `exit_vwap` are quantity-weighted from fill price and quantity. Funding and cost-only adjustment rows contribute to cost aggregates but not to entry or exit quantity.
+
+The default close tolerance is `0.00000001`. A position is fully closed only when `remaining_qty` is within that tolerance and no blocking quantity flag is present.
+
+Current statuses:
+
+- `complete`: entry and exit quantities are present and the residual quantity is zero within tolerance.
+- `open_position`: entry quantity exists but exit quantity is absent or smaller than entry quantity.
+- `missing_entry_fill`: no usable entry fill exists.
+- `quantity_mismatch`: exit quantity exceeds entry quantity.
+- `fill_conflict`: the same venue fill identifier appears with a different quantitative payload.
+
+Quality flags keep non-blocking audit details visible. Exact duplicate fills are ignored and flagged with `duplicate_fill_ignored`; cancelled/corrected/voided rows are ignored and flagged with `cancelled_fill_ignored`. A conflicting duplicate is never resolved arbitrarily and blocks net PnL certification.
+
+PostgreSQL fixture coverage for manual or CI-backed checks lives in `tests/fixtures/fill_quantity_aggregation_postgres.sql`. It seeds a complete partial-entry/TP1/trailing case, an open partial-exit case, and a conflicting duplicate venue fill case against the real `fill_cost_ledger` schema.
+
 ## Fee Conversion
 
 `fee_amount` preserves the provider-reported amount for audit, including provider sign conventions. `fee_usdt` stores the normalized USDT cost used by certification and is non-negative; provider-signed charged fees such as `-0.02 USDT` are stored as `fee_amount=-0.020000000000` and `fee_usdt=0.020000000000`.

--- a/tests/fixtures/fill_quantity_aggregation_postgres.sql
+++ b/tests/fixtures/fill_quantity_aggregation_postgres.sql
@@ -1,0 +1,56 @@
+-- PostgreSQL fixture for #190 partial-fill quantity aggregation.
+-- Requires the fill_cost_ledger table from Doctrine migration Version20260625010000.
+-- The fixture intentionally uses exact internal_trade_id + exchange + market_type scopes.
+
+DELETE FROM fill_cost_ledger
+WHERE source = 'fill_quantity_aggregation_fixture_v1';
+
+INSERT INTO fill_cost_ledger (
+    idempotency_key,
+    payload_hash,
+    internal_trade_id,
+    internal_position_id,
+    position_id,
+    exchange,
+    market_type,
+    symbol,
+    side,
+    fill_id,
+    exchange_fill_id,
+    exchange_order_id,
+    client_order_id,
+    order_intent_id,
+    fill_role,
+    liquidity_role,
+    price,
+    quantity,
+    notional,
+    fee_amount,
+    fee_currency,
+    fee_usdt,
+    funding_usdt,
+    spread_cost_usdt,
+    slippage_cost_usdt,
+    borrow_cost_usdt,
+    liquidation_fee_usdt,
+    occurred_at,
+    source,
+    source_version,
+    quality_flags,
+    raw_reference,
+    created_at
+) VALUES
+-- Complete long: partial entry fills + TP1 + trailing remainder.
+('fixture:bitmart:futures:exchange_fill:pf-entry-1', repeat('a', 64), 'fixture-trade-complete', 'fixture-pos-complete', 'BM-POS-1', 'bitmart', 'futures', 'BTCUSDT', 'BUY', 'pf-entry-1', 'pf-entry-1', 'ord-entry-1', 'client-entry-1', NULL, 'entry', 'maker', 100.000000000000, 0.400000000000, 40.000000000000, -0.020000000000, 'USDT', 0.020000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 10:00:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"partial_entry"}'::jsonb, now()),
+('fixture:bitmart:futures:exchange_fill:pf-entry-2', repeat('b', 64), 'fixture-trade-complete', 'fixture-pos-complete', 'BM-POS-1', 'bitmart', 'futures', 'BTCUSDT', 'BUY', 'pf-entry-2', 'pf-entry-2', 'ord-entry-1', 'client-entry-1', NULL, 'entry', 'taker', 101.000000000000, 0.600000000000, 60.600000000000, -0.030000000000, 'USDT', 0.030000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 10:00:20+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"partial_entry"}'::jsonb, now()),
+('fixture:bitmart:futures:exchange_fill:pf-tp1', repeat('c', 64), 'fixture-trade-complete', 'fixture-pos-complete', 'BM-POS-1', 'bitmart', 'futures', 'BTCUSDT', 'SELL', 'pf-tp1', 'pf-tp1', 'ord-tp1', 'client-tp1', NULL, 'exit', 'maker', 110.000000000000, 0.500000000000, 55.000000000000, -0.040000000000, 'USDT', 0.040000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 10:10:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"tp1"}'::jsonb, now()),
+('fixture:bitmart:futures:exchange_fill:pf-trailing', repeat('d', 64), 'fixture-trade-complete', 'fixture-pos-complete', 'BM-POS-1', 'bitmart', 'futures', 'BTCUSDT', 'SELL', 'pf-trailing', 'pf-trailing', 'ord-trailing', 'client-trailing', NULL, 'exit', 'taker', 108.000000000000, 0.500000000000, 54.000000000000, -0.050000000000, 'USDT', 0.050000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 10:20:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"trailing_remainder"}'::jsonb, now()),
+('fixture:bitmart:futures:internal:pf-funding', repeat('e', 64), 'fixture-trade-complete', 'fixture-pos-complete', 'BM-POS-1', 'bitmart', 'futures', 'BTCUSDT', NULL, 'pf-funding', NULL, NULL, NULL, NULL, 'funding', 'unknown', NULL, NULL, NULL, NULL, NULL, NULL, 0.120000000000, NULL, NULL, NULL, NULL, '2026-06-25 10:15:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"funding_credit"}'::jsonb, now()),
+
+-- Open after TP1: residual quantity must remain positive.
+('fixture:fake:paper:exchange_fill:open-entry', repeat('f', 64), 'fixture-trade-open', 'fixture-pos-open', 'FAKE-POS-1', 'fake', 'paper', 'ETHUSDT', 'BUY', 'open-entry', 'open-entry', 'ord-open-entry', 'client-open-entry', NULL, 'entry', 'maker', 200.000000000000, 2.000000000000, 400.000000000000, 0.000000000000, 'USDT', 0.000000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 11:00:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"open_partial_exit"}'::jsonb, now()),
+('fixture:fake:paper:exchange_fill:open-tp1', repeat('1', 64), 'fixture-trade-open', 'fixture-pos-open', 'FAKE-POS-1', 'fake', 'paper', 'ETHUSDT', 'SELL', 'open-tp1', 'open-tp1', 'ord-open-tp1', 'client-open-tp1', NULL, 'exit', 'maker', 210.000000000000, 0.800000000000, 168.000000000000, 0.000000000000, 'USDT', 0.000000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 11:05:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"open_partial_exit"}'::jsonb, now()),
+
+-- Conflicting replay: same exchange_fill_id with different quantity/price must be flagged by the service.
+('fixture:fake:paper:exchange_fill:conflict-a', repeat('2', 64), 'fixture-trade-conflict', 'fixture-pos-conflict', 'FAKE-POS-2', 'fake', 'paper', 'SOLUSDT', 'BUY', 'conflict-a', 'same-exchange-fill-id', 'ord-conflict', 'client-conflict', NULL, 'entry', 'maker', 50.000000000000, 1.000000000000, 50.000000000000, 0.000000000000, 'USDT', 0.000000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 12:00:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"conflicting_duplicate"}'::jsonb, now()),
+('fixture:fake:paper:exchange_fill:conflict-b', repeat('3', 64), 'fixture-trade-conflict', 'fixture-pos-conflict', 'FAKE-POS-2', 'fake', 'paper', 'SOLUSDT', 'BUY', 'conflict-b', 'same-exchange-fill-id', 'ord-conflict', 'client-conflict', NULL, 'entry', 'maker', 51.000000000000, 1.000000000000, 51.000000000000, 0.000000000000, 'USDT', 0.000000000000, NULL, NULL, NULL, NULL, NULL, '2026-06-25 12:00:00+00', 'fill_quantity_aggregation_fixture_v1', 'postgres_fixture_v1', '[]'::jsonb, '{"case":"conflicting_duplicate"}'::jsonb, now());

--- a/trading-app/migrations/Version20260625000000.php
+++ b/trading-app/migrations/Version20260625000000.php
@@ -524,6 +524,7 @@ LEFT JOIN LATERAL (
 LEFT JOIN LATERAL (
   SELECT ARRAY_REMOVE(ARRAY[
     CASE WHEN m.close_event_id IS NULL THEN 'unmatched' END,
+    CASE WHEN m.close_event_id IS NOT NULL THEN 'ledger_quantity_aggregate_missing' END,
     CASE WHEN m.close_event_id IS NOT NULL AND money.gross_realized_pnl_usdt IS NULL THEN 'missing_gross_pnl' END,
     CASE WHEN m.close_event_id IS NOT NULL AND money.entry_fee_usdt IS NULL THEN 'missing_entry_fee' END,
     CASE WHEN m.close_event_id IS NOT NULL AND money.exit_fee_usdt IS NULL THEN 'missing_exit_fee' END,

--- a/trading-app/migrations/Version20260625020000.php
+++ b/trading-app/migrations/Version20260625020000.php
@@ -566,7 +566,7 @@ SQL);
     {
         $previousMigrationClass = __NAMESPACE__ . '\\Version20260625000000';
         if (!class_exists($previousMigrationClass, false)) {
-            require_once __DIR__ . '/Version20260623010000.php';
+            require_once __DIR__ . '/Version20260625000000.php';
         }
         if (!is_a($previousMigrationClass, AbstractMigration::class, true)) {
             $this->throwIrreversibleMigrationException('Previous certified net PnL view migration is not loadable.');

--- a/trading-app/migrations/Version20260625020000.php
+++ b/trading-app/migrations/Version20260625020000.php
@@ -17,11 +17,11 @@ use Psr\Log\NullLogger;
  * complète, la cohérence de quantité et le lineage sont démontrés. Sinon `net_pnl_usdt` reste
  * NULL et les raisons sont exposées dans `pnl_quality_flags`.
  */
-final class Version20260625000000 extends AbstractMigration
+final class Version20260625020000 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'DATA-002: expose certified net PnL contract fields in position_trade_analysis_v2';
+        return 'DATA-002: gate certified net PnL on ledger quantity aggregate in position_trade_analysis_v2';
     }
 
     public function up(Schema $schema): void
@@ -524,6 +524,7 @@ LEFT JOIN LATERAL (
 LEFT JOIN LATERAL (
   SELECT ARRAY_REMOVE(ARRAY[
     CASE WHEN m.close_event_id IS NULL THEN 'unmatched' END,
+    CASE WHEN m.close_event_id IS NOT NULL THEN 'ledger_quantity_aggregate_missing' END,
     CASE WHEN m.close_event_id IS NOT NULL AND money.gross_realized_pnl_usdt IS NULL THEN 'missing_gross_pnl' END,
     CASE WHEN m.close_event_id IS NOT NULL AND money.entry_fee_usdt IS NULL THEN 'missing_entry_fee' END,
     CASE WHEN m.close_event_id IS NOT NULL AND money.exit_fee_usdt IS NULL THEN 'missing_exit_fee' END,
@@ -563,12 +564,12 @@ SQL);
 
     public function down(Schema $schema): void
     {
-        $previousMigrationClass = __NAMESPACE__ . '\\Version20260623010000';
+        $previousMigrationClass = __NAMESPACE__ . '\\Version20260625000000';
         if (!class_exists($previousMigrationClass, false)) {
             require_once __DIR__ . '/Version20260623010000.php';
         }
         if (!is_a($previousMigrationClass, AbstractMigration::class, true)) {
-            $this->throwIrreversibleMigrationException('Previous position_trade_analysis_v2 migration is not loadable.');
+            $this->throwIrreversibleMigrationException('Previous certified net PnL view migration is not loadable.');
         }
 
         /** @var class-string<AbstractMigration> $previousMigrationClass */
@@ -577,6 +578,5 @@ SQL);
         foreach ($previous->getSql() as $query) {
             $this->addSql($query->getStatement(), $query->getParameters(), $query->getTypes());
         }
-        $this->addSql('DROP FUNCTION IF EXISTS trading_v3_safe_numeric(text)');
     }
 }

--- a/trading-app/src/Repository/FillCostLedgerEntryRepository.php
+++ b/trading-app/src/Repository/FillCostLedgerEntryRepository.php
@@ -57,6 +57,24 @@ class FillCostLedgerEntryRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    /**
+     * @return FillCostLedgerEntry[]
+     */
+    public function findByInternalTradeIdAndVenue(string $internalTradeId, string $exchange, string $marketType): array
+    {
+        return $this->createQueryBuilder('entry')
+            ->andWhere('entry.internalTradeId = :internalTradeId')
+            ->andWhere('entry.exchange = :exchange')
+            ->andWhere('entry.marketType = :marketType')
+            ->setParameter('internalTradeId', $internalTradeId)
+            ->setParameter('exchange', strtolower(trim($exchange)))
+            ->setParameter('marketType', strtolower(trim($marketType)))
+            ->orderBy('entry.occurredAt', 'ASC')
+            ->addOrderBy('entry.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function save(FillCostLedgerEntry $entry): void
     {
         $this->getEntityManager()->persist($entry);

--- a/trading-app/src/Trading/Pnl/FillQuantityAggregationResult.php
+++ b/trading-app/src/Trading/Pnl/FillQuantityAggregationResult.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Pnl;
+
+final readonly class FillQuantityAggregationResult
+{
+    /**
+     * @param list<string> $quantityQualityFlags
+     */
+    public function __construct(
+        public string $internalTradeId,
+        public string $exchange,
+        public string $marketType,
+        public ?\DateTimeImmutable $entryFirstFillAt,
+        public ?\DateTimeImmutable $entryLastFillAt,
+        public ?float $entryQty,
+        public ?float $entryVwap,
+        public ?\DateTimeImmutable $exitFirstFillAt,
+        public ?\DateTimeImmutable $exitLastFillAt,
+        public ?float $exitQty,
+        public ?float $exitVwap,
+        public ?float $remainingQty,
+        public bool $positionFullyClosed,
+        public string $quantityStatus,
+        public array $quantityQualityFlags,
+        public ?float $feeUsdt,
+        public ?float $fundingUsdt,
+        public ?float $spreadCostUsdt,
+        public ?float $slippageCostUsdt,
+        public ?float $borrowCostUsdt,
+        public ?float $liquidationFeeUsdt,
+    ) {
+    }
+
+    public function netPnlCertificationAllowed(): bool
+    {
+        return $this->quantityStatus === 'complete'
+            && $this->positionFullyClosed
+            && $this->remainingQty !== null
+            && abs($this->remainingQty) <= FillQuantityAggregationService::DEFAULT_QUANTITY_TOLERANCE
+            && !\in_array('fill_conflict', $this->quantityQualityFlags, true);
+    }
+}

--- a/trading-app/src/Trading/Pnl/FillQuantityAggregationService.php
+++ b/trading-app/src/Trading/Pnl/FillQuantityAggregationService.php
@@ -103,6 +103,9 @@ final readonly class FillQuantityAggregationService
 
         $entryAggregate = $this->aggregateFillSide($entryFills);
         $exitAggregate = $this->aggregateFillSide($exitFills);
+        if ($entryAggregate['invalid'] === true || $exitAggregate['invalid'] === true) {
+            $flags[] = 'invalid_quantitative_fill';
+        }
         $remainingQty = null;
         if ($entryAggregate['qty'] !== null && $exitAggregate['qty'] !== null) {
             $remainingQty = $entryAggregate['qty'] - $exitAggregate['qty'];
@@ -207,7 +210,7 @@ final readonly class FillQuantityAggregationService
 
     /**
      * @param list<FillCostLedgerEntry> $fills
-     * @return array{firstAt:?\DateTimeImmutable,lastAt:?\DateTimeImmutable,qty:?float,vwap:?float}
+     * @return array{firstAt:?\DateTimeImmutable,lastAt:?\DateTimeImmutable,qty:?float,vwap:?float,invalid:bool}
      */
     private function aggregateFillSide(array $fills): array
     {
@@ -217,15 +220,18 @@ final readonly class FillQuantityAggregationService
                 'lastAt' => null,
                 'qty' => null,
                 'vwap' => null,
+                'invalid' => false,
             ];
         }
 
         $quantity = 0.0;
         $notional = 0.0;
+        $invalid = false;
         foreach ($fills as $fill) {
             $fillQuantity = $fill->getQuantity() !== null ? (float) $fill->getQuantity() : null;
             $fillPrice = $fill->getPrice() !== null ? (float) $fill->getPrice() : null;
             if ($fillQuantity === null || $fillPrice === null || $fillQuantity <= 0.0 || $fillPrice <= 0.0) {
+                $invalid = true;
                 continue;
             }
 
@@ -238,6 +244,7 @@ final readonly class FillQuantityAggregationService
             'lastAt' => $fills[\count($fills) - 1]->getOccurredAt(),
             'qty' => $quantity > 0.0 ? $quantity : null,
             'vwap' => $quantity > 0.0 ? $notional / $quantity : null,
+            'invalid' => $invalid,
         ];
     }
 
@@ -249,6 +256,9 @@ final readonly class FillQuantityAggregationService
     {
         if (\in_array('fill_conflict', $existingFlags, true)) {
             return ['fill_conflict', ['fill_conflict'], false];
+        }
+        if (\in_array('invalid_quantitative_fill', $existingFlags, true)) {
+            return ['invalid_fill_quantity', ['invalid_quantitative_fill'], false];
         }
         if ($entryQty === null) {
             return ['missing_entry_fill', ['missing_entry_fill'], false];

--- a/trading-app/src/Trading/Pnl/FillQuantityAggregationService.php
+++ b/trading-app/src/Trading/Pnl/FillQuantityAggregationService.php
@@ -170,13 +170,21 @@ final readonly class FillQuantityAggregationService
             return null;
         }
 
-        $fingerprint = implode('|', [
-            $entry->getFillRole(),
-            (string) $entry->getPrice(),
-            (string) $entry->getQuantity(),
-            (string) $entry->getFeeUsdt(),
-            $entry->getOccurredAt()->format(\DateTimeInterface::ATOM),
-        ]);
+        $fingerprint = json_encode([
+            'fill_role' => $entry->getFillRole(),
+            'price' => $entry->getPrice(),
+            'quantity' => $entry->getQuantity(),
+            'notional' => $entry->getNotional(),
+            'fee_amount' => $entry->getFeeAmount(),
+            'fee_currency' => $entry->getFeeCurrency(),
+            'fee_usdt' => $entry->getFeeUsdt(),
+            'funding_usdt' => $entry->getFundingUsdt(),
+            'spread_cost_usdt' => $entry->getSpreadCostUsdt(),
+            'slippage_cost_usdt' => $entry->getSlippageCostUsdt(),
+            'borrow_cost_usdt' => $entry->getBorrowCostUsdt(),
+            'liquidation_fee_usdt' => $entry->getLiquidationFeeUsdt(),
+            'occurred_at' => $entry->getOccurredAt()->format(\DateTimeInterface::ATOM),
+        ], \JSON_THROW_ON_ERROR);
         if (!isset($seenFillFingerprints[$identity])) {
             $seenFillFingerprints[$identity] = $fingerprint;
 

--- a/trading-app/src/Trading/Pnl/FillQuantityAggregationService.php
+++ b/trading-app/src/Trading/Pnl/FillQuantityAggregationService.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Pnl;
+
+use App\Entity\FillCostLedgerEntry;
+use App\Repository\FillCostLedgerEntryRepository;
+
+final readonly class FillQuantityAggregationService
+{
+    public const DEFAULT_QUANTITY_TOLERANCE = 0.00000001;
+
+    public function __construct(
+        private ?FillCostLedgerEntryRepository $ledger = null,
+        private float $quantityTolerance = self::DEFAULT_QUANTITY_TOLERANCE,
+    ) {
+    }
+
+    public function aggregateByTradeVenue(
+        string $internalTradeId,
+        string $exchange,
+        string $marketType,
+    ): FillQuantityAggregationResult {
+        if (!$this->ledger instanceof FillCostLedgerEntryRepository) {
+            throw new \LogicException('A fill-cost ledger repository is required for aggregateByTradeVenue().');
+        }
+
+        return $this->aggregateEntries(
+            $this->ledger->findByInternalTradeIdAndVenue($internalTradeId, $exchange, $marketType),
+            $internalTradeId,
+            $exchange,
+            $marketType,
+        );
+    }
+
+    /**
+     * @param iterable<FillCostLedgerEntry> $entries
+     */
+    public function aggregateEntries(
+        iterable $entries,
+        string $internalTradeId,
+        string $exchange,
+        string $marketType,
+    ): FillQuantityAggregationResult {
+        $exchange = strtolower(trim($exchange));
+        $marketType = strtolower(trim($marketType));
+
+        $entryFills = [];
+        $exitFills = [];
+        $flags = [];
+        $seenFillFingerprints = [];
+        $costs = [
+            'feeUsdt' => null,
+            'fundingUsdt' => null,
+            'spreadCostUsdt' => null,
+            'slippageCostUsdt' => null,
+            'borrowCostUsdt' => null,
+            'liquidationFeeUsdt' => null,
+        ];
+
+        foreach ($entries as $entry) {
+            if (!$entry instanceof FillCostLedgerEntry) {
+                continue;
+            }
+            if ($entry->getInternalTradeId() !== $internalTradeId) {
+                continue;
+            }
+            if ($entry->getExchange() !== $exchange || $entry->getMarketType() !== $marketType) {
+                continue;
+            }
+
+            $entryFlags = $entry->getQualityFlags();
+            if ($this->isCancelledOrCorrected($entryFlags)) {
+                $flags[] = 'cancelled_fill_ignored';
+                continue;
+            }
+
+            $duplicateState = $this->duplicateState($entry, $seenFillFingerprints);
+            if ($duplicateState === 'duplicate') {
+                $flags[] = 'duplicate_fill_ignored';
+                continue;
+            }
+            if ($duplicateState === 'conflict') {
+                $flags[] = 'fill_conflict';
+                continue;
+            }
+
+            $this->addCosts($costs, $entry);
+
+            $role = strtolower($entry->getFillRole());
+            if ($role === 'entry') {
+                $entryFills[] = $entry;
+                continue;
+            }
+            if ($role === 'exit') {
+                $exitFills[] = $entry;
+            }
+        }
+
+        usort($entryFills, self::sortByOccurrence(...));
+        usort($exitFills, self::sortByOccurrence(...));
+
+        $entryAggregate = $this->aggregateFillSide($entryFills);
+        $exitAggregate = $this->aggregateFillSide($exitFills);
+        $remainingQty = null;
+        if ($entryAggregate['qty'] !== null && $exitAggregate['qty'] !== null) {
+            $remainingQty = $entryAggregate['qty'] - $exitAggregate['qty'];
+        } elseif ($entryAggregate['qty'] !== null) {
+            $remainingQty = $entryAggregate['qty'];
+        }
+
+        [$quantityStatus, $statusFlags, $positionFullyClosed] = $this->quantityStatus(
+            $entryAggregate['qty'],
+            $exitAggregate['qty'],
+            $remainingQty,
+            $flags,
+        );
+        $flags = array_values(array_unique([...$flags, ...$statusFlags]));
+
+        return new FillQuantityAggregationResult(
+            internalTradeId: $internalTradeId,
+            exchange: $exchange,
+            marketType: $marketType,
+            entryFirstFillAt: $entryAggregate['firstAt'],
+            entryLastFillAt: $entryAggregate['lastAt'],
+            entryQty: $entryAggregate['qty'],
+            entryVwap: $entryAggregate['vwap'],
+            exitFirstFillAt: $exitAggregate['firstAt'],
+            exitLastFillAt: $exitAggregate['lastAt'],
+            exitQty: $exitAggregate['qty'],
+            exitVwap: $exitAggregate['vwap'],
+            remainingQty: $remainingQty !== null && abs($remainingQty) <= $this->quantityTolerance ? 0.0 : $remainingQty,
+            positionFullyClosed: $positionFullyClosed,
+            quantityStatus: $quantityStatus,
+            quantityQualityFlags: $flags,
+            feeUsdt: $costs['feeUsdt'],
+            fundingUsdt: $costs['fundingUsdt'],
+            spreadCostUsdt: $costs['spreadCostUsdt'],
+            slippageCostUsdt: $costs['slippageCostUsdt'],
+            borrowCostUsdt: $costs['borrowCostUsdt'],
+            liquidationFeeUsdt: $costs['liquidationFeeUsdt'],
+        );
+    }
+
+    /**
+     * @param list<string> $qualityFlags
+     */
+    private function isCancelledOrCorrected(array $qualityFlags): bool
+    {
+        foreach ($qualityFlags as $flag) {
+            if (\in_array($flag, ['fill_cancelled', 'fill_corrected', 'fill_reversed', 'voided'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string,string> $seenFillFingerprints
+     */
+    private function duplicateState(FillCostLedgerEntry $entry, array &$seenFillFingerprints): ?string
+    {
+        $identity = $entry->getExchangeFillId();
+        if ($identity === null) {
+            return null;
+        }
+
+        $fingerprint = implode('|', [
+            $entry->getFillRole(),
+            (string) $entry->getPrice(),
+            (string) $entry->getQuantity(),
+            (string) $entry->getFeeUsdt(),
+            $entry->getOccurredAt()->format(\DateTimeInterface::ATOM),
+        ]);
+        if (!isset($seenFillFingerprints[$identity])) {
+            $seenFillFingerprints[$identity] = $fingerprint;
+
+            return null;
+        }
+
+        return $seenFillFingerprints[$identity] === $fingerprint ? 'duplicate' : 'conflict';
+    }
+
+    /**
+     * @param array{feeUsdt:?float,fundingUsdt:?float,spreadCostUsdt:?float,slippageCostUsdt:?float,borrowCostUsdt:?float,liquidationFeeUsdt:?float} $costs
+     */
+    private function addCosts(array &$costs, FillCostLedgerEntry $entry): void
+    {
+        $this->addCost($costs['feeUsdt'], $entry->getFeeUsdt());
+        $this->addCost($costs['fundingUsdt'], $entry->getFundingUsdt());
+        $this->addCost($costs['spreadCostUsdt'], $entry->getSpreadCostUsdt());
+        $this->addCost($costs['slippageCostUsdt'], $entry->getSlippageCostUsdt());
+        $this->addCost($costs['borrowCostUsdt'], $entry->getBorrowCostUsdt());
+        $this->addCost($costs['liquidationFeeUsdt'], $entry->getLiquidationFeeUsdt());
+    }
+
+    private function addCost(?float &$aggregate, ?string $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        $aggregate = ($aggregate ?? 0.0) + (float) $value;
+    }
+
+    /**
+     * @param list<FillCostLedgerEntry> $fills
+     * @return array{firstAt:?\DateTimeImmutable,lastAt:?\DateTimeImmutable,qty:?float,vwap:?float}
+     */
+    private function aggregateFillSide(array $fills): array
+    {
+        if ($fills === []) {
+            return [
+                'firstAt' => null,
+                'lastAt' => null,
+                'qty' => null,
+                'vwap' => null,
+            ];
+        }
+
+        $quantity = 0.0;
+        $notional = 0.0;
+        foreach ($fills as $fill) {
+            $fillQuantity = $fill->getQuantity() !== null ? (float) $fill->getQuantity() : null;
+            $fillPrice = $fill->getPrice() !== null ? (float) $fill->getPrice() : null;
+            if ($fillQuantity === null || $fillPrice === null || $fillQuantity <= 0.0 || $fillPrice <= 0.0) {
+                continue;
+            }
+
+            $quantity += $fillQuantity;
+            $notional += $fillQuantity * $fillPrice;
+        }
+
+        return [
+            'firstAt' => $fills[0]->getOccurredAt(),
+            'lastAt' => $fills[\count($fills) - 1]->getOccurredAt(),
+            'qty' => $quantity > 0.0 ? $quantity : null,
+            'vwap' => $quantity > 0.0 ? $notional / $quantity : null,
+        ];
+    }
+
+    /**
+     * @param list<string> $existingFlags
+     * @return array{0:string,1:list<string>,2:bool}
+     */
+    private function quantityStatus(?float $entryQty, ?float $exitQty, ?float $remainingQty, array $existingFlags): array
+    {
+        if (\in_array('fill_conflict', $existingFlags, true)) {
+            return ['fill_conflict', ['fill_conflict'], false];
+        }
+        if ($entryQty === null) {
+            return ['missing_entry_fill', ['missing_entry_fill'], false];
+        }
+        if ($exitQty === null || $remainingQty === null) {
+            return ['open_position', ['missing_exit_fill', 'position_not_fully_closed'], false];
+        }
+        if ($exitQty - $entryQty > $this->quantityTolerance) {
+            return ['quantity_mismatch', ['exit_qty_exceeds_entry_qty'], false];
+        }
+        if (abs($remainingQty) <= $this->quantityTolerance) {
+            return ['complete', [], true];
+        }
+
+        return ['open_position', ['position_not_fully_closed'], false];
+    }
+
+    private static function sortByOccurrence(FillCostLedgerEntry $left, FillCostLedgerEntry $right): int
+    {
+        return [$left->getOccurredAt()->getTimestamp(), $left->getFillId()]
+            <=> [$right->getOccurredAt()->getTimestamp(), $right->getFillId()];
+    }
+}

--- a/trading-app/src/Trading/Pnl/NetPnlCertificationService.php
+++ b/trading-app/src/Trading/Pnl/NetPnlCertificationService.php
@@ -112,6 +112,48 @@ final class NetPnlCertificationService
     }
 
     /**
+     * @param list<TradeFill> $entryFills
+     * @param list<TradeFill> $exitFills
+     */
+    public function certifyWithQuantityAggregation(
+        array $entryFills,
+        array $exitFills,
+        TradeCosts $costs,
+        string $side,
+        FillQuantityAggregationResult $quantityAggregation,
+        bool $lineageSufficient,
+        bool $identifierConflict,
+        ?float $riskUsdtAtEntry = null,
+    ): NetPnlCertificationResult {
+        $quantityBlocksCertification = !$quantityAggregation->netPnlCertificationAllowed();
+        $result = $this->certify(
+            entryFills: $entryFills,
+            exitFills: $exitFills,
+            costs: $costs,
+            side: $side,
+            positionFullyClosed: $quantityAggregation->positionFullyClosed && !$quantityBlocksCertification,
+            lineageSufficient: $lineageSufficient,
+            identifierConflict: $identifierConflict || \in_array('fill_conflict', $quantityAggregation->quantityQualityFlags, true),
+            riskUsdtAtEntry: $riskUsdtAtEntry,
+        );
+        if (!$quantityBlocksCertification) {
+            return $result;
+        }
+
+        return new NetPnlCertificationResult(
+            certified: false,
+            costCompleteness: $result->costCompleteness,
+            grossRealizedPnlUsdt: $result->grossRealizedPnlUsdt,
+            entryFeeUsdt: $result->entryFeeUsdt,
+            exitFeeUsdt: $result->exitFeeUsdt,
+            totalKnownCostUsdt: null,
+            netPnlUsdt: null,
+            realizedNetPnlR: null,
+            qualityFlags: array_values(array_unique([...$result->qualityFlags, ...$quantityAggregation->quantityQualityFlags])),
+        );
+    }
+
+    /**
      * @param list<TradeFill> $fills
      * @param list<string> $flags
      */

--- a/trading-app/tests/Trading/Pnl/FillQuantityAggregationServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillQuantityAggregationServiceTest.php
@@ -146,6 +146,22 @@ final class FillQuantityAggregationServiceTest extends TestCase
         self::assertFalse($conflictResult->netPnlCertificationAllowed());
     }
 
+    public function testDuplicateWithDifferentCostComponentIsAConflict(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, exchangeFillId: 'venue-fill-1', fundingUsdt: 0.10),
+            self::fill('entry-repriced-cost', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, exchangeFillId: 'venue-fill-1', fundingUsdt: 0.12),
+            self::fill('exit', 'exit', '2026-06-25 10:05:00 UTC', 101.0, 1.0, exchangeFillId: 'venue-fill-2'),
+        ], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertSame('fill_conflict', $result->quantityStatus);
+        self::assertContains('fill_conflict', $result->quantityQualityFlags);
+        self::assertFalse($result->netPnlCertificationAllowed());
+        self::assertEqualsWithDelta(0.10, $result->fundingUsdt, 1e-12);
+    }
+
     public function testCancelledOrCorrectedFillIsIgnoredAuditably(): void
     {
         $service = new FillQuantityAggregationService();
@@ -226,6 +242,9 @@ final class FillQuantityAggregationServiceTest extends TestCase
         ?float $feeUsdt = null,
         ?float $fundingUsdt = null,
         ?float $spreadCostUsdt = null,
+        ?float $slippageCostUsdt = null,
+        ?float $borrowCostUsdt = null,
+        ?float $liquidationFeeUsdt = null,
         ?string $exchangeFillId = null,
         array $qualityFlags = [],
         ?string $side = null,
@@ -251,6 +270,9 @@ final class FillQuantityAggregationServiceTest extends TestCase
             ->setFeeUsdt($feeUsdt !== null ? sprintf('%.12F', $feeUsdt) : null)
             ->setFundingUsdt($fundingUsdt !== null ? sprintf('%.12F', $fundingUsdt) : null)
             ->setSpreadCostUsdt($spreadCostUsdt !== null ? sprintf('%.12F', $spreadCostUsdt) : null)
+            ->setSlippageCostUsdt($slippageCostUsdt !== null ? sprintf('%.12F', $slippageCostUsdt) : null)
+            ->setBorrowCostUsdt($borrowCostUsdt !== null ? sprintf('%.12F', $borrowCostUsdt) : null)
+            ->setLiquidationFeeUsdt($liquidationFeeUsdt !== null ? sprintf('%.12F', $liquidationFeeUsdt) : null)
             ->setExchangeFillId($exchangeFillId)
             ->setSide($side)
             ->setQualityFlags($qualityFlags);

--- a/trading-app/tests/Trading/Pnl/FillQuantityAggregationServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillQuantityAggregationServiceTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Pnl;
+
+use App\Entity\FillCostLedgerEntry;
+use App\Trading\Pnl\FillQuantityAggregationResult;
+use App\Trading\Pnl\FillQuantityAggregationService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FillQuantityAggregationService::class)]
+#[CoversClass(FillQuantityAggregationResult::class)]
+final class FillQuantityAggregationServiceTest extends TestCase
+{
+    public function testAggregatesPartialEntryAndTp1TrailingExitAsClosedTrade(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('entry-a', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 0.4, exchange: 'bitmart', marketType: 'futures', feeUsdt: 0.02),
+            self::fill('entry-b', 'entry', '2026-06-25 10:00:20 UTC', 101.0, 0.6, exchange: 'bitmart', marketType: 'futures', feeUsdt: 0.03),
+            self::fill('tp1', 'exit', '2026-06-25 10:10:00 UTC', 110.0, 0.5, exchange: 'bitmart', marketType: 'futures', feeUsdt: 0.04),
+            self::fill('trailing', 'exit', '2026-06-25 10:20:00 UTC', 108.0, 0.5, exchange: 'bitmart', marketType: 'futures', feeUsdt: 0.05),
+            self::fill('funding-credit', 'funding', '2026-06-25 10:15:00 UTC', null, null, exchange: 'bitmart', marketType: 'futures', fundingUsdt: 0.12),
+            self::fill('spread', 'adjustment', '2026-06-25 10:20:01 UTC', null, null, exchange: 'bitmart', marketType: 'futures', spreadCostUsdt: 0.07),
+        ], internalTradeId: 'shared-trade-id', exchange: 'bitmart', marketType: 'futures');
+
+        self::assertSame('shared-trade-id', $result->internalTradeId);
+        self::assertSame('bitmart', $result->exchange);
+        self::assertSame('futures', $result->marketType);
+        self::assertEquals(new \DateTimeImmutable('2026-06-25 10:00:00 UTC'), $result->entryFirstFillAt);
+        self::assertEquals(new \DateTimeImmutable('2026-06-25 10:00:20 UTC'), $result->entryLastFillAt);
+        self::assertEqualsWithDelta(1.0, $result->entryQty, 1e-12);
+        self::assertEqualsWithDelta(100.6, $result->entryVwap, 1e-12);
+        self::assertEquals(new \DateTimeImmutable('2026-06-25 10:10:00 UTC'), $result->exitFirstFillAt);
+        self::assertEquals(new \DateTimeImmutable('2026-06-25 10:20:00 UTC'), $result->exitLastFillAt);
+        self::assertEqualsWithDelta(1.0, $result->exitQty, 1e-12);
+        self::assertEqualsWithDelta(109.0, $result->exitVwap, 1e-12);
+        self::assertEqualsWithDelta(0.0, $result->remainingQty, 1e-12);
+        self::assertTrue($result->positionFullyClosed);
+        self::assertSame('complete', $result->quantityStatus);
+        self::assertSame([], $result->quantityQualityFlags);
+        self::assertEqualsWithDelta(0.14, $result->feeUsdt, 1e-12);
+        self::assertEqualsWithDelta(0.12, $result->fundingUsdt, 1e-12);
+        self::assertEqualsWithDelta(0.07, $result->spreadCostUsdt, 1e-12);
+        self::assertTrue($result->netPnlCertificationAllowed());
+    }
+
+    public function testPartialExitKeepsTradeOpenAndBlocksNetPnlCertification(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 2.0),
+            self::fill('tp1', 'exit', '2026-06-25 10:05:00 UTC', 105.0, 0.8),
+        ], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertEqualsWithDelta(2.0, $result->entryQty, 1e-12);
+        self::assertEqualsWithDelta(0.8, $result->exitQty, 1e-12);
+        self::assertEqualsWithDelta(1.2, $result->remainingQty, 1e-12);
+        self::assertFalse($result->positionFullyClosed);
+        self::assertSame('open_position', $result->quantityStatus);
+        self::assertContains('position_not_fully_closed', $result->quantityQualityFlags);
+        self::assertFalse($result->netPnlCertificationAllowed());
+    }
+
+    public function testOneWaySingleEntrySingleExitIsComplete(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, side: 'BUY'),
+            self::fill('exit', 'exit', '2026-06-25 10:05:00 UTC', 103.0, 1.0, side: 'SELL'),
+        ], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertEqualsWithDelta(1.0, $result->entryQty, 1e-12);
+        self::assertEqualsWithDelta(1.0, $result->exitQty, 1e-12);
+        self::assertEqualsWithDelta(0.0, $result->remainingQty, 1e-12);
+        self::assertTrue($result->positionFullyClosed);
+        self::assertSame('complete', $result->quantityStatus);
+    }
+
+    public function testHedgeShortPartialStopUsesFillRolesAndKeepsResidualOpen(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('short-entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, side: 'SELL'),
+            self::fill('partial-stop', 'exit', '2026-06-25 10:03:00 UTC', 102.0, 0.4, side: 'BUY'),
+        ], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertEqualsWithDelta(1.0, $result->entryQty, 1e-12);
+        self::assertEqualsWithDelta(0.4, $result->exitQty, 1e-12);
+        self::assertEqualsWithDelta(0.6, $result->remainingQty, 1e-12);
+        self::assertFalse($result->positionFullyClosed);
+        self::assertSame('open_position', $result->quantityStatus);
+        self::assertContains('position_not_fully_closed', $result->quantityQualityFlags);
+    }
+
+    public function testOverExitIsQuantityMismatchAndNeverClosed(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0),
+            self::fill('exit-a', 'exit', '2026-06-25 10:05:00 UTC', 101.0, 0.7),
+            self::fill('exit-b', 'exit', '2026-06-25 10:06:00 UTC', 102.0, 0.5),
+        ], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertEqualsWithDelta(-0.2, $result->remainingQty, 1e-12);
+        self::assertFalse($result->positionFullyClosed);
+        self::assertSame('quantity_mismatch', $result->quantityStatus);
+        self::assertContains('exit_qty_exceeds_entry_qty', $result->quantityQualityFlags);
+        self::assertFalse($result->netPnlCertificationAllowed());
+    }
+
+    public function testDuplicateExactFillDoesNotChangeAggregateButConflictingDuplicateIsFlagged(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $exactDuplicate = [
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, exchangeFillId: 'venue-fill-1'),
+            self::fill('entry-replay', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, exchangeFillId: 'venue-fill-1'),
+            self::fill('exit', 'exit', '2026-06-25 10:05:00 UTC', 101.0, 1.0, exchangeFillId: 'venue-fill-2'),
+        ];
+
+        $replayResult = $service->aggregateEntries($exactDuplicate, internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertEqualsWithDelta(1.0, $replayResult->entryQty, 1e-12);
+        self::assertSame('complete', $replayResult->quantityStatus);
+        self::assertContains('duplicate_fill_ignored', $replayResult->quantityQualityFlags);
+        self::assertTrue($replayResult->netPnlCertificationAllowed());
+
+        $conflictingDuplicate = [
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, exchangeFillId: 'venue-fill-1'),
+            self::fill('entry-conflict', 'entry', '2026-06-25 10:00:00 UTC', 101.0, 1.0, exchangeFillId: 'venue-fill-1'),
+            self::fill('exit', 'exit', '2026-06-25 10:05:00 UTC', 102.0, 1.0, exchangeFillId: 'venue-fill-2'),
+        ];
+
+        $conflictResult = $service->aggregateEntries($conflictingDuplicate, internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertSame('fill_conflict', $conflictResult->quantityStatus);
+        self::assertContains('fill_conflict', $conflictResult->quantityQualityFlags);
+        self::assertFalse($conflictResult->netPnlCertificationAllowed());
+    }
+
+    public function testCancelledOrCorrectedFillIsIgnoredAuditably(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('entry-cancelled', 'entry', '2026-06-25 09:59:00 UTC', 99.0, 1.0, qualityFlags: ['fill_cancelled']),
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0),
+            self::fill('exit', 'exit', '2026-06-25 10:05:00 UTC', 101.0, 1.0),
+        ], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertEqualsWithDelta(1.0, $result->entryQty, 1e-12);
+        self::assertEqualsWithDelta(100.0, $result->entryVwap, 1e-12);
+        self::assertSame('complete', $result->quantityStatus);
+        self::assertContains('cancelled_fill_ignored', $result->quantityQualityFlags);
+    }
+
+    public function testSameInternalTradeIdOnDifferentVenuesStaysSeparated(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $fills = [
+            self::fill('bitmart-entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0, exchange: 'bitmart', marketType: 'futures'),
+            self::fill('bitmart-exit', 'exit', '2026-06-25 10:05:00 UTC', 101.0, 1.0, exchange: 'bitmart', marketType: 'futures'),
+            self::fill('fake-entry', 'entry', '2026-06-25 10:00:00 UTC', 200.0, 2.0, exchange: 'fake', marketType: 'paper'),
+            self::fill('fake-exit', 'exit', '2026-06-25 10:05:00 UTC', 201.0, 1.0, exchange: 'fake', marketType: 'paper'),
+        ];
+
+        $bitmart = $service->aggregateEntries($fills, internalTradeId: 'shared-trade-id', exchange: 'bitmart', marketType: 'futures');
+        $fake = $service->aggregateEntries($fills, internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertEqualsWithDelta(0.0, $bitmart->remainingQty, 1e-12);
+        self::assertSame('complete', $bitmart->quantityStatus);
+        self::assertEqualsWithDelta(1.0, $fake->remainingQty, 1e-12);
+        self::assertSame('open_position', $fake->quantityStatus);
+    }
+
+    public function testOrderExpiredWithoutFillProducesMissingEntryStatus(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertNull($result->entryQty);
+        self::assertNull($result->exitQty);
+        self::assertNull($result->remainingQty);
+        self::assertFalse($result->positionFullyClosed);
+        self::assertSame('missing_entry_fill', $result->quantityStatus);
+        self::assertContains('missing_entry_fill', $result->quantityQualityFlags);
+        self::assertFalse($result->netPnlCertificationAllowed());
+    }
+
+    /**
+     * @param list<string> $qualityFlags
+     */
+    private static function fill(
+        string $fillId,
+        string $role,
+        string $occurredAt,
+        ?float $price,
+        ?float $quantity,
+        string $exchange = 'fake',
+        string $marketType = 'paper',
+        ?float $feeUsdt = null,
+        ?float $fundingUsdt = null,
+        ?float $spreadCostUsdt = null,
+        ?string $exchangeFillId = null,
+        array $qualityFlags = [],
+        ?string $side = null,
+    ): FillCostLedgerEntry {
+        $entry = new FillCostLedgerEntry(
+            idempotencyKey: sprintf('%s:%s:%s', $exchange, $marketType, $fillId),
+            payloadHash: hash('sha256', $fillId),
+            exchange: $exchange,
+            marketType: $marketType,
+            symbol: 'BTCUSDT',
+            fillId: $fillId,
+            fillRole: $role,
+            occurredAt: new \DateTimeImmutable($occurredAt),
+            source: 'test',
+            sourceVersion: 'test_v1',
+        );
+
+        return $entry
+            ->setInternalTradeId('shared-trade-id')
+            ->setPrice($price !== null ? sprintf('%.12F', $price) : null)
+            ->setQuantity($quantity !== null ? sprintf('%.12F', $quantity) : null)
+            ->setNotional($price !== null && $quantity !== null ? sprintf('%.12F', $price * $quantity) : null)
+            ->setFeeUsdt($feeUsdt !== null ? sprintf('%.12F', $feeUsdt) : null)
+            ->setFundingUsdt($fundingUsdt !== null ? sprintf('%.12F', $fundingUsdt) : null)
+            ->setSpreadCostUsdt($spreadCostUsdt !== null ? sprintf('%.12F', $spreadCostUsdt) : null)
+            ->setExchangeFillId($exchangeFillId)
+            ->setSide($side)
+            ->setQualityFlags($qualityFlags);
+    }
+}

--- a/trading-app/tests/Trading/Pnl/FillQuantityAggregationServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillQuantityAggregationServiceTest.php
@@ -162,6 +162,21 @@ final class FillQuantityAggregationServiceTest extends TestCase
         self::assertContains('cancelled_fill_ignored', $result->quantityQualityFlags);
     }
 
+    public function testInvalidQuantitativeFillBlocksCertificationEvenWhenRemainingRowsBalance(): void
+    {
+        $service = new FillQuantityAggregationService();
+
+        $result = $service->aggregateEntries([
+            self::fill('entry-missing-quantity', 'entry', '2026-06-25 09:59:00 UTC', 99.0, null),
+            self::fill('entry', 'entry', '2026-06-25 10:00:00 UTC', 100.0, 1.0),
+            self::fill('exit', 'exit', '2026-06-25 10:05:00 UTC', 101.0, 1.0),
+        ], internalTradeId: 'shared-trade-id', exchange: 'fake', marketType: 'paper');
+
+        self::assertSame('invalid_fill_quantity', $result->quantityStatus);
+        self::assertContains('invalid_quantitative_fill', $result->quantityQualityFlags);
+        self::assertFalse($result->netPnlCertificationAllowed());
+    }
+
     public function testSameInternalTradeIdOnDifferentVenuesStaysSeparated(): void
     {
         $service = new FillQuantityAggregationService();

--- a/trading-app/tests/Trading/Pnl/NetPnlCertificationServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/NetPnlCertificationServiceTest.php
@@ -245,4 +245,51 @@ final class NetPnlCertificationServiceTest extends TestCase
         self::assertNull($result->netPnlUsdt);
         self::assertContains('invalid_side', $result->qualityFlags);
     }
+
+    public function testQuantityAggregationConflictBlocksCertificationEvenWithBalancedFillQuantities(): void
+    {
+        $service = new NetPnlCertificationService();
+
+        $result = $service->certifyWithQuantityAggregation(
+            entryFills: [
+                new TradeFill('entry-1', 'BUY', 1.0, 100.0, 0.01, 'USDT', 'maker', new \DateTimeImmutable('2026-06-25 10:00:00 UTC')),
+            ],
+            exitFills: [
+                new TradeFill('exit-1', 'SELL', 1.0, 110.0, 0.01, 'USDT', 'taker', new \DateTimeImmutable('2026-06-25 10:10:00 UTC')),
+            ],
+            costs: TradeCosts::zeroKnown(),
+            side: 'LONG',
+            quantityAggregation: new \App\Trading\Pnl\FillQuantityAggregationResult(
+                internalTradeId: 'trade-conflict',
+                exchange: 'fake',
+                marketType: 'paper',
+                entryFirstFillAt: new \DateTimeImmutable('2026-06-25 10:00:00 UTC'),
+                entryLastFillAt: new \DateTimeImmutable('2026-06-25 10:00:00 UTC'),
+                entryQty: 1.0,
+                entryVwap: 100.0,
+                exitFirstFillAt: new \DateTimeImmutable('2026-06-25 10:10:00 UTC'),
+                exitLastFillAt: new \DateTimeImmutable('2026-06-25 10:10:00 UTC'),
+                exitQty: 1.0,
+                exitVwap: 110.0,
+                remainingQty: 0.0,
+                positionFullyClosed: false,
+                quantityStatus: 'fill_conflict',
+                quantityQualityFlags: ['fill_conflict'],
+                feeUsdt: 0.02,
+                fundingUsdt: 0.0,
+                spreadCostUsdt: 0.0,
+                slippageCostUsdt: 0.0,
+                borrowCostUsdt: 0.0,
+                liquidationFeeUsdt: 0.0,
+            ),
+            lineageSufficient: true,
+            identifierConflict: false,
+            riskUsdtAtEntry: 5.0,
+        );
+
+        self::assertFalse($result->certified);
+        self::assertNull($result->netPnlUsdt);
+        self::assertContains('fill_conflict', $result->qualityFlags);
+        self::assertContains('position_not_fully_closed', $result->qualityFlags);
+    }
 }

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -342,16 +342,16 @@ final class PositionTradeAnalysisViewTest extends TestCase
         self::assertNull($bySymbol['ADAUSDT']['net_pnl_usdt']);
         self::assertStringContainsString('quantity_mismatch', (string) $bySymbol['ADAUSDT']['pnl_quality_flags']);
 
-        self::assertSame('complete', $bySymbol['BTCUSDT']['cost_completeness']);
+        self::assertSame('partial', $bySymbol['BTCUSDT']['cost_completeness']);
         self::assertSame('fake_paper_fill_ledger_v1', $bySymbol['BTCUSDT']['pnl_source']);
         self::assertEqualsWithDelta(9.6, (float) $bySymbol['BTCUSDT']['gross_realized_pnl_usdt'], 1e-9);
         self::assertEqualsWithDelta(0.05, (float) $bySymbol['BTCUSDT']['entry_fee_usdt'], 1e-9);
         self::assertEqualsWithDelta(0.05, (float) $bySymbol['BTCUSDT']['exit_fee_usdt'], 1e-9);
-        self::assertEqualsWithDelta(0.16, (float) $bySymbol['BTCUSDT']['total_known_cost_usdt'], 1e-9);
-        self::assertEqualsWithDelta(9.44, (float) $bySymbol['BTCUSDT']['net_pnl_usdt'], 1e-9);
-        self::assertEqualsWithDelta(1.888, (float) $bySymbol['BTCUSDT']['realized_net_pnl_r'], 1e-9);
+        self::assertNull($bySymbol['BTCUSDT']['total_known_cost_usdt']);
+        self::assertNull($bySymbol['BTCUSDT']['net_pnl_usdt']);
+        self::assertNull($bySymbol['BTCUSDT']['realized_net_pnl_r']);
         self::assertTrue(filter_var($bySymbol['BTCUSDT']['position_fully_closed'], FILTER_VALIDATE_BOOLEAN));
-        self::assertSame('[]', (string) $bySymbol['BTCUSDT']['pnl_quality_flags']);
+        self::assertStringContainsString('ledger_quantity_aggregate_missing', (string) $bySymbol['BTCUSDT']['pnl_quality_flags']);
 
         self::assertSame('partial', $bySymbol['ETHUSDT']['cost_completeness']);
         self::assertNull($bySymbol['ETHUSDT']['net_pnl_usdt']);

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Schema\Schema;
 use DoctrineMigrations\Version20260622000000;
 use DoctrineMigrations\Version20260623010000;
 use DoctrineMigrations\Version20260625000000;
+use DoctrineMigrations\Version20260625020000;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -29,6 +30,7 @@ use Psr\Log\NullLogger;
 #[CoversClass(Version20260622000000::class)]
 #[CoversClass(Version20260623010000::class)]
 #[CoversClass(Version20260625000000::class)]
+#[CoversClass(Version20260625020000::class)]
 final class PositionTradeAnalysisViewTest extends TestCase
 {
     private Connection $conn;
@@ -870,8 +872,11 @@ SQL);
         if (!class_exists(Version20260625000000::class, false)) {
             require_once \dirname(__DIR__, 3) . '/migrations/Version20260625000000.php';
         }
+        if (!class_exists(Version20260625020000::class, false)) {
+            require_once \dirname(__DIR__, 3) . '/migrations/Version20260625020000.php';
+        }
 
-        foreach ([Version20260622000000::class, Version20260623010000::class, Version20260625000000::class] as $migrationClass) {
+        foreach ([Version20260622000000::class, Version20260623010000::class, Version20260625000000::class, Version20260625020000::class] as $migrationClass) {
             $migration = new $migrationClass($this->conn, new NullLogger());
             $migration->up(new Schema());
             foreach ($migration->getSql() as $query) {


### PR DESCRIPTION
Part of #190
Related to #173
Related to #204
Related to #207
Related to #208

## Summary

Adds deterministic quantity aggregation on top of the persistent fill/cost ledger for partial entries, partial exits, TP1/trailing remainder, scale-out, partial stops, and duplicate/correction visibility.

## Changes

- Adds `FillQuantityAggregationService` and `FillQuantityAggregationResult`.
- Aggregates only by exact `internal_trade_id + exchange + market_type`; no symbol-only or time-window matching.
- Computes entry/exit first/last fill timestamps, entry/exit quantities, VWAPs, residual quantity, close state, quantity status, quality flags, and aggregated known costs.
- Adds a repository read by exact trade+venue scope.
- Adds `NetPnlCertificationService::certifyWithQuantityAggregation()` so certified net PnL remains null when quantity aggregation is incomplete or conflicting.
- Documents quantity statuses, certification gating, tolerance, and Bitmart `paid_fees` source field.
- Adds PostgreSQL fixture SQL for complete partial-entry/TP1/trailing, open partial-exit, and conflicting duplicate cases.

## Quantity statuses

- `complete`
- `open_position`
- `missing_entry_fill`
- `quantity_mismatch`
- `fill_conflict`

## Out of scope

- No strategy, MTF, EntryZone, Risk/Leverage, SL/TP, or live guard changes.
- No heuristic backfill and no symbol/time matching.
- No Bitmart/OKX/Hyperliquid net PnL certification.
- No destructive schema change.

## Verification

Executed locally:

- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/phpunit tests/Trading/Pnl tests/Exchange/Event/DoctrineExchangeLocalProjectionStoreTest.php tests/Exchange/Adapter/FakeExchangeAdapterTest.php tests/Exchange/Adapter/BitmartExchangeAdapterTest.php tests/Exchange/Reconciliation/ExchangeReconciliationServiceTest.php --no-coverage` -> OK, 103 tests / 563 assertions.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' vendor/bin/phpstan analyse --no-progress src/Trading/Pnl/FillQuantityAggregationResult.php src/Trading/Pnl/FillQuantityAggregationService.php src/Trading/Pnl/NetPnlCertificationService.php src/Repository/FillCostLedgerEntryRepository.php tests/Trading/Pnl/FillQuantityAggregationServiceTest.php tests/Trading/Pnl/NetPnlCertificationServiceTest.php --memory-limit=1G` -> OK.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/console lint:yaml config` -> OK.
- `DEFAULT_URI=http://localhost APP_ENV=test DATABASE_URL='sqlite:///:memory:' php bin/console lint:container --no-debug` -> OK, with pre-existing PHP 8.4 deprecation in `EntryZoneStatsCommand`.
- `git diff --check` -> OK.

PostgreSQL note:

- A PostgreSQL fixture was added at `tests/fixtures/fill_quantity_aggregation_postgres.sql`.
- No PostgreSQL `DATABASE_URL` is configured locally and Docker is not reachable (`~/.docker/run/docker.sock` missing), so fixture execution must be covered in a PostgreSQL-capable environment/CI.

## #190 remaining after this PR

#190 should stay open after this PR unless the remaining certification/backfill/consumer migration work is completed separately.