### PR TITLE
Issue 190: cut over position analysis reporting to v2

### DIFF
--- a/docs/handbook/technical/certified-net-pnl-contract.md
+++ b/docs/handbook/technical/certified-net-pnl-contract.md
@@ -68,6 +68,8 @@ Conclusion : seul Fake/Paper peut servir de reference complete dans ce lot. Les 
 Le ledger persistant v1 est documente dans `docs/handbook/technical/fill-cost-ledger.md`.
 Le dry-run de divergence v1/v2 pre-backfill est documente dans
 `docs/handbook/technical/position-trade-analysis-backfill-divergence.md`.
+La bascule progressive des consommateurs applicatifs v1 -> v2 est documentee dans
+`docs/handbook/technical/position-trade-analysis-consumer-cutover.md`.
 
 Il introduit la table `fill_cost_ledger`, reliee au trade logique par `internal_trade_id` lorsque le lineage exact est disponible. L'idempotence est portee par `exchange + market_type + exchange_fill_id` quand l'exchange fournit un identifiant de fill, sinon par un identifiant interne deterministe documente.
 

--- a/docs/handbook/technical/position-trade-analysis-consumer-cutover.md
+++ b/docs/handbook/technical/position-trade-analysis-consumer-cutover.md
@@ -1,0 +1,85 @@
+# `position_trade_analysis` consumer cutover v1 -> v2
+
+Issue #190 bascule les consommateurs applicatifs vers la surface versionnee
+`position_trade_analysis_v2` sans supprimer la vue historique `position_trade_analysis`.
+La bascule est progressive, read-only et reversible.
+
+## Inventaire consommateurs
+
+| Consommateur | Etat | Decision |
+|---|---|---|
+| `GET /api/positions/analysis` | Lit deja `position_trade_analysis_v2` via `PositionTradeAnalysisReaderInterface`. | Reste v2. |
+| Orchestrateur Python `/runs/{run_id}/outcome` | Consomme l'API Symfony outcome. | Reste v2 indirectement. |
+| Page Twig `/reporting/position-trade-analysis` | Ancien consommateur direct v1. | Migree via `PositionTradeAnalysisReportingService`. |
+| Commande `app:position-trade-analysis:backfill-divergence` | Compare explicitement v1 et v2. | Reste double lecture intentionnelle. |
+| Entite/repository v1 | Necessaires au rollback et a l'observation. | Conserves. |
+| SQL direct applicatif | Aucun autre consommateur runtime identifie hors backfill. | Rien a migrer dans ce lot. |
+| Exports | Aucun export dedie identifie pour cette surface. | Non applicable. |
+
+## Switch
+
+La source par defaut du reporting web est configuree par :
+
+```bash
+POSITION_TRADE_ANALYSIS_REPORTING_SOURCE=v2
+```
+
+Valeurs supportees :
+
+- `v2` : source primaire certifiee, par defaut ;
+- `v1` : rollback explicite vers la vue historique ;
+- `dual` : lit v1 et v2, affiche v2, et expose les compteurs de divergence.
+
+La page web accepte aussi `?source=v1|v2|dual` pour forcer une lecture ponctuelle sans
+changer la configuration du deploiement.
+
+## Regles PnL
+
+- Les lignes v2 affichent `pnl_usdt` uniquement quand `hasCertifiedNetPnl()` est vrai.
+- Une ligne v2 incomplete garde `recorded_pnl_usdt` et `estimated_net_pnl_usdt` visibles comme
+  valeurs non certifiees, mais le net certifie reste vide.
+- Les lignes v1 sont marquees `legacy_v1` et `legacy_recorded_pnl`.
+- Les flags de qualite v2 restent visibles ; le reporting ajoute `net_pnl_not_certified`,
+  `close_unmatched` et `cost_<status>` quand la ligne n'est pas certifiee.
+
+## Rollback
+
+Rollback rapide :
+
+```bash
+POSITION_TRADE_ANALYSIS_REPORTING_SOURCE=v1
+php bin/console cache:clear
+```
+
+Le rollback ne modifie aucune donnee. Il ne reconstruit pas les relations et ne change pas les
+strategies, MTF, EntryZone, Risk/Leverage, SL/TP ou guards live.
+
+Si `v2` est indisponible, la page echoue explicitement avec une erreur de source au lieu de
+presenter un resultat vide. Le fallback vers v1 doit etre volontaire.
+
+## Double lecture et divergences
+
+Le mode `dual` compare les lignes par `entry_event_id` uniquement :
+
+- `common_rows` : lignes presentes dans les deux vues ;
+- `divergent_rows` : ecart PnL au-dela de l'epsilon technique ;
+- `v1_only_rows` / `v2_only_rows` : lignes presentes dans une seule vue.
+
+La comparaison est separee de la pagination d'affichage : les lignes affichees restent bornees
+par la limite UI, tandis que les compteurs v1/v2 sont calcules sur une fenetre deterministe
+`entryTime DESC` limitee a 5000 lignes. Au-dela de cette limite, relancer le dry-run backfill
+paginated reste la source d'audit exhaustive.
+
+Pour les lignes v2 certifiees, la comparaison utilise `net_pnl_usdt`; sinon elle utilise
+`recorded_pnl_usdt`. Aucune divergence n'est resolue arbitrairement dans l'UI.
+
+## Retrait v1
+
+La vue v1 et son repository doivent rester disponibles tant que #190 n'a pas valide :
+
+- un rapport dry-run v1/v2 sur fenetres historiques reelles ;
+- l'absence de divergence bloquante ;
+- la disponibilite de rollback pendant la periode d'observation ;
+- la migration ou justification de tous les consommateurs runtime.
+
+La suppression de v1 demande une PR separee et une validation explicite.

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -58,6 +58,7 @@ parameters:
     env(OKX_DEMO_TRADING_ENABLED): '0'
     env(OKX_LIVE_ENABLED): '0'
     env(MTF_VALIDATION_FALLBACK_ALERT_THRESHOLD): '1'
+    env(POSITION_TRADE_ANALYSIS_REPORTING_SOURCE): 'v2'
     app.trade_entry_default_mode: 'scalper_micro'
 
     # Configuration TradeEntry - Valeurs par défaut (déplacées dans services_trade_entry.yaml)
@@ -105,6 +106,16 @@ services:
 
     App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportServiceInterface:
         alias: App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportService
+
+    App\Trading\Reporting\PositionTradeAnalysisLegacyReaderInterface:
+        alias: App\Repository\PositionTradeAnalysisRepository
+
+    App\Trading\Reporting\PositionTradeAnalysisCertifiedReaderInterface:
+        alias: App\Repository\PositionTradeAnalysisV2Repository
+
+    App\Trading\Reporting\PositionTradeAnalysisReportingService:
+        arguments:
+            $configuredSource: '%env(string:POSITION_TRADE_ANALYSIS_REPORTING_SOURCE)%'
 
 
 

--- a/trading-app/src/Controller/Web/ReportingController.php
+++ b/trading-app/src/Controller/Web/ReportingController.php
@@ -6,7 +6,9 @@ namespace App\Controller\Web;
 
 use App\MtfRunner\Service\MtfReportingService;
 use App\MtfRunner\Service\SymbolInvestigationService;
-use App\Repository\PositionTradeAnalysisRepository;
+use App\Trading\Reporting\PositionTradeAnalysisReportingService;
+use App\Trading\Reporting\PositionTradeAnalysisReportingSource;
+use App\Trading\Reporting\PositionTradeAnalysisReportingSourceException;
 use DateTimeImmutable;
 use DateTimeZone;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -19,7 +21,7 @@ class ReportingController extends AbstractController
     public function __construct(
         private readonly MtfReportingService $reportingService,
         private readonly SymbolInvestigationService $symbolInvestigationService,
-        private readonly PositionTradeAnalysisRepository $positionTradeAnalysisRepository,
+        private readonly PositionTradeAnalysisReportingService $positionTradeAnalysisReportingService,
     ) {
     }
 
@@ -100,6 +102,7 @@ class ReportingController extends AbstractController
         $to = $request->query->get('to', '');
         $sort = $request->query->get('sort', 'entryTime');
         $direction = $request->query->get('direction', 'DESC');
+        $source = $request->query->get('source');
 
         $filters = [
             'symbol' => $symbol ?: null,
@@ -108,16 +111,26 @@ class ReportingController extends AbstractController
             'to' => $to ?: null,
         ];
 
-        $trades = $this->positionTradeAnalysisRepository->search($filters, [
-            'sort' => $sort,
-            'direction' => $direction,
-        ]);
+        $error = null;
+        try {
+            $result = $this->positionTradeAnalysisReportingService->search($filters, [
+                'sort' => $sort,
+                'direction' => $direction,
+            ], source: is_string($source) ? $source : null);
+        } catch (PositionTradeAnalysisReportingSourceException $e) {
+            $error = $e->getMessage();
+            $result = null;
+        }
 
         return $this->render('reporting/position_trade_analysis.html.twig', [
             'filters' => $filters,
             'sort' => $sort,
             'direction' => $direction,
-            'trades' => $trades,
+            'source' => $source,
+            'source_options' => PositionTradeAnalysisReportingSource::all(),
+            'result' => $result,
+            'trades' => $result?->rows ?? [],
+            'error' => $error,
         ]);
     }
 

--- a/trading-app/src/Repository/PositionTradeAnalysisRepository.php
+++ b/trading-app/src/Repository/PositionTradeAnalysisRepository.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Reporting\PositionTradeAnalysisLegacyReaderInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * Repository de la vue HISTORIQUE v1 (`position_trade_analysis`). Inchangé par OBS-003 v2
  * — la lecture des outcomes passe par {@see PositionTradeAnalysisV2Repository}.
+ *
+ * @extends ServiceEntityRepository<PositionTradeAnalysis>
  */
-final class PositionTradeAnalysisRepository extends ServiceEntityRepository
+final class PositionTradeAnalysisRepository extends ServiceEntityRepository implements PositionTradeAnalysisLegacyReaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {

--- a/trading-app/src/Repository/PositionTradeAnalysisV2Repository.php
+++ b/trading-app/src/Repository/PositionTradeAnalysisV2Repository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Trading\Entity\PositionTradeAnalysisV2;
+use App\Trading\Reporting\PositionTradeAnalysisCertifiedReaderInterface;
 use App\Trading\Service\PositionTradeAnalysisReaderInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -15,7 +16,7 @@ use Doctrine\Persistence\ManagerRegistry;
  *
  * @extends ServiceEntityRepository<PositionTradeAnalysisV2>
  */
-final class PositionTradeAnalysisV2Repository extends ServiceEntityRepository implements PositionTradeAnalysisReaderInterface
+final class PositionTradeAnalysisV2Repository extends ServiceEntityRepository implements PositionTradeAnalysisReaderInterface, PositionTradeAnalysisCertifiedReaderInterface
 {
     public function __construct(ManagerRegistry $registry)
     {
@@ -37,6 +38,58 @@ final class PositionTradeAnalysisV2Repository extends ServiceEntityRepository im
             $qb->andWhere('pta.setId = :sid')
                 ->setParameter('sid', $setId);
         }
+
+        return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * @param array{symbol?: string|null, from?: string|null, to?: string|null, timeframe?: string|null} $filters
+     * @param array{sort?: string, direction?: string} $options
+     * @return PositionTradeAnalysisV2[]
+     */
+    public function search(array $filters, array $options = [], int $limit = 200): array
+    {
+        $qb = $this->createQueryBuilder('pta')
+            ->orderBy('pta.entryTime', 'DESC')
+            ->setMaxResults(max(1, $limit));
+
+        if (!empty($filters['symbol'])) {
+            $qb->andWhere('pta.symbol = :symbol')
+                ->setParameter('symbol', strtoupper($filters['symbol']));
+        }
+
+        if (!empty($filters['timeframe'])) {
+            $qb->andWhere('pta.timeframe = :tf')
+                ->setParameter('tf', $filters['timeframe']);
+        }
+
+        if (!empty($filters['from'])) {
+            $qb->andWhere('pta.entryTime >= :from')
+                ->setParameter('from', $filters['from']);
+        }
+
+        if (!empty($filters['to'])) {
+            $qb->andWhere('pta.entryTime <= :to')
+                ->setParameter('to', $filters['to']);
+        }
+
+        $sort = $options['sort'] ?? 'entryTime';
+        $direction = strtoupper($options['direction'] ?? 'DESC');
+        if (!in_array($direction, ['ASC', 'DESC'], true)) {
+            $direction = 'DESC';
+        }
+
+        $allowedSorts = [
+            'entryTime' => 'entryTime',
+            'closeTime' => 'closeTime',
+            'expectedRMultiple' => 'expectedRMultiple',
+            'pnlR' => 'realizedNetPnlR',
+            'pnlUsdt' => 'netPnlUsdt',
+            'mfePct' => 'mfePct',
+            'maePct' => 'maePct',
+        ];
+
+        $qb->orderBy('pta.' . ($allowedSorts[$sort] ?? 'entryTime'), $direction);
 
         return $qb->getQuery()->getResult();
     }

--- a/trading-app/src/Trading/Reporting/PositionTradeAnalysisCertifiedReaderInterface.php
+++ b/trading-app/src/Trading/Reporting/PositionTradeAnalysisCertifiedReaderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Reporting;
+
+use App\Trading\Entity\PositionTradeAnalysisV2;
+
+interface PositionTradeAnalysisCertifiedReaderInterface
+{
+    /**
+     * @param array{symbol?: string|null, from?: string|null, to?: string|null, timeframe?: string|null} $filters
+     * @param array{sort?: string, direction?: string} $options
+     * @return PositionTradeAnalysisV2[]
+     */
+    public function search(array $filters, array $options = [], int $limit = 200): array;
+}

--- a/trading-app/src/Trading/Reporting/PositionTradeAnalysisLegacyReaderInterface.php
+++ b/trading-app/src/Trading/Reporting/PositionTradeAnalysisLegacyReaderInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Reporting;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+
+interface PositionTradeAnalysisLegacyReaderInterface
+{
+    /**
+     * @param array{symbol?: string|null, from?: string|null, to?: string|null, timeframe?: string|null} $filters
+     * @param array{sort?: string, direction?: string} $options
+     * @return PositionTradeAnalysis[]
+     */
+    public function search(array $filters, array $options = [], int $limit = 200): array;
+}

--- a/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportRow.php
+++ b/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportRow.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Reporting;
+
+final readonly class PositionTradeAnalysisReportRow
+{
+    /**
+     * @param list<string> $qualityFlags
+     */
+    public function __construct(
+        public int $entryEventId,
+        public string $sourceVersion,
+        public string $symbol,
+        public ?string $timeframe,
+        public \DateTimeImmutable $entryTime,
+        public ?\DateTimeImmutable $closeTime,
+        public ?float $expectedRMultiple,
+        public ?float $pnlR,
+        public ?float $pnlUsdt,
+        public ?float $recordedPnlUsdt,
+        public ?float $estimatedNetPnlUsdt,
+        public ?float $mfePct,
+        public ?float $maePct,
+        public ?float $entryRsi,
+        public ?float $entryAtr,
+        public ?float $entryMa9,
+        public ?float $entryMa21,
+        public ?float $entryVwap,
+        public string $costCompleteness,
+        public array $qualityFlags,
+        public string $closeMatchStatus,
+        public string $closeMatchedBy,
+        public string $analysisStatus,
+        public string $pnlDefinition,
+        public bool $dataComplete,
+        public bool $netCertified,
+    ) {
+    }
+}

--- a/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingResult.php
+++ b/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingResult.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Reporting;
+
+final readonly class PositionTradeAnalysisReportingResult
+{
+    /**
+     * @param list<PositionTradeAnalysisReportRow> $rows
+     * @param array<string,mixed> $summary
+     */
+    public function __construct(
+        public string $activeSource,
+        public string $primarySource,
+        public bool $dualRead,
+        public array $rows,
+        public array $summary,
+    ) {
+    }
+}

--- a/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingService.php
+++ b/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingService.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Reporting;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Entity\PositionTradeAnalysisV2;
+
+final class PositionTradeAnalysisReportingService
+{
+    private const DUAL_COMPARISON_LIMIT = 5000;
+
+    public function __construct(
+        private readonly PositionTradeAnalysisLegacyReaderInterface $legacyReader,
+        private readonly PositionTradeAnalysisCertifiedReaderInterface $certifiedReader,
+        private readonly string $configuredSource = PositionTradeAnalysisReportingSource::V2,
+    ) {
+    }
+
+    /**
+     * @param array{symbol?: string|null, from?: string|null, to?: string|null, timeframe?: string|null} $filters
+     * @param array{sort?: string, direction?: string} $options
+     */
+    public function search(array $filters, array $options = [], int $limit = 200, ?string $source = null): PositionTradeAnalysisReportingResult
+    {
+        $activeSource = PositionTradeAnalysisReportingSource::normalize($source, $this->configuredSource);
+
+        if ($activeSource === PositionTradeAnalysisReportingSource::V1) {
+            $legacyRows = $this->fetchLegacy($filters, $options, $limit);
+            $rows = array_map([$this, 'fromLegacy'], $legacyRows);
+
+            return new PositionTradeAnalysisReportingResult(
+                activeSource: $activeSource,
+                primarySource: PositionTradeAnalysisReportingSource::V1,
+                dualRead: false,
+                rows: $rows,
+                summary: $this->summary($activeSource, PositionTradeAnalysisReportingSource::V1, $rows, [
+                    'pnl_definition' => 'legacy_recorded_pnl',
+                ]),
+            );
+        }
+
+        if ($activeSource === PositionTradeAnalysisReportingSource::DUAL) {
+            $comparisonOptions = ['sort' => 'entryTime', 'direction' => 'DESC'];
+            $legacyComparisonRows = $this->fetchLegacy($filters, $comparisonOptions, self::DUAL_COMPARISON_LIMIT);
+            $certifiedComparisonRows = $this->fetchCertified($filters, $comparisonOptions, self::DUAL_COMPARISON_LIMIT);
+            $certifiedDisplayRows = $this->fetchCertified($filters, $options, $limit);
+            $rows = array_map([$this, 'fromCertified'], $certifiedDisplayRows);
+            $divergence = $this->compareLegacyAndCertified($legacyComparisonRows, $certifiedComparisonRows);
+
+            return new PositionTradeAnalysisReportingResult(
+                activeSource: $activeSource,
+                primarySource: PositionTradeAnalysisReportingSource::V2,
+                dualRead: true,
+                rows: $rows,
+                summary: $this->summary($activeSource, PositionTradeAnalysisReportingSource::V2, $rows, [
+                    'pnl_definition' => 'certified_net_v1',
+                    'display_limit' => $limit,
+                    'comparison_limit' => self::DUAL_COMPARISON_LIMIT,
+                    'comparison_sort' => 'entryTime DESC',
+                    'v1_rows' => count($legacyComparisonRows),
+                    'v2_rows' => count($certifiedComparisonRows),
+                    'common_rows' => $divergence['common_rows'],
+                    'divergent_rows' => $divergence['divergent_rows'],
+                    'v1_only_rows' => $divergence['v1_only_rows'],
+                    'v2_only_rows' => $divergence['v2_only_rows'],
+                ]),
+            );
+        }
+
+        $certifiedRows = $this->fetchCertified($filters, $options, $limit);
+        $rows = array_map([$this, 'fromCertified'], $certifiedRows);
+
+        return new PositionTradeAnalysisReportingResult(
+            activeSource: PositionTradeAnalysisReportingSource::V2,
+            primarySource: PositionTradeAnalysisReportingSource::V2,
+            dualRead: false,
+            rows: $rows,
+            summary: $this->summary(PositionTradeAnalysisReportingSource::V2, PositionTradeAnalysisReportingSource::V2, $rows, [
+                'pnl_definition' => 'certified_net_v1',
+            ]),
+        );
+    }
+
+    /**
+     * @param array{symbol?: string|null, from?: string|null, to?: string|null, timeframe?: string|null} $filters
+     * @param array{sort?: string, direction?: string} $options
+     * @return PositionTradeAnalysis[]
+     */
+    private function fetchLegacy(array $filters, array $options, int $limit): array
+    {
+        try {
+            return $this->legacyReader->search($filters, $options, $limit);
+        } catch (\Throwable $e) {
+            throw new PositionTradeAnalysisReportingSourceException(PositionTradeAnalysisReportingSource::V1, $e);
+        }
+    }
+
+    /**
+     * @param array{symbol?: string|null, from?: string|null, to?: string|null, timeframe?: string|null} $filters
+     * @param array{sort?: string, direction?: string} $options
+     * @return PositionTradeAnalysisV2[]
+     */
+    private function fetchCertified(array $filters, array $options, int $limit): array
+    {
+        try {
+            return $this->certifiedReader->search($filters, $options, $limit);
+        } catch (\Throwable $e) {
+            throw new PositionTradeAnalysisReportingSourceException(PositionTradeAnalysisReportingSource::V2, $e);
+        }
+    }
+
+    private function fromLegacy(PositionTradeAnalysis $row): PositionTradeAnalysisReportRow
+    {
+        return new PositionTradeAnalysisReportRow(
+            entryEventId: $row->getEntryEventId(),
+            sourceVersion: PositionTradeAnalysisReportingSource::V1,
+            symbol: $row->getSymbol(),
+            timeframe: $row->getTimeframe(),
+            entryTime: $row->getEntryTime(),
+            closeTime: $row->getCloseTime(),
+            expectedRMultiple: $row->getExpectedRMultiple(),
+            pnlR: $row->getPnlR(),
+            pnlUsdt: $row->getPnlUsdt(),
+            recordedPnlUsdt: $row->getPnlUsdt(),
+            estimatedNetPnlUsdt: null,
+            mfePct: $row->getMfePct(),
+            maePct: $row->getMaePct(),
+            entryRsi: $row->getEntryRsi(),
+            entryAtr: $row->getEntryAtr(),
+            entryMa9: $row->getEntryMa9(),
+            entryMa21: $row->getEntryMa21(),
+            entryVwap: $row->getEntryVwap(),
+            costCompleteness: 'legacy',
+            qualityFlags: ['legacy_v1'],
+            closeMatchStatus: $row->getCloseEventId() === null ? 'unmatched' : 'legacy',
+            closeMatchedBy: 'legacy_v1',
+            analysisStatus: $row->getCloseEventId() === null ? 'legacy_unmatched' : 'legacy_closed',
+            pnlDefinition: 'legacy_recorded_pnl',
+            dataComplete: false,
+            netCertified: false,
+        );
+    }
+
+    private function fromCertified(PositionTradeAnalysisV2 $row): PositionTradeAnalysisReportRow
+    {
+        $certified = $row->hasCertifiedNetPnl();
+        $flags = $row->getPnlQualityFlags();
+        if (!$certified) {
+            $flags[] = 'net_pnl_not_certified';
+        }
+        if (!$row->isMatchedClosed()) {
+            $flags[] = 'close_unmatched';
+        }
+        if (!$row->isCostComplete()) {
+            $flags[] = 'cost_' . $row->getCostCompleteness();
+        }
+        $flags = array_values(array_unique($flags));
+
+        return new PositionTradeAnalysisReportRow(
+            entryEventId: $row->getEntryEventId(),
+            sourceVersion: PositionTradeAnalysisReportingSource::V2,
+            symbol: $row->getSymbol(),
+            timeframe: $row->getTimeframe(),
+            entryTime: $row->getEntryTime(),
+            closeTime: $row->getCloseTime(),
+            expectedRMultiple: $row->getExpectedRMultiple(),
+            pnlR: $row->getRealizedNetPnlR(),
+            pnlUsdt: $certified ? $row->getNetPnlUsdt() : null,
+            recordedPnlUsdt: $row->getRecordedPnlUsdt(),
+            estimatedNetPnlUsdt: $row->getEstimatedNetPnlUsdt(),
+            mfePct: $row->getMfePct(),
+            maePct: $row->getMaePct(),
+            entryRsi: $row->getEntryRsi(),
+            entryAtr: $row->getEntryAtr(),
+            entryMa9: $row->getEntryMa9(),
+            entryMa21: $row->getEntryMa21(),
+            entryVwap: $row->getEntryVwap(),
+            costCompleteness: $row->getCostCompleteness(),
+            qualityFlags: $flags,
+            closeMatchStatus: $row->getCloseMatchStatus(),
+            closeMatchedBy: $row->getCloseMatchedBy(),
+            analysisStatus: $row->getAnalysisStatus(),
+            pnlDefinition: 'certified_net_v1',
+            dataComplete: $certified,
+            netCertified: $certified,
+        );
+    }
+
+    /**
+     * @param list<PositionTradeAnalysisReportRow> $rows
+     * @param array<string,mixed> $extra
+     * @return array<string,mixed>
+     */
+    private function summary(string $activeSource, string $primarySource, array $rows, array $extra): array
+    {
+        $dataComplete = true;
+        foreach ($rows as $row) {
+            if (!$row->dataComplete) {
+                $dataComplete = false;
+                break;
+            }
+        }
+
+        return $extra + [
+            'active_source' => $activeSource,
+            'primary_source' => $primarySource,
+            'rollback_source' => PositionTradeAnalysisReportingSource::V1,
+            'row_count' => count($rows),
+            'data_complete' => $dataComplete,
+        ];
+    }
+
+    /**
+     * @param PositionTradeAnalysis[] $legacyRows
+     * @param PositionTradeAnalysisV2[] $certifiedRows
+     * @return array{common_rows:int, divergent_rows:int, v1_only_rows:int, v2_only_rows:int}
+     */
+    private function compareLegacyAndCertified(array $legacyRows, array $certifiedRows): array
+    {
+        $legacyById = [];
+        foreach ($legacyRows as $row) {
+            $legacyById[$row->getEntryEventId()] = $row;
+        }
+
+        $certifiedById = [];
+        foreach ($certifiedRows as $row) {
+            $certifiedById[$row->getEntryEventId()] = $row;
+        }
+
+        $commonIds = array_intersect(array_keys($legacyById), array_keys($certifiedById));
+        $divergent = 0;
+        foreach ($commonIds as $id) {
+            $legacyPnl = $legacyById[$id]->getPnlUsdt();
+            $v2Pnl = $certifiedById[$id]->hasCertifiedNetPnl()
+                ? $certifiedById[$id]->getNetPnlUsdt()
+                : $certifiedById[$id]->getRecordedPnlUsdt();
+
+            if ($legacyPnl === null || $v2Pnl === null) {
+                if ($legacyPnl !== $v2Pnl) {
+                    ++$divergent;
+                }
+                continue;
+            }
+
+            if (abs($legacyPnl - $v2Pnl) > 0.000001) {
+                ++$divergent;
+            }
+        }
+
+        return [
+            'common_rows' => count($commonIds),
+            'divergent_rows' => $divergent,
+            'v1_only_rows' => count(array_diff(array_keys($legacyById), array_keys($certifiedById))),
+            'v2_only_rows' => count(array_diff(array_keys($certifiedById), array_keys($legacyById))),
+        ];
+    }
+}

--- a/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingSource.php
+++ b/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingSource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Reporting;
+
+final class PositionTradeAnalysisReportingSource
+{
+    public const V1 = 'v1';
+    public const V2 = 'v2';
+    public const DUAL = 'dual';
+
+    /**
+     * @return list<string>
+     */
+    public static function all(): array
+    {
+        return [self::V2, self::V1, self::DUAL];
+    }
+
+    public static function normalize(?string $requested, string $configured): string
+    {
+        $source = strtolower(trim($requested ?? ''));
+        if ($source === '') {
+            $source = strtolower(trim($configured));
+        }
+
+        return in_array($source, self::all(), true) ? $source : self::V2;
+    }
+}

--- a/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingSourceException.php
+++ b/trading-app/src/Trading/Reporting/PositionTradeAnalysisReportingSourceException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Reporting;
+
+final class PositionTradeAnalysisReportingSourceException extends \RuntimeException
+{
+    public function __construct(public readonly string $source, \Throwable $previous)
+    {
+        parent::__construct(
+            sprintf('position_trade_analysis reporting source "%s" is unavailable.', $source),
+            0,
+            $previous,
+        );
+    }
+}

--- a/trading-app/templates/reporting/position_trade_analysis.html.twig
+++ b/trading-app/templates/reporting/position_trade_analysis.html.twig
@@ -10,9 +10,26 @@
     </div>
 
     <div class="alert alert-info">
-        <p class="mb-1"><strong>Descriptif :</strong> vue SQL mixant entrées/sorties et snapshots indicateurs (position_trade_analysis).</p>
+        <p class="mb-1"><strong>Source :</strong> {{ result ? result.primarySource : 'indisponible' }}{% if result and result.dualRead %} (double lecture v1/v2 active){% endif %}.</p>
+        <p class="mb-1"><strong>PnL :</strong> {{ result ? result.summary.pnl_definition : 'non disponible' }}. Les lignes v2 incomplètes ne publient pas de net certifié.</p>
         <p class="mb-0"><strong>Exemple :</strong> filtrez par symbole (ex: <code>AIXBTUSDT</code>) et date d’entrée pour comparer le R attendu vs le PnL réel.</p>
     </div>
+
+    {% if error %}
+        <div class="alert alert-danger">
+            {{ error }}
+        </div>
+    {% endif %}
+
+    {% if result and result.dualRead %}
+        <div class="alert alert-warning">
+            Double lecture : {{ result.summary.common_rows }} lignes communes,
+            {{ result.summary.divergent_rows }} divergences,
+            {{ result.summary.v1_only_rows }} v1 seules,
+            {{ result.summary.v2_only_rows }} v2 seules
+            (comparaison {{ result.summary.comparison_sort }}, limite {{ result.summary.comparison_limit }}).
+        </div>
+    {% endif %}
 
     <form method="get" class="row g-3 mb-4">
         <div class="col-md-3">
@@ -30,6 +47,16 @@
         <div class="col-md-2">
             <label class="form-label">Au (UTC)</label>
             <input type="date" class="form-control" name="to" value="{{ filters.to ?? '' }}">
+        </div>
+        <div class="col-md-2">
+            <label for="source" class="form-label">Source</label>
+            <select id="source" name="source" class="form-select">
+                {% for option in source_options %}
+                    <option value="{{ option }}" {{ result and result.activeSource == option ? 'selected' : (not result and source == option ? 'selected' : '') }}>
+                        {{ option }}
+                    </option>
+                {% endfor %}
+            </select>
         </div>
         <div class="col-md-2 align-self-end">
             <button type="submit" class="btn btn-primary w-100">
@@ -53,6 +80,7 @@
                     <th>R attendu</th>
                     <th>R réalisé</th>
                     <th>PnL USDT</th>
+                    <th>Qualité</th>
                     <th>MFE/MAE (%)</th>
                     <th>RSI/ATR (entrée)</th>
                     <th>MA/VWAP</th>
@@ -74,7 +102,29 @@
                             {{ trade.pnlR ?? '—' }}
                         </td>
                         <td class="{{ trade.pnlUsdt is not null and trade.pnlUsdt < 0 ? 'text-danger' : 'text-success' }}">
-                            {{ trade.pnlUsdt ?? '—' }}
+                            <div>{{ trade.pnlUsdt ?? '—' }}</div>
+                            {% if trade.recordedPnlUsdt is not null and (not trade.netCertified or trade.sourceVersion == 'v1') %}
+                                <small class="text-muted">recorded {{ trade.recordedPnlUsdt }}</small>
+                            {% endif %}
+                            {% if trade.estimatedNetPnlUsdt is not null and not trade.netCertified %}
+                                <small class="d-block text-muted">estimé {{ trade.estimatedNetPnlUsdt }}</small>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div>
+                                <span class="badge {{ trade.netCertified ? 'bg-success' : 'bg-warning text-dark' }}">
+                                    {{ trade.costCompleteness }}
+                                </span>
+                                <span class="badge bg-secondary">{{ trade.sourceVersion }}</span>
+                            </div>
+                            <div class="small text-muted">{{ trade.analysisStatus }} / {{ trade.closeMatchStatus }}</div>
+                            {% if trade.qualityFlags %}
+                                <div class="small">
+                                    {% for flag in trade.qualityFlags %}
+                                        <span class="badge bg-light text-dark border">{{ flag }}</span>
+                                    {% endfor %}
+                                </div>
+                            {% endif %}
                         </td>
                         <td>
                             <div>MFE {{ trade.mfePct ?? '—' }}%</div>
@@ -92,7 +142,7 @@
                     </tr>
                 {% else %}
                     <tr>
-                        <td colspan="10" class="text-center text-muted">Aucun trade trouvé avec ces filtres.</td>
+                        <td colspan="11" class="text-center text-muted">Aucun trade trouvé avec ces filtres.</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/trading-app/tests/Trading/Reporting/PositionTradeAnalysisReportingServiceTest.php
+++ b/trading-app/tests/Trading/Reporting/PositionTradeAnalysisReportingServiceTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Reporting;
+
+use App\Trading\Entity\PositionTradeAnalysis;
+use App\Trading\Entity\PositionTradeAnalysisV2;
+use App\Trading\Reporting\PositionTradeAnalysisCertifiedReaderInterface;
+use App\Trading\Reporting\PositionTradeAnalysisLegacyReaderInterface;
+use App\Trading\Reporting\PositionTradeAnalysisReportRow;
+use App\Trading\Reporting\PositionTradeAnalysisReportingResult;
+use App\Trading\Reporting\PositionTradeAnalysisReportingService;
+use App\Trading\Reporting\PositionTradeAnalysisReportingSource;
+use App\Trading\Reporting\PositionTradeAnalysisReportingSourceException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PositionTradeAnalysisReportingService::class)]
+#[CoversClass(PositionTradeAnalysisReportingSource::class)]
+#[CoversClass(PositionTradeAnalysisReportingResult::class)]
+#[CoversClass(PositionTradeAnalysisReportRow::class)]
+#[CoversClass(PositionTradeAnalysisReportingSourceException::class)]
+final class PositionTradeAnalysisReportingServiceTest extends TestCase
+{
+    public function testDefaultV2ConsumerUsesCertifiedNetPnlAndExposesQualityMetadata(): void
+    {
+        $service = new PositionTradeAnalysisReportingService(
+            new RecordingLegacyReader([$this->legacyRow(['entryEventId' => 101, 'pnlUsdt' => 12.0])]),
+            new RecordingCertifiedReader([$this->v2Row([
+                'entryEventId' => 101,
+                'recordedPnlUsdt' => 12.0,
+                'netPnlUsdt' => 10.5,
+                'costCompleteness' => 'complete',
+                'closeEventId' => 201,
+                'closeMatchStatus' => 'matched',
+                'closeMatchedBy' => 'matched_internal_trade_id',
+                'analysisStatus' => 'matched_closed',
+                'pnlQualityFlags' => ['ledger_complete'],
+            ])]),
+            'v2',
+        );
+
+        $result = $service->search(['symbol' => 'btcusdt'], ['sort' => 'pnlUsdt'], 50);
+
+        self::assertSame('v2', $result->activeSource);
+        self::assertSame('certified_net_v1', $result->summary['pnl_definition']);
+        self::assertFalse($result->dualRead);
+        self::assertCount(1, $result->rows);
+        self::assertSame(10.5, $result->rows[0]->pnlUsdt);
+        self::assertSame(12.0, $result->rows[0]->recordedPnlUsdt);
+        self::assertTrue($result->rows[0]->netCertified);
+        self::assertTrue($result->rows[0]->dataComplete);
+        self::assertSame(['ledger_complete'], $result->rows[0]->qualityFlags);
+    }
+
+    public function testIncompleteV2NeverDisplaysRecordedPnlAsCertifiedNetPnl(): void
+    {
+        $service = new PositionTradeAnalysisReportingService(
+            new RecordingLegacyReader([]),
+            new RecordingCertifiedReader([$this->v2Row([
+                'recordedPnlUsdt' => 7.25,
+                'estimatedNetPnlUsdt' => 6.8,
+                'netPnlUsdt' => null,
+                'costCompleteness' => 'partial',
+                'closeEventId' => 301,
+                'closeMatchStatus' => 'matched',
+                'closeMatchedBy' => 'matched_internal_trade_id',
+                'analysisStatus' => 'matched_closed',
+            ])]),
+            'v2',
+        );
+
+        $result = $service->search([], [], 200);
+
+        self::assertNull($result->rows[0]->pnlUsdt);
+        self::assertSame(7.25, $result->rows[0]->recordedPnlUsdt);
+        self::assertSame(6.8, $result->rows[0]->estimatedNetPnlUsdt);
+        self::assertFalse($result->rows[0]->netCertified);
+        self::assertFalse($result->rows[0]->dataComplete);
+        self::assertContains('net_pnl_not_certified', $result->rows[0]->qualityFlags);
+        self::assertContains('cost_partial', $result->rows[0]->qualityFlags);
+    }
+
+    public function testRollbackSourceUsesLegacyRowsWithoutTouchingUnavailableV2(): void
+    {
+        $legacyReader = new RecordingLegacyReader([$this->legacyRow([
+            'entryEventId' => 401,
+            'pnlUsdt' => -3.0,
+            'closeEventId' => 501,
+        ])]);
+        $service = new PositionTradeAnalysisReportingService(
+            $legacyReader,
+            new ThrowingCertifiedReader(),
+            'v2',
+        );
+
+        $result = $service->search([], [], 200, 'v1');
+
+        self::assertSame('v1', $result->activeSource);
+        self::assertSame('legacy_recorded_pnl', $result->summary['pnl_definition']);
+        self::assertSame(-3.0, $result->rows[0]->pnlUsdt);
+        self::assertSame('v1', $result->rows[0]->sourceVersion);
+        self::assertFalse($result->rows[0]->netCertified);
+        self::assertFalse($result->rows[0]->dataComplete);
+        self::assertSame(['legacy_v1'], $result->rows[0]->qualityFlags);
+        self::assertSame(1, $legacyReader->calls);
+    }
+
+    public function testV2SourceUnavailableFailsClosedUntilExplicitRollback(): void
+    {
+        $service = new PositionTradeAnalysisReportingService(
+            new RecordingLegacyReader([$this->legacyRow(['pnlUsdt' => 1.0])]),
+            new ThrowingCertifiedReader(),
+            'v2',
+        );
+
+        try {
+            $service->search([], [], 200);
+            self::fail('v2 indisponible ne doit pas produire un résultat vide ni basculer implicitement.');
+        } catch (PositionTradeAnalysisReportingSourceException $exception) {
+            self::assertSame('v2', $exception->source);
+        }
+
+        self::assertSame('v1', $service->search([], [], 200, 'v1')->activeSource);
+    }
+
+    public function testDualReadDetectsDivergenceAndKeepsV2AsPrimarySurface(): void
+    {
+        $service = new PositionTradeAnalysisReportingService(
+            new RecordingLegacyReader([$this->legacyRow(['entryEventId' => 601, 'pnlUsdt' => 12.0])]),
+            new RecordingCertifiedReader([$this->v2Row([
+                'entryEventId' => 601,
+                'recordedPnlUsdt' => 12.0,
+                'netPnlUsdt' => 10.75,
+                'costCompleteness' => 'complete',
+                'closeEventId' => 701,
+                'closeMatchStatus' => 'matched',
+                'closeMatchedBy' => 'matched_internal_trade_id',
+                'analysisStatus' => 'matched_closed',
+            ])]),
+            'dual',
+        );
+
+        $result = $service->search([], [], 200);
+
+        self::assertSame('dual', $result->activeSource);
+        self::assertTrue($result->dualRead);
+        self::assertSame('v2', $result->primarySource);
+        self::assertSame(1, $result->summary['common_rows']);
+        self::assertSame(1, $result->summary['divergent_rows']);
+        self::assertSame(0, $result->summary['v1_only_rows']);
+        self::assertSame(0, $result->summary['v2_only_rows']);
+        self::assertSame(10.75, $result->rows[0]->pnlUsdt);
+    }
+
+    public function testDualReadComparesBeforeApplyingDisplayLimit(): void
+    {
+        $service = new PositionTradeAnalysisReportingService(
+            new RecordingLegacyReader([
+                $this->legacyRow(['entryEventId' => 603, 'pnlUsdt' => 3.0]),
+                $this->legacyRow(['entryEventId' => 602, 'pnlUsdt' => 2.0]),
+                $this->legacyRow(['entryEventId' => 601, 'pnlUsdt' => 1.0]),
+            ]),
+            new RecordingCertifiedReader([
+                $this->v2Row([
+                    'entryEventId' => 602,
+                    'recordedPnlUsdt' => 2.0,
+                    'netPnlUsdt' => 2.0,
+                    'costCompleteness' => 'complete',
+                    'closeEventId' => 702,
+                    'closeMatchStatus' => 'matched',
+                    'closeMatchedBy' => 'matched_internal_trade_id',
+                    'analysisStatus' => 'matched_closed',
+                ]),
+                $this->v2Row([
+                    'entryEventId' => 601,
+                    'recordedPnlUsdt' => 1.0,
+                    'netPnlUsdt' => 1.0,
+                    'costCompleteness' => 'complete',
+                    'closeEventId' => 701,
+                    'closeMatchStatus' => 'matched',
+                    'closeMatchedBy' => 'matched_internal_trade_id',
+                    'analysisStatus' => 'matched_closed',
+                ]),
+            ]),
+            'dual',
+        );
+
+        $result = $service->search([], ['sort' => 'pnlUsdt'], 1);
+
+        self::assertCount(1, $result->rows);
+        self::assertSame(2, $result->summary['common_rows']);
+        self::assertSame(1, $result->summary['v1_only_rows']);
+        self::assertSame(0, $result->summary['v2_only_rows']);
+        self::assertSame(1, $result->summary['display_limit']);
+        self::assertSame(5000, $result->summary['comparison_limit']);
+        self::assertSame('entryTime DESC', $result->summary['comparison_sort']);
+    }
+
+    public function testFiltersSortAndLimitAreForwardedToSelectedReader(): void
+    {
+        $legacyReader = new RecordingLegacyReader([]);
+        $certifiedReader = new RecordingCertifiedReader([]);
+        $service = new PositionTradeAnalysisReportingService($legacyReader, $certifiedReader, 'v2');
+
+        $service->search(['symbol' => 'ETHUSDT'], ['sort' => 'entryTime', 'direction' => 'ASC'], 12);
+
+        self::assertSame(0, $legacyReader->calls);
+        self::assertSame(1, $certifiedReader->calls);
+        self::assertSame(['symbol' => 'ETHUSDT'], $certifiedReader->lastFilters);
+        self::assertSame(['sort' => 'entryTime', 'direction' => 'ASC'], $certifiedReader->lastOptions);
+        self::assertSame(12, $certifiedReader->lastLimit);
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     */
+    private function legacyRow(array $overrides = []): PositionTradeAnalysis
+    {
+        $defaults = [
+            'entryEventId' => 1,
+            'symbol' => 'BTCUSDT',
+            'timeframe' => '5m',
+            'entryTime' => new \DateTimeImmutable('2026-06-17T08:30:00+00:00'),
+            'pnlUsdt' => 1.0,
+        ];
+
+        return $this->hydrate(PositionTradeAnalysis::class, array_merge($defaults, $overrides));
+    }
+
+    /**
+     * @param array<string,mixed> $overrides
+     */
+    private function v2Row(array $overrides = []): PositionTradeAnalysisV2
+    {
+        $defaults = [
+            'entryEventId' => 1,
+            'symbol' => 'BTCUSDT',
+            'timeframe' => '5m',
+            'entryTime' => new \DateTimeImmutable('2026-06-17T08:30:00+00:00'),
+            'closeMatchStatus' => 'unmatched',
+            'closeMatchedBy' => 'unmatched',
+            'analysisStatus' => 'unmatched',
+            'costCompleteness' => 'not_applicable',
+        ];
+
+        return $this->hydrate(PositionTradeAnalysisV2::class, array_merge($defaults, $overrides));
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $class
+     * @param array<string,mixed> $data
+     * @return T
+     */
+    private function hydrate(string $class, array $data): object
+    {
+        $entity = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+        $ref = new \ReflectionObject($entity);
+        foreach ($data as $property => $value) {
+            if (!$ref->hasProperty($property)) {
+                continue;
+            }
+
+            $p = $ref->getProperty($property);
+            $p->setAccessible(true);
+            $p->setValue($entity, $value);
+        }
+
+        return $entity;
+    }
+}
+
+final class RecordingLegacyReader implements PositionTradeAnalysisLegacyReaderInterface
+{
+    public int $calls = 0;
+
+    /** @var array<string,mixed>|null */
+    public ?array $lastFilters = null;
+
+    /** @var array<string,mixed>|null */
+    public ?array $lastOptions = null;
+
+    public ?int $lastLimit = null;
+
+    /** @param list<PositionTradeAnalysis> $rows */
+    public function __construct(private readonly array $rows)
+    {
+    }
+
+    public function search(array $filters, array $options = [], int $limit = 200): array
+    {
+        ++$this->calls;
+        $this->lastFilters = $filters;
+        $this->lastOptions = $options;
+        $this->lastLimit = $limit;
+
+        return array_slice($this->rows, 0, $limit);
+    }
+}
+
+final class RecordingCertifiedReader implements PositionTradeAnalysisCertifiedReaderInterface
+{
+    public int $calls = 0;
+
+    /** @var array<string,mixed>|null */
+    public ?array $lastFilters = null;
+
+    /** @var array<string,mixed>|null */
+    public ?array $lastOptions = null;
+
+    public ?int $lastLimit = null;
+
+    /** @param list<PositionTradeAnalysisV2> $rows */
+    public function __construct(private readonly array $rows)
+    {
+    }
+
+    public function search(array $filters, array $options = [], int $limit = 200): array
+    {
+        ++$this->calls;
+        $this->lastFilters = $filters;
+        $this->lastOptions = $options;
+        $this->lastLimit = $limit;
+
+        return array_slice($this->rows, 0, $limit);
+    }
+}
+
+final class ThrowingCertifiedReader implements PositionTradeAnalysisCertifiedReaderInterface
+{
+    public function search(array $filters, array $options = [], int $limit = 200): array
+    {
+        throw new \RuntimeException('position_trade_analysis_v2 missing');
+    }
+}


### PR DESCRIPTION
Part of #190
Related to #189
Related to #173
Related to #204

## Summary
- Add a read-only reporting cutover service for `position_trade_analysis` consumers with `v2`, `v1` rollback, and `dual` read modes.
- Move `/reporting/position-trade-analysis` from direct v1 repository reads to the cutover service while keeping the same route and filters.
- Add v2 search support, visible quality/completeness metadata, explicit certified-net PnL display rules, and consumer cutover documentation.

## Safety
- v1 remains available for rollback and the backfill divergence command remains intentionally dual-read.
- v2 source failures fail closed instead of silently returning an empty result.
- Incomplete v2 rows never display recorded/estimated PnL as certified net PnL.
- No strategy, MTF, EntryZone, Risk/Leverage, SL/TP, or live guard changes.

## Tests
- `cd trading-app && ./vendor/bin/phpunit tests/Trading/Reporting/PositionTradeAnalysisReportingServiceTest.php tests/Trading/Service/RunTradeOutcomeServiceTest.php tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReportServiceTest.php`
- `cd trading-app && ./vendor/bin/phpstan analyse -c phpstan.dist.neon src/Trading/Reporting src/Repository/PositionTradeAnalysisRepository.php src/Repository/PositionTradeAnalysisV2Repository.php src/Controller/Web/ReportingController.php tests/Trading/Reporting/PositionTradeAnalysisReportingServiceTest.php`
- `cd trading-app && php bin/console lint:container --no-debug`
- `cd trading-app && php bin/console lint:yaml config`
- `cd trading-app && php bin/console lint:twig templates/reporting/position_trade_analysis.html.twig`
- `git diff --check`

Note: docker-compose validation could not run locally because the Docker daemon socket was unavailable; the same PHPUnit coverage was run via the local project vendor binary.