### PR TITLE
Issue 188: add runtime recipe runner

### DIFF
--- a/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
+++ b/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
@@ -1,8 +1,7 @@
 # Recette runtime orchestrateur R1-R16
 
-Cette recette documente le premier lot de #188 : documentation et fixtures
-reproductibles uniquement. Elle ne modifie aucun comportement de production et
-reste en dry-run par defaut.
+Cette recette documente les fixtures et le runner reproductible de #188. Elle ne
+modifie aucun comportement de production et reste en dry-run par defaut.
 
 ## Perimetre
 
@@ -157,6 +156,68 @@ un scenario non execute en `PASS`.
 | R14 - Garde-fous live | mutation negative | Tenter OKX/Hyperliquid `dry_run=false` ou live non allowliste. | Refus avant dispatch, 422/skip audit, aucun appel metier. |
 | R15 - Temporal Schedule | nominal | Creer un schedule dry-run vers le dashboard nominal. | Schedule visible, pause/reprise, `ok=false` echoue vraiment dans Temporal. |
 | R16 - Rollback | nominal | Pauser le schedule cible puis verifier le chemin legacy documente. | Nouveau schedule pause, legacy non concurrent, temps de rollback mesure. |
+
+## Runner reproductible
+
+Le runner unique est :
+
+```bash
+cd python-orchestrator
+python scripts/runtime_recipe_runner.py \
+  --orchestrator-url http://localhost:8099 \
+  --confirm DRY_RUN_ONLY \
+  --export-dir var/runtime-recipe/latest \
+  --keep-fixtures
+```
+
+Garanties du runner :
+
+- refuse de demarrer sans `--confirm DRY_RUN_ONLY` ;
+- applique les fixtures par `dashboard.name` et `(dashboard_id, set_id)` ;
+- force `dry_run=true`, `workers=1` et `sync_tables=false` lors des mutations de sets ;
+- n'envoie jamais le champ `payload`, produit cote serveur ;
+- exporte `var/runtime-recipe/latest/runtime-recipe-report.json` ;
+- produit uniquement des statuts `PASS`, `FAIL` ou `BLOCKED` ;
+- redige `BLOCKED` lorsque la panne/crash/Temporal reel n'a pas ete injecte ou confirme ;
+- peut desactiver les dashboards a la fin avec `--cleanup` si `--keep-fixtures` n'est pas utilise.
+
+Scenarios lances par defaut :
+
+```text
+R1, R2, R5, R6, R8, R10, R11, R14, R15, R16
+```
+
+Pour cibler un sous-ensemble :
+
+```bash
+python scripts/runtime_recipe_runner.py \
+  --orchestrator-url http://localhost:8099 \
+  --confirm DRY_RUN_ONLY \
+  --export-dir var/runtime-recipe/r1-r2 \
+  --scenario R1 \
+  --scenario R2 \
+  --keep-fixtures
+```
+
+R15 peut executer la previsualisation Temporal si Temporal est disponible :
+
+```bash
+python scripts/runtime_recipe_runner.py \
+  --orchestrator-url http://localhost:8099 \
+  --confirm DRY_RUN_ONLY \
+  --temporal-available \
+  --temporal-dry-run-command \
+    python ../cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py create \
+    --dry-run --dashboard-id '{dashboard_id}' \
+    --schedule-id recipe-orchestrator-r1-r16 \
+    --workflow-id recipe-orchestrator-r1-r16-runner \
+    --cron '*/5 * * * *'
+```
+
+Le runner ne tue pas de conteneur et ne pause pas un schedule reel sans action
+operateur. Les scenarios qui exigent ce type de controle, notamment R10 et le
+rollback effectif R16, restent `BLOCKED` jusqu'a execution sur une stack de
+recette dediee.
 
 ## Commandes de recette guidee
 

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -330,6 +330,33 @@ Ces tests visent notamment les branches d'erreur de `symfony_client.py` (transpo
 JSON malformé) ; la couverture globale monte au-dessus de la baseline QA-001 et le gate
 `--cov-fail-under=95` reste inchangé.
 
+### Runner de recette runtime R1-R16 (#188)
+
+Le script `scripts/runtime_recipe_runner.py` applique les fixtures
+`fixtures/runtime-recipe/*.json`, force le dry-run et exporte un rapport JSON
+`PASS` / `FAIL` / `BLOCKED`.
+
+```bash
+cd python-orchestrator
+python scripts/runtime_recipe_runner.py \
+  --orchestrator-url http://localhost:8099 \
+  --confirm DRY_RUN_ONLY \
+  --export-dir var/runtime-recipe/latest \
+  --keep-fixtures
+```
+
+Par defaut, il cible les scenarios critiques `R1`, `R2`, `R5`, `R6`, `R8`,
+`R10`, `R11`, `R14`, `R15` et `R16`. Il ne coupe pas de service et ne pause pas de
+schedule reel : les scenarios qui exigent une panne/crash/Temporal reel sont
+marques `BLOCKED` si la condition n'est pas observable depuis le runner.
+
+Commandes de verification locale :
+
+```bash
+cd python-orchestrator
+python -m pytest tests/test_runtime_recipe_runner.py tests/test_runtime_recipe_fixtures.py
+```
+
 ## Dépendances
 
 - `requirements.txt` : runtime uniquement, versions **épinglées** (reproductibilité).

--- a/python-orchestrator/scripts/__init__.py
+++ b/python-orchestrator/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts operationnels du Python orchestrator."""

--- a/python-orchestrator/scripts/runtime_recipe_runner.py
+++ b/python-orchestrator/scripts/runtime_recipe_runner.py
@@ -1,0 +1,759 @@
+"""Runner reproductible de recette runtime R1-R16 (#188).
+
+Le runner applique les fixtures Fake/Paper dry-run, execute les scenarios
+automatisables via l'API HTTP existante, exporte un rapport JSON et marque
+explicitement `BLOCKED` les scenarios qui exigent une panne/crash/Temporal reel
+non pilote par ce script. Il ne modifie aucune strategie et force toujours
+`dry_run=true` sur les appels d'execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Protocol, Sequence
+from uuid import uuid4
+
+import httpx
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FIXTURES_DIR = ROOT / "fixtures" / "runtime-recipe"
+DEFAULT_EXPORT_DIR = ROOT / "var" / "runtime-recipe"
+CONFIRMATION_TOKEN = "DRY_RUN_ONLY"
+
+SET_FIELDS = {
+    "set_id",
+    "enabled",
+    "action",
+    "exchange",
+    "market_type",
+    "mtf_profile",
+    "environment",
+    "dry_run",
+    "workers",
+    "sync_tables",
+    "symbols",
+    "contracts_limit",
+    "priority",
+}
+
+ALL_SCENARIOS = tuple(f"R{i}" for i in range(1, 17))
+DEFAULT_SCENARIOS = ("R1", "R2", "R5", "R6", "R8", "R10", "R11", "R14", "R15", "R16")
+
+SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|secret|password|passwd|token|signature|private[_-]?key|"
+    r"authorization|x-bitmart-sign)",
+    re.IGNORECASE,
+)
+
+
+class RecipeHttpClient(Protocol):
+    def request(
+        self, method: str, path: str, *, json_body: Any = None, timeout: float = 30.0
+    ) -> tuple[int, Any]:
+        """Execute une requete HTTP et retourne `(status_code, body)`."""
+
+
+class HttpxRecipeHttpClient:
+    """Client HTTP simple vers l'API Python orchestrator."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def request(
+        self, method: str, path: str, *, json_body: Any = None, timeout: float = 30.0
+    ) -> tuple[int, Any]:
+        try:
+            with httpx.Client(timeout=timeout) as client:
+                response = client.request(method, f"{self.base_url}{path}", json=json_body)
+        except httpx.HTTPError as exc:
+            return 0, {"detail": str(exc)}
+        try:
+            body: Any = response.json()
+        except ValueError:
+            body = {"raw": response.text}
+        return response.status_code, body
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    export_dir: Path
+    fixtures_dir: Path = DEFAULT_FIXTURES_DIR
+    orchestrator_url: str = "http://localhost:8099"
+    confirmation_token: str | None = None
+    timeout_seconds: float = 30.0
+    temporal_available: bool = False
+    temporal_dry_run_command: Sequence[str] | None = None
+    cleanup: bool = False
+
+
+class RecipeRunner:
+    def __init__(
+        self,
+        config: RunnerConfig,
+        *,
+        http_client: RecipeHttpClient | None = None,
+    ) -> None:
+        self.config = config
+        self.http = http_client or HttpxRecipeHttpClient(config.orchestrator_url)
+        self.fixtures = self._load_fixtures()
+        self.invocation_id = ""
+
+    def run(
+        self,
+        *,
+        scenarios: Iterable[str] | None = None,
+        keep_fixtures: bool = False,
+    ) -> dict[str, Any]:
+        self._assert_confirmed()
+        selected = tuple(scenarios or DEFAULT_SCENARIOS)
+        started_at = datetime.now(timezone.utc).isoformat()
+        self.invocation_id = uuid4().hex[:12]
+
+        service_ok, service_note = self._check_orchestrator()
+        dashboards: dict[str, dict[str, Any]] = {}
+        results: list[dict[str, Any]] = []
+
+        if service_ok:
+            dashboards = self._apply_all_fixtures()
+            for scenario in selected:
+                results.append(self._run_scenario(scenario, dashboards))
+            if self.config.cleanup and not keep_fixtures:
+                self._cleanup_dashboards(dashboards)
+        else:
+            for scenario in selected:
+                results.append(self._result(scenario, "BLOCKED", service_note))
+
+        report = {
+            "metadata": {
+                "started_at": started_at,
+                "finished_at": datetime.now(timezone.utc).isoformat(),
+                "dry_run_forced": True,
+                "confirmation_token": "REDACTED",
+                "invocation_id": self.invocation_id,
+                "orchestrator_url": self.config.orchestrator_url,
+                "fixtures_dir": str(self.config.fixtures_dir),
+                "cleanup_requested": self.config.cleanup,
+            },
+            "dashboards": dashboards,
+            "results": results,
+            "summary": {
+                "scenario_counts": dict(Counter(item["status"] for item in results)),
+                "ready_for_final_report": False,
+            },
+        }
+        report = self._redact(report)
+        self._export(report)
+        return report
+
+    def _assert_confirmed(self) -> None:
+        if self.config.confirmation_token != CONFIRMATION_TOKEN:
+            raise SystemExit(
+                f"refusing to run recipe without --confirm {CONFIRMATION_TOKEN}; "
+                "this runner is dry-run only."
+            )
+
+    def _check_orchestrator(self) -> tuple[bool, str]:
+        status, body = self.http.request("GET", "/healthcheck", timeout=self.config.timeout_seconds)
+        if 200 <= status < 300:
+            return True, "orchestrator reachable"
+        return False, f"orchestrator unavailable: status={status}, body={body}"
+
+    def _load_fixtures(self) -> dict[str, dict[str, Any]]:
+        nominal = self._read_fixture("r1_r16_nominal_fake_dashboard.json")
+        degraded = self._read_fixture("r1_r16_degraded_fake_dashboard.json")
+        return {"nominal": nominal, "degraded": degraded}
+
+    def _read_fixture(self, filename: str) -> dict[str, Any]:
+        return json.loads((self.config.fixtures_dir / filename).read_text(encoding="utf-8"))
+
+    def _apply_all_fixtures(self) -> dict[str, dict[str, Any]]:
+        return {name: self._apply_fixture(fixture) for name, fixture in self.fixtures.items()}
+
+    def _apply_fixture(self, fixture: dict[str, Any]) -> dict[str, Any]:
+        dashboard_id = self._upsert_dashboard(fixture["dashboard"])
+        existing_sets = {
+            item["set_id"]: item
+            for item in self._request_ok("GET", f"/dashboards/{dashboard_id}/sets")
+        }
+        fixture_set_ids = {item["set_id"] for item in fixture["sets"]}
+        for set_id, existing_set in existing_sets.items():
+            if set_id not in fixture_set_ids and existing_set.get("enabled") is True:
+                self._request_ok(
+                    "PATCH",
+                    f"/dashboards/{dashboard_id}/sets/{set_id}",
+                    json_body={"enabled": False, "dry_run": True},
+                )
+        for fixture_set in fixture["sets"]:
+            payload = {key: fixture_set[key] for key in SET_FIELDS if key in fixture_set}
+            payload["dry_run"] = True
+            payload["workers"] = 1
+            payload["sync_tables"] = False
+            if fixture_set["set_id"] in existing_sets:
+                patch_payload = {key: value for key, value in payload.items() if key != "set_id"}
+                self._request_ok(
+                    "PATCH",
+                    f"/dashboards/{dashboard_id}/sets/{fixture_set['set_id']}",
+                    json_body=patch_payload,
+                )
+            else:
+                self._request_ok(
+                    "POST",
+                    f"/dashboards/{dashboard_id}/sets",
+                    json_body=payload,
+                    expected=(200, 201),
+                )
+        return {"id": dashboard_id, "name": fixture["dashboard"]["name"]}
+
+    def _upsert_dashboard(self, dashboard_payload: dict[str, Any]) -> int:
+        dashboards = self._request_ok("GET", "/dashboards")
+        for dashboard in dashboards:
+            if dashboard["name"] == dashboard_payload["name"]:
+                self._request_ok(
+                    "PATCH",
+                    f"/dashboards/{dashboard['id']}",
+                    json_body=dashboard_payload,
+                )
+                return int(dashboard["id"])
+        created = self._request_ok(
+            "POST",
+            "/dashboards",
+            json_body=dashboard_payload,
+            expected=(200, 201),
+        )
+        return int(created["id"])
+
+    def _request_ok(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        expected: tuple[int, ...] = (200,),
+    ) -> Any:
+        status, body = self.http.request(
+            method,
+            path,
+            json_body=json_body,
+            timeout=self.config.timeout_seconds,
+        )
+        if status not in expected:
+            raise RuntimeError(f"{method} {path} failed: status={status}, body={body}")
+        return body
+
+    def _run_scenario(self, scenario: str, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        handlers = {
+            "R1": self._scenario_r1,
+            "R2": self._scenario_r2,
+            "R5": self._scenario_r5,
+            "R6": self._scenario_r6,
+            "R8": self._scenario_r8,
+            "R10": self._scenario_r10,
+            "R11": self._scenario_r11,
+            "R14": self._scenario_r14,
+            "R15": self._scenario_r15,
+            "R16": self._scenario_r16,
+        }
+        handler = handlers.get(scenario)
+        if handler is None:
+            return self._result(scenario, "BLOCKED", "scenario documented but not automated in this runner")
+        return handler(dashboards)
+
+    def _scenario_r1(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        dashboard_id = dashboards["nominal"]["id"]
+        self._set_enabled(dashboard_id, "recipe_fake_regular", True)
+        self._set_enabled(dashboard_id, "recipe_fake_scalper", False)
+        self._set_enabled(dashboard_id, "recipe_fake_scalper_micro", False)
+        response = self._run_dashboard(dashboard_id, self._scenario_key("recipe-r1"))
+        ok = response.get("status") == "success" and response.get("summary", {}).get("total_calls") == 1
+        return self._result("R1", "PASS" if ok else "FAIL", "single-set nominal run", response)
+
+    def _scenario_r2(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        dashboard_id = dashboards["nominal"]["id"]
+        for set_id in ("recipe_fake_regular", "recipe_fake_scalper", "recipe_fake_scalper_micro"):
+            self._set_enabled(dashboard_id, set_id, True)
+        self._set_enabled(dashboard_id, "recipe_fake_disabled", False)
+        response = self._run_dashboard(dashboard_id, self._scenario_key("recipe-r2"))
+        ok = response.get("status") == "success" and response.get("summary", {}).get("total_calls") == 3
+        return self._result("R2", "PASS" if ok else "FAIL", "multi-set nominal run", response)
+
+    def _scenario_r5(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        dashboard_id = dashboards["degraded"]["id"]
+        self._set_enabled(dashboard_id, "recipe_fake_not_materialized", False)
+        self._set_enabled(dashboard_id, "recipe_fake_error_regular", True)
+        self._set_enabled(dashboard_id, "recipe_fake_overlap_scalper", False)
+        response = self._run_dashboard(dashboard_id, self._scenario_key("recipe-r5"))
+        detail = self._fetch_run_detail(response)
+        ok = (
+            not self._is_transport_failure(response)
+            and response.get("summary", {}).get("failed", 0) >= 1
+            and response.get("status") != "success"
+            and self._has_r5_functional_failure_evidence(detail)
+        )
+        return self._result(
+            "R5",
+            "PASS" if ok else "FAIL",
+            "functional Symfony error remains failed",
+            {"run": response, "detail": detail},
+        )
+
+    def _scenario_r6(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        dashboard_id = dashboards["degraded"]["id"]
+        self._set_enabled(dashboard_id, "recipe_fake_not_materialized", False)
+        self._set_enabled(dashboard_id, "recipe_fake_error_regular", False)
+        self._set_enabled(dashboard_id, "recipe_fake_overlap_scalper", True)
+        response = self._run_dashboard(dashboard_id, self._scenario_key("recipe-r6"))
+        if self._is_transport_failure(response):
+            return self._result(
+                "R6",
+                "FAIL",
+                "orchestrator transport failure is not Symfony outage evidence",
+                response,
+            )
+        if response.get("status") == "success":
+            return self._result(
+                "R6",
+                "BLOCKED",
+                "Symfony outage/timeout was not injected or observed during this run",
+                response,
+            )
+        detail = self._fetch_run_detail(response)
+        ok = response.get("summary", {}).get("failed", 0) >= 1 and self._has_outage_evidence(detail)
+        return self._result(
+            "R6",
+            "PASS" if ok else "FAIL",
+            "Symfony outage/timeout surfaced as a failed set",
+            {"run": response, "detail": detail},
+        )
+
+    def _scenario_r8(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        dashboard_id = dashboards["nominal"]["id"]
+        self._set_enabled(dashboard_id, "recipe_fake_regular", True)
+        self._set_enabled(dashboard_id, "recipe_fake_scalper", False)
+        self._set_enabled(dashboard_id, "recipe_fake_scalper_micro", False)
+        replay_key = self._scenario_key("recipe-r8")
+        first = self._run_dashboard(dashboard_id, replay_key)
+        second = self._run_dashboard(dashboard_id, replay_key)
+        ok = (
+            self._has_real_run(first)
+            and self._has_real_run(second)
+            and self._is_successful_run(first)
+            and self._is_successful_run(second)
+            and first.get("run_id") == second.get("run_id")
+        )
+        return self._result(
+            "R8",
+            "PASS" if ok else "FAIL",
+            "same idempotency key replays same run",
+            {"first": first, "second": second},
+        )
+
+    def _scenario_r10(self, _dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        return self._result(
+            "R10",
+            "BLOCKED",
+            "requires controlled orchestrator crash after claim; this runner does not kill services",
+        )
+
+    def _scenario_r11(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        dashboard_id = dashboards["degraded"]["id"]
+        self._set_enabled(dashboard_id, "recipe_fake_not_materialized", False)
+        self._set_enabled(dashboard_id, "recipe_fake_error_regular", False)
+        self._set_enabled(dashboard_id, "recipe_fake_overlap_scalper", True)
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first, second = list(
+                executor.map(
+                    lambda item: self._run_dashboard(
+                        dashboard_id,
+                        self._scenario_key(f"recipe-r11-{item[0]}"),
+                        tick_timestamp=item[1],
+                    ),
+                    (
+                        ("a", "2026-06-26T00:00:00Z"),
+                        ("b", "2026-06-26T00:00:01Z"),
+                    ),
+                )
+            )
+        distinct_real_runs = (
+            self._has_real_run(first)
+            and self._has_real_run(second)
+            and first.get("run_id") != second.get("run_id")
+        )
+        first_detail = self._fetch_run_detail(first)
+        second_detail = self._fetch_run_detail(second)
+        overlap_observed = self._has_overlap_guard_evidence(first, first_detail) or (
+            self._has_overlap_guard_evidence(second, second_detail)
+        )
+        both_success = first.get("status") == "success" and second.get("status") == "success"
+        if distinct_real_runs and overlap_observed:
+            status = "PASS"
+            notes = "overlapping ticks surfaced lock or in-flight evidence"
+        elif distinct_real_runs and both_success:
+            status = "BLOCKED"
+            notes = "overlap contention was not observed; both runs completed sequentially"
+        else:
+            status = "FAIL"
+            notes = "overlapping ticks did not produce valid lock or in-flight evidence"
+        return self._result(
+            "R11",
+            status,
+            notes,
+            {
+                "first": first,
+                "second": second,
+                "first_detail": first_detail,
+                "second_detail": second_detail,
+            },
+        )
+
+    def _scenario_r14(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        dashboard_id = dashboards["nominal"]["id"]
+        status, body = self.http.request(
+            "POST",
+            f"/dashboards/{dashboard_id}/sets",
+            json_body={
+                "set_id": "recipe_okx_live_forbidden_probe",
+                "enabled": False,
+                "action": "mtf_run",
+                "exchange": "okx",
+                "market_type": "perpetual",
+                "mtf_profile": "regular",
+                "environment": "demo",
+                "dry_run": False,
+                "workers": 1,
+                "sync_tables": False,
+                "symbols": ["BTCUSDT"],
+                "contracts_limit": None,
+                "priority": -100,
+            },
+            timeout=self.config.timeout_seconds,
+        )
+        ok = self._is_expected_live_guard_refusal(status, body)
+        if not ok:
+            self._delete_set_if_present(dashboard_id, "recipe_okx_live_forbidden_probe")
+        return self._result(
+            "R14",
+            "PASS" if ok else "FAIL",
+            "live guard refused non-dry-run set before dispatch",
+            {"status": status, "body": body},
+        )
+
+    def _scenario_r15(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        if not self.config.temporal_available:
+            return self._result("R15", "BLOCKED", "Temporal availability not confirmed")
+        command = tuple(self.config.temporal_dry_run_command or ())
+        if command and command[0] == "--":
+            command = command[1:]
+        if not command:
+            return self._result("R15", "BLOCKED", "no Temporal dry-run command configured")
+        rendered_command = [
+            part.replace("{dashboard_id}", str(dashboards["nominal"]["id"])) for part in command
+        ]
+        if "--dry-run" not in rendered_command:
+            return self._result(
+                "R15",
+                "FAIL",
+                "Temporal schedule command missing required --dry-run flag",
+                {"command": rendered_command},
+            )
+        try:
+            completed = subprocess.run(
+                rendered_command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self.config.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return self._result(
+                "R15",
+                "FAIL",
+                "Temporal schedule dry-run command timed out",
+                {
+                    "timeout_seconds": self.config.timeout_seconds,
+                    "stdout": self._normalize_subprocess_output(exc.stdout),
+                    "stderr": self._normalize_subprocess_output(exc.stderr),
+                },
+            )
+        except OSError as exc:
+            return self._result(
+                "R15",
+                "FAIL",
+                "Temporal schedule dry-run command failed to start",
+                {
+                    "error_type": exc.__class__.__name__,
+                    "error": str(exc),
+                },
+            )
+        ok = completed.returncode == 0
+        return self._result(
+            "R15",
+            "PASS" if ok else "FAIL",
+            "Temporal schedule dry-run command",
+            {
+                "returncode": completed.returncode,
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+            },
+        )
+
+    @staticmethod
+    def _normalize_subprocess_output(value: str | bytes | None) -> str | None:
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return value
+
+    def _scenario_r16(self, _dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        if not self.config.temporal_available:
+            return self._result("R16", "BLOCKED", "Temporal availability not confirmed")
+        return self._result(
+            "R16",
+            "BLOCKED",
+            "pause/resume rollback requires an existing Temporal schedule and operator confirmation",
+        )
+
+    def _set_enabled(self, dashboard_id: int, set_id: str, enabled: bool) -> None:
+        self._request_ok(
+            "PATCH",
+            f"/dashboards/{dashboard_id}/sets/{set_id}",
+            json_body={"enabled": enabled, "dry_run": True},
+        )
+
+    def _run_dashboard(
+        self,
+        dashboard_id: int,
+        scenario_key: str,
+        *,
+        tick_timestamp: str = "2026-06-26T00:00:00Z",
+    ) -> dict[str, Any]:
+        status, body = self.http.request(
+            "POST",
+            "/orchestrator/run",
+            json_body={
+                "dashboard_id": str(dashboard_id),
+                "schedule_id": "runtime-recipe-runner",
+                "tick_timestamp": tick_timestamp,
+                "idempotency_key": scenario_key,
+                "dry_run": True,
+            },
+            timeout=self.config.timeout_seconds,
+        )
+        if status == 0 or status >= 500:
+            return {
+                "ok": False,
+                "status": "transport_error",
+                "summary": {"total_calls": 0, "success": 0, "failed": 1},
+                "error": body,
+            }
+        return body if isinstance(body, dict) else {"ok": False, "status": "invalid_response", "body": body}
+
+    def _fetch_run_detail(self, response: dict[str, Any]) -> dict[str, Any]:
+        run_id = response.get("run_id")
+        if not run_id:
+            return {}
+        status, body = self.http.request(
+            "GET",
+            f"/runs/{run_id}",
+            timeout=self.config.timeout_seconds,
+        )
+        if status == 200 and isinstance(body, dict):
+            return body
+        return {"detail_unavailable": True, "status": status, "body": body}
+
+    def _delete_set_if_present(self, dashboard_id: int, set_id: str) -> None:
+        self.http.request(
+            "DELETE",
+            f"/dashboards/{dashboard_id}/sets/{set_id}",
+            timeout=self.config.timeout_seconds,
+        )
+
+    def _scenario_key(self, base_key: str) -> str:
+        return f"{base_key}-{self.invocation_id}"
+
+    def _has_real_run(self, response: dict[str, Any]) -> bool:
+        return bool(response.get("run_id")) and response.get("status") not in {
+            "transport_error",
+            "invalid_response",
+            "no_sets",
+        }
+
+    def _is_successful_run(self, response: dict[str, Any]) -> bool:
+        summary = response.get("summary", {})
+        return (
+            response.get("ok") is True
+            and response.get("status") == "success"
+            and isinstance(summary, dict)
+            and summary.get("failed", 0) == 0
+        )
+
+    def _is_transport_failure(self, response: dict[str, Any]) -> bool:
+        return response.get("status") == "transport_error"
+
+    def _has_r5_functional_failure_evidence(self, detail: dict[str, Any]) -> bool:
+        for item in self._iter_run_set_evidence(detail):
+            if item.get("set_id") != "recipe_fake_error_regular":
+                continue
+            if item.get("ok") is True:
+                continue
+            text = json.dumps(item, sort_keys=True).lower()
+            if self._looks_like_outage(text, item.get("status")):
+                return False
+            if item.get("status") in {400, 409, 422}:
+                return True
+            return any(
+                marker in text
+                for marker in ("ok=false", "json", "validation", "business", "functional")
+            )
+        return False
+
+    def _has_overlap_guard_evidence(
+        self, response: dict[str, Any], detail: dict[str, Any]
+    ) -> bool:
+        if response.get("status") == "running":
+            return bool(response.get("run_id"))
+        text = json.dumps(list(self._iter_run_set_evidence(detail)), sort_keys=True).lower()
+        return "locked:" in text or "held by run" in text or "overlapping live set rejected" in text
+
+    def _has_outage_evidence(self, detail: dict[str, Any]) -> bool:
+        for item in self._iter_run_set_evidence(detail):
+            text = json.dumps(item, sort_keys=True).lower()
+            if self._looks_like_outage(text, item.get("status")):
+                return True
+        return False
+
+    def _iter_run_set_evidence(self, detail: dict[str, Any]) -> Iterable[dict[str, Any]]:
+        last_json = detail.get("last_json")
+        last_sets = last_json.get("sets") if isinstance(last_json, dict) else None
+        if isinstance(last_sets, list):
+            for item in last_sets:
+                if isinstance(item, dict):
+                    yield item
+        sets = detail.get("sets")
+        if isinstance(sets, list):
+            for item in sets:
+                if isinstance(item, dict):
+                    yield item
+
+    def _looks_like_outage(self, text: str, status: Any) -> bool:
+        if isinstance(status, int) and status >= 500:
+            return True
+        return any(
+            marker in text
+            for marker in ("timeout", "unavailable", "connection", "mtf run failed", "transport")
+        )
+
+    def _is_expected_live_guard_refusal(self, status: int, body: Any) -> bool:
+        if status != 422:
+            return False
+        text = (
+            json.dumps(body, sort_keys=True).lower()
+            if isinstance(body, (dict, list))
+            else str(body).lower()
+        )
+        return any(
+            marker in text
+            for marker in ("live", "dry_run", "guard", "forbidden", "interdit", "non autor")
+        )
+
+    def _cleanup_dashboards(self, dashboards: dict[str, dict[str, Any]]) -> None:
+        for dashboard in dashboards.values():
+            self.http.request(
+                "PATCH",
+                f"/dashboards/{dashboard['id']}",
+                json_body={"enabled": False},
+                timeout=self.config.timeout_seconds,
+            )
+
+    def _result(
+        self, scenario: str, status: str, notes: str, evidence: Any | None = None
+    ) -> dict[str, Any]:
+        return {
+            "scenario": scenario,
+            "status": status,
+            "notes": notes,
+            "evidence": self._redact(evidence or {}),
+        }
+
+    def _export(self, report: dict[str, Any]) -> None:
+        self.config.export_dir.mkdir(parents=True, exist_ok=True)
+        (self.config.export_dir / "runtime-recipe-report.json").write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def _redact(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: ("REDACTED" if SECRET_KEY_RE.search(str(key)) else self._redact(child))
+                for key, child in value.items()
+            }
+        if isinstance(value, list):
+            redacted: list[Any] = []
+            redact_next = False
+            for child in value:
+                if redact_next:
+                    redacted.append("REDACTED")
+                    redact_next = False
+                    continue
+                redacted_child = self._redact(child)
+                redacted.append(redacted_child)
+                if (
+                    isinstance(child, str)
+                    and child.lstrip().startswith("-")
+                    and "=" not in child
+                    and SECRET_KEY_RE.search(child)
+                ):
+                    redact_next = True
+            return redacted
+        if isinstance(value, str) and SECRET_KEY_RE.search(value):
+            return "REDACTED"
+        return value
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the TradingV3 orchestrator runtime recipe in dry-run mode."
+    )
+    parser.add_argument("--orchestrator-url", default="http://localhost:8099")
+    parser.add_argument("--fixtures-dir", type=Path, default=DEFAULT_FIXTURES_DIR)
+    parser.add_argument("--export-dir", type=Path, default=DEFAULT_EXPORT_DIR)
+    parser.add_argument("--scenario", action="append", choices=ALL_SCENARIOS)
+    parser.add_argument("--timeout-seconds", type=float, default=30.0)
+    parser.add_argument("--confirm", required=True, help=f"Must be {CONFIRMATION_TOKEN}")
+    parser.add_argument("--keep-fixtures", action="store_true")
+    parser.add_argument("--cleanup", action="store_true")
+    parser.add_argument("--temporal-available", action="store_true")
+    parser.add_argument("--temporal-dry-run-command", nargs=argparse.REMAINDER)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    config = RunnerConfig(
+        export_dir=args.export_dir,
+        fixtures_dir=args.fixtures_dir,
+        orchestrator_url=args.orchestrator_url,
+        confirmation_token=args.confirm,
+        timeout_seconds=args.timeout_seconds,
+        temporal_available=args.temporal_available,
+        temporal_dry_run_command=args.temporal_dry_run_command,
+        cleanup=args.cleanup,
+    )
+    report = RecipeRunner(config).run(
+        scenarios=tuple(args.scenario) if args.scenario else None,
+        keep_fixtures=args.keep_fixtures,
+    )
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 1 if report["summary"]["scenario_counts"].get("FAIL", 0) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python-orchestrator/tests/test_runtime_recipe_runner.py
+++ b/python-orchestrator/tests/test_runtime_recipe_runner.py
@@ -1,0 +1,764 @@
+"""Tests du runner de recette runtime R1-R16 (#188)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+import scripts.runtime_recipe_runner as runner_module
+from scripts.runtime_recipe_runner import RecipeRunner, RunnerConfig
+
+
+class FakeRecipeApi:
+    """HTTP API en memoire pour tester le runner sans socket."""
+
+    def __init__(
+        self,
+        *,
+        health_ok: bool = True,
+        run_transport_error: bool = False,
+        overlap_guard: bool = False,
+        r5_outage: bool = False,
+        r6_outage: bool = False,
+        r6_business_failure: bool = False,
+        r8_failure: bool = False,
+        r11_outage: bool = False,
+        live_probe_status: int = 422,
+        live_probe_body: dict[str, Any] | None = None,
+    ) -> None:
+        self.health_ok = health_ok
+        self.run_transport_error = run_transport_error
+        self.overlap_guard = overlap_guard
+        self.r5_outage = r5_outage
+        self.r6_outage = r6_outage
+        self.r6_business_failure = r6_business_failure
+        self.r8_failure = r8_failure
+        self.r11_outage = r11_outage
+        self.live_probe_status = live_probe_status
+        self.live_probe_body = live_probe_body or {"detail": "live non autorise pour la recette"}
+        self.r11_seen = 0
+        self.lock = Lock()
+        self.dashboards: list[dict[str, Any]] = []
+        self.sets: dict[int, list[dict[str, Any]]] = {}
+        self.requests: list[dict[str, Any]] = []
+        self.runs_by_key: dict[str, dict[str, Any]] = {}
+        self.run_details: dict[str, dict[str, Any]] = {}
+        self.next_dashboard_id = 1
+        self.next_set_id = 1
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Any = None,
+        timeout: float = 30.0,
+    ) -> tuple[int, Any]:
+        self.requests.append({"method": method, "path": path, "json": json_body, "timeout": timeout})
+
+        if path == "/healthcheck":
+            return (200, {"status": "ok"}) if self.health_ok else (503, {"status": "down"})
+        if path == "/dashboards" and method == "GET":
+            return 200, list(self.dashboards)
+        if path == "/dashboards" and method == "POST":
+            dashboard = {
+                "id": self.next_dashboard_id,
+                "name": json_body["name"],
+                "enabled": json_body.get("enabled", True),
+                "description": json_body.get("description"),
+            }
+            self.next_dashboard_id += 1
+            self.dashboards.append(dashboard)
+            self.sets[dashboard["id"]] = []
+            return 201, dashboard
+        if path.startswith("/dashboards/") and "/sets" not in path and method == "PATCH":
+            dashboard_id = int(path.split("/")[2])
+            dashboard = self._dashboard(dashboard_id)
+            dashboard.update(json_body)
+            return 200, dashboard
+        if path.endswith("/sets") and method == "GET":
+            dashboard_id = int(path.split("/")[2])
+            return 200, list(self.sets.get(dashboard_id, []))
+        if path.endswith("/sets") and method == "POST":
+            dashboard_id = int(path.split("/")[2])
+            return self._create_set(dashboard_id, json_body)
+        if "/sets/" in path and method == "PATCH":
+            dashboard_id = int(path.split("/")[2])
+            set_id = path.rsplit("/", 1)[1]
+            return self._patch_set(dashboard_id, set_id, json_body)
+        if "/sets/" in path and method == "DELETE":
+            dashboard_id = int(path.split("/")[2])
+            set_id = path.rsplit("/", 1)[1]
+            before = len(self.sets.get(dashboard_id, []))
+            self.sets[dashboard_id] = [
+                item for item in self.sets.get(dashboard_id, []) if item["set_id"] != set_id
+            ]
+            return (204, {}) if len(self.sets[dashboard_id]) != before else (404, {"detail": "set not found"})
+        if path == "/orchestrator/run" and method == "POST":
+            return self._run(json_body)
+        if path.startswith("/runs/") and method == "GET":
+            run_id = path.split("/", 2)[2]
+            detail = self.run_details.get(run_id)
+            return (200, detail) if detail is not None else (404, {"detail": "run not found"})
+        return 404, {"detail": f"unexpected {method} {path}"}
+
+    def _dashboard(self, dashboard_id: int) -> dict[str, Any]:
+        for dashboard in self.dashboards:
+            if dashboard["id"] == dashboard_id:
+                return dashboard
+        raise AssertionError(f"dashboard {dashboard_id} not found")
+
+    def _create_set(self, dashboard_id: int, body: dict[str, Any]) -> tuple[int, Any]:
+        if body["dry_run"] is not True:
+            if 200 <= self.live_probe_status < 300:
+                created = {
+                    "id": self.next_set_id,
+                    "dashboard_id": dashboard_id,
+                    **body,
+                    "payload": self._payload(body),
+                }
+                self.next_set_id += 1
+                self.sets[dashboard_id].append(created)
+                return self.live_probe_status, created
+            return self.live_probe_status, self.live_probe_body
+        created = {
+            "id": self.next_set_id,
+            "dashboard_id": dashboard_id,
+            **body,
+            "payload": self._payload(body),
+        }
+        self.next_set_id += 1
+        self.sets[dashboard_id].append(created)
+        return 201, created
+
+    def _patch_set(self, dashboard_id: int, set_id: str, body: dict[str, Any]) -> tuple[int, Any]:
+        if body.get("dry_run") is not True:
+            return 422, {"detail": "live non autorise pour la recette"}
+        for item in self.sets[dashboard_id]:
+            if item["set_id"] == set_id:
+                item.update(body)
+                item["payload"] = self._payload(item)
+                return 200, item
+        return 404, {"detail": "set not found"}
+
+    def _payload(self, body: dict[str, Any]) -> dict[str, Any] | None:
+        symbols = body.get("symbols") or []
+        if not symbols:
+            return None
+        return {
+            "dry_run": body.get("dry_run", True),
+            "workers": 1,
+            "exchange": body["exchange"],
+            "market_type": body["market_type"],
+            "mtf_profile": body["mtf_profile"],
+            "sync_tables": False,
+            "process_tp_sl": False,
+            "symbols": symbols,
+        }
+
+    def _run(self, body: dict[str, Any]) -> tuple[int, Any]:
+        if self.run_transport_error:
+            return 503, {"detail": "orchestrator unavailable"}
+        assert body["dry_run"] is True
+        dashboard_id = int(body["dashboard_id"])
+        key = body["idempotency_key"]
+        if key in self.runs_by_key:
+            return 200, self.runs_by_key[key]
+        active_sets = [item for item in self.sets[dashboard_id] if item["enabled"]]
+        set_results = [self._set_result(item, key) for item in active_sets]
+        if self.overlap_guard and key.startswith("recipe-r11-"):
+            with self.lock:
+                self.r11_seen += 1
+                if self.r11_seen > 1:
+                    set_results = [
+                        {
+                            "set_id": item["set_id"],
+                            "ok": False,
+                            "status": None,
+                            "business_status": None,
+                            "error": f"locked: {item['set_id']} held by run run_recipe-r11-a",
+                            "response_json": None,
+                        }
+                        for item in active_sets
+                    ]
+        failed = sum(1 for item in set_results if not item["ok"])
+        success = len(active_sets) - failed
+        status = "success" if failed == 0 else ("failed" if success == 0 else "partial_failure")
+        run_id = f"run_{key}"
+        response = {
+            "ok": failed == 0,
+            "run_id": run_id,
+            "status": status,
+            "summary": {"total_calls": len(active_sets), "success": success, "failed": failed},
+        }
+        last_sets = [
+            {
+                "set_id": item["set_id"],
+                "ok": item["ok"],
+                "status": item["status"],
+                "business_status": item["business_status"],
+                "error": item["error"],
+            }
+            for item in set_results
+        ]
+        self.run_details[run_id] = {
+            "run_id": run_id,
+            "status": status,
+            "last_json": {"sets": last_sets},
+            "sets": set_results,
+        }
+        self.runs_by_key[key] = response
+        return 200, response
+
+    def _set_result(self, item: dict[str, Any], key: str) -> dict[str, Any]:
+        if item["payload"] is None:
+            return {
+                "set_id": item["set_id"],
+                "ok": False,
+                "status": None,
+                "business_status": None,
+                "error": "set payload not materialized (no concrete symbols)",
+                "response_json": None,
+            }
+        if item["symbols"] == ["ERR400USDT"]:
+            if self.r5_outage and key.startswith("recipe-r5-"):
+                return {
+                    "set_id": item["set_id"],
+                    "ok": False,
+                    "status": 503,
+                    "business_status": None,
+                    "error": "mtf run failed: Symfony unavailable",
+                    "response_json": {"message": "Symfony unavailable"},
+                }
+            return {
+                "set_id": item["set_id"],
+                "ok": False,
+                "status": 400,
+                "business_status": "error",
+                "error": "functional 400 validation error",
+                "response_json": {"status": "error", "message": "functional validation error"},
+            }
+        if self.r11_outage and key.startswith("recipe-r11-"):
+            return {
+                "set_id": item["set_id"],
+                "ok": False,
+                "status": 503,
+                "business_status": None,
+                "error": "mtf run failed: Symfony unavailable",
+                "response_json": {"message": "Symfony unavailable"},
+            }
+        if self.r6_outage and key.startswith("recipe-r6-"):
+            return {
+                "set_id": item["set_id"],
+                "ok": False,
+                "status": 503,
+                "business_status": None,
+                "error": "mtf run failed: Symfony timeout",
+                "response_json": {"message": "Symfony timeout"},
+            }
+        if self.r6_business_failure and key.startswith("recipe-r6-"):
+            return {
+                "set_id": item["set_id"],
+                "ok": False,
+                "status": 400,
+                "business_status": "error",
+                "error": "functional validation error",
+                "response_json": {"status": "error", "message": "functional validation error"},
+            }
+        if self.r8_failure and key.startswith("recipe-r8-"):
+            return {
+                "set_id": item["set_id"],
+                "ok": False,
+                "status": 400,
+                "business_status": "error",
+                "error": "functional replay setup failure",
+                "response_json": {"status": "error"},
+            }
+        return {
+            "set_id": item["set_id"],
+            "ok": True,
+            "status": 200,
+            "business_status": "success",
+            "error": None,
+            "response_json": {"status": "success"},
+        }
+
+
+def test_runner_applies_fixtures_idempotently_without_sending_payload(tmp_path: Path):
+    api = FakeRecipeApi()
+    runner = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    )
+
+    first = runner.run(scenarios=("R1",), keep_fixtures=True)
+    second = runner.run(scenarios=("R1",), keep_fixtures=True)
+
+    assert first["summary"]["scenario_counts"]["PASS"] >= 1
+    assert second["dashboards"]["nominal"]["id"] == first["dashboards"]["nominal"]["id"]
+    assert any(request["path"] == "/healthcheck" for request in api.requests)
+    matching_dashboards = [
+        dashboard
+        for dashboard in api.dashboards
+        if dashboard["name"] == "recipe-r1-r16-nominal-fake"
+    ]
+    assert len(matching_dashboards) == 1
+    assert len(api.sets[first["dashboards"]["nominal"]["id"]]) == 4
+    run_keys = [
+        request["json"]["idempotency_key"]
+        for request in api.requests
+        if request["path"] == "/orchestrator/run"
+    ]
+    assert len(run_keys) == 2
+    assert all(key.startswith("recipe-r1-") for key in run_keys)
+    assert run_keys[0] != run_keys[1]
+    for request in api.requests:
+        if request["method"] in {"POST", "PATCH"} and "/sets" in request["path"]:
+            assert "payload" not in request["json"]
+            assert request["json"]["dry_run"] is True
+
+
+def test_runner_disables_stale_sets_when_reusing_recipe_dashboard(tmp_path: Path):
+    api = FakeRecipeApi()
+    runner = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    )
+
+    first = runner.run(scenarios=("R1",), keep_fixtures=True)
+    dashboard_id = first["dashboards"]["nominal"]["id"]
+    api._create_set(
+        dashboard_id,
+        {
+            "set_id": "recipe_fake_stale_enabled",
+            "enabled": True,
+            "action": "mtf_run",
+            "exchange": "fake",
+            "market_type": "perpetual",
+            "mtf_profile": "regular",
+            "environment": "test",
+            "dry_run": True,
+            "workers": 4,
+            "sync_tables": False,
+            "symbols": ["STALEUSDT"],
+            "contracts_limit": None,
+            "priority": 100,
+        },
+    )
+
+    second = runner.run(scenarios=("R1",), keep_fixtures=True)
+
+    r1 = second["results"][0]
+    stale = next(item for item in api.sets[dashboard_id] if item["set_id"] == "recipe_fake_stale_enabled")
+    assert stale["enabled"] is False
+    assert r1["evidence"]["summary"]["total_calls"] == 1
+
+
+def test_runner_forces_dry_run_exports_report_and_redacts_sensitive_values(tmp_path: Path):
+    api = FakeRecipeApi()
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R1", "R8"), keep_fixtures=True)
+
+    exported = json.loads((tmp_path / "runtime-recipe-report.json").read_text(encoding="utf-8"))
+    assert exported["metadata"]["dry_run_forced"] is True
+    assert exported["metadata"]["confirmation_token"] == "REDACTED"
+    assert all(result["status"] in {"PASS", "FAIL", "BLOCKED"} for result in exported["results"])
+    assert all(
+        request["json"].get("dry_run") is True
+        for request in api.requests
+        if request["path"] == "/orchestrator/run"
+    )
+    r8_keys = [
+        request["json"]["idempotency_key"]
+        for request in api.requests
+        if request["path"] == "/orchestrator/run"
+        and request["json"]["idempotency_key"].startswith("recipe-r8-")
+    ]
+    assert len(r8_keys) == 2
+    assert len(set(r8_keys)) == 1
+    assert report == exported
+
+
+def test_runner_marks_missing_services_and_temporal_absence_blocked(tmp_path: Path):
+    api = FakeRecipeApi(health_ok=False)
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY", temporal_available=False),
+        http_client=api,
+    ).run(scenarios=("R1", "R15", "R16"), keep_fixtures=True)
+
+    statuses = {item["scenario"]: item["status"] for item in report["results"]}
+    assert statuses["R1"] == "BLOCKED"
+    assert statuses["R15"] == "BLOCKED"
+    assert statuses["R16"] == "BLOCKED"
+    assert report["summary"]["scenario_counts"]["BLOCKED"] == 3
+
+
+def test_runner_exercises_live_guard_without_dispatching_live(tmp_path: Path):
+    api = FakeRecipeApi()
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R14",), keep_fixtures=True)
+
+    r14 = next(item for item in report["results"] if item["scenario"] == "R14")
+    assert r14["status"] == "PASS"
+    assert "live guard refused" in r14["notes"]
+    assert not any(request["path"] == "/orchestrator/run" for request in api.requests)
+    probe_requests = [
+        request
+        for request in api.requests
+        if request["method"] == "POST"
+        and request["path"].endswith("/sets")
+        and request["json"]["set_id"] == "recipe_okx_live_forbidden_probe"
+    ]
+    assert probe_requests[0]["json"]["enabled"] is False
+
+
+def test_temporal_command_parser_accepts_flagged_arguments():
+    args = runner_module._parse_args(
+        [
+            "--confirm",
+            "DRY_RUN_ONLY",
+            "--temporal-dry-run-command",
+            "python",
+            "../cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py",
+            "create",
+            "--dry-run",
+            "--dashboard-id",
+            "{dashboard_id}",
+            "--schedule-id",
+            "recipe-orchestrator-r1-r16",
+        ]
+    )
+
+    assert args.temporal_dry_run_command == [
+        "python",
+        "../cron_symfony_mtf_workers/scripts/manage_orchestrator_schedule.py",
+        "create",
+        "--dry-run",
+        "--dashboard-id",
+        "{dashboard_id}",
+        "--schedule-id",
+        "recipe-orchestrator-r1-r16",
+    ]
+
+
+def test_r11_uses_distinct_anchors_for_schedule_overlap(tmp_path: Path):
+    api = FakeRecipeApi(overlap_guard=True)
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R11",), keep_fixtures=True)
+
+    r11 = report["results"][0]
+    assert r11["status"] == "PASS"
+    run_requests = [request for request in api.requests if request["path"] == "/orchestrator/run"]
+    assert len(run_requests) == 2
+    keys = [request["json"]["idempotency_key"] for request in run_requests]
+    ticks = [request["json"]["tick_timestamp"] for request in run_requests]
+    assert keys[0] != keys[1]
+    assert all(key.startswith("recipe-r11-") for key in keys)
+    assert set(ticks) == {"2026-06-26T00:00:00Z", "2026-06-26T00:00:01Z"}
+
+
+def test_r11_blocks_when_overlap_contention_is_not_observed(tmp_path: Path):
+    api = FakeRecipeApi()
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R11",), keep_fixtures=True)
+
+    r11 = report["results"][0]
+    assert r11["status"] == "BLOCKED"
+    assert "not observed" in r11["notes"]
+
+
+def test_r11_rejects_both_failed_without_overlap_evidence(tmp_path: Path):
+    api = FakeRecipeApi(r11_outage=True)
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R11",), keep_fixtures=True)
+
+    r11 = report["results"][0]
+    assert r11["status"] == "FAIL"
+
+
+def test_r14_rejects_non_guard_errors(tmp_path: Path):
+    for status, body in (
+        (500, {"detail": "database unavailable"}),
+        (409, {"detail": "set already exists"}),
+        (422, {"detail": "unrelated validation error"}),
+    ):
+        api = FakeRecipeApi(live_probe_status=status, live_probe_body=body)
+        report = RecipeRunner(
+            RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+            http_client=api,
+        ).run(scenarios=("R14",), keep_fixtures=True)
+
+        r14 = report["results"][0]
+        assert r14["status"] == "FAIL"
+
+
+def test_r14_deletes_probe_when_live_guard_accepts_it(tmp_path: Path):
+    api = FakeRecipeApi(live_probe_status=201)
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R14",), keep_fixtures=True)
+
+    r14 = report["results"][0]
+    assert r14["status"] == "FAIL"
+    assert any(
+        request["method"] == "DELETE"
+        and request["path"].endswith("/sets/recipe_okx_live_forbidden_probe")
+        for request in api.requests
+    )
+    nominal_id = report["dashboards"]["nominal"]["id"]
+    assert all(
+        item["set_id"] != "recipe_okx_live_forbidden_probe"
+        for item in api.sets[nominal_id]
+    )
+
+
+def test_r5_rejects_symfony_outage_as_functional_evidence(tmp_path: Path):
+    api = FakeRecipeApi(r5_outage=True)
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R5",), keep_fixtures=True)
+
+    r5 = report["results"][0]
+    assert r5["status"] == "FAIL"
+
+
+def test_r6_requires_outage_evidence_before_passing(tmp_path: Path):
+    business_api = FakeRecipeApi(r6_business_failure=True)
+    business_report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=business_api,
+    ).run(scenarios=("R6",), keep_fixtures=True)
+
+    assert business_report["results"][0]["status"] == "FAIL"
+
+    outage_api = FakeRecipeApi(r6_outage=True)
+    outage_report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=outage_api,
+    ).run(scenarios=("R6",), keep_fixtures=True)
+
+    assert outage_report["results"][0]["status"] == "PASS"
+
+
+def test_transport_failures_do_not_pass_recipe_scenarios(tmp_path: Path):
+    api = FakeRecipeApi(run_transport_error=True)
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R5", "R6", "R8", "R11"), keep_fixtures=True)
+
+    statuses = {item["scenario"]: item["status"] for item in report["results"]}
+    assert statuses == {"R5": "FAIL", "R6": "FAIL", "R8": "FAIL", "R11": "FAIL"}
+
+
+def test_r8_replay_requires_successful_original_run(tmp_path: Path):
+    api = FakeRecipeApi(r8_failure=True)
+
+    report = RecipeRunner(
+        RunnerConfig(export_dir=tmp_path, confirmation_token="DRY_RUN_ONLY"),
+        http_client=api,
+    ).run(scenarios=("R8",), keep_fixtures=True)
+
+    assert report["results"][0]["status"] == "FAIL"
+
+
+def test_temporal_dry_run_command_is_bounded_by_timeout(tmp_path: Path, monkeypatch):
+    api = FakeRecipeApi()
+
+    def timeout_run(*args, **kwargs):
+        assert kwargs["timeout"] == 0.25
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(runner_module.subprocess, "run", timeout_run)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            timeout_seconds=0.25,
+            temporal_available=True,
+            temporal_dry_run_command=(
+                "temporal",
+                "schedule",
+                "describe",
+                "{dashboard_id}",
+                "--dry-run",
+            ),
+        ),
+        http_client=api,
+    ).run(scenarios=("R15",), keep_fixtures=True)
+
+    r15 = report["results"][0]
+    assert r15["status"] == "FAIL"
+    assert "timed out" in r15["notes"]
+
+
+def test_temporal_timeout_bytes_are_exported_as_text(tmp_path: Path, monkeypatch):
+    api = FakeRecipeApi()
+
+    def timeout_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=args[0],
+            timeout=kwargs["timeout"],
+            output=b"partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    monkeypatch.setattr(runner_module.subprocess, "run", timeout_run)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            timeout_seconds=0.25,
+            temporal_available=True,
+            temporal_dry_run_command=("temporal", "schedule", "describe", "--dry-run"),
+        ),
+        http_client=api,
+    ).run(scenarios=("R15",), keep_fixtures=True)
+
+    exported = json.loads((tmp_path / "runtime-recipe-report.json").read_text(encoding="utf-8"))
+    evidence = exported["results"][0]["evidence"]
+    assert report == exported
+    assert evidence["stdout"] == "partial stdout"
+    assert evidence["stderr"] == "partial stderr"
+
+
+def test_temporal_command_replaces_only_dashboard_id_token(tmp_path: Path, monkeypatch):
+    api = FakeRecipeApi()
+    observed: dict[str, Any] = {}
+
+    def successful_run(args, **kwargs):
+        observed["args"] = args
+
+        class Completed:
+            returncode = 0
+            stdout = "ok"
+            stderr = ""
+
+        return Completed()
+
+    monkeypatch.setattr(runner_module.subprocess, "run", successful_run)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            temporal_available=True,
+            temporal_dry_run_command=(
+                "temporal",
+                "schedule",
+                "create",
+                "--dashboard-id",
+                "{dashboard_id}",
+                "--memo",
+                '{"literal": "{kept}"}',
+                "--dry-run",
+            ),
+        ),
+        http_client=api,
+    ).run(scenarios=("R15",), keep_fixtures=True)
+
+    assert report["results"][0]["status"] == "PASS"
+    assert observed["args"][4] == str(report["dashboards"]["nominal"]["id"])
+    assert observed["args"][6] == '{"literal": "{kept}"}'
+
+
+def test_temporal_command_requires_dry_run_flag(tmp_path: Path, monkeypatch):
+    api = FakeRecipeApi()
+
+    def forbidden_run(*args, **kwargs):
+        raise AssertionError("subprocess.run must not execute a non-dry-run command")
+
+    monkeypatch.setattr(runner_module.subprocess, "run", forbidden_run)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            temporal_available=True,
+            temporal_dry_run_command=(
+                "temporal",
+                "schedule",
+                "create",
+                "--dashboard-id",
+                "{dashboard_id}",
+            ),
+        ),
+        http_client=api,
+    ).run(scenarios=("R15",), keep_fixtures=True)
+
+    r15 = report["results"][0]
+    assert r15["status"] == "FAIL"
+    assert "missing required --dry-run" in r15["notes"]
+
+
+def test_temporal_rejected_command_redacts_secret_flag_values(tmp_path: Path, monkeypatch):
+    api = FakeRecipeApi()
+
+    def forbidden_run(*args, **kwargs):
+        raise AssertionError("subprocess.run must not execute a non-dry-run command")
+
+    monkeypatch.setattr(runner_module.subprocess, "run", forbidden_run)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            temporal_available=True,
+            temporal_dry_run_command=(
+                "temporal",
+                "schedule",
+                "create",
+                "--api-key",
+                "plaincredential123",
+            ),
+        ),
+        http_client=api,
+    ).run(scenarios=("R15",), keep_fixtures=True)
+
+    exported_raw = (tmp_path / "runtime-recipe-report.json").read_text(encoding="utf-8")
+    command = report["results"][0]["evidence"]["command"]
+    assert "plaincredential123" not in exported_raw
+    assert command[-2:] == ["REDACTED", "REDACTED"]
+
+
+def test_temporal_launch_error_is_reported_without_aborting_later_scenarios(
+    tmp_path: Path, monkeypatch
+):
+    api = FakeRecipeApi()
+
+    def missing_run(*args, **kwargs):
+        raise FileNotFoundError("temporal executable not found")
+
+    monkeypatch.setattr(runner_module.subprocess, "run", missing_run)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            temporal_available=True,
+            temporal_dry_run_command=("temporal-missing", "schedule", "describe", "--dry-run"),
+        ),
+        http_client=api,
+    ).run(scenarios=("R15", "R16"), keep_fixtures=True)
+
+    statuses = {item["scenario"]: item["status"] for item in report["results"]}
+    assert statuses == {"R15": "FAIL", "R16": "BLOCKED"}
+    exported = json.loads((tmp_path / "runtime-recipe-report.json").read_text(encoding="utf-8"))
+    assert exported["summary"]["scenario_counts"] == {"FAIL": 1, "BLOCKED": 1}


### PR DESCRIPTION
Part of #188
Related to #173
Depends on/extends #213

## Summary
- add a dry-run-only runtime recipe runner for orchestrator R1/R2/R5/R6/R8/R10/R11/R14/R15/R16
- apply the existing Fake/Paper runtime fixtures idempotently without sending raw payloads
- export PASS/FAIL/BLOCKED JSON reports with redaction and document the command/runbook

## Tests
- cd python-orchestrator && python3 -m pytest tests/test_runtime_recipe_runner.py tests/test_runtime_recipe_fixtures.py -q
- cd python-orchestrator && python3 -m pytest
- cd python-orchestrator && python3 -m mkdocs build --strict
- cd python-orchestrator && python3 -m compileall scripts
- git diff --check