### PR TITLE
Issue 188: add orchestrator runtime recipe fixtures

### DIFF
--- a/docs/handbook/graphs/orchestrator-runtime-recipe-r1-r16.puml
+++ b/docs/handbook/graphs/orchestrator-runtime-recipe-r1-r16.puml
@@ -1,0 +1,29 @@
+@startuml
+title TradingV3 runtime recipe R1-R16
+
+actor Operator
+participant "Temporal Schedule" as Temporal
+participant "Python Orchestrator" as Orchestrator
+database "orchestration schema" as Db
+participant "Symfony /api/mtf/run" as Symfony
+participant "Cockpit /orchestration" as Cockpit
+
+Operator -> Orchestrator: Apply recipe fixtures\nFake/Paper dry-run dashboards
+Orchestrator -> Db: Upsert dashboard + sets
+Operator -> Orchestrator: POST /orchestrator/run\nmanual R1-R14 probes
+Temporal -> Orchestrator: Scheduled POST /orchestrator/run\nR15 probes
+Orchestrator -> Db: Claim run + run_sets
+Orchestrator -> Symfony: POST /api/mtf/run\nsync_tables=false, dry_run=true
+Symfony --> Orchestrator: status / error payload
+Orchestrator -> Db: Persist summary, per-set result, audit
+Cockpit -> Orchestrator: Read latest run
+Operator -> Temporal: Pause/resume schedule\nrollback R16
+
+note right of Orchestrator
+No mainnet.
+No strategy changes.
+No live OKX/Hyperliquid.
+No raw sensitive payloads.
+end note
+
+@enduml

--- a/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
+++ b/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
@@ -1,0 +1,246 @@
+# Recette runtime orchestrateur R1-R16
+
+Cette recette documente le premier lot de #188 : documentation et fixtures
+reproductibles uniquement. Elle ne modifie aucun comportement de production et
+reste en dry-run par defaut.
+
+## Perimetre
+
+La recette valide la chaine cible :
+
+```text
+Temporal Schedule
+  -> OrchestratorCronWorkflow
+  -> POST /orchestrator/run
+  -> dashboards + sets persistants
+  -> snapshot open-state
+  -> POST Symfony /api/mtf/run
+  -> runs + run_sets + audit + metriques
+  -> cockpit /orchestration
+```
+
+Hors perimetre de ce lot :
+
+- execution automatique de toute la matrice ;
+- changement strategie, MTF, EntryZone, Risk/Leverage ou SL/TP ;
+- activation mainnet ;
+- activation live OKX ou Hyperliquid ;
+- suppression du chemin legacy.
+
+## Preconditions
+
+Verifier avant toute recette :
+
+- `main` contient les migrations orchestrateur Alembic ;
+- `docker compose --profile orchestrator up -d` demarre l'API Python ;
+- Symfony expose `GET /api/mtf/contracts`, `GET /api/exchange/open-state` et
+  `POST /api/mtf/run` ;
+- le worker Temporal cible est disponible dans `cron_symfony_mtf_workers` ;
+- le cockpit `/orchestration` est accessible depuis le reseau de confiance ;
+- les anciennes taches legacy restent pausables sans etre supprimees ;
+- aucune variable live n'est necessaire.
+
+Variables non sensibles utiles :
+
+| Variable | Exemple | Role |
+| --- | --- | --- |
+| `ORCHESTRATOR_RUN_URL` | `http://python-orchestrator:8099/orchestrator/run` | URL appelee par Temporal. |
+| `ORCHESTRATOR_DASHBOARD_ID` | `1` | Dashboard cible du schedule. |
+| `ORCHESTRATOR_SCHEDULE_ID` | `recipe-orchestrator-r1-r16` | Identifiant du schedule Temporal de recette. |
+| `ORCHESTRATOR_WORKFLOW_ID` | `recipe-orchestrator-r1-r16-runner` | Workflow cible. |
+| `ORCHESTRATOR_CRON` | `*/5 * * * *` | Frequence de recette. |
+| `TEMPORAL_ADDRESS` | `temporal:7233` | Endpoint Temporal interne. |
+| `TEMPORAL_NAMESPACE` | `default` | Namespace Temporal. |
+| `TASK_QUEUE_NAME` | `cron_symfony_mtf_workers` | Task queue du worker. |
+
+Ne jamais consigner de cle API, signature, token, header d'authentification ou
+payload signe dans les preuves.
+
+## Fixtures
+
+Fixtures versionnees :
+
+- `python-orchestrator/fixtures/runtime-recipe/r1_r16_nominal_fake_dashboard.json`
+- `python-orchestrator/fixtures/runtime-recipe/r1_r16_degraded_fake_dashboard.json`
+
+Elles utilisent uniquement :
+
+- `exchange=fake` ;
+- `market_type=perpetual` ;
+- `environment=demo` ;
+- `dry_run=true` ;
+- `workers=1` ;
+- profils `regular`, `scalper`, `scalper_micro`.
+
+Application idempotente attendue :
+
+1. chercher le dashboard par `dashboard.name` ;
+2. le creer s'il est absent, sinon le mettre a jour ;
+3. chercher chaque set par `(dashboard_id, set_id)` ;
+4. le creer s'il est absent, sinon le mettre a jour ;
+5. ne jamais envoyer le champ `payload`, produit cote serveur ;
+6. relire les sets et verifier l'unicite de `set_id`.
+
+Exemple d'application manuelle du dashboard nominal :
+
+```bash
+export RECIPE_DASHBOARD_NAME=recipe-r1-r16-nominal-fake
+RECIPE_DASHBOARD_ID=$(
+  curl -sS http://localhost:8099/dashboards \
+    | python3 -c 'import json, os, sys; name=os.environ["RECIPE_DASHBOARD_NAME"]; print(next((str(d["id"]) for d in json.load(sys.stdin) if d["name"] == name), ""))'
+)
+
+if [ -z "$RECIPE_DASHBOARD_ID" ]; then
+  RECIPE_DASHBOARD_ID=$(
+    curl -sS -X POST http://localhost:8099/dashboards \
+      -H 'Content-Type: application/json' \
+      -d '{"name":"recipe-r1-r16-nominal-fake","enabled":true,"description":"Recette runtime R1-R16 - profils regular, scalper et scalper_micro en Fake/Paper dry-run."}' \
+      | python3 -c 'import json, sys; print(json.load(sys.stdin)["id"])'
+  )
+fi
+
+curl -sS -X POST "http://localhost:8099/dashboards/${RECIPE_DASHBOARD_ID}/sets" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "set_id": "recipe_fake_regular",
+        "enabled": true,
+        "action": "mtf_run",
+        "exchange": "fake",
+        "market_type": "perpetual",
+        "mtf_profile": "regular",
+        "environment": "demo",
+        "dry_run": true,
+        "workers": 1,
+        "sync_tables": false,
+        "symbols": ["BTCUSDT", "ETHUSDT"],
+        "priority": 30
+      }'
+```
+
+Pour une execution reproductible, preferer le runner du prochain lot #188. Cette
+PR livre seulement les donnees et le contrat d'application.
+
+## Format des resultats
+
+Chaque scenario doit produire une ligne :
+
+| Champ | Valeurs | Description |
+| --- | --- | --- |
+| `scenario` | `R1` a `R16` | Scenario teste. |
+| `status` | `PASS`, `FAIL`, `BLOCKED` | Statut de recette. |
+| `run_id` | chaine | Identifiant orchestrateur si applicable. |
+| `dashboard` | chaine ou id | Dashboard utilise. |
+| `sets` | liste | Sets attendus et observes. |
+| `evidence` | liste | Preuves minimales. |
+| `notes` | texte court | Ecart ou justification. |
+
+`BLOCKED` est obligatoire lorsqu'une dependance runtime manque. Ne pas convertir
+un scenario non execute en `PASS`.
+
+## Matrice R1-R16
+
+| Scenario | Fixture | Procedure | Preuves attendues |
+| --- | --- | --- | --- |
+| R1 - Run nominal un set | nominal, `recipe_fake_regular` seul actif | Desactiver temporairement les deux autres sets actifs, puis `POST /orchestrator/run` avec `dashboard_id`. | `status=success`, un `run_set`, appel Symfony capture, cockpit dernier run coherent. |
+| R2 - Run nominal multi-sets | nominal | Executer le dashboard nominal complet. | Trois sets actifs dispatches, ordre deterministe par priorite, resume exact. |
+| R3 - Set desactive | nominal, `recipe_fake_disabled` | Verifier que le set desactive existe puis lancer R2. | Aucun `run_set` pour `recipe_fake_disabled`, exclusion visible dans la configuration. |
+| R4 - Payload non materialise | degraded, `recipe_fake_not_materialized` | Lancer le dashboard degrade sans refresh reussi. | Aucun appel Symfony pour ce set, erreur `not_materialized`, run non marque success. |
+| R5 - Erreur fonctionnelle Symfony | degraded, `recipe_fake_error_regular` | Stubber ou provoquer HTTP 400, 409, `ok=false`, JSON invalide. | Set en echec, corps utile redacted, summary coherent. |
+| R6 - Symfony indisponible/timeout | degraded | Couper Symfony ou router le set vers un stub timeout/5xx. | Retry/timeout bornes, aucun succes masque, replay possible. |
+| R7 - Echec partiel | degraded | Mixer un set nominal et un set en erreur. | `partial_failure`, compteurs success/failed exacts. |
+| R8 - Idempotence | nominal | Rejouer le meme `idempotency_key`. | Aucun doublon `runs`/`run_sets`, replay explicite du resultat. |
+| R9 - Replay explicite | nominal | Rejouer un run termine via la meme cle ou le meme tick. | Relation lisible avec le run initial, aucun effet de bord duplique. |
+| R10 - Crash et reprise | degraded ou nominal | Interrompre l'orchestrateur apres claim, attendre expiration puis relancer. | Claim repris, set non perdu, pas de double execution observee. |
+| R11 - Chevauchement schedules | degraded, `recipe_fake_overlap_scalper` | Declencher deux ticks proches avec meme dashboard. | Lock ou `running` in-flight visible, pas de double dispatch incompatible. |
+| R12 - Contention entre profils | nominal + degraded | Cibler `BTCUSDT` depuis deux profils Fake dry-run. | Distinction lock orchestration / lock metier, aucun live. |
+| R13 - Snapshot obsolete | guided, pas validable par fixture dry-run seule | Avec les fixtures dry-run, fournir un snapshot absent doit rester non bloquant; la branche fail-closed ne concerne que les sets effectivement live. Marquer `BLOCKED` tant qu'un harness local dedie ne cree pas un set `fake/demo` effectivement live sans mainnet ni exchange reel. | Preuve minimale dans ce lot : dry-run sans snapshot ne trade pas en live et ne valide pas R13. Preuve finale attendue plus tard : refus fail-closed live avant dispatch, sans fallback exchange silencieux. |
+| R14 - Garde-fous live | mutation negative | Tenter OKX/Hyperliquid `dry_run=false` ou live non allowliste. | Refus avant dispatch, 422/skip audit, aucun appel metier. |
+| R15 - Temporal Schedule | nominal | Creer un schedule dry-run vers le dashboard nominal. | Schedule visible, pause/reprise, `ok=false` echoue vraiment dans Temporal. |
+| R16 - Rollback | nominal | Pauser le schedule cible puis verifier le chemin legacy documente. | Nouveau schedule pause, legacy non concurrent, temps de rollback mesure. |
+
+## Commandes de recette guidee
+
+Run manuel :
+
+```bash
+curl -sS -X POST http://localhost:8099/orchestrator/run \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "dashboard_id": "'"${RECIPE_DASHBOARD_ID}"'",
+        "schedule_id": "manual-r1-r16",
+        "tick_timestamp": "2026-06-26T00:00:00Z",
+        "idempotency_key": "recipe-r1-r16-manual-001",
+        "dry_run": true
+      }'
+```
+
+Schedule Temporal en previsualisation :
+
+```bash
+cd cron_symfony_mtf_workers
+python scripts/manage_orchestrator_schedule.py create \
+  --dry-run \
+  --dashboard-id "${RECIPE_DASHBOARD_ID}" \
+  --schedule-id recipe-orchestrator-r1-r16 \
+  --workflow-id recipe-orchestrator-r1-r16-runner \
+  --cron '*/5 * * * *'
+```
+
+Creation reelle uniquement apres validation des preconditions :
+
+```bash
+python scripts/manage_orchestrator_schedule.py create \
+  --dashboard-id "${RECIPE_DASHBOARD_ID}" \
+  --schedule-id recipe-orchestrator-r1-r16 \
+  --workflow-id recipe-orchestrator-r1-r16-runner \
+  --cron '*/5 * * * *'
+```
+
+Rollback de recette :
+
+```bash
+python scripts/manage_orchestrator_schedule.py pause \
+  --schedule-id recipe-orchestrator-r1-r16
+
+python scripts/manage_orchestrator_schedule.py status \
+  --schedule-id recipe-orchestrator-r1-r16
+```
+
+Ne reprendre un schedule legacy MTF que si le schedule cible est pause et que le
+runbook [migration legacy vers orchestrateur](../technical/legacy-migration.md)
+est suivi.
+
+## Nettoyage
+
+Nettoyage logique recommande :
+
+1. pauser le schedule de recette ;
+2. exporter les preuves strictement redacted ;
+3. desactiver les dashboards `recipe-r1-r16-*` ;
+4. conserver les lignes `runs` et `run_sets` utiles au rapport final ;
+5. supprimer uniquement les fixtures de base de recette locale si elles ne sont
+   plus necessaires.
+
+Exemple :
+
+```bash
+curl -sS -X PATCH "http://localhost:8099/dashboards/${RECIPE_DASHBOARD_ID}" \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled":false}'
+```
+
+## Preuves minimales
+
+Pour chaque scenario execute :
+
+- `run_id` ;
+- dashboard et sets attendus ;
+- statut global ;
+- compteurs `total_calls`, `success`, `failed` ;
+- extrait redacted de `Run.last_json` ;
+- detail `run_sets` du set fautif si applicable ;
+- evenement Temporal ou statut schedule pour R15/R16 ;
+- capture cockpit si utile ;
+- liste explicite des scenarios `BLOCKED`.
+
+Diagramme source : `docs/handbook/graphs/orchestrator-runtime-recipe-r1-r16.puml`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
   - Runbooks:
       - Exploitation: runbooks/operations.md
       - Investigation: runbooks/investigation.md
+      - Recette orchestrateur R1-R16: runbooks/orchestrator-runtime-recipe-r1-r16.md
   - Inventaires:
       - Couverture projet: inventories/project-inventory.md
 

--- a/python-orchestrator/fixtures/runtime-recipe/r1_r16_degraded_fake_dashboard.json
+++ b/python-orchestrator/fixtures/runtime-recipe/r1_r16_degraded_fake_dashboard.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://pivox.local/schemas/orchestrator-runtime-recipe-fixture-v1.json",
+  "fixture_id": "runtime-recipe-r1-r16-degraded-fake-v1",
+  "version": 1,
+  "dry_run_only": true,
+  "purpose": "Dashboard Fake/Paper dry-run reserve aux scenarios degrades R4 a R13.",
+  "dashboard": {
+    "name": "recipe-r1-r16-degraded-fake",
+    "enabled": true,
+    "description": "Recette runtime R1-R16 - cas degrades Fake/Paper, dry-run uniquement."
+  },
+  "sets": [
+    {
+      "set_id": "recipe_fake_not_materialized",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "fake",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": [],
+      "contracts_limit": 2,
+      "priority": 30,
+      "recipe_role": "r4_payload_missing_after_refresh_failure"
+    },
+    {
+      "set_id": "recipe_fake_error_regular",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "fake",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["ERR400USDT"],
+      "contracts_limit": null,
+      "priority": 20,
+      "recipe_role": "r5_functional_error_target"
+    },
+    {
+      "set_id": "recipe_fake_overlap_scalper",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "fake",
+      "market_type": "perpetual",
+      "mtf_profile": "scalper",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 10,
+      "recipe_role": "r11_r12_overlap_probe"
+    }
+  ],
+  "scenario_mapping": {
+    "R4": ["recipe_fake_not_materialized"],
+    "R5": ["recipe_fake_error_regular"],
+    "R6": ["recipe_fake_error_regular"],
+    "R7": ["recipe_fake_not_materialized", "recipe_fake_error_regular", "recipe_fake_overlap_scalper"],
+    "R8": ["recipe_fake_overlap_scalper"],
+    "R9": ["recipe_fake_overlap_scalper"],
+    "R10": ["recipe_fake_overlap_scalper"],
+    "R11": ["recipe_fake_overlap_scalper"],
+    "R12": ["recipe_fake_overlap_scalper"],
+    "R13": ["recipe_fake_not_materialized"]
+  },
+  "expected_invariants": {
+    "dry_run": true,
+    "mainnet": false,
+    "workers_per_set": 1,
+    "fixture_application": "upsert_by_dashboard_name_and_set_id"
+  }
+}

--- a/python-orchestrator/fixtures/runtime-recipe/r1_r16_nominal_fake_dashboard.json
+++ b/python-orchestrator/fixtures/runtime-recipe/r1_r16_nominal_fake_dashboard.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://pivox.local/schemas/orchestrator-runtime-recipe-fixture-v1.json",
+  "fixture_id": "runtime-recipe-r1-r16-nominal-fake-v1",
+  "version": 1,
+  "dry_run_only": true,
+  "purpose": "Dashboard Fake/Paper dry-run pour la recette nominale R1-R3 et le socle R8/R15/R16.",
+  "dashboard": {
+    "name": "recipe-r1-r16-nominal-fake",
+    "enabled": true,
+    "description": "Recette runtime R1-R16 - profils regular, scalper et scalper_micro en Fake/Paper dry-run."
+  },
+  "sets": [
+    {
+      "set_id": "recipe_fake_regular",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "fake",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT", "ETHUSDT"],
+      "contracts_limit": null,
+      "priority": 30,
+      "recipe_role": "r1_single_set"
+    },
+    {
+      "set_id": "recipe_fake_scalper",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "fake",
+      "market_type": "perpetual",
+      "mtf_profile": "scalper",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["SOLUSDT", "LINKUSDT"],
+      "contracts_limit": null,
+      "priority": 20,
+      "recipe_role": "r2_multi_set_scalper"
+    },
+    {
+      "set_id": "recipe_fake_scalper_micro",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "fake",
+      "market_type": "perpetual",
+      "mtf_profile": "scalper_micro",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["XRPUSDT", "ADAUSDT"],
+      "contracts_limit": null,
+      "priority": 10,
+      "recipe_role": "r2_multi_set_scalper_micro"
+    },
+    {
+      "set_id": "recipe_fake_disabled",
+      "enabled": false,
+      "action": "mtf_run",
+      "exchange": "fake",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["DOGEUSDT"],
+      "contracts_limit": null,
+      "priority": 99,
+      "recipe_role": "r3_disabled_set"
+    }
+  ],
+  "scenario_mapping": {
+    "R1": ["recipe_fake_regular"],
+    "R2": ["recipe_fake_regular", "recipe_fake_scalper", "recipe_fake_scalper_micro"],
+    "R3": ["recipe_fake_disabled"],
+    "R8": ["recipe_fake_regular"],
+    "R15": ["recipe_fake_regular", "recipe_fake_scalper", "recipe_fake_scalper_micro"],
+    "R16": ["recipe_fake_regular", "recipe_fake_scalper", "recipe_fake_scalper_micro"]
+  },
+  "expected_invariants": {
+    "dry_run": true,
+    "mainnet": false,
+    "workers_per_set": 1,
+    "fixture_application": "upsert_by_dashboard_name_and_set_id"
+  }
+}

--- a/python-orchestrator/tests/test_runtime_recipe_fixtures.py
+++ b/python-orchestrator/tests/test_runtime_recipe_fixtures.py
@@ -1,0 +1,173 @@
+"""Validation des fixtures de recette runtime R1-R16 (#188)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "runtime-recipe"
+
+SET_FIELDS = {
+    "set_id",
+    "enabled",
+    "action",
+    "exchange",
+    "market_type",
+    "mtf_profile",
+    "environment",
+    "dry_run",
+    "workers",
+    "sync_tables",
+    "symbols",
+    "contracts_limit",
+    "priority",
+}
+
+SECRET_RE = re.compile(
+    r"(api[_-]?key|secret|password|passwd|token|signature|private[_-]?key|"
+    r"authorization|x-bitmart-sign|begin private key)",
+    re.IGNORECASE,
+)
+
+
+def _fixture_paths() -> list[Path]:
+    return sorted(FIXTURE_DIR.glob("*.json"))
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _walk(value: Any):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield str(key)
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+    elif isinstance(value, str):
+        yield value
+
+
+def _dashboard_by_name(client, name: str) -> dict[str, Any] | None:
+    response = client.get("/dashboards")
+    assert response.status_code == 200
+    for dashboard in response.json():
+        if dashboard["name"] == name:
+            return dashboard
+    return None
+
+
+def _apply_fixture(client, fixture: dict[str, Any]) -> int:
+    dashboard_payload = fixture["dashboard"]
+    existing = _dashboard_by_name(client, dashboard_payload["name"])
+    if existing is None:
+        created = client.post("/dashboards", json=dashboard_payload)
+        assert created.status_code == 201
+        dashboard_id = created.json()["id"]
+    else:
+        patched = client.patch(f"/dashboards/{existing['id']}", json=dashboard_payload)
+        assert patched.status_code == 200
+        dashboard_id = existing["id"]
+
+    existing_sets = {
+        item["set_id"]: item
+        for item in client.get(f"/dashboards/{dashboard_id}/sets").json()
+    }
+    for fixture_set in fixture["sets"]:
+        payload = {key: fixture_set[key] for key in SET_FIELDS if key in fixture_set}
+        if fixture_set["set_id"] in existing_sets:
+            patch_payload = {key: value for key, value in payload.items() if key != "set_id"}
+            response = client.patch(
+                f"/dashboards/{dashboard_id}/sets/{fixture_set['set_id']}",
+                json=patch_payload,
+            )
+            assert response.status_code == 200
+        else:
+            response = client.post(f"/dashboards/{dashboard_id}/sets", json=payload)
+            assert response.status_code == 201
+    return dashboard_id
+
+
+def test_runtime_recipe_fixture_files_are_valid_json():
+    paths = _fixture_paths()
+    assert paths, "expected runtime recipe fixtures"
+    for path in paths:
+        fixture = _load(path)
+        assert fixture["version"] == 1
+        assert fixture["dry_run_only"] is True
+        assert fixture["dashboard"]["enabled"] is True
+        assert fixture["sets"], path.name
+        assert fixture["scenario_mapping"], path.name
+
+
+def test_runtime_recipe_fixtures_are_fake_dry_run_only():
+    profiles: set[str] = set()
+    for path in _fixture_paths():
+        fixture = _load(path)
+        for item in fixture["sets"]:
+            profiles.add(item["mtf_profile"])
+            assert item["exchange"] == "fake"
+            assert item["market_type"] == "perpetual"
+            assert item["environment"] == "demo"
+            assert item["dry_run"] is True
+            assert item["workers"] == 1
+            for symbol in item["symbols"]:
+                assert symbol == symbol.strip().upper()
+                assert symbol.endswith("USDT")
+    assert {"regular", "scalper", "scalper_micro"}.issubset(profiles)
+
+
+def test_runtime_recipe_fixtures_do_not_contain_secret_material():
+    for path in _fixture_paths():
+        fixture = _load(path)
+        for text in _walk(fixture):
+            assert SECRET_RE.search(text) is None, f"{path.name} contains sensitive marker: {text}"
+
+
+def test_runtime_recipe_fixtures_apply_repeatedly_without_duplicates(api_client):
+    for path in _fixture_paths():
+        fixture = _load(path)
+
+        first_dashboard_id = _apply_fixture(api_client, fixture)
+        second_dashboard_id = _apply_fixture(api_client, fixture)
+
+        assert second_dashboard_id == first_dashboard_id
+        dashboards = [
+            item
+            for item in api_client.get("/dashboards").json()
+            if item["name"] == fixture["dashboard"]["name"]
+        ]
+        assert len(dashboards) == 1
+
+        sets = api_client.get(f"/dashboards/{first_dashboard_id}/sets").json()
+        expected_ids = {item["set_id"] for item in fixture["sets"]}
+        observed_ids = {item["set_id"] for item in sets}
+        assert expected_ids == observed_ids
+        assert len(sets) == len(expected_ids)
+
+
+def test_runtime_recipe_fixtures_generate_server_payloads(api_client):
+    nominal = _load(FIXTURE_DIR / "r1_r16_nominal_fake_dashboard.json")
+    dashboard_id = _apply_fixture(api_client, nominal)
+
+    sets = {
+        item["set_id"]: item
+        for item in api_client.get(f"/dashboards/{dashboard_id}/sets").json()
+    }
+
+    assert sets["recipe_fake_regular"]["payload"] == {
+        "dry_run": True,
+        "workers": 1,
+        "exchange": "fake",
+        "market_type": "perpetual",
+        "mtf_profile": "regular",
+        "sync_tables": False,
+        "process_tp_sl": False,
+        "symbols": ["BTCUSDT", "ETHUSDT"],
+    }
+    assert sets["recipe_fake_disabled"]["payload"]["dry_run"] is True


### PR DESCRIPTION
## Summary
- Add Fake/Paper dry-run dashboard fixtures for the R1-R16 orchestrator runtime recipe.
- Document prerequisites, PASS/FAIL/BLOCKED matrix, evidence, cleanup, rollback, and Temporal schedule probes.
- Add fixture validation tests covering JSON shape, dry-run invariants, repeated application without duplicates, server payload generation, and secret-like value scanning.

## Verification
- `python3 -m pytest tests/test_runtime_recipe_fixtures.py -q` from `python-orchestrator` → 5 passed.
- `python3 -m pytest` from `python-orchestrator` → 410 passed, 3 skipped.
- `python3 -m json.tool` on both runtime recipe fixtures.
- `python3 -m mkdocs build --strict`.
- `python3` YAML parse for `mkdocs.yml`.
- Secret-like value scan on runtime recipe docs/fixtures.
- `git diff --check`.

Part of #188
Related to #173

References previous roadmap/dependency work by content: #189, #190, #205, #206, #212.