### PR TITLE
Add deterministic backtest contracts

### DIFF
--- a/docs/handbook/technical/backtesting-engine.md
+++ b/docs/handbook/technical/backtesting-engine.md
@@ -67,6 +67,10 @@ sortir des bornes du dataset.
 Un run backtest ne peut utiliser qu'une config dont le profil correspond au
 profil du run.
 
+La configuration effective est gelee recursivement a la creation du snapshot :
+un dictionnaire source mute apres coup ne peut pas modifier les parametres du
+run ni invalider silencieusement `config_hash`.
+
 ### Reproductibilite
 
 `BacktestRunRequest` porte :
@@ -84,6 +88,9 @@ profil du run.
 
 Le fingerprint de reproductibilite est un hash canonique des inputs. A inputs
 identiques, le fingerprint doit rester identique.
+
+Tous les timestamps des contrats sont UTC-aware. Une date naive ou dans un autre
+offset est rejetee par validation Pydantic avant toute comparaison de bornes.
 
 ### Politique intra-bougie
 
@@ -144,4 +151,3 @@ tests golden dedies.
 cd python-orchestrator
 python3 -m pytest tests/test_backtesting_contracts.py -q
 ```
-

--- a/docs/handbook/technical/backtesting-engine.md
+++ b/docs/handbook/technical/backtesting-engine.md
@@ -1,0 +1,147 @@
+# Backtesting net deterministe
+
+## Statut
+
+ADR et contrats de donnees v1 pour #191.
+
+Ce lot ne livre pas encore un moteur Backtrader executable. Il fixe la frontiere
+de contrat entre les futurs composants :
+
+```text
+Dataset Builder
+  -> Effective Config snapshot
+  -> TradingCore adapter
+  -> Backtrader adapter
+  -> Execution simulator
+  -> Net cost model
+  -> Backtest ledger
+  -> Metrics and statistical validation
+```
+
+Cette separation evite de recopier arbitrairement la strategie dans Python. Les
+regles de trading restent portees par TradingCore ou par un adapter explicite et
+testable.
+
+## Decision
+
+Le backtesting #191 sera implemente en lots atomiques. Le premier lot livre :
+
+- des contrats Pydantic immuables dans `python-orchestrator/app/backtesting/contracts.py` ;
+- des tests unitaires verrouillant les invariants minimaux ;
+- cette page d'architecture.
+
+Backtrader sera branche derriere ces contrats dans une PR suivante. Les resultats
+de backtest ne seront jamais presentes comme preuve live.
+
+## Invariants verrouilles par les contrats v1
+
+### Dataset versionne
+
+`DatasetDescriptor` identifie un jeu de donnees par :
+
+- `dataset_id` ;
+- source ;
+- exchange ;
+- market type ;
+- symboles ;
+- timeframes ;
+- periode UTC ;
+- ranges manquants ;
+- flags qualite ;
+- `build_version` ;
+- checksum `sha256`.
+
+La periode doit etre bornee (`end_at > start_at`) et les runs ne peuvent pas
+sortir des bornes du dataset.
+
+### Config effective
+
+`EffectiveConfigSnapshot` capture :
+
+- profil (`regular`, `scalper`, `scalper_micro`) ;
+- hash `sha256` ;
+- version de contrat ;
+- couches chargees ;
+- configuration effective serialisee.
+
+Un run backtest ne peut utiliser qu'une config dont le profil correspond au
+profil du run.
+
+### Reproductibilite
+
+`BacktestRunRequest` porte :
+
+- dataset ;
+- config ;
+- profil execute ;
+- symboles et timeframes inclus dans le dataset ;
+- periode ;
+- commit Git ;
+- version moteur ;
+- seed ;
+- version du modele de cout ;
+- politique intra-bougie.
+
+Le fingerprint de reproductibilite est un hash canonique des inputs. A inputs
+identiques, le fingerprint doit rester identique.
+
+### Politique intra-bougie
+
+La politique par defaut est conservatrice :
+
+```text
+conservative_stop_first
+```
+
+Les autres modes admissibles sont :
+
+```text
+path_from_lower_timeframe
+reject_ambiguous_trade
+```
+
+Le mode optimiste `tp_first` n'existe pas dans le contrat v1.
+
+### Ledger simule
+
+`BacktestTradeLedgerEntry` represente un trade simule execute. Il exige :
+
+- un `initial_stop` positif ;
+- un stop long sous l'entree ;
+- un stop short au-dessus de l'entree ;
+- des couts nets explicites (`fee_usdt`, `spread_cost_usdt`, `slippage_cost_usdt`,
+  `funding_usdt`, borrow/liquidation si applicables) ;
+- le commit Git, le dataset et le hash de config.
+
+Un trade simule sans SL est invalide. Les signaux non executes seront modelises
+dans un contrat separe lors du lot execution simulator.
+
+## Relation avec #132
+
+#132 reste ouverte tant que le vrai jeu de donnees n'a pas produit de baseline
+quantifiee exploitable. Cela ne bloque pas ce lot de contrats #191 : le moteur est
+prepare maintenant, puis les couts et la calibration seront compares a la baseline
+reelle lorsque les donnees seront disponibles.
+
+## Hors scope de ce lot
+
+- execution Backtrader ;
+- dataset builder ;
+- adapter TradingCore ;
+- simulation maker/taker ;
+- partial fills ;
+- funding historique ;
+- rapports de metrics ;
+- simulation 100 trades ;
+- validation statistique.
+
+Ces elements restent dans #191 et doivent etre livres par PRs suivantes avec
+tests golden dedies.
+
+## Validation locale
+
+```bash
+cd python-orchestrator
+python3 -m pytest tests/test_backtesting_contracts.py -q
+```
+

--- a/docs/handbook/technical/backtesting-engine.md
+++ b/docs/handbook/technical/backtesting-engine.md
@@ -118,6 +118,7 @@ Le mode optimiste `tp_first` n'existe pas dans le contrat v1.
 - un stop short au-dessus de l'entree ;
 - des couts nets explicites (`fee_usdt`, `spread_cost_usdt`, `slippage_cost_usdt`,
   `funding_usdt`, borrow/liquidation si applicables) ;
+- des valeurs numeriques finies uniquement, avec `net_pnl_usdt = gross_pnl_usdt - total_known_cost_usdt` ;
 - le commit Git, le dataset et le hash de config.
 
 Un trade simule sans SL est invalide. Les signaux non executes seront modelises

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Temporal workers: technical/temporal.md
       - Migration legacy → orchestrateur: technical/legacy-migration.md
       - Python orchestrator: technical/python-orchestrator.md
+      - Backtesting net deterministe: technical/backtesting-engine.md
       - Frontend et Ops: technical/frontend.md
       - Architecture cible trading platform: technical/trading-platform-target-architecture.md
       - Architecture Trading Core modulaire: technical/trading-core-modular-architecture.md

--- a/python-orchestrator/app/backtesting/__init__.py
+++ b/python-orchestrator/app/backtesting/__init__.py
@@ -1,0 +1,6 @@
+"""Backtesting contracts for TradingV3.
+
+This package intentionally starts with stable data contracts only. Backtrader
+adapters and execution simulation live in later #191 slices.
+"""
+

--- a/python-orchestrator/app/backtesting/contracts.py
+++ b/python-orchestrator/app/backtesting/contracts.py
@@ -12,7 +12,7 @@ import json
 from collections.abc import Mapping as MappingAbc
 from datetime import datetime, timezone
 from enum import Enum
-from math import isclose
+from math import isclose, isfinite
 from typing import Any, Iterator, Mapping
 
 from pydantic import (
@@ -128,6 +128,10 @@ def _deep_freeze(value: Any) -> Any:
         return tuple(_deep_freeze(item) for item in value)
     if isinstance(value, set | frozenset):
         raise ValueError("effective_config must contain JSON-compatible values")
+    if isinstance(value, float):
+        if not isfinite(value):
+            raise ValueError("effective_config must contain finite floats")
+        return value
     if isinstance(value, _JSON_SCALAR_TYPES):
         return value
     raise ValueError("effective_config must contain JSON-compatible values")

--- a/python-orchestrator/app/backtesting/contracts.py
+++ b/python-orchestrator/app/backtesting/contracts.py
@@ -12,6 +12,7 @@ import json
 from collections.abc import Mapping as MappingAbc
 from datetime import datetime, timezone
 from enum import Enum
+from math import isclose
 from typing import Any, Iterator, Mapping
 
 from pydantic import (
@@ -265,7 +266,7 @@ class BacktestTradeLedgerEntry(BaseModel):
     This contract covers executed simulated trades and requires an immediate SL.
     """
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, allow_inf_nan=False)
 
     backtest_run_id: str = Field(..., min_length=1)
     dataset_id: str = Field(..., min_length=1)
@@ -303,13 +304,16 @@ class BacktestTradeLedgerEntry(BaseModel):
         return _require_utc(value)
 
     @model_validator(mode="after")
-    def _validate_stop(self) -> "BacktestTradeLedgerEntry":
+    def _validate_ledger(self) -> "BacktestTradeLedgerEntry":
         if self.initial_stop is None or self.initial_stop <= 0:
             raise ValueError("initial_stop is required and must be positive")
         if self.direction is Direction.LONG and self.initial_stop >= self.entry_price:
             raise ValueError("long initial_stop must be below entry_price")
         if self.direction is Direction.SHORT and self.initial_stop <= self.entry_price:
             raise ValueError("short initial_stop must be above entry_price")
+        expected_net_pnl = self.gross_pnl_usdt - self.total_known_cost_usdt
+        if not isclose(self.net_pnl_usdt, expected_net_pnl, rel_tol=1e-9, abs_tol=1e-9):
+            raise ValueError("net_pnl_usdt must equal gross_pnl_usdt minus known costs")
         return self
 
     @computed_field

--- a/python-orchestrator/app/backtesting/contracts.py
+++ b/python-orchestrator/app/backtesting/contracts.py
@@ -9,11 +9,20 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime
+from collections.abc import Mapping as MappingAbc
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Mapping
+from typing import Any, Iterator, Mapping
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 
 _SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
@@ -49,12 +58,61 @@ class IntraBarPolicy(str, Enum):
 
 
 def _canonical_hash(payload: Mapping[str, Any]) -> str:
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    encoded = json.dumps(_deep_thaw(payload), sort_keys=True, separators=(",", ":"), default=str)
     return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 
 def _tuple_subset(values: tuple[str, ...], allowed: tuple[str, ...]) -> bool:
     return set(values).issubset(set(allowed))
+
+
+def _require_utc(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("datetime must be UTC-aware")
+    if value.utcoffset() != timezone.utc.utcoffset(value):
+        raise ValueError("datetime must be UTC-aware")
+    return value.astimezone(timezone.utc)
+
+
+class FrozenDict(MappingAbc):
+    """Recursive immutable mapping for config snapshots."""
+
+    def __init__(self, value: Mapping[str, Any]) -> None:
+        self._data = {str(key): _deep_freeze(item) for key, item in value.items()}
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __repr__(self) -> str:
+        return repr(self._data)
+
+
+def _deep_freeze(value: Any) -> Any:
+    if isinstance(value, FrozenDict):
+        return value
+    if isinstance(value, MappingAbc):
+        return FrozenDict(value)
+    if isinstance(value, list | tuple):
+        return tuple(_deep_freeze(item) for item in value)
+    return value
+
+
+def _deep_thaw(value: Any) -> Any:
+    if isinstance(value, FrozenDict):
+        return {key: _deep_thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_deep_thaw(item) for item in value]
+    if isinstance(value, list):
+        return [_deep_thaw(item) for item in value]
+    if isinstance(value, MappingAbc):
+        return {str(key): _deep_thaw(item) for key, item in value.items()}
+    return value
 
 
 class DatasetDescriptor(BaseModel):
@@ -82,6 +140,11 @@ class DatasetDescriptor(BaseModel):
             return ()
         return tuple(str(item).strip() for item in value if str(item).strip())
 
+    @field_validator("start_at", "end_at")
+    @classmethod
+    def _validate_utc(cls, value: datetime) -> datetime:
+        return _require_utc(value)
+
     @model_validator(mode="after")
     def _validate_bounds(self) -> "DatasetDescriptor":
         if self.end_at <= self.start_at:
@@ -92,18 +155,29 @@ class DatasetDescriptor(BaseModel):
 class EffectiveConfigSnapshot(BaseModel):
     """Versioned effective config used by a backtest run."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     profile: Profile
     config_hash: str = Field(..., pattern=_SHA256_PATTERN)
     config_version: str = Field(..., min_length=1)
     source_layers: tuple[str, ...] = Field(..., min_length=1)
-    effective_config: Mapping[str, Any] = Field(..., min_length=1)
+    effective_config: FrozenDict = Field(...)
 
     @field_validator("source_layers", mode="before")
     @classmethod
     def _normalize_layers(cls, value: Any) -> tuple[str, ...]:
         return tuple(str(item).strip() for item in value if str(item).strip())
+
+    @field_validator("effective_config", mode="before")
+    @classmethod
+    def _freeze_config(cls, value: Any) -> FrozenDict:
+        if not isinstance(value, MappingAbc):
+            raise ValueError("effective_config must be a mapping")
+        return FrozenDict(value)
+
+    @field_serializer("effective_config")
+    def _serialize_config(self, value: FrozenDict) -> dict[str, Any]:
+        return _deep_thaw(value)
 
     @model_validator(mode="after")
     def _validate_config(self) -> "EffectiveConfigSnapshot":
@@ -136,6 +210,11 @@ class BacktestRunRequest(BaseModel):
     @classmethod
     def _normalize_tuple(cls, value: Any) -> tuple[str, ...]:
         return tuple(str(item).strip() for item in value if str(item).strip())
+
+    @field_validator("period_start", "period_end")
+    @classmethod
+    def _validate_utc(cls, value: datetime) -> datetime:
+        return _require_utc(value)
 
     @model_validator(mode="after")
     def _validate_scope(self) -> "BacktestRunRequest":
@@ -202,6 +281,11 @@ class BacktestTradeLedgerEntry(BaseModel):
             return ()
         return tuple(str(item).strip() for item in value if str(item).strip())
 
+    @field_validator("signal_at")
+    @classmethod
+    def _validate_utc(cls, value: datetime) -> datetime:
+        return _require_utc(value)
+
     @model_validator(mode="after")
     def _validate_stop(self) -> "BacktestTradeLedgerEntry":
         if self.initial_stop is None or self.initial_stop <= 0:
@@ -228,4 +312,3 @@ class BacktestTradeLedgerEntry(BaseModel):
     @property
     def result_is_live_proof(self) -> bool:
         return False
-

--- a/python-orchestrator/app/backtesting/contracts.py
+++ b/python-orchestrator/app/backtesting/contracts.py
@@ -1,0 +1,231 @@
+"""Versioned contracts for deterministic net backtests.
+
+These models are the first #191 slice. They define the boundary between dataset
+builders, effective config snapshots, future Backtrader adapters, execution
+simulation, cost models and reports. No trading strategy is implemented here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from enum import Enum
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator, model_validator
+
+
+_SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
+_GIT_SHA_PATTERN = r"^[0-9a-f]{40}$"
+
+
+class Profile(str, Enum):
+    REGULAR = "regular"
+    SCALPER = "scalper"
+    SCALPER_MICRO = "scalper_micro"
+
+
+class MarketType(str, Enum):
+    PERPETUAL = "perpetual"
+    SPOT = "spot"
+
+
+class Direction(str, Enum):
+    LONG = "long"
+    SHORT = "short"
+
+
+class OrderType(str, Enum):
+    MAKER = "maker"
+    TAKER = "taker"
+    MARKET = "market"
+
+
+class IntraBarPolicy(str, Enum):
+    CONSERVATIVE_STOP_FIRST = "conservative_stop_first"
+    PATH_FROM_LOWER_TIMEFRAME = "path_from_lower_timeframe"
+    REJECT_AMBIGUOUS_TRADE = "reject_ambiguous_trade"
+
+
+def _canonical_hash(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _tuple_subset(values: tuple[str, ...], allowed: tuple[str, ...]) -> bool:
+    return set(values).issubset(set(allowed))
+
+
+class DatasetDescriptor(BaseModel):
+    """Immutable descriptor for a versioned backtest dataset."""
+
+    model_config = ConfigDict(frozen=True)
+
+    dataset_id: str = Field(..., min_length=1)
+    source: str = Field(..., min_length=1)
+    exchange: str = Field(..., min_length=1)
+    market_type: MarketType
+    symbols: tuple[str, ...] = Field(..., min_length=1)
+    timeframes: tuple[str, ...] = Field(..., min_length=1)
+    start_at: datetime
+    end_at: datetime
+    missing_ranges: tuple[str, ...] = ()
+    quality_flags: tuple[str, ...] = ()
+    build_version: str = Field(..., min_length=1)
+    checksum: str = Field(..., pattern=_SHA256_PATTERN)
+
+    @field_validator("symbols", "timeframes", "missing_ranges", "quality_flags", mode="before")
+    @classmethod
+    def _normalize_tuple(cls, value: Any) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        return tuple(str(item).strip() for item in value if str(item).strip())
+
+    @model_validator(mode="after")
+    def _validate_bounds(self) -> "DatasetDescriptor":
+        if self.end_at <= self.start_at:
+            raise ValueError("dataset end_at must be after start_at")
+        return self
+
+
+class EffectiveConfigSnapshot(BaseModel):
+    """Versioned effective config used by a backtest run."""
+
+    model_config = ConfigDict(frozen=True)
+
+    profile: Profile
+    config_hash: str = Field(..., pattern=_SHA256_PATTERN)
+    config_version: str = Field(..., min_length=1)
+    source_layers: tuple[str, ...] = Field(..., min_length=1)
+    effective_config: Mapping[str, Any] = Field(..., min_length=1)
+
+    @field_validator("source_layers", mode="before")
+    @classmethod
+    def _normalize_layers(cls, value: Any) -> tuple[str, ...]:
+        return tuple(str(item).strip() for item in value if str(item).strip())
+
+    @model_validator(mode="after")
+    def _validate_config(self) -> "EffectiveConfigSnapshot":
+        if not self.source_layers:
+            raise ValueError("source_layers must not be empty")
+        if not self.effective_config:
+            raise ValueError("effective_config must not be empty")
+        return self
+
+
+class BacktestRunRequest(BaseModel):
+    """Input contract for a deterministic net backtest run."""
+
+    model_config = ConfigDict(frozen=True)
+
+    dataset: DatasetDescriptor
+    config: EffectiveConfigSnapshot
+    profile: Profile
+    symbols: tuple[str, ...] = Field(..., min_length=1)
+    timeframes: tuple[str, ...] = Field(..., min_length=1)
+    period_start: datetime
+    period_end: datetime
+    git_commit_sha: str = Field(..., pattern=_GIT_SHA_PATTERN)
+    engine_version: str = Field(..., min_length=1)
+    random_seed: int = Field(..., ge=0)
+    cost_model_version: str = Field(..., min_length=1)
+    intra_bar_policy: IntraBarPolicy = IntraBarPolicy.CONSERVATIVE_STOP_FIRST
+
+    @field_validator("symbols", "timeframes", mode="before")
+    @classmethod
+    def _normalize_tuple(cls, value: Any) -> tuple[str, ...]:
+        return tuple(str(item).strip() for item in value if str(item).strip())
+
+    @model_validator(mode="after")
+    def _validate_scope(self) -> "BacktestRunRequest":
+        if self.config.profile is not self.profile:
+            raise ValueError("config profile must match run profile")
+        if not _tuple_subset(self.symbols, self.dataset.symbols):
+            raise ValueError("symbols must be contained in dataset")
+        if not _tuple_subset(self.timeframes, self.dataset.timeframes):
+            raise ValueError("timeframes must be contained in dataset")
+        if self.period_end <= self.period_start:
+            raise ValueError("period_end must be after period_start")
+        if self.period_start < self.dataset.start_at or self.period_end > self.dataset.end_at:
+            raise ValueError("period must stay inside dataset bounds")
+        return self
+
+    @computed_field
+    @property
+    def result_is_live_proof(self) -> bool:
+        return False
+
+    def reproducibility_fingerprint(self) -> str:
+        payload = self.model_dump(mode="json", exclude={"result_is_live_proof"})
+        return _canonical_hash(payload)
+
+
+class BacktestTradeLedgerEntry(BaseModel):
+    """Output ledger row for one simulated executed trade.
+
+    Signals that do not execute should be exported separately by later slices.
+    This contract covers executed simulated trades and requires an immediate SL.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    backtest_run_id: str = Field(..., min_length=1)
+    dataset_id: str = Field(..., min_length=1)
+    config_hash: str = Field(..., pattern=_SHA256_PATTERN)
+    git_commit_sha: str = Field(..., pattern=_GIT_SHA_PATTERN)
+    profile: Profile
+    exchange: str = Field(..., min_length=1)
+    market_type: MarketType
+    symbol: str = Field(..., min_length=1)
+    direction: Direction
+    signal_at: datetime
+    entry_order_type: OrderType
+    entry_price: float = Field(..., gt=0)
+    entry_quantity: float = Field(..., gt=0)
+    initial_stop: float | None = Field(...)
+    gross_pnl_usdt: float
+    net_pnl_usdt: float
+    pnl_r: float
+    fee_usdt: float = Field(..., ge=0)
+    spread_cost_usdt: float = Field(..., ge=0)
+    slippage_cost_usdt: float = Field(..., ge=0)
+    funding_usdt: float
+    borrow_cost_usdt: float = Field(default=0.0, ge=0)
+    liquidation_fee_usdt: float = Field(default=0.0, ge=0)
+    quality_flags: tuple[str, ...] = ()
+
+    @field_validator("quality_flags", mode="before")
+    @classmethod
+    def _normalize_flags(cls, value: Any) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        return tuple(str(item).strip() for item in value if str(item).strip())
+
+    @model_validator(mode="after")
+    def _validate_stop(self) -> "BacktestTradeLedgerEntry":
+        if self.initial_stop is None or self.initial_stop <= 0:
+            raise ValueError("initial_stop is required and must be positive")
+        if self.direction is Direction.LONG and self.initial_stop >= self.entry_price:
+            raise ValueError("long initial_stop must be below entry_price")
+        if self.direction is Direction.SHORT and self.initial_stop <= self.entry_price:
+            raise ValueError("short initial_stop must be above entry_price")
+        return self
+
+    @computed_field
+    @property
+    def total_known_cost_usdt(self) -> float:
+        return (
+            self.fee_usdt
+            + self.spread_cost_usdt
+            + self.slippage_cost_usdt
+            - self.funding_usdt
+            + self.borrow_cost_usdt
+            + self.liquidation_fee_usdt
+        )
+
+    @computed_field
+    @property
+    def result_is_live_proof(self) -> bool:
+        return False
+

--- a/python-orchestrator/app/backtesting/contracts.py
+++ b/python-orchestrator/app/backtesting/contracts.py
@@ -66,6 +66,26 @@ def _tuple_subset(values: tuple[str, ...], allowed: tuple[str, ...]) -> bool:
     return set(values).issubset(set(allowed))
 
 
+def _normalize_string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raise ValueError("field must be a sequence of strings")
+    try:
+        iterator = iter(value)
+    except TypeError as exc:
+        raise ValueError("field must be a sequence of strings") from exc
+
+    normalized: list[str] = []
+    for item in iterator:
+        if not isinstance(item, str):
+            raise ValueError("field must contain only strings")
+        stripped = item.strip()
+        if stripped:
+            normalized.append(stripped)
+    return tuple(normalized)
+
+
 def _require_utc(value: datetime) -> datetime:
     if value.tzinfo is None or value.utcoffset() is None:
         raise ValueError("datetime must be UTC-aware")
@@ -136,9 +156,7 @@ class DatasetDescriptor(BaseModel):
     @field_validator("symbols", "timeframes", "missing_ranges", "quality_flags", mode="before")
     @classmethod
     def _normalize_tuple(cls, value: Any) -> tuple[str, ...]:
-        if value is None:
-            return ()
-        return tuple(str(item).strip() for item in value if str(item).strip())
+        return _normalize_string_tuple(value)
 
     @field_validator("start_at", "end_at")
     @classmethod
@@ -166,7 +184,7 @@ class EffectiveConfigSnapshot(BaseModel):
     @field_validator("source_layers", mode="before")
     @classmethod
     def _normalize_layers(cls, value: Any) -> tuple[str, ...]:
-        return tuple(str(item).strip() for item in value if str(item).strip())
+        return _normalize_string_tuple(value)
 
     @field_validator("effective_config", mode="before")
     @classmethod
@@ -209,7 +227,7 @@ class BacktestRunRequest(BaseModel):
     @field_validator("symbols", "timeframes", mode="before")
     @classmethod
     def _normalize_tuple(cls, value: Any) -> tuple[str, ...]:
-        return tuple(str(item).strip() for item in value if str(item).strip())
+        return _normalize_string_tuple(value)
 
     @field_validator("period_start", "period_end")
     @classmethod
@@ -277,9 +295,7 @@ class BacktestTradeLedgerEntry(BaseModel):
     @field_validator("quality_flags", mode="before")
     @classmethod
     def _normalize_flags(cls, value: Any) -> tuple[str, ...]:
-        if value is None:
-            return ()
-        return tuple(str(item).strip() for item in value if str(item).strip())
+        return _normalize_string_tuple(value)
 
     @field_validator("signal_at")
     @classmethod

--- a/python-orchestrator/app/backtesting/contracts.py
+++ b/python-orchestrator/app/backtesting/contracts.py
@@ -28,6 +28,7 @@ from pydantic import (
 
 _SHA256_PATTERN = r"^sha256:[0-9a-f]{64}$"
 _GIT_SHA_PATTERN = r"^[0-9a-f]{40}$"
+_JSON_SCALAR_TYPES = (str, int, float, bool, type(None))
 
 
 class Profile(str, Enum):
@@ -74,6 +75,8 @@ def _normalize_string_tuple(value: Any) -> tuple[str, ...]:
         raise ValueError("field must be a sequence of strings")
     if isinstance(value, MappingAbc):
         raise ValueError("field must be a sequence of strings")
+    if isinstance(value, set | frozenset):
+        raise ValueError("field must be an ordered sequence of strings")
     try:
         iterator = iter(value)
     except TypeError as exc:
@@ -123,7 +126,11 @@ def _deep_freeze(value: Any) -> Any:
         return FrozenDict(value)
     if isinstance(value, list | tuple):
         return tuple(_deep_freeze(item) for item in value)
-    return value
+    if isinstance(value, set | frozenset):
+        raise ValueError("effective_config must contain JSON-compatible values")
+    if isinstance(value, _JSON_SCALAR_TYPES):
+        return value
+    raise ValueError("effective_config must contain JSON-compatible values")
 
 
 def _deep_thaw(value: Any) -> Any:

--- a/python-orchestrator/app/backtesting/contracts.py
+++ b/python-orchestrator/app/backtesting/contracts.py
@@ -72,6 +72,8 @@ def _normalize_string_tuple(value: Any) -> tuple[str, ...]:
         return ()
     if isinstance(value, str):
         raise ValueError("field must be a sequence of strings")
+    if isinstance(value, MappingAbc):
+        raise ValueError("field must be a sequence of strings")
     try:
         iterator = iter(value)
     except TypeError as exc:

--- a/python-orchestrator/tests/test_backtesting_contracts.py
+++ b/python-orchestrator/tests/test_backtesting_contracts.py
@@ -162,6 +162,47 @@ def test_run_request_rejects_non_utc_datetimes_cleanly() -> None:
         )
 
 
+def test_sequence_fields_reject_scalar_strings_and_non_string_items() -> None:
+    with pytest.raises(ValidationError, match="must be a sequence of strings"):
+        DatasetDescriptor(
+            **{
+                **_dataset().model_dump(),
+                "symbols": "BTCUSDT",
+            }
+        )
+
+    with pytest.raises(ValidationError, match="must contain only strings"):
+        DatasetDescriptor(
+            **{
+                **_dataset().model_dump(),
+                "timeframes": ("1m", None),
+            }
+        )
+
+    with pytest.raises(ValidationError, match="must be a sequence of strings"):
+        EffectiveConfigSnapshot(
+            **{
+                **_config().model_dump(),
+                "source_layers": "base",
+            }
+        )
+
+    with pytest.raises(ValidationError, match="must be a sequence of strings"):
+        BacktestRunRequest(
+            dataset=_dataset(),
+            config=_config(),
+            profile=Profile.SCALPER,
+            symbols="BTCUSDT",
+            timeframes=("1m",),
+            period_start=_dt("2026-01-02T00:00:00"),
+            period_end=_dt("2026-01-03T00:00:00"),
+            git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+            engine_version="backtest-contracts-v1",
+            random_seed=191,
+            cost_model_version="net-cost-v1",
+        )
+
+
 def test_trade_ledger_entry_requires_stop_and_net_cost_components() -> None:
     entry = BacktestTradeLedgerEntry(
         backtest_run_id="bt_191",

--- a/python-orchestrator/tests/test_backtesting_contracts.py
+++ b/python-orchestrator/tests/test_backtesting_contracts.py
@@ -121,6 +121,47 @@ def test_run_request_rejects_profile_mismatch_and_dataset_escape() -> None:
         )
 
 
+def test_effective_config_snapshot_deep_freezes_payload() -> None:
+    payload = {
+        "risk": {"risk_pct": 0.01},
+        "entry": {"modes": ["maker"]},
+    }
+
+    snapshot = EffectiveConfigSnapshot(
+        profile=Profile.SCALPER,
+        config_hash="sha256:" + "b" * 64,
+        config_version="effective-config-v1",
+        source_layers=("base", "mode/scalper"),
+        effective_config=payload,
+    )
+    payload["risk"]["risk_pct"] = 0.99
+    payload["entry"]["modes"].append("taker")
+
+    assert snapshot.effective_config["risk"]["risk_pct"] == 0.01
+    assert snapshot.effective_config["entry"]["modes"] == ("maker",)
+    with pytest.raises(TypeError):
+        snapshot.effective_config["risk"]["risk_pct"] = 0.02
+
+
+def test_run_request_rejects_non_utc_datetimes_cleanly() -> None:
+    naive_start = datetime.fromisoformat("2026-01-02T00:00:00")
+
+    with pytest.raises(ValidationError, match="datetime must be UTC-aware"):
+        BacktestRunRequest(
+            dataset=_dataset(),
+            config=_config(),
+            profile=Profile.SCALPER,
+            symbols=("BTCUSDT",),
+            timeframes=("1m",),
+            period_start=naive_start,
+            period_end=_dt("2026-01-03T00:00:00"),
+            git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+            engine_version="backtest-contracts-v1",
+            random_seed=191,
+            cost_model_version="net-cost-v1",
+        )
+
+
 def test_trade_ledger_entry_requires_stop_and_net_cost_components() -> None:
     entry = BacktestTradeLedgerEntry(
         backtest_run_id="bt_191",

--- a/python-orchestrator/tests/test_backtesting_contracts.py
+++ b/python-orchestrator/tests/test_backtesting_contracts.py
@@ -240,6 +240,25 @@ def test_sequence_fields_reject_scalar_strings_and_non_string_items() -> None:
             }
         )
 
+    with pytest.raises(ValidationError, match="must be an ordered sequence of strings"):
+        DatasetDescriptor(
+            **{
+                **_dataset().model_dump(),
+                "symbols": {"BTCUSDT", "ETHUSDT"},
+            }
+        )
+
+
+def test_effective_config_snapshot_rejects_non_json_collections() -> None:
+    with pytest.raises(ValidationError, match="effective_config must contain JSON-compatible values"):
+        EffectiveConfigSnapshot(
+            profile=Profile.SCALPER,
+            config_hash="sha256:" + "b" * 64,
+            config_version="effective-config-v1",
+            source_layers=("base", "mode/scalper"),
+            effective_config={"entry": {"modes": {"maker", "taker"}}},
+        )
+
 
 def test_trade_ledger_entry_requires_stop_and_net_cost_components() -> None:
     entry = _ledger_entry()

--- a/python-orchestrator/tests/test_backtesting_contracts.py
+++ b/python-orchestrator/tests/test_backtesting_contracts.py
@@ -232,6 +232,14 @@ def test_sequence_fields_reject_scalar_strings_and_non_string_items() -> None:
             cost_model_version="net-cost-v1",
         )
 
+    with pytest.raises(ValidationError, match="must be a sequence of strings"):
+        DatasetDescriptor(
+            **{
+                **_dataset().model_dump(),
+                "symbols": {"BTCUSDT": False},
+            }
+        )
+
 
 def test_trade_ledger_entry_requires_stop_and_net_cost_components() -> None:
     entry = _ledger_entry()

--- a/python-orchestrator/tests/test_backtesting_contracts.py
+++ b/python-orchestrator/tests/test_backtesting_contracts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from math import nan
+from math import inf, nan
 
 import pytest
 from pydantic import ValidationError
@@ -257,6 +257,18 @@ def test_effective_config_snapshot_rejects_non_json_collections() -> None:
             config_version="effective-config-v1",
             source_layers=("base", "mode/scalper"),
             effective_config={"entry": {"modes": {"maker", "taker"}}},
+        )
+
+
+@pytest.mark.parametrize("value", (nan, inf))
+def test_effective_config_snapshot_rejects_non_finite_floats(value: float) -> None:
+    with pytest.raises(ValidationError, match="effective_config must contain finite floats"):
+        EffectiveConfigSnapshot(
+            profile=Profile.SCALPER,
+            config_hash="sha256:" + "b" * 64,
+            config_version="effective-config-v1",
+            source_layers=("base", "mode/scalper"),
+            effective_config={"risk": {"risk_pct": value}},
         )
 
 

--- a/python-orchestrator/tests/test_backtesting_contracts.py
+++ b/python-orchestrator/tests/test_backtesting_contracts.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.backtesting.contracts import (
+    BacktestRunRequest,
+    BacktestTradeLedgerEntry,
+    DatasetDescriptor,
+    Direction,
+    EffectiveConfigSnapshot,
+    IntraBarPolicy,
+    MarketType,
+    OrderType,
+    Profile,
+)
+
+
+def _dt(value: str) -> datetime:
+    return datetime.fromisoformat(value).replace(tzinfo=timezone.utc)
+
+
+def _dataset() -> DatasetDescriptor:
+    return DatasetDescriptor(
+        dataset_id="ds_btc_2026_01",
+        source="fixture",
+        exchange="fake",
+        market_type=MarketType.PERPETUAL,
+        symbols=("BTCUSDT", "ETHUSDT"),
+        timeframes=("1m", "5m", "15m"),
+        start_at=_dt("2026-01-01T00:00:00"),
+        end_at=_dt("2026-01-31T00:00:00"),
+        missing_ranges=(),
+        quality_flags=(),
+        build_version="dataset-builder-v1",
+        checksum="sha256:" + "a" * 64,
+    )
+
+
+def _config(profile: Profile = Profile.SCALPER) -> EffectiveConfigSnapshot:
+    return EffectiveConfigSnapshot(
+        profile=profile,
+        config_hash="sha256:" + "b" * 64,
+        config_version="effective-config-v1",
+        source_layers=("base", f"mode/{profile.value}", "exchange/fake"),
+        effective_config={
+            "risk": {"risk_pct": 0.01},
+            "entry": {"maker_first": True},
+        },
+    )
+
+
+def test_run_request_fingerprint_is_stable_for_same_inputs() -> None:
+    request = BacktestRunRequest(
+        dataset=_dataset(),
+        config=_config(),
+        profile=Profile.SCALPER,
+        symbols=("BTCUSDT",),
+        timeframes=("1m", "5m"),
+        period_start=_dt("2026-01-02T00:00:00"),
+        period_end=_dt("2026-01-03T00:00:00"),
+        git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+        engine_version="backtest-contracts-v1",
+        random_seed=191,
+        cost_model_version="net-cost-v1",
+    )
+
+    same_request = BacktestRunRequest.model_validate(request.model_dump())
+
+    assert request.reproducibility_fingerprint() == same_request.reproducibility_fingerprint()
+    assert request.intra_bar_policy is IntraBarPolicy.CONSERVATIVE_STOP_FIRST
+    assert request.result_is_live_proof is False
+
+
+def test_run_request_rejects_profile_mismatch_and_dataset_escape() -> None:
+    with pytest.raises(ValidationError, match="config profile must match run profile"):
+        BacktestRunRequest(
+            dataset=_dataset(),
+            config=_config(Profile.REGULAR),
+            profile=Profile.SCALPER,
+            symbols=("BTCUSDT",),
+            timeframes=("1m",),
+            period_start=_dt("2026-01-02T00:00:00"),
+            period_end=_dt("2026-01-03T00:00:00"),
+            git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+            engine_version="backtest-contracts-v1",
+            random_seed=191,
+            cost_model_version="net-cost-v1",
+        )
+
+    with pytest.raises(ValidationError, match="symbols must be contained in dataset"):
+        BacktestRunRequest(
+            dataset=_dataset(),
+            config=_config(),
+            profile=Profile.SCALPER,
+            symbols=("SOLUSDT",),
+            timeframes=("1m",),
+            period_start=_dt("2026-01-02T00:00:00"),
+            period_end=_dt("2026-01-03T00:00:00"),
+            git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+            engine_version="backtest-contracts-v1",
+            random_seed=191,
+            cost_model_version="net-cost-v1",
+        )
+
+    with pytest.raises(ValidationError, match="period must stay inside dataset bounds"):
+        BacktestRunRequest(
+            dataset=_dataset(),
+            config=_config(),
+            profile=Profile.SCALPER,
+            symbols=("BTCUSDT",),
+            timeframes=("1m",),
+            period_start=_dt("2025-12-31T00:00:00"),
+            period_end=_dt("2026-01-03T00:00:00"),
+            git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+            engine_version="backtest-contracts-v1",
+            random_seed=191,
+            cost_model_version="net-cost-v1",
+        )
+
+
+def test_trade_ledger_entry_requires_stop_and_net_cost_components() -> None:
+    entry = BacktestTradeLedgerEntry(
+        backtest_run_id="bt_191",
+        dataset_id="ds_btc_2026_01",
+        config_hash="sha256:" + "b" * 64,
+        git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+        profile=Profile.SCALPER,
+        exchange="fake",
+        market_type=MarketType.PERPETUAL,
+        symbol="BTCUSDT",
+        direction=Direction.LONG,
+        signal_at=_dt("2026-01-02T00:00:00"),
+        entry_order_type=OrderType.MAKER,
+        entry_price=100.0,
+        entry_quantity=1.0,
+        initial_stop=98.0,
+        gross_pnl_usdt=5.0,
+        net_pnl_usdt=4.2,
+        pnl_r=2.1,
+        fee_usdt=0.2,
+        spread_cost_usdt=0.1,
+        slippage_cost_usdt=0.1,
+        funding_usdt=-0.4,
+        quality_flags=(),
+    )
+
+    assert entry.total_known_cost_usdt == pytest.approx(0.8)
+    assert entry.result_is_live_proof is False
+
+    with pytest.raises(ValidationError, match="initial_stop is required"):
+        BacktestTradeLedgerEntry(
+            **{**entry.model_dump(), "initial_stop": None}
+        )

--- a/python-orchestrator/tests/test_backtesting_contracts.py
+++ b/python-orchestrator/tests/test_backtesting_contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from math import nan
 
 import pytest
 from pydantic import ValidationError
@@ -50,6 +51,35 @@ def _config(profile: Profile = Profile.SCALPER) -> EffectiveConfigSnapshot:
             "entry": {"maker_first": True},
         },
     )
+
+
+def _ledger_entry(**overrides: object) -> BacktestTradeLedgerEntry:
+    payload = {
+        "backtest_run_id": "bt_191",
+        "dataset_id": "ds_btc_2026_01",
+        "config_hash": "sha256:" + "b" * 64,
+        "git_commit_sha": "12c9a9fbe369b49afd3d98e495991a21381e8b7b",
+        "profile": Profile.SCALPER,
+        "exchange": "fake",
+        "market_type": MarketType.PERPETUAL,
+        "symbol": "BTCUSDT",
+        "direction": Direction.LONG,
+        "signal_at": _dt("2026-01-02T00:00:00"),
+        "entry_order_type": OrderType.MAKER,
+        "entry_price": 100.0,
+        "entry_quantity": 1.0,
+        "initial_stop": 98.0,
+        "gross_pnl_usdt": 5.0,
+        "net_pnl_usdt": 4.2,
+        "pnl_r": 2.1,
+        "fee_usdt": 0.2,
+        "spread_cost_usdt": 0.1,
+        "slippage_cost_usdt": 0.1,
+        "funding_usdt": -0.4,
+        "quality_flags": (),
+    }
+    payload.update(overrides)
+    return BacktestTradeLedgerEntry(**payload)
 
 
 def test_run_request_fingerprint_is_stable_for_same_inputs() -> None:
@@ -204,30 +234,7 @@ def test_sequence_fields_reject_scalar_strings_and_non_string_items() -> None:
 
 
 def test_trade_ledger_entry_requires_stop_and_net_cost_components() -> None:
-    entry = BacktestTradeLedgerEntry(
-        backtest_run_id="bt_191",
-        dataset_id="ds_btc_2026_01",
-        config_hash="sha256:" + "b" * 64,
-        git_commit_sha="12c9a9fbe369b49afd3d98e495991a21381e8b7b",
-        profile=Profile.SCALPER,
-        exchange="fake",
-        market_type=MarketType.PERPETUAL,
-        symbol="BTCUSDT",
-        direction=Direction.LONG,
-        signal_at=_dt("2026-01-02T00:00:00"),
-        entry_order_type=OrderType.MAKER,
-        entry_price=100.0,
-        entry_quantity=1.0,
-        initial_stop=98.0,
-        gross_pnl_usdt=5.0,
-        net_pnl_usdt=4.2,
-        pnl_r=2.1,
-        fee_usdt=0.2,
-        spread_cost_usdt=0.1,
-        slippage_cost_usdt=0.1,
-        funding_usdt=-0.4,
-        quality_flags=(),
-    )
+    entry = _ledger_entry()
 
     assert entry.total_known_cost_usdt == pytest.approx(0.8)
     assert entry.result_is_live_proof is False
@@ -236,3 +243,13 @@ def test_trade_ledger_entry_requires_stop_and_net_cost_components() -> None:
         BacktestTradeLedgerEntry(
             **{**entry.model_dump(), "initial_stop": None}
         )
+
+
+def test_trade_ledger_entry_rejects_non_finite_values() -> None:
+    with pytest.raises(ValidationError):
+        _ledger_entry(initial_stop=nan)
+
+
+def test_trade_ledger_entry_rejects_inconsistent_net_pnl() -> None:
+    with pytest.raises(ValidationError, match="net_pnl_usdt must equal gross_pnl_usdt minus known costs"):
+        _ledger_entry(net_pnl_usdt=5.0)


### PR DESCRIPTION
## Summary
- Add the first #191 vertical slice: immutable Python contracts for deterministic net backtest inputs and simulated trade ledger rows.
- Document the Backtrader architecture decision as an adapter behind explicit dataset/config/execution/cost/ledger boundaries.
- Add focused pytest coverage for reproducibility fingerprints, dataset scope validation, profile isolation, conservative same-bar policy, and the invariant that no simulated executed trade can exist without an immediate SL.

## Scope
This is PR 1 from the recommended #191 split: ADR + data/backtest contracts only. It does not introduce a Backtrader runtime, execution simulator, dataset builder, cost model, metrics report, or strategy changes.

## Dependency note
#132 remains open until a real populated dataset is available. Per maintainer direction, that baseline is not blocking this contracts-only #191 slice; calibration and comparisons will be revisited once a real dataset exists.

## Validation
- `cd python-orchestrator && python3 -m pytest tests/test_backtesting_contracts.py -q`
- `cd python-orchestrator && python3 -m pytest tests/test_backtesting_contracts.py tests/test_schemas.py tests/test_settings.py -q`
- `cd python-orchestrator && python3 -m pytest -q`
- `cd python-orchestrator && python3 -m py_compile app/backtesting/contracts.py`
- `python3 -m mkdocs build --strict`
- `git diff --check`

Part of #191
Related to #173
Related to #190
Related to #132
Related to #217
