### PR TITLE
Fix baseline export and fresh migrations

### DIFF
--- a/docs/handbook/reports/bad-trades-baseline.md
+++ b/docs/handbook/reports/bad-trades-baseline.md
@@ -25,8 +25,8 @@ Exporter les donnees :
 psql "$DATABASE_URL" \
   -v from_ts='2026-01-01 00:00:00+00' \
   -v to_ts='2026-12-31 23:59:59+00' \
-  -v output_file='/tmp/bad-trades-baseline-v2.csv' \
-  -f docs/handbook/reports/queries/bad-trades-baseline-v2.sql
+  -f docs/handbook/reports/queries/bad-trades-baseline-v2.sql \
+  > /tmp/bad-trades-baseline-v2.csv
 ```
 
 Generer le rapport :

--- a/docs/handbook/reports/queries/bad-trades-baseline-v2.sql
+++ b/docs/handbook/reports/queries/bad-trades-baseline-v2.sql
@@ -4,8 +4,8 @@
 --   psql "$DATABASE_URL" \
 --     -v from_ts='2026-01-01 00:00:00+00' \
 --     -v to_ts='2026-12-31 23:59:59+00' \
---     -v output_file='/tmp/bad-trades-baseline-v2.csv' \
---     -f docs/handbook/reports/queries/bad-trades-baseline-v2.sql
+--     -f docs/handbook/reports/queries/bad-trades-baseline-v2.sql \
+--     > /tmp/bad-trades-baseline-v2.csv
 --
 -- The export is intentionally conservative:
 -- - base population comes from position_trade_analysis_v2;
@@ -24,12 +24,7 @@
 \else
   \set to_ts '9999-12-31 23:59:59+00'
 \endif
-\if :{?output_file}
-\else
-  \set output_file 'bad-trades-baseline-v2.csv'
-\endif
-
-\copy (
+COPY (
 WITH scoped AS (
   SELECT pta.*
   FROM position_trade_analysis_v2 pta
@@ -367,4 +362,4 @@ SELECT
   expected_r_multiple
 FROM output_rows
 ORDER BY entry_time ASC, entry_event_id ASC
-) TO :'output_file' CSV HEADER
+) TO STDOUT WITH (FORMAT csv, HEADER true)

--- a/docs/handbook/reports/queries/bad-trades-baseline-v2.sql
+++ b/docs/handbook/reports/queries/bad-trades-baseline-v2.sql
@@ -362,4 +362,4 @@ SELECT
   expected_r_multiple
 FROM output_rows
 ORDER BY entry_time ASC, entry_event_id ASC
-) TO STDOUT WITH (FORMAT csv, HEADER true)
+) TO STDOUT WITH (FORMAT csv, HEADER true);

--- a/trading-app/migrations/Version20260623010000.php
+++ b/trading-app/migrations/Version20260623010000.php
@@ -38,8 +38,8 @@ final class Version20260623010000 extends AbstractMigration
     {
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS

--- a/trading-app/migrations/Version20260623010000.php
+++ b/trading-app/migrations/Version20260623010000.php
@@ -38,8 +38,8 @@ final class Version20260623010000 extends AbstractMigration
     {
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'trade_id\')');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'position_id\')');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS

--- a/trading-app/migrations/Version20260625000000.php
+++ b/trading-app/migrations/Version20260625000000.php
@@ -51,8 +51,8 @@ $$
 SQL);
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS
@@ -466,7 +466,7 @@ SELECT
   ELSE NULL END                                   AS realized_net_pnl_r,
   CASE
     WHEN ce.extra IS NULL THEN NULL
-    WHEN ce.extra ? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
+    WHEN ce.extra ?? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
     ELSE NULL
   END                                             AS position_fully_closed,
   money.pnl_source,

--- a/trading-app/migrations/Version20260625000000.php
+++ b/trading-app/migrations/Version20260625000000.php
@@ -51,8 +51,8 @@ $$
 SQL);
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'trade_id\')');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'position_id\')');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS
@@ -466,7 +466,7 @@ SELECT
   ELSE NULL END                                   AS realized_net_pnl_r,
   CASE
     WHEN ce.extra IS NULL THEN NULL
-    WHEN ce.extra ?? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
+    WHEN jsonb_exists(ce.extra, 'position_fully_closed') THEN (ce.extra->> 'position_fully_closed') = 'true'
     ELSE NULL
   END                                             AS position_fully_closed,
   money.pnl_source,

--- a/trading-app/migrations/Version20260625020000.php
+++ b/trading-app/migrations/Version20260625020000.php
@@ -51,8 +51,8 @@ $$
 SQL);
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS
@@ -466,7 +466,7 @@ SELECT
   ELSE NULL END                                   AS realized_net_pnl_r,
   CASE
     WHEN ce.extra IS NULL THEN NULL
-    WHEN ce.extra ? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
+    WHEN ce.extra ?? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
     ELSE NULL
   END                                             AS position_fully_closed,
   money.pnl_source,

--- a/trading-app/migrations/Version20260625020000.php
+++ b/trading-app/migrations/Version20260625020000.php
@@ -51,8 +51,8 @@ $$
 SQL);
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'trade_id\')');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'position_id\')');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS
@@ -466,7 +466,7 @@ SELECT
   ELSE NULL END                                   AS realized_net_pnl_r,
   CASE
     WHEN ce.extra IS NULL THEN NULL
-    WHEN ce.extra ?? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
+    WHEN jsonb_exists(ce.extra, 'position_fully_closed') THEN (ce.extra->> 'position_fully_closed') = 'true'
     ELSE NULL
   END                                             AS position_fully_closed,
   money.pnl_source,

--- a/trading-app/migrations/Version20260626000000.php
+++ b/trading-app/migrations/Version20260626000000.php
@@ -74,8 +74,8 @@ $$
 SQL);
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS
@@ -528,7 +528,7 @@ SELECT
   END                                             AS mfe_mae_data_quality,
   CASE
     WHEN ce.extra IS NULL THEN NULL
-    WHEN ce.extra ? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
+    WHEN ce.extra ?? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
     ELSE NULL
   END                                             AS position_fully_closed,
   money.pnl_source,

--- a/trading-app/migrations/Version20260626000000.php
+++ b/trading-app/migrations/Version20260626000000.php
@@ -74,8 +74,8 @@ $$
 SQL);
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_internal ON trade_lifecycle_event (event_type, internal_trade_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE internal_trade_id IS NOT NULL');
         $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_position ON trade_lifecycle_event (event_type, position_id, symbol, exchange, market_type, run_id, happened_at, id) WHERE position_id IS NOT NULL');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'trade_id\'');
-        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE extra ?? \'position_id\'');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_trade ON trade_lifecycle_event (event_type, (extra->>\'trade_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'trade_id\')');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_tle_v2_fifo_extra_position ON trade_lifecycle_event (event_type, (extra->>\'position_id\'), symbol, exchange, market_type, run_id, happened_at, id) WHERE jsonb_exists(extra, \'position_id\')');
         $this->addSql('DROP VIEW IF EXISTS position_trade_analysis_v2');
         $this->addSql(<<<'SQL'
 CREATE VIEW position_trade_analysis_v2 AS
@@ -528,7 +528,7 @@ SELECT
   END                                             AS mfe_mae_data_quality,
   CASE
     WHEN ce.extra IS NULL THEN NULL
-    WHEN ce.extra ?? 'position_fully_closed' THEN (ce.extra->> 'position_fully_closed') = 'true'
+    WHEN jsonb_exists(ce.extra, 'position_fully_closed') THEN (ce.extra->> 'position_fully_closed') = 'true'
     ELSE NULL
   END                                             AS position_fully_closed,
   money.pnl_source,

--- a/trading-app/scripts/bad_trades_baseline.py
+++ b/trading-app/scripts/bad_trades_baseline.py
@@ -360,9 +360,9 @@ def build_baseline(input_csv: Path, seed: int = 132, monte_carlo_runs: int = 100
             "all_certified": simulate_group(certified, seed, monte_carlo_runs),
         },
         "coverage_gaps": [
-            "direction/side is not exposed by position_trade_analysis_v2; direction segmentation is not computed by this export.",
-            "EntryZone distance and entry extension require trade_zone_events or lifecycle extra fields joined by decision_key; they are reported as a_valider unless exported separately.",
-            "maker/taker requires fill ledger aggregation; it is not present in position_trade_analysis_v2.",
+            "direction/side is certified only when a unique order_intent is matched by internal_trade_id and exact exchange/market/symbol scope.",
+            "EntryZone distance requires a unique trade_zone_events match through the order_intent decision_key and exact exchange/market/symbol/timeframe scope.",
+            "maker/taker is available only when fill_cost_ledger rows exist for the same internal_trade_id and exact exchange/market/symbol scope.",
             "TP/SL recalculation causes are not certified by v2 and must be joined from lifecycle events before causal claims.",
             "Compounding ON needs real account equity or risk fraction per trade; v2 only exposes risk_usdt_at_entry.",
         ],
@@ -410,7 +410,7 @@ def render_markdown(result: dict[str, Any]) -> str:
     lines = [
         "# Baseline bad trades certifiee v2",
         "",
-        "Ce rapport est genere uniquement depuis `position_trade_analysis_v2` avec lignes certifiees.",
+        "Ce rapport est genere depuis l'export `bad-trades-baseline-v2.sql`, base sur `position_trade_analysis_v2` et enrichi par `order_intent`, `trade_zone_events` et `fill_cost_ledger` lorsque les identifiants sont uniques.",
         "Les lignes partielles, inconnues, ambigues, legacy ou a couts incomplets sont segmentees et exclues des metriques nettes.",
         "",
         "## Population",


### PR DESCRIPTION
## Summary
- Replace raw PostgreSQL JSONB `?` checks in recent migrations with `jsonb_exists(...)` so Doctrine DBAL/PDO do not treat them as placeholders.
- Make the #132 baseline export use `COPY ... TO STDOUT`, with docs updated to redirect the CSV output explicitly.
- Align the generated baseline report wording with the current enriched export scope.

## Why
During the #132 PostgreSQL extraction, a fresh local database initially failed on migrations because DBAL interpreted raw JSONB `?` operators as placeholders. The first escape attempt using `??` still reached PostgreSQL as a non-existent operator in CI. `jsonb_exists(...)` avoids that ambiguity and keeps the SQL portable through DBAL.

## Validation
- `python3 -m pytest trading-app/tests/scripts/test_bad_trades_baseline.py -q` -> 3 passed
- `python3 -m py_compile trading-app/scripts/bad_trades_baseline.py`
- `docker compose exec -T trading-app-php vendor/bin/phpunit --bootstrap vendor/autoload.php tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php tests/Trading/View/PositionTradeAnalysisViewTest.php` -> 19 tests, 183 assertions
- PostgreSQL smoke test for `jsonb_exists(...)` and corrected index predicate
- `docker compose exec -T trading-app-php php bin/console lint:container --no-debug`
- `php -l` on touched migrations
- `git diff --check`

Related to #132.
