### PR TITLE
Issue 190 - Backfill dry-run v1/v2 divergence

### DIFF
--- a/docs/handbook/technical/certified-net-pnl-contract.md
+++ b/docs/handbook/technical/certified-net-pnl-contract.md
@@ -66,6 +66,8 @@ Conclusion : seul Fake/Paper peut servir de reference complete dans ce lot. Les 
 ## Ledger fills/couts
 
 Le ledger persistant v1 est documente dans `docs/handbook/technical/fill-cost-ledger.md`.
+Le dry-run de divergence v1/v2 pre-backfill est documente dans
+`docs/handbook/technical/position-trade-analysis-backfill-divergence.md`.
 
 Il introduit la table `fill_cost_ledger`, reliee au trade logique par `internal_trade_id` lorsque le lineage exact est disponible. L'idempotence est portee par `exchange + market_type + exchange_fill_id` quand l'exchange fournit un identifiant de fill, sinon par un identifiant interne deterministe documente.
 

--- a/docs/handbook/technical/position-trade-analysis-backfill-divergence.md
+++ b/docs/handbook/technical/position-trade-analysis-backfill-divergence.md
@@ -1,0 +1,122 @@
+# `position_trade_analysis` v1/v2 backfill divergence dry-run
+
+Issue #190 ajoute une commande de lecture seule pour auditer les donnees historiques avant
+tout backfill du contrat `position_trade_analysis_v2`. Elle compare la vue historique
+`position_trade_analysis` et la vue versionnee `position_trade_analysis_v2` sans reconstruire de
+relation par symbole seul ni par fenetre temporelle.
+
+## Commande
+
+```bash
+php bin/console app:position-trade-analysis:backfill-divergence \
+  --from=2026-06-01 \
+  --to=2026-06-30 \
+  --mtf-profile=scalper \
+  --exchange=fake \
+  --market-type=perpetual \
+  --symbol=BTCUSDT \
+  --limit=500 \
+  --batch-size=100 \
+  --export-json=/tmp/pta-backfill-report.json \
+  --export-csv=/tmp/pta-backfill-report.csv
+```
+
+Le mode par defaut est `--dry-run=1`. Une valeur date-only sur `--to` couvre toute la journee
+UTC (`23:59:59.999999`). `--apply` existe uniquement comme garde explicite et
+echoue volontairement dans cette PR. Aucun write n'est effectue par la commande.
+
+## Cle de comparaison
+
+La comparaison v1/v2 se fait uniquement par `entry_event_id`, l'identifiant persistant de
+l'evenement d'entree commun aux deux vues. Les filtres `symbol`, `mtf-profile`, `exchange` et
+`market-type` ne servent qu'a reduire le perimetre de lecture ; ils ne creent jamais de relation
+entre une entree et une cloture.
+
+Les lignes historiques ou v1 a rapproche une cloture par symbole/temps restent visibles comme
+divergentes si v2 ne dispose pas d'un identifiant exact (`internal_trade_id`, `trade_id` ou
+`position_id` borne a la venue).
+
+## Pagination
+
+La lecture est bornee par `--limit` (maximum 5000). Le rapport expose :
+
+- `pagination.resume_cursor` : curseur d'entree recu ;
+- `pagination.next_cursor` : dernier `entry_event_id` retourne ;
+- `pagination.truncated` : vrai si plus de lignes existent au-dela de la page courante.
+
+Pour reprendre :
+
+```bash
+php bin/console app:position-trade-analysis:backfill-divergence \
+  --resume-cursor=123456 \
+  --limit=500 \
+  --export-json=/tmp/pta-backfill-report-next.json
+```
+
+## Classifications
+
+Le champ `rows[].classification` peut valoir :
+
+- `certified` : v2 est complete et expose un `net_pnl_usdt` certifie ;
+- `partial` : ligne exploitable partiellement mais non certifiable ;
+- `unknown` : etat ou couts inconnus ;
+- `unmatched` : v2 ne rapproche pas la cloture par identifiant exact ;
+- `identifier_conflict` : conflit d'identifiants conserve en flag ;
+- `quantity_mismatch` : quantite incoherente ;
+- `costs_incomplete` : couts partiels, jamais convertis en zero ;
+- `v1_only` : presente seulement dans v1 ;
+- `v2_only` : presente seulement dans v2 ;
+- `pnl_divergence` : ecart PnL entre v1 et v2 au-dela de l'epsilon technique.
+
+Une ligne incomplete n'est jamais presentee comme complete. Les valeurs absentes restent `null`.
+Le delta `pnl_delta_usdt` compare v1 au `net_pnl_usdt` lorsque v2 est certifiee
+(`cost_completeness=complete` et net present). Pour les lignes non certifiees, il compare v1 a
+`recorded_pnl_usdt`, puis a `gross_realized_pnl_usdt` seulement si le recorded est absent.
+
+## Rapport
+
+Le JSON contient :
+
+- `metadata` : filtres, cle de comparaison, mode read-only ;
+- `summary` : volumes v1/v2, lignes communes, divergences, certifications, exclusions, taux de
+  preuve lineage/cout/quantite ;
+- `pagination` : limite, curseur et statut de troncature ;
+- `proposal` : `ready_for_backfill=false` si une divergence, une exclusion ou une pagination
+  tronquee subsiste ;
+- `rows` : details par `entry_event_id`, avec deltas PnL, duration, MFE et MAE.
+
+Exemple minimal :
+
+```json
+{
+  "metadata": {
+    "dry_run": true,
+    "read_only": true,
+    "comparison_key": "entry_event_id"
+  },
+  "summary": {
+    "v1_rows": 2,
+    "v2_rows": 2,
+    "common_rows": 2,
+    "certified_rows": 1,
+    "excluded_rows": 1,
+    "classification_counts": {
+      "certified": 1,
+      "unmatched": 1
+    }
+  },
+  "proposal": {
+    "ready_for_backfill": false,
+    "blocking_reason": "divergence_or_incomplete_data",
+    "apply_mode_available": false
+  }
+}
+```
+
+## Garanties
+
+- Aucun fallback par symbole seul.
+- Aucun rapprochement par fenetre temporelle pour le backfill.
+- Aucun cout absent transforme en zero.
+- Aucun changement live, strategie, MTF, EntryZone, Risk/Leverage ou SL/TP.
+- Aucun payload brut sensible exporte.

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -100,6 +100,12 @@ services:
     App\Trading\Lineage\ReadModel\LineageReadStoreInterface:
         alias: App\Trading\Lineage\ReadModel\DoctrineLineageReadStore
 
+    App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReaderInterface:
+        alias: App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReader
+
+    App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportServiceInterface:
+        alias: App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportService
+
 
 
     # MTF Services

--- a/trading-app/src/Command/PositionTradeAnalysisBackfillDivergenceCommand.php
+++ b/trading-app/src/Command/PositionTradeAnalysisBackfillDivergenceCommand.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use App\Trading\Backfill\BackfillDivergenceCriteria;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceExporter;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportServiceInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:position-trade-analysis:backfill-divergence',
+    description: 'Dry-run read-only audit comparing position_trade_analysis v1 and v2 for #190 backfill readiness.'
+)]
+final class PositionTradeAnalysisBackfillDivergenceCommand extends Command
+{
+    private const MAX_LIMIT = 5000;
+    private const MAX_BATCH_SIZE = 1000;
+
+    public function __construct(
+        private readonly PositionTradeAnalysisBackfillDivergenceReportServiceInterface $reportService,
+        private readonly PositionTradeAnalysisBackfillDivergenceExporter $exporter,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Inclusive period start, UTC-compatible datetime.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Inclusive period end, UTC-compatible datetime.')
+            ->addOption('mtf-profile', null, InputOption::VALUE_REQUIRED, 'MTF profile filter using v2 lineage only.')
+            ->addOption('exchange', null, InputOption::VALUE_REQUIRED, 'Exchange filter using v2 venue context only.')
+            ->addOption('market-type', null, InputOption::VALUE_REQUIRED, 'Market type filter using v2 venue context only.')
+            ->addOption('symbol', null, InputOption::VALUE_REQUIRED, 'Symbol filter. Used only as a filter, never as a matching key.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, sprintf('Maximum rows to report, 1-%d.', self::MAX_LIMIT), '500')
+            ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, sprintf('Read batch hint, 1-%d.', self::MAX_BATCH_SIZE), '100')
+            ->addOption('resume-cursor', null, InputOption::VALUE_REQUIRED, 'Exclusive entry_event_id cursor for deterministic resume.')
+            ->addOption('dry-run', null, InputOption::VALUE_OPTIONAL, 'Must stay true in this PR.', '1')
+            ->addOption('apply', null, InputOption::VALUE_NONE, 'Explicit apply mode placeholder; disabled in this PR.')
+            ->addOption('export-json', null, InputOption::VALUE_REQUIRED, 'Write the full report as JSON.')
+            ->addOption('export-csv', null, InputOption::VALUE_REQUIRED, 'Write report rows as CSV.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ((bool) $input->getOption('apply')) {
+            $io->error('Apply mode is intentionally disabled in this PR. No writes were performed.');
+
+            return Command::FAILURE;
+        }
+
+        $dryRun = filter_var($input->getOption('dry-run'), FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+        if ($dryRun !== true) {
+            $io->error('Only dry-run mode is allowed in this PR. Use --dry-run=1 and do not use --apply.');
+
+            return Command::FAILURE;
+        }
+
+        $limit = $this->intOption($input, 'limit');
+        if ($limit < 1 || $limit > self::MAX_LIMIT) {
+            $io->error(sprintf('Limit must be between 1 and %d.', self::MAX_LIMIT));
+
+            return Command::FAILURE;
+        }
+
+        $batchSize = $this->intOption($input, 'batch-size');
+        if ($batchSize < 1 || $batchSize > self::MAX_BATCH_SIZE) {
+            $io->error(sprintf('Batch size must be between 1 and %d.', self::MAX_BATCH_SIZE));
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $criteria = new BackfillDivergenceCriteria(
+                from: $this->dateOption($input, 'from'),
+                to: $this->dateOption($input, 'to'),
+                profile: $this->stringOption($input, 'mtf-profile'),
+                exchange: $this->stringOption($input, 'exchange'),
+                marketType: $this->stringOption($input, 'market-type'),
+                symbol: $this->normalizeSymbol($this->stringOption($input, 'symbol')),
+                limit: $limit,
+                batchSize: $batchSize,
+                resumeCursor: $this->nullableIntOption($input, 'resume-cursor'),
+                dryRun: true,
+            );
+        } catch (\InvalidArgumentException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $report = $this->reportService->buildReport($criteria);
+
+        $jsonPath = $this->stringOption($input, 'export-json');
+        if ($jsonPath !== null) {
+            $this->exporter->exportJson($report, $jsonPath);
+        }
+
+        $csvPath = $this->stringOption($input, 'export-csv');
+        if ($csvPath !== null) {
+            $this->exporter->exportCsv($report, $csvPath);
+        }
+
+        $io->title('Position trade analysis backfill divergence dry-run');
+        $io->text('Dry-run: yes');
+        $io->text('Read-only: yes');
+        $io->text('Comparison key: entry_event_id');
+        $io->text('No symbol-only or time-window matching is used.');
+        $summary = is_array($report['summary'] ?? null) ? $report['summary'] : [];
+        $pagination = is_array($report['pagination'] ?? null) ? $report['pagination'] : [];
+        $proposal = is_array($report['proposal'] ?? null) ? $report['proposal'] : [];
+
+        $io->table(['Metric', 'Value'], [
+            ['v1 rows', (string) ($summary['v1_rows'] ?? 0)],
+            ['v2 rows', (string) ($summary['v2_rows'] ?? 0)],
+            ['common rows', (string) ($summary['common_rows'] ?? 0)],
+            ['certified rows', (string) ($summary['certified_rows'] ?? 0)],
+            ['excluded rows', (string) ($summary['excluded_rows'] ?? 0)],
+            ['divergent rows', (string) ($summary['divergent_rows'] ?? 0)],
+            ['truncated', ($pagination['truncated'] ?? false) ? 'yes' : 'no'],
+            ['next cursor', (string) ($pagination['next_cursor'] ?? '')],
+            ['ready for backfill', ($proposal['ready_for_backfill'] ?? false) ? 'yes' : 'no'],
+            ['blocking reason', (string) ($proposal['blocking_reason'] ?? '')],
+        ]);
+
+        if ($jsonPath !== null) {
+            $io->text(sprintf('JSON export: %s', $jsonPath));
+        }
+        if ($csvPath !== null) {
+            $io->text(sprintf('CSV export: %s', $csvPath));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function intOption(InputInterface $input, string $name): int
+    {
+        $value = $input->getOption($name);
+        if (!is_scalar($value) || !is_numeric((string) $value)) {
+            return 0;
+        }
+
+        return (int) $value;
+    }
+
+    private function nullableIntOption(InputInterface $input, string $name): ?int
+    {
+        $value = $input->getOption($name);
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (!is_scalar($value) || !is_numeric((string) $value)) {
+            throw new \InvalidArgumentException(sprintf('Option --%s must be an integer.', $name));
+        }
+
+        return (int) $value;
+    }
+
+    private function stringOption(InputInterface $input, string $name): ?string
+    {
+        $value = $input->getOption($name);
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function normalizeSymbol(?string $symbol): ?string
+    {
+        return $symbol === null ? null : strtoupper($symbol);
+    }
+
+    private function dateOption(InputInterface $input, string $name): ?\DateTimeImmutable
+    {
+        $value = $this->stringOption($input, $name);
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            $date = new \DateTimeImmutable($value, new \DateTimeZone('UTC'));
+            $errors = \DateTimeImmutable::getLastErrors();
+            if (is_array($errors) && ((int) $errors['warning_count'] > 0 || (int) $errors['error_count'] > 0)) {
+                throw new \InvalidArgumentException(sprintf('Option --%s must be a valid datetime.', $name));
+            }
+            if ($name === 'to' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1) {
+                return $date->setTime(23, 59, 59, 999999);
+            }
+
+            return $date;
+        } catch (\Throwable $e) {
+            if ($e instanceof \InvalidArgumentException) {
+                throw $e;
+            }
+
+            throw new \InvalidArgumentException(sprintf('Option --%s must be a valid datetime.', $name));
+        }
+    }
+}

--- a/trading-app/src/Trading/Backfill/BackfillDivergenceCriteria.php
+++ b/trading-app/src/Trading/Backfill/BackfillDivergenceCriteria.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Backfill;
+
+final readonly class BackfillDivergenceCriteria
+{
+    public function __construct(
+        public ?\DateTimeImmutable $from = null,
+        public ?\DateTimeImmutable $to = null,
+        public ?string $profile = null,
+        public ?string $exchange = null,
+        public ?string $marketType = null,
+        public ?string $symbol = null,
+        public int $limit = 500,
+        public int $batchSize = 100,
+        public ?int $resumeCursor = null,
+        public bool $dryRun = true,
+    ) {
+    }
+}

--- a/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceExporter.php
+++ b/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceExporter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Backfill;
+
+final class PositionTradeAnalysisBackfillDivergenceExporter
+{
+    /**
+     * @param array<string,mixed> $report
+     */
+    public function exportJson(array $report, string $path): void
+    {
+        $this->ensureDirectory($path);
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        file_put_contents($path, $json . "\n");
+    }
+
+    /**
+     * @param array<string,mixed> $report
+     */
+    public function exportCsv(array $report, string $path): void
+    {
+        $this->ensureDirectory($path);
+        $handle = fopen($path, 'wb');
+        if ($handle === false) {
+            throw new \RuntimeException(sprintf('Unable to open CSV export path "%s".', $path));
+        }
+
+        $columns = [
+            'entry_event_id',
+            'classification',
+            'symbol',
+            'exchange',
+            'market_type',
+            'profile',
+            'entry_time',
+            'v1_present',
+            'v2_present',
+            'close_match_status',
+            'close_matched_by',
+            'cost_completeness',
+            'v1_pnl_usdt',
+            'v2_pnl_usdt',
+            'pnl_delta_usdt',
+            'holding_time_delta_sec',
+            'mfe_delta_pct',
+            'mae_delta_pct',
+        ];
+        fputcsv($handle, $columns, ',', '"', '\\');
+
+        /** @var list<array<string,mixed>> $rows */
+        $rows = is_array($report['rows'] ?? null) ? $report['rows'] : [];
+        foreach ($rows as $row) {
+            fputcsv($handle, array_map(
+                static fn (string $column): mixed => $row[$column] ?? null,
+                $columns,
+            ), ',', '"', '\\');
+        }
+
+        fclose($handle);
+    }
+
+    private function ensureDirectory(string $path): void
+    {
+        $directory = dirname($path);
+        if ($directory === '' || $directory === '.') {
+            return;
+        }
+        if (!is_dir($directory) && !mkdir($directory, 0755, true) && !is_dir($directory)) {
+            throw new \RuntimeException(sprintf('Unable to create export directory "%s".', $directory));
+        }
+    }
+}

--- a/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReader.php
+++ b/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReader.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Backfill;
+
+use Doctrine\DBAL\Connection;
+
+final readonly class PositionTradeAnalysisBackfillDivergenceReader implements PositionTradeAnalysisBackfillDivergenceReaderInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function fetchRows(BackfillDivergenceCriteria $criteria): array
+    {
+        $where = [];
+        $params = [
+            'limit' => $criteria->limit,
+        ];
+
+        if ($criteria->resumeCursor !== null) {
+            $where[] = 'COALESCE(v1.entry_event_id, v2.entry_event_id) > :resume_cursor';
+            $params['resume_cursor'] = $criteria->resumeCursor;
+        }
+        if ($criteria->from !== null) {
+            $where[] = 'COALESCE(v2.entry_time, v1.entry_time) >= :from_ts';
+            $params['from_ts'] = $criteria->from->format('Y-m-d H:i:s.uP');
+        }
+        if ($criteria->to !== null) {
+            $where[] = 'COALESCE(v2.entry_time, v1.entry_time) <= :to_ts';
+            $params['to_ts'] = $criteria->to->format('Y-m-d H:i:s.uP');
+        }
+        if ($criteria->symbol !== null && $criteria->symbol !== '') {
+            $where[] = 'COALESCE(v2.symbol, v1.symbol) = :symbol';
+            $params['symbol'] = $criteria->symbol;
+        }
+        if ($criteria->profile !== null && $criteria->profile !== '') {
+            $where[] = 'v2.mtf_profile = :profile';
+            $params['profile'] = $criteria->profile;
+        }
+        if ($criteria->exchange !== null && $criteria->exchange !== '') {
+            $where[] = 'v2.exchange = :exchange';
+            $params['exchange'] = $criteria->exchange;
+        }
+        if ($criteria->marketType !== null && $criteria->marketType !== '') {
+            $where[] = 'v2.market_type = :market_type';
+            $params['market_type'] = $criteria->marketType;
+        }
+
+        $sql = <<<SQL
+SELECT
+    COALESCE(v1.entry_event_id, v2.entry_event_id) AS entry_event_id,
+    (v1.entry_event_id IS NOT NULL) AS v1_present,
+    (v2.entry_event_id IS NOT NULL) AS v2_present,
+    COALESCE(v2.symbol, v1.symbol) AS symbol,
+    v2.exchange AS exchange,
+    v2.market_type AS market_type,
+    v2.mtf_profile AS profile,
+    COALESCE(v2.entry_time, v1.entry_time) AS entry_time,
+    v1.close_event_id AS v1_close_event_id,
+    v2.close_event_id AS v2_close_event_id,
+    v1.pnl_usdt AS v1_pnl_usdt,
+    v2.recorded_pnl_usdt AS v2_recorded_pnl_usdt,
+    v2.gross_realized_pnl_usdt AS v2_gross_realized_pnl_usdt,
+    v2.net_pnl_usdt AS v2_net_pnl_usdt,
+    v1.holding_time_sec AS v1_holding_time_sec,
+    v2.holding_time_sec AS v2_holding_time_sec,
+    v1.mfe_pct AS v1_mfe_pct,
+    v2.mfe_pct AS v2_mfe_pct,
+    v1.mae_pct AS v1_mae_pct,
+    v2.mae_pct AS v2_mae_pct,
+    v2.internal_trade_id AS v2_internal_trade_id,
+    v2.trade_id AS v2_trade_id,
+    v2.position_id AS v2_position_id,
+    v2.close_match_status AS v2_close_match_status,
+    v2.close_matched_by AS v2_close_matched_by,
+    v2.analysis_status AS v2_analysis_status,
+    v2.cost_completeness AS v2_cost_completeness,
+    v2.position_fully_closed AS v2_position_fully_closed,
+    v2.pnl_quality_flags AS v2_pnl_quality_flags
+FROM position_trade_analysis v1
+FULL OUTER JOIN position_trade_analysis_v2 v2
+    ON v2.entry_event_id = v1.entry_event_id
+SQL;
+
+        if ($where !== []) {
+            $sql .= "\nWHERE " . implode("\n  AND ", $where);
+        }
+
+        $sql .= "\nORDER BY COALESCE(v1.entry_event_id, v2.entry_event_id) ASC\nLIMIT :limit";
+
+        /** @var list<array<string,mixed>> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+
+        return $rows;
+    }
+}

--- a/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderInterface.php
+++ b/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Backfill;
+
+interface PositionTradeAnalysisBackfillDivergenceReaderInterface
+{
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function fetchRows(BackfillDivergenceCriteria $criteria): array;
+}

--- a/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportService.php
+++ b/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportService.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Backfill;
+
+final readonly class PositionTradeAnalysisBackfillDivergenceReportService implements PositionTradeAnalysisBackfillDivergenceReportServiceInterface
+{
+    private const PNL_DIVERGENCE_EPSILON = 0.000001;
+
+    public function __construct(private PositionTradeAnalysisBackfillDivergenceReaderInterface $reader)
+    {
+    }
+
+    public function buildReport(BackfillDivergenceCriteria $criteria): array
+    {
+        $fetchedRows = $this->fetchRows($criteria);
+        $truncated = count($fetchedRows) > $criteria->limit;
+        $sourceRows = $truncated ? array_slice($fetchedRows, 0, $criteria->limit) : $fetchedRows;
+
+        $rows = [];
+        $counts = [];
+        $v1Rows = 0;
+        $v2Rows = 0;
+        $commonRows = 0;
+        $divergentRows = 0;
+        $certifiedRows = 0;
+        $lineageEvidenceRows = 0;
+        $costEvidenceRows = 0;
+        $quantityEvidenceRows = 0;
+
+        foreach ($sourceRows as $sourceRow) {
+            $normalized = $this->normalizeRow($sourceRow);
+            if ($normalized['v1_present']) {
+                $v1Rows++;
+            }
+            if ($normalized['v2_present']) {
+                $v2Rows++;
+            }
+            if ($normalized['v1_present'] && $normalized['v2_present']) {
+                $commonRows++;
+            }
+            if ($normalized['has_lineage_evidence']) {
+                $lineageEvidenceRows++;
+            }
+            if ($normalized['has_cost_evidence']) {
+                $costEvidenceRows++;
+            }
+            if ($normalized['has_quantity_evidence']) {
+                $quantityEvidenceRows++;
+            }
+            if ($normalized['classification'] === 'pnl_divergence') {
+                $divergentRows++;
+            }
+            if ($normalized['classification'] === 'certified') {
+                $certifiedRows++;
+            }
+            $counts[$normalized['classification']] = ($counts[$normalized['classification']] ?? 0) + 1;
+            $rows[] = $normalized;
+        }
+
+        $nextCursor = $rows === [] ? null : (int) $rows[array_key_last($rows)]['entry_event_id'];
+        $excludedRows = count($rows) - $certifiedRows;
+        $ready = $excludedRows === 0 && !$truncated;
+
+        return [
+            'metadata' => [
+                'generated_at' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTimeInterface::ATOM),
+                'dry_run' => $criteria->dryRun,
+                'read_only' => true,
+                'comparison_key' => 'entry_event_id',
+                'matching_policy' => 'v1/v2 comparison only; no symbol-only or time-window backfill matching',
+                'filters' => [
+                    'from' => $criteria->from?->format(\DateTimeInterface::ATOM),
+                    'to' => $criteria->to?->format(\DateTimeInterface::ATOM),
+                    'profile' => $criteria->profile,
+                    'exchange' => $criteria->exchange,
+                    'market_type' => $criteria->marketType,
+                    'symbol' => $criteria->symbol,
+                ],
+            ],
+            'pagination' => [
+                'limit' => $criteria->limit,
+                'batch_size' => $criteria->batchSize,
+                'resume_cursor' => $criteria->resumeCursor,
+                'next_cursor' => $nextCursor,
+                'truncated' => $truncated,
+            ],
+            'summary' => [
+                'v1_rows' => $v1Rows,
+                'v2_rows' => $v2Rows,
+                'common_rows' => $commonRows,
+                'v1_only_rows' => $counts['v1_only'] ?? 0,
+                'v2_only_rows' => $counts['v2_only'] ?? 0,
+                'divergent_rows' => $divergentRows,
+                'certified_rows' => $certifiedRows,
+                'excluded_rows' => $excludedRows,
+                'classification_counts' => $counts,
+                'lineage_evidence_rate' => $this->rate($lineageEvidenceRows, count($rows)),
+                'cost_evidence_rate' => $this->rate($costEvidenceRows, count($rows)),
+                'quantity_evidence_rate' => $this->rate($quantityEvidenceRows, count($rows)),
+                'pnl_delta_usdt_sum' => $this->sumColumn($rows, 'pnl_delta_usdt'),
+                'holding_time_delta_sec_sum' => $this->sumColumn($rows, 'holding_time_delta_sec'),
+                'mfe_delta_pct_sum' => $this->sumColumn($rows, 'mfe_delta_pct'),
+                'mae_delta_pct_sum' => $this->sumColumn($rows, 'mae_delta_pct'),
+            ],
+            'proposal' => [
+                'ready_for_backfill' => $ready,
+                'blocking_reason' => $ready ? null : ($truncated ? 'pagination_truncated' : 'divergence_or_incomplete_data'),
+                'apply_mode_available' => false,
+            ],
+            'rows' => $rows,
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function fetchRows(BackfillDivergenceCriteria $criteria): array
+    {
+        $rows = [];
+        $cursor = $criteria->resumeCursor;
+        $target = $criteria->limit + 1;
+
+        while (count($rows) < $target) {
+            $batchLimit = min($criteria->batchSize, $target - count($rows));
+            $batchCriteria = new BackfillDivergenceCriteria(
+                from: $criteria->from,
+                to: $criteria->to,
+                profile: $criteria->profile,
+                exchange: $criteria->exchange,
+                marketType: $criteria->marketType,
+                symbol: $criteria->symbol,
+                limit: $batchLimit,
+                batchSize: $criteria->batchSize,
+                resumeCursor: $cursor,
+                dryRun: $criteria->dryRun,
+            );
+            $batch = $this->reader->fetchRows($batchCriteria);
+            if ($batch === []) {
+                break;
+            }
+
+            $advanced = false;
+            foreach ($batch as $row) {
+                $entryEventId = $this->intOrNull($row['entry_event_id'] ?? null);
+                if ($entryEventId === null || ($cursor !== null && $entryEventId <= $cursor)) {
+                    continue;
+                }
+
+                $rows[] = $row;
+                $cursor = $entryEventId;
+                $advanced = true;
+                if (count($rows) >= $target) {
+                    break 2;
+                }
+            }
+
+            if (!$advanced || count($batch) < $batchLimit) {
+                break;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return array<string,mixed>
+     */
+    private function normalizeRow(array $row): array
+    {
+        $v1Present = $this->bool($row['v1_present'] ?? false);
+        $v2Present = $this->bool($row['v2_present'] ?? false);
+        $flags = $this->flags($row['v2_pnl_quality_flags'] ?? []);
+        $v2Pnl = $this->v2ComparablePnl($row);
+        $v1Pnl = $this->float($row['v1_pnl_usdt'] ?? null);
+        $pnlDelta = $this->delta($v1Pnl, $v2Pnl);
+        $classification = $this->classify($row, $v1Present, $v2Present, $flags, $pnlDelta);
+
+        return [
+            'entry_event_id' => (int) $row['entry_event_id'],
+            'classification' => $classification,
+            'symbol' => $row['symbol'] ?? null,
+            'exchange' => $row['exchange'] ?? null,
+            'market_type' => $row['market_type'] ?? null,
+            'profile' => $row['profile'] ?? null,
+            'entry_time' => $this->stringOrNull($row['entry_time'] ?? null),
+            'v1_present' => $v1Present,
+            'v2_present' => $v2Present,
+            'v1_close_event_id' => $this->intOrNull($row['v1_close_event_id'] ?? null),
+            'v2_close_event_id' => $this->intOrNull($row['v2_close_event_id'] ?? null),
+            'internal_trade_id' => $row['v2_internal_trade_id'] ?? null,
+            'trade_id' => $row['v2_trade_id'] ?? null,
+            'position_id' => $row['v2_position_id'] ?? null,
+            'close_match_status' => $row['v2_close_match_status'] ?? null,
+            'close_matched_by' => $row['v2_close_matched_by'] ?? null,
+            'analysis_status' => $row['v2_analysis_status'] ?? null,
+            'cost_completeness' => $row['v2_cost_completeness'] ?? null,
+            'position_fully_closed' => $this->nullableBool($row['v2_position_fully_closed'] ?? null),
+            'quality_flags' => $flags,
+            'v1_pnl_usdt' => $v1Pnl,
+            'v2_pnl_usdt' => $v2Pnl,
+            'pnl_delta_usdt' => $pnlDelta,
+            'holding_time_delta_sec' => $this->delta($this->float($row['v1_holding_time_sec'] ?? null), $this->float($row['v2_holding_time_sec'] ?? null)),
+            'mfe_delta_pct' => $this->delta($this->float($row['v1_mfe_pct'] ?? null), $this->float($row['v2_mfe_pct'] ?? null)),
+            'mae_delta_pct' => $this->delta($this->float($row['v1_mae_pct'] ?? null), $this->float($row['v2_mae_pct'] ?? null)),
+            'has_lineage_evidence' => $v2Present && (($row['v2_internal_trade_id'] ?? null) !== null || ($row['v2_trade_id'] ?? null) !== null || ($row['v2_position_id'] ?? null) !== null),
+            'has_cost_evidence' => $v2Present && in_array($row['v2_cost_completeness'] ?? null, ['partial', 'complete'], true),
+            'has_quantity_evidence' => $v2Present && $this->nullableBool($row['v2_position_fully_closed'] ?? null) === true && !in_array('quantity_mismatch', $flags, true),
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @param list<string> $flags
+     */
+    private function classify(array $row, bool $v1Present, bool $v2Present, array $flags, ?float $pnlDelta): string
+    {
+        if ($v1Present && !$v2Present) {
+            return 'v1_only';
+        }
+        if (!$v1Present && $v2Present) {
+            return 'v2_only';
+        }
+        if (!$v1Present && !$v2Present) {
+            return 'unknown';
+        }
+        if (in_array('identifier_conflict', $flags, true)) {
+            return 'identifier_conflict';
+        }
+        if (($row['v2_close_match_status'] ?? null) === 'unmatched' || ($row['v2_analysis_status'] ?? null) === 'unmatched') {
+            return 'unmatched';
+        }
+        if (in_array('quantity_mismatch', $flags, true)) {
+            return 'quantity_mismatch';
+        }
+        if ($pnlDelta !== null && abs($pnlDelta) > self::PNL_DIVERGENCE_EPSILON) {
+            return 'pnl_divergence';
+        }
+        if (($row['v2_cost_completeness'] ?? null) === 'complete' && ($row['v2_net_pnl_usdt'] ?? null) !== null) {
+            return 'certified';
+        }
+        if (($row['v2_cost_completeness'] ?? null) === 'unknown') {
+            return 'unknown';
+        }
+        if (($row['v2_cost_completeness'] ?? null) === 'partial') {
+            return 'costs_incomplete';
+        }
+
+        return 'partial';
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     */
+    private function sumColumn(array $rows, string $column): ?float
+    {
+        $sum = null;
+        foreach ($rows as $row) {
+            if (!is_float($row[$column] ?? null) && !is_int($row[$column] ?? null)) {
+                continue;
+            }
+            $sum = ($sum ?? 0.0) + (float) $row[$column];
+        }
+
+        return $sum === null ? null : round($sum, 8);
+    }
+
+    private function rate(int $num, int $den): ?float
+    {
+        return $den > 0 ? round($num / $den, 6) : null;
+    }
+
+    private function delta(?float $left, ?float $right): ?float
+    {
+        return $left !== null && $right !== null ? round($right - $left, 8) : null;
+    }
+
+    private function firstFloat(mixed ...$values): ?float
+    {
+        foreach ($values as $value) {
+            $float = $this->float($value);
+            if ($float !== null) {
+                return $float;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function v2ComparablePnl(array $row): ?float
+    {
+        if (($row['v2_cost_completeness'] ?? null) === 'complete' && ($row['v2_net_pnl_usdt'] ?? null) !== null) {
+            return $this->float($row['v2_net_pnl_usdt']);
+        }
+
+        return $this->firstFloat(
+            $row['v2_recorded_pnl_usdt'] ?? null,
+            $row['v2_gross_realized_pnl_usdt'] ?? null,
+        );
+    }
+
+    private function float(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_int($value) || is_float($value) || is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    private function intOrNull(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (is_int($value) || is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    private function bool(mixed $value): bool
+    {
+        if ($value === 't' || $value === 'true' || $value === '1') {
+            return true;
+        }
+        if ($value === 'f' || $value === 'false' || $value === '0') {
+            return false;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOL);
+    }
+
+    private function nullableBool(mixed $value): ?bool
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return $this->bool($value);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function flags(mixed $value): array
+    {
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            $value = is_array($decoded) ? $decoded : [];
+        }
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $flag): bool => is_string($flag) && $flag !== ''));
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(\DateTimeInterface::ATOM);
+        }
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (string) $value;
+    }
+}

--- a/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportServiceInterface.php
+++ b/trading-app/src/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Backfill;
+
+interface PositionTradeAnalysisBackfillDivergenceReportServiceInterface
+{
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildReport(BackfillDivergenceCriteria $criteria): array;
+}

--- a/trading-app/tests/Command/PositionTradeAnalysisBackfillDivergenceCommandTest.php
+++ b/trading-app/tests/Command/PositionTradeAnalysisBackfillDivergenceCommandTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Command;
+
+use App\Command\PositionTradeAnalysisBackfillDivergenceCommand;
+use App\Trading\Backfill\BackfillDivergenceCriteria;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceExporter;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportServiceInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(PositionTradeAnalysisBackfillDivergenceCommand::class)]
+#[CoversClass(PositionTradeAnalysisBackfillDivergenceExporter::class)]
+#[CoversClass(BackfillDivergenceCriteria::class)]
+final class PositionTradeAnalysisBackfillDivergenceCommandTest extends TestCase
+{
+    public function testDryRunCommandBuildsBoundedReportAndExportsJsonAndCsv(): void
+    {
+        $tmpDir = sys_get_temp_dir() . '/pta-backfill-' . bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($tmpDir));
+
+        $service = new StubBackfillReportService([
+            'metadata' => [
+                'dry_run' => true,
+                'read_only' => true,
+                'comparison_key' => 'entry_event_id',
+            ],
+            'summary' => [
+                'v1_rows' => 1,
+                'v2_rows' => 1,
+                'common_rows' => 1,
+                'certified_rows' => 1,
+                'excluded_rows' => 0,
+                'classification_counts' => ['certified' => 1],
+            ],
+            'pagination' => [
+                'limit' => 100,
+                'batch_size' => 50,
+                'resume_cursor' => null,
+                'next_cursor' => 42,
+                'truncated' => false,
+            ],
+            'proposal' => [
+                'ready_for_backfill' => true,
+                'blocking_reason' => null,
+            ],
+            'rows' => [[
+                'entry_event_id' => 42,
+                'classification' => 'certified',
+                'symbol' => 'BTCUSDT',
+                'exchange' => 'fake',
+                'market_type' => 'perpetual',
+                'pnl_delta_usdt' => 0.0,
+            ]],
+        ]);
+        $command = new PositionTradeAnalysisBackfillDivergenceCommand(
+            $service,
+            new PositionTradeAnalysisBackfillDivergenceExporter(),
+        );
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-30',
+            '--mtf-profile' => 'scalper',
+            '--exchange' => 'fake',
+            '--market-type' => 'perpetual',
+            '--symbol' => 'btcusdt',
+            '--limit' => '100',
+            '--batch-size' => '50',
+            '--export-json' => $tmpDir . '/report.json',
+            '--export-csv' => $tmpDir . '/report.csv',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Dry-run: yes', $tester->getDisplay());
+        self::assertStringContainsString('Read-only: yes', $tester->getDisplay());
+        self::assertNotNull($service->criteria);
+        self::assertSame('BTCUSDT', $service->criteria->symbol);
+        self::assertSame('fake', $service->criteria->exchange);
+        self::assertSame(100, $service->criteria->limit);
+        self::assertSame(50, $service->criteria->batchSize);
+        self::assertTrue($service->criteria->dryRun);
+        self::assertSame('2026-06-30 23:59:59.999999', $service->criteria->to?->format('Y-m-d H:i:s.u'));
+        self::assertFileExists($tmpDir . '/report.json');
+        self::assertFileExists($tmpDir . '/report.csv');
+        self::assertStringContainsString('"comparison_key": "entry_event_id"', (string) file_get_contents($tmpDir . '/report.json'));
+        self::assertStringContainsString('entry_event_id,classification,symbol,exchange,market_type', (string) file_get_contents($tmpDir . '/report.csv'));
+    }
+
+    public function testApplyModeIsRejectedAndDoesNotCallReportService(): void
+    {
+        $service = new StubBackfillReportService(['rows' => []]);
+        $command = new PositionTradeAnalysisBackfillDivergenceCommand(
+            $service,
+            new PositionTradeAnalysisBackfillDivergenceExporter(),
+        );
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['--apply' => true]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertNull($service->criteria);
+        self::assertStringContainsString('Apply mode is intentionally disabled', $tester->getDisplay());
+    }
+
+    public function testRejectsLimitAboveMaximumBeforeQuerying(): void
+    {
+        $service = new StubBackfillReportService(['rows' => []]);
+        $command = new PositionTradeAnalysisBackfillDivergenceCommand(
+            $service,
+            new PositionTradeAnalysisBackfillDivergenceExporter(),
+        );
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['--limit' => '50001']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertNull($service->criteria);
+        self::assertStringContainsString('Limit must be between 1 and 5000', $tester->getDisplay());
+    }
+
+    public function testRejectsParserWarningsForInvalidDateBounds(): void
+    {
+        $service = new StubBackfillReportService(['rows' => []]);
+        $command = new PositionTradeAnalysisBackfillDivergenceCommand(
+            $service,
+            new PositionTradeAnalysisBackfillDivergenceExporter(),
+        );
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['--to' => '2026-06-31']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertNull($service->criteria);
+        self::assertStringContainsString('Option --to must be a valid datetime.', $tester->getDisplay());
+    }
+}
+
+final class StubBackfillReportService implements PositionTradeAnalysisBackfillDivergenceReportServiceInterface
+{
+    public ?BackfillDivergenceCriteria $criteria = null;
+
+    /**
+     * @param array<string,mixed> $report
+     */
+    public function __construct(private readonly array $report)
+    {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildReport(BackfillDivergenceCriteria $criteria): array
+    {
+        $this->criteria = $criteria;
+
+        return $this->report;
+    }
+}

--- a/trading-app/tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php
+++ b/trading-app/tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Backfill;
+
+use App\Trading\Backfill\BackfillDivergenceCriteria;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReader;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportService;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
+use DoctrineMigrations\Version20251129000000;
+use DoctrineMigrations\Version20260622000000;
+use DoctrineMigrations\Version20260623010000;
+use DoctrineMigrations\Version20260625000000;
+use DoctrineMigrations\Version20260625020000;
+use DoctrineMigrations\Version20260626000000;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+#[CoversClass(PositionTradeAnalysisBackfillDivergenceReader::class)]
+#[CoversClass(PositionTradeAnalysisBackfillDivergenceReportService::class)]
+final class PositionTradeAnalysisBackfillDivergenceReaderTest extends TestCase
+{
+    private Connection $conn;
+
+    protected function setUp(): void
+    {
+        $dsn = $_ENV['DATABASE_URL'] ?? $_SERVER['DATABASE_URL'] ?? getenv('DATABASE_URL') ?: '';
+        if (!is_string($dsn) || !preg_match('/^(postgres|postgresql|pdo-pgsql)/', $dsn)) {
+            self::markTestSkipped('PostgreSQL DATABASE_URL required for the backfill divergence reader integration test.');
+        }
+
+        try {
+            $conn = DriverManager::getConnection(['url' => $dsn]);
+            $conn->executeQuery('SELECT 1');
+            $conn->executeStatement("SET TIME ZONE 'UTC'");
+            $this->conn = $conn;
+        } catch (\Throwable $e) {
+            self::markTestSkipped('PostgreSQL not reachable: ' . $e->getMessage());
+        }
+
+        $this->createMinimalSchema();
+        $this->applyViewMigrations();
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->conn)) {
+            $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis_v2');
+            $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
+            $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
+            $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
+            $this->conn->close();
+        }
+    }
+
+    public function testReaderSurfacesV1SymbolTimeMatchAsV2UnmatchedInsteadOfBackfillMatch(): void
+    {
+        $run = 'run_backfill_divergence';
+
+        $this->entry('BTCUSDT', $run, ['trade_id' => 'T-good'], '2026-06-20 10:00:00+00', 300);
+        $this->close('BTCUSDT', $run, ['trade_id' => 'T-good', 'pnl' => 5.0], null, '2026-06-20 10:05:00+00', 400);
+
+        $this->entry('BTCUSDT', $run, ['trade_id' => 'T-legacy-only'], '2026-06-20 10:10:00+00', 301);
+        $this->close('BTCUSDT', $run, ['trade_id' => 'unrelated-close', 'pnl' => -7.0], null, '2026-06-20 10:15:00+00', 401);
+
+        $service = new PositionTradeAnalysisBackfillDivergenceReportService(
+            new PositionTradeAnalysisBackfillDivergenceReader($this->conn),
+        );
+        $report = $service->buildReport(new BackfillDivergenceCriteria(symbol: 'BTCUSDT', limit: 10));
+
+        $rowsByEntryId = [];
+        foreach ($report['rows'] as $row) {
+            $rowsByEntryId[$row['entry_event_id']] = $row;
+        }
+
+        self::assertArrayHasKey(301, $rowsByEntryId);
+        self::assertSame('unmatched', $rowsByEntryId[301]['classification']);
+        self::assertSame(401, $rowsByEntryId[301]['v1_close_event_id']);
+        self::assertNull($rowsByEntryId[301]['v2_close_event_id']);
+        self::assertSame('unmatched', $rowsByEntryId[301]['close_match_status']);
+        self::assertSame('entry_event_id', $report['metadata']['comparison_key']);
+    }
+
+    private function createMinimalSchema(): void
+    {
+        $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis_v2');
+        $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
+        $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
+        $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
+
+        $this->conn->executeStatement(<<<'SQL'
+CREATE TABLE trade_lifecycle_event (
+    id BIGSERIAL PRIMARY KEY,
+    symbol VARCHAR(50) NOT NULL,
+    event_type VARCHAR(32) NOT NULL,
+    run_id VARCHAR(64),
+    internal_trade_id VARCHAR(96),
+    position_id VARCHAR(64),
+    timeframe VARCHAR(8),
+    config_profile VARCHAR(64),
+    exchange VARCHAR(32) DEFAULT 'bitmart',
+    market_type VARCHAR(32) DEFAULT 'perpetual',
+    extra JSONB,
+    happened_at TIMESTAMPTZ NOT NULL
+)
+SQL);
+
+        $this->conn->executeStatement(<<<'SQL'
+CREATE TABLE indicator_snapshots (
+    id BIGSERIAL PRIMARY KEY,
+    symbol VARCHAR(50) NOT NULL,
+    timeframe VARCHAR(8) NOT NULL,
+    kline_time TIMESTAMPTZ NOT NULL,
+    values JSONB
+)
+SQL);
+    }
+
+    private function applyViewMigrations(): void
+    {
+        $classes = [
+            Version20251129000000::class => 'Version20251129000000.php',
+            Version20260622000000::class => 'Version20260622000000.php',
+            Version20260623010000::class => 'Version20260623010000.php',
+            Version20260625000000::class => 'Version20260625000000.php',
+            Version20260625020000::class => 'Version20260625020000.php',
+            Version20260626000000::class => 'Version20260626000000.php',
+        ];
+
+        foreach ($classes as $class => $file) {
+            if (!class_exists($class, false)) {
+                require_once \dirname(__DIR__, 3) . '/migrations/' . $file;
+            }
+            $migration = new $class($this->conn, new NullLogger());
+            $migration->up(new Schema());
+            foreach ($migration->getSql() as $query) {
+                $this->conn->executeStatement($query->getStatement(), $query->getParameters(), $query->getTypes());
+            }
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    private function entry(string $symbol, string $runId, array $extra, string $happenedAt, int $forcedId): void
+    {
+        $extra += [
+            'orchestration_run_id' => $runId,
+            'orchestration_dashboard_id' => 'dash-backfill',
+            'orchestration_set_id' => 'set-backfill',
+        ];
+
+        $this->conn->executeStatement(
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, config_profile, exchange, market_type, extra, happened_at)
+             VALUES (?, ?, \'order_submitted\', ?, \'scalper\', \'fake\', \'perpetual\', ?::jsonb, ?)',
+            [$forcedId, $symbol, $runId, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $extra
+     */
+    private function close(string $symbol, string $runId, array $extra, ?string $positionId, string $happenedAt, int $forcedId): void
+    {
+        $this->conn->executeStatement(
+            'INSERT INTO trade_lifecycle_event (id, symbol, event_type, run_id, position_id, exchange, market_type, extra, happened_at)
+             VALUES (?, ?, \'position_closed\', ?, ?, \'fake\', \'perpetual\', ?::jsonb, ?)',
+            [$forcedId, $symbol, $runId, $positionId, json_encode($extra, JSON_THROW_ON_ERROR), $happenedAt]
+        );
+    }
+}

--- a/trading-app/tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportServiceTest.php
+++ b/trading-app/tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportServiceTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Backfill;
+
+use App\Trading\Backfill\BackfillDivergenceCriteria;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReaderInterface;
+use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PositionTradeAnalysisBackfillDivergenceReportService::class)]
+#[CoversClass(BackfillDivergenceCriteria::class)]
+final class PositionTradeAnalysisBackfillDivergenceReportServiceTest extends TestCase
+{
+    public function testClassifiesCertifiedPartialLegacyAndDivergenceRowsWithoutMutatingSource(): void
+    {
+        $reader = new RecordingDivergenceReader([
+            $this->row(101, [
+                'v1_present' => true,
+                'v2_present' => true,
+                'v1_pnl_usdt' => '12.50000000',
+                'v2_recorded_pnl_usdt' => '12.50000000',
+                'v2_net_pnl_usdt' => '12.50000000',
+                'v2_cost_completeness' => 'complete',
+                'v2_close_match_status' => 'matched',
+                'v2_analysis_status' => 'matched_closed',
+                'v2_position_fully_closed' => true,
+            ]),
+            $this->row(102, [
+                'v1_present' => true,
+                'v2_present' => true,
+                'v1_pnl_usdt' => '-4.00000000',
+                'v2_recorded_pnl_usdt' => '-4.00000000',
+                'v2_cost_completeness' => 'unknown',
+                'v2_close_match_status' => 'matched',
+                'v2_analysis_status' => 'matched_closed',
+            ]),
+            $this->row(103, [
+                'v1_present' => true,
+                'v2_present' => false,
+            ]),
+            $this->row(104, [
+                'v1_present' => true,
+                'v2_present' => true,
+                'v1_pnl_usdt' => '10.00000000',
+                'v2_recorded_pnl_usdt' => '7.50000000',
+                'v2_cost_completeness' => 'partial',
+                'v2_close_match_status' => 'matched',
+                'v2_analysis_status' => 'matched_closed',
+            ]),
+            $this->row(105, [
+                'v1_present' => true,
+                'v2_present' => true,
+                'v2_cost_completeness' => 'partial',
+                'v2_close_match_status' => 'matched',
+                'v2_pnl_quality_flags' => ['identifier_conflict'],
+            ]),
+        ]);
+
+        $service = new PositionTradeAnalysisBackfillDivergenceReportService($reader);
+        $criteria = new BackfillDivergenceCriteria(
+            from: new \DateTimeImmutable('2026-06-01 00:00:00 UTC'),
+            to: new \DateTimeImmutable('2026-06-30 23:59:59 UTC'),
+            profile: 'scalper',
+            exchange: 'fake',
+            marketType: 'perpetual',
+            symbol: 'BTCUSDT',
+            limit: 5,
+            batchSize: 2,
+            resumeCursor: 100,
+            dryRun: true,
+        );
+
+        $report = $service->buildReport($criteria);
+
+        self::assertCount(3, $reader->criteria);
+        self::assertSame(100, $reader->criteria[0]->resumeCursor);
+        self::assertSame(2, $reader->criteria[0]->limit);
+        self::assertSame(102, $reader->criteria[1]->resumeCursor);
+        self::assertSame(2, $reader->criteria[1]->limit);
+        self::assertSame(104, $reader->criteria[2]->resumeCursor);
+        self::assertSame(2, $reader->criteria[2]->limit);
+        self::assertSame(5, $report['summary']['v1_rows']);
+        self::assertSame(4, $report['summary']['v2_rows']);
+        self::assertSame(4, $report['summary']['common_rows']);
+        self::assertSame(1, $report['summary']['certified_rows']);
+        self::assertSame(4, $report['summary']['excluded_rows']);
+        self::assertSame(1, $report['summary']['divergent_rows']);
+        self::assertSame([
+            'certified' => 1,
+            'unknown' => 1,
+            'v1_only' => 1,
+            'pnl_divergence' => 1,
+            'identifier_conflict' => 1,
+        ], $report['summary']['classification_counts']);
+        self::assertFalse($report['proposal']['ready_for_backfill']);
+        self::assertSame('divergence_or_incomplete_data', $report['proposal']['blocking_reason']);
+        self::assertSame(105, $report['pagination']['next_cursor']);
+        self::assertTrue($report['metadata']['dry_run']);
+        self::assertTrue($report['metadata']['read_only']);
+        self::assertSame('entry_event_id', $report['metadata']['comparison_key']);
+    }
+
+    public function testPaginationTruncatesToLimitAndKeepsDeterministicCursor(): void
+    {
+        $reader = new RecordingDivergenceReader([
+            $this->row(201),
+            $this->row(202),
+            $this->row(203),
+            $this->row(204),
+        ]);
+
+        $service = new PositionTradeAnalysisBackfillDivergenceReportService($reader);
+        $report = $service->buildReport(new BackfillDivergenceCriteria(limit: 3, batchSize: 2));
+
+        self::assertTrue($report['pagination']['truncated']);
+        self::assertSame(203, $report['pagination']['next_cursor']);
+        self::assertSame([201, 202, 203], array_column($report['rows'], 'entry_event_id'));
+    }
+
+    public function testLegacyPnlComparesAgainstRecordedBeforeGross(): void
+    {
+        $reader = new RecordingDivergenceReader([
+            $this->row(250, [
+                'v1_pnl_usdt' => '9.44000000',
+                'v2_recorded_pnl_usdt' => '9.44000000',
+                'v2_gross_realized_pnl_usdt' => '9.60000000',
+                'v2_net_pnl_usdt' => null,
+                'v2_cost_completeness' => 'partial',
+            ]),
+        ]);
+
+        $report = (new PositionTradeAnalysisBackfillDivergenceReportService($reader))
+            ->buildReport(new BackfillDivergenceCriteria());
+
+        self::assertSame('costs_incomplete', $report['rows'][0]['classification']);
+        self::assertSame(0.0, $report['rows'][0]['pnl_delta_usdt']);
+        self::assertSame(0, $report['summary']['divergent_rows']);
+    }
+
+    public function testCertifiedPnlComparesAgainstNetBeforeRecorded(): void
+    {
+        $reader = new RecordingDivergenceReader([
+            $this->row(260, [
+                'v1_pnl_usdt' => '9.44000000',
+                'v2_recorded_pnl_usdt' => '9.44000000',
+                'v2_gross_realized_pnl_usdt' => '9.60000000',
+                'v2_net_pnl_usdt' => '9.10000000',
+                'v2_cost_completeness' => 'complete',
+            ]),
+        ]);
+
+        $report = (new PositionTradeAnalysisBackfillDivergenceReportService($reader))
+            ->buildReport(new BackfillDivergenceCriteria());
+
+        self::assertSame('pnl_divergence', $report['rows'][0]['classification']);
+        self::assertSame(-0.34, $report['rows'][0]['pnl_delta_usdt']);
+        self::assertSame(1, $report['summary']['divergent_rows']);
+        self::assertSame(0, $report['summary']['certified_rows']);
+    }
+
+    public function testEmptyDatasetIsReadOnlyAndBackfillReady(): void
+    {
+        $service = new PositionTradeAnalysisBackfillDivergenceReportService(new RecordingDivergenceReader([]));
+
+        $report = $service->buildReport(new BackfillDivergenceCriteria());
+
+        self::assertSame(0, $report['summary']['v1_rows']);
+        self::assertSame(0, $report['summary']['v2_rows']);
+        self::assertSame([], $report['rows']);
+        self::assertTrue($report['proposal']['ready_for_backfill']);
+        self::assertTrue($report['metadata']['dry_run']);
+    }
+
+    public function testUnknownRawPayloadColumnsAreNotExported(): void
+    {
+        $service = new PositionTradeAnalysisBackfillDivergenceReportService(new RecordingDivergenceReader([
+            $this->row(301, [
+                'api_secret' => 'should-not-leak',
+                'raw_payload' => ['token' => 'should-not-leak'],
+            ]),
+        ]));
+
+        $report = $service->buildReport(new BackfillDivergenceCriteria());
+        $json = json_encode($report, JSON_THROW_ON_ERROR);
+
+        self::assertStringNotContainsString('should-not-leak', $json);
+        self::assertStringNotContainsString('raw_payload', $json);
+        self::assertStringNotContainsString('api_secret', $json);
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     * @return array<string,mixed>
+     */
+    private function row(int $entryEventId, array $overrides = []): array
+    {
+        return $overrides + [
+            'entry_event_id' => $entryEventId,
+            'v1_present' => true,
+            'v2_present' => true,
+            'symbol' => 'BTCUSDT',
+            'exchange' => 'fake',
+            'market_type' => 'perpetual',
+            'profile' => 'scalper',
+            'entry_time' => '2026-06-15 10:00:00+00',
+            'v1_pnl_usdt' => '1.00000000',
+            'v1_holding_time_sec' => '60',
+            'v1_mfe_pct' => '0.01',
+            'v1_mae_pct' => '-0.005',
+            'v2_recorded_pnl_usdt' => '1.00000000',
+            'v2_net_pnl_usdt' => null,
+            'v2_holding_time_sec' => '60',
+            'v2_mfe_pct' => '0.01',
+            'v2_mae_pct' => '-0.005',
+            'v2_close_match_status' => 'matched',
+            'v2_analysis_status' => 'matched_closed',
+            'v2_cost_completeness' => 'partial',
+            'v2_position_fully_closed' => true,
+            'v2_pnl_quality_flags' => [],
+        ];
+    }
+}
+
+final class RecordingDivergenceReader implements PositionTradeAnalysisBackfillDivergenceReaderInterface
+{
+    /** @var list<BackfillDivergenceCriteria> */
+    public array $criteria = [];
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     */
+    public function __construct(private readonly array $rows)
+    {
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function fetchRows(BackfillDivergenceCriteria $criteria): array
+    {
+        $this->criteria[] = $criteria;
+
+        $rows = array_values(array_filter(
+            $this->rows,
+            static fn (array $row): bool => $criteria->resumeCursor === null || (int) $row['entry_event_id'] > $criteria->resumeCursor,
+        ));
+
+        return array_slice($rows, 0, $criteria->limit);
+    }
+}


### PR DESCRIPTION
Part of #190
Related to #132
Related to #173

## Summary
- add a read-only dry-run command comparing position_trade_analysis v1 and position_trade_analysis_v2 by entry_event_id only
- classify certified, partial/unknown/unmatched/conflict/cost/quantity/v1-only/v2-only/PnL divergence rows without symbol-only or time-window backfill matching
- export bounded JSON/CSV reports with deterministic cursor pagination and explicit disabled apply mode
- document the command, classifications, pagination, and no-secret/no-heuristic guarantees

## Tests
- ./vendor/bin/phpunit --display-deprecations tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportServiceTest.php tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php tests/Command/PositionTradeAnalysisBackfillDivergenceCommandTest.php
  - PostgreSQL integration test skipped locally because PostgreSQL is not reachable on DATABASE_URL
- ./vendor/bin/phpstan analyse src/Command/PositionTradeAnalysisBackfillDivergenceCommand.php src/Trading/Backfill tests/Command/PositionTradeAnalysisBackfillDivergenceCommandTest.php tests/Trading/Backfill --memory-limit=1G
- php bin/console lint:container --no-debug
  - passes; existing PHP 8.4 deprecation is emitted by App\Command\TradeQuality\EntryZoneStatsCommand::__construct()
- php bin/console lint:yaml config
- git diff --cached --check

## Notes
- apply mode is intentionally unavailable in this PR
- #190 should remain open after merge until the consumer switch PR is complete
