### PR TITLE
COMMON-001 demo/testnet safety envelope

### DIFF
--- a/docs/handbook/technical/demo-testnet-safety-envelope.md
+++ b/docs/handbook/technical/demo-testnet-safety-envelope.md
@@ -1,0 +1,115 @@
+# Demo/Testnet Safety Envelope
+
+## Objectif
+
+Le safety envelope `COMMON-001` ajoute un contrat commun avant toute execution
+mutative OKX demo ou Hyperliquid testnet.
+
+Il ne branche aucun runtime, ne place aucun ordre et ne lit aucun secret. Il fournit
+une decision pure et auditable pour verifier si une demande reste en simulation
+locale, devient candidate demo/testnet, ou peut etre autorisee en demo/testnet par
+une future PR dediee.
+
+## Terminologie
+
+| Terme | Sens |
+|---|---|
+| `local_dry_run` | Simulation locale. Aucun ordre exchange. |
+| `demo` | Environnement OKX demo uniquement. |
+| `testnet` | Environnement Hyperliquid testnet uniquement. |
+| `mainnet` | Interdit en ecriture dans cette serie. |
+| `dry_run=true` | Aucun ordre envoye a l'exchange. |
+| `dry_run=false` | Ecriture demandee, autorisable uniquement en `demo` ou `testnet` si tous les guards passent. |
+
+Le terme "live demo" ne signifie jamais mainnet. Dans TradingV3, il signifie
+uniquement `dry_run=false` sur `environment=demo|testnet`, avec activation explicite
+et guards complets.
+
+## Contrat PHP
+
+Le contrat est isole dans `App\TradingCore\Execution\Safety` :
+
+- `ExchangeRuntimeEnvironment`
+- `DemoTradingSafetyLevel`
+- `DemoTradingSafetyPolicy`
+- `DemoTradingSafetyDecision`
+- `DemoTradingSafetyPolicyEvaluator`
+
+`DemoTradingSafetyPolicyEvaluator` est pur :
+
+- aucun appel HTTP ;
+- aucun appel exchange ;
+- aucun acces a Symfony, Doctrine, Messenger ou Temporal ;
+- aucun secret requis ;
+- aucun effet de bord runtime.
+
+## Niveaux de decision
+
+| Niveau | Signification |
+|---|---|
+| `blocked` | La demande est refusee et expose `blocking_errors`. |
+| `local_dry_run` | Simulation locale autorisee, sans ordre exchange. |
+| `demo_testnet_candidate` | Environnement demo/testnet en dry-run, candidat a une future activation controlee. |
+| `demo_testnet_enabled` | Ecriture demo/testnet autorisee par la policy. |
+
+## Guards
+
+Une demande d'ecriture est toute policy avec `dry_run=false`.
+
+Guards invariants :
+
+- `mainnet_write_enabled=true` bloque toujours ;
+- `environment=mainnet` avec `dry_run=false` bloque toujours ;
+- `environment=local_dry_run` avec `dry_run=false` bloque toujours.
+
+Guards obligatoires pour `demo|testnet` avec `dry_run=false` :
+
+- `demo_testnet_write_enabled=true` ;
+- `kill_switch_enabled=false` ;
+- `require_stop_loss=true` ;
+- `allowed_symbols` ou `allowed_markets` non vide ;
+- `max_notional` positif et renseigne.
+
+Les erreurs sont explicites :
+
+- `mainnet_write_enabled_must_remain_false`
+- `mainnet_write_forbidden`
+- `local_dry_run_cannot_write`
+- `demo_testnet_write_not_enabled`
+- `kill_switch_enabled`
+- `stop_loss_required`
+- `allowed_symbols_or_markets_required`
+- `max_notional_required`
+
+## Redaction
+
+`DemoTradingSafetyDecision::toRedactedArray()` expose un payload d'audit sans secret.
+Les champs sensibles du `audit_context` sont remplaces par `[redacted]` si leur cle
+contient notamment :
+
+- `secret`
+- `token`
+- `api_key`
+- `private_key`
+- `passphrase`
+- `password`
+- `signature`
+
+Les exemples, tests et docs ne contiennent pas de secrets reels.
+
+## Hors scope
+
+Cette PR ne fait pas :
+
+- activation OKX demo ;
+- activation Hyperliquid testnet ;
+- branchement TradeEntry, MTF, Temporal ou Messenger ;
+- appel REST/WS ;
+- modification strategie, EntryZone, Risk/Leverage ou SL/TP metier ;
+- suppression ou modification Bitmart legacy.
+
+## Rollback
+
+Rollback applicatif : supprimer l'usage futur du service ou revenir au commit
+precedent. Comme `COMMON-001` n'est pas branche au runtime existant, son rollback
+n'affecte pas les flux MTF, TradeEntry, OKX dry-run ou Hyperliquid dry-run actuels.

--- a/docs/handbook/technical/demo-testnet-safety-envelope.md
+++ b/docs/handbook/technical/demo-testnet-safety-envelope.md
@@ -68,7 +68,14 @@ Guards obligatoires pour `demo|testnet` avec `dry_run=false` :
 - `kill_switch_enabled=false` ;
 - `require_stop_loss=true` ;
 - `allowed_symbols` ou `allowed_markets` non vide ;
-- `max_notional` positif et renseigne.
+- `max_notional` positif, fini et renseigne ;
+- `requested_symbol` ou `requested_market` present et autorise par la whitelist ;
+- `requested_notional` positif, fini et inferieur ou egal a `max_notional` ;
+- `stop_loss_present=true`.
+
+Une policy avec seulement une configuration globale ne suffit donc pas pour obtenir
+`demo_testnet_enabled`. Le niveau enabled prouve que la requete concrete comparee
+a la policy respecte aussi la whitelist, le plafond notionnel et la presence SL.
 
 Les erreurs sont explicites :
 
@@ -80,6 +87,12 @@ Les erreurs sont explicites :
 - `stop_loss_required`
 - `allowed_symbols_or_markets_required`
 - `max_notional_required`
+- `requested_notional_required`
+- `max_notional_exceeded`
+- `requested_symbol_or_market_required`
+- `requested_symbol_or_market_not_allowed`
+- `stop_loss_presence_required`
+- `stop_loss_missing`
 
 ## Redaction
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
       - Fake / Paper gateway: technical/fake-paper-gateway.md
       - OKX dry-run: technical/okx-dry-run.md
       - Hyperliquid dry-run: technical/hyperliquid-dry-run.md
+      - Demo/Testnet safety envelope: technical/demo-testnet-safety-envelope.md
       - Exchange readiness consolidation: technical/exchange-readiness-consolidation.md
       - Exchange readiness matrix: technical/exchange-readiness-matrix.md
       - Exchange runtime gates: technical/exchange-runtime-gates.md

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyDecision.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyDecision.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+final readonly class DemoTradingSafetyDecision
+{
+    /**
+     * @param list<string> $blockingErrors
+     * @param list<string> $warnings
+     */
+    public function __construct(
+        public bool $allowed,
+        public DemoTradingSafetyLevel $level,
+        public array $blockingErrors,
+        public array $warnings,
+        public DemoTradingSafetyPolicy $policy,
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toRedactedArray(): array
+    {
+        return [
+            'allowed' => $this->allowed,
+            'level' => $this->level->value,
+            'blocking_errors' => $this->blockingErrors,
+            'warnings' => $this->warnings,
+            'policy' => $this->policy->toRedactedArray(),
+        ];
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyLevel.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyLevel.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+enum DemoTradingSafetyLevel: string
+{
+    case Blocked = 'blocked';
+    case LocalDryRun = 'local_dry_run';
+    case DemoTestnetCandidate = 'demo_testnet_candidate';
+    case DemoTestnetEnabled = 'demo_testnet_enabled';
+}

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
@@ -87,16 +87,19 @@ final readonly class DemoTradingSafetyPolicy
 
     private static function isSensitiveKey(string $key): bool
     {
-        $normalized = strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $key));
+        $normalized = trim((string) preg_replace('/[^a-z0-9]+/', '_', strtolower($key)), '_');
         $compacted = str_replace('_', '', $normalized);
 
-        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature'] as $needle) {
+        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature', 'authorization', 'cookie'] as $needle) {
             if (str_contains($normalized, $needle) || str_contains($compacted, str_replace('_', '', $needle))) {
                 return true;
             }
         }
 
-        return $normalized === 'key' || str_ends_with($normalized, '_key') || str_ends_with($compacted, 'key');
+        return $normalized === 'key'
+            || str_ends_with($normalized, '_key')
+            || str_ends_with($normalized, '_sign')
+            || str_ends_with($compacted, 'key');
     }
 
     private static function redact(mixed $value, ?string $key = null): mixed

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
@@ -87,15 +87,16 @@ final readonly class DemoTradingSafetyPolicy
 
     private static function isSensitiveKey(string $key): bool
     {
-        $normalized = strtolower($key);
+        $normalized = strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $key));
+        $compacted = str_replace('_', '', $normalized);
 
         foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature'] as $needle) {
-            if (str_contains($normalized, $needle)) {
+            if (str_contains($normalized, $needle) || str_contains($compacted, str_replace('_', '', $needle))) {
                 return true;
             }
         }
 
-        return $normalized === 'key' || str_ends_with($normalized, '_key');
+        return $normalized === 'key' || str_ends_with($normalized, '_key') || str_ends_with($compacted, 'key');
     }
 
     private static function redact(mixed $value, ?string $key = null): mixed

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
@@ -31,8 +31,8 @@ final readonly class DemoTradingSafetyPolicy
         public ?float $maxNotional = null,
         array $auditContext = [],
     ) {
-        if ($maxNotional !== null && $maxNotional <= 0.0) {
-            throw new \InvalidArgumentException('maxNotional must be positive when provided.');
+        if ($maxNotional !== null && (!is_finite($maxNotional) || $maxNotional <= 0.0)) {
+            throw new \InvalidArgumentException('maxNotional must be positive and finite when provided.');
         }
 
         $this->allowedSymbols = self::normalizeStringList($allowedSymbols, 'allowedSymbols');

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
@@ -14,6 +14,10 @@ final readonly class DemoTradingSafetyPolicy
     /** @var array<string,mixed> */
     public array $auditContext;
 
+    public ?string $requestedSymbol;
+
+    public ?string $requestedMarket;
+
     /**
      * @param list<string> $allowedSymbols
      * @param list<string> $allowedMarkets
@@ -29,14 +33,24 @@ final readonly class DemoTradingSafetyPolicy
         array $allowedSymbols = [],
         array $allowedMarkets = [],
         public ?float $maxNotional = null,
+        ?string $requestedSymbol = null,
+        ?string $requestedMarket = null,
+        public ?float $requestedNotional = null,
+        public ?bool $stopLossPresent = null,
         array $auditContext = [],
     ) {
         if ($maxNotional !== null && (!is_finite($maxNotional) || $maxNotional <= 0.0)) {
             throw new \InvalidArgumentException('maxNotional must be positive and finite when provided.');
         }
 
+        if ($requestedNotional !== null && (!is_finite($requestedNotional) || $requestedNotional <= 0.0)) {
+            throw new \InvalidArgumentException('requestedNotional must be positive and finite when provided.');
+        }
+
         $this->allowedSymbols = self::normalizeStringList($allowedSymbols, 'allowedSymbols');
         $this->allowedMarkets = self::normalizeStringList($allowedMarkets, 'allowedMarkets');
+        $this->requestedSymbol = self::normalizeNullableString($requestedSymbol);
+        $this->requestedMarket = self::normalizeNullableString($requestedMarket);
         $this->auditContext = $auditContext;
     }
 
@@ -60,6 +74,10 @@ final readonly class DemoTradingSafetyPolicy
             'allowed_symbols' => $this->allowedSymbols,
             'allowed_markets' => $this->allowedMarkets,
             'max_notional' => $this->maxNotional,
+            'requested_symbol' => $this->requestedSymbol,
+            'requested_market' => $this->requestedMarket,
+            'requested_notional' => $this->requestedNotional,
+            'stop_loss_present' => $this->stopLossPresent,
             'audit_context' => self::redact($this->auditContext),
         ];
     }
@@ -83,6 +101,17 @@ final readonly class DemoTradingSafetyPolicy
         }
 
         return array_values($normalized);
+    }
+
+    private static function normalizeNullableString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
     }
 
     private static function isSensitiveKey(string $key): bool

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+final readonly class DemoTradingSafetyPolicy
+{
+    /** @var list<string> */
+    public array $allowedSymbols;
+
+    /** @var list<string> */
+    public array $allowedMarkets;
+
+    /** @var array<string,mixed> */
+    public array $auditContext;
+
+    /**
+     * @param list<string> $allowedSymbols
+     * @param list<string> $allowedMarkets
+     * @param array<string,mixed> $auditContext
+     */
+    public function __construct(
+        public ExchangeRuntimeEnvironment $environment,
+        public bool $dryRun = true,
+        public bool $mainnetWriteEnabled = false,
+        public bool $demoTestnetWriteEnabled = false,
+        public bool $killSwitchEnabled = true,
+        public bool $requireStopLoss = true,
+        array $allowedSymbols = [],
+        array $allowedMarkets = [],
+        public ?float $maxNotional = null,
+        array $auditContext = [],
+    ) {
+        if ($maxNotional !== null && $maxNotional <= 0.0) {
+            throw new \InvalidArgumentException('maxNotional must be positive when provided.');
+        }
+
+        $this->allowedSymbols = self::normalizeStringList($allowedSymbols, 'allowedSymbols');
+        $this->allowedMarkets = self::normalizeStringList($allowedMarkets, 'allowedMarkets');
+        $this->auditContext = $auditContext;
+    }
+
+    public function isWriteRequested(): bool
+    {
+        return $this->dryRun === false;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toRedactedArray(): array
+    {
+        return [
+            'environment' => $this->environment->value,
+            'dry_run' => $this->dryRun,
+            'mainnet_write_enabled' => $this->mainnetWriteEnabled,
+            'demo_testnet_write_enabled' => $this->demoTestnetWriteEnabled,
+            'kill_switch_enabled' => $this->killSwitchEnabled,
+            'require_stop_loss' => $this->requireStopLoss,
+            'allowed_symbols' => $this->allowedSymbols,
+            'allowed_markets' => $this->allowedMarkets,
+            'max_notional' => $this->maxNotional,
+            'audit_context' => self::redact($this->auditContext),
+        ];
+    }
+
+    /**
+     * @param list<string> $values
+     * @return list<string>
+     */
+    private static function normalizeStringList(array $values, string $field): array
+    {
+        $normalized = [];
+        foreach ($values as $value) {
+            if (!is_string($value)) {
+                throw new \InvalidArgumentException(sprintf('%s must contain only strings.', $field));
+            }
+
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                $normalized[] = $trimmed;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    private static function isSensitiveKey(string $key): bool
+    {
+        $normalized = strtolower($key);
+
+        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature'] as $needle) {
+            if (str_contains($normalized, $needle)) {
+                return true;
+            }
+        }
+
+        return $normalized === 'key' || str_ends_with($normalized, '_key');
+    }
+
+    private static function redact(mixed $value, ?string $key = null): mixed
+    {
+        if ($key !== null && self::isSensitiveKey($key)) {
+            return '[redacted]';
+        }
+
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        $redacted = [];
+        foreach ($value as $childKey => $childValue) {
+            $redacted[$childKey] = self::redact(
+                $childValue,
+                is_string($childKey) ? $childKey : null,
+            );
+        }
+
+        return $redacted;
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicy.php
@@ -90,7 +90,7 @@ final readonly class DemoTradingSafetyPolicy
         $normalized = trim((string) preg_replace('/[^a-z0-9]+/', '_', strtolower($key)), '_');
         $compacted = str_replace('_', '', $normalized);
 
-        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature', 'authorization', 'cookie'] as $needle) {
+        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature', 'authorization', 'cookie', 'memo', 'credential'] as $needle) {
             if (str_contains($normalized, $needle) || str_contains($compacted, str_replace('_', '', $needle))) {
                 return true;
             }

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluator.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluator.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+final class DemoTradingSafetyPolicyEvaluator
+{
+    public function evaluate(DemoTradingSafetyPolicy $policy): DemoTradingSafetyDecision
+    {
+        $blockingErrors = [];
+        $warnings = [];
+
+        if ($policy->mainnetWriteEnabled) {
+            $blockingErrors[] = 'mainnet_write_enabled_must_remain_false';
+        }
+
+        if ($policy->environment === ExchangeRuntimeEnvironment::MAINNET && $policy->isWriteRequested()) {
+            $blockingErrors[] = 'mainnet_write_forbidden';
+        }
+
+        if ($policy->isWriteRequested()) {
+            if ($policy->environment === ExchangeRuntimeEnvironment::LOCAL_DRY_RUN) {
+                $blockingErrors[] = 'local_dry_run_cannot_write';
+            }
+
+            if ($policy->environment->isDemoOrTestnet()) {
+                $blockingErrors = array_merge($blockingErrors, $this->demoTestnetWriteErrors($policy));
+            }
+        }
+
+        if ($blockingErrors !== []) {
+            return new DemoTradingSafetyDecision(
+                allowed: false,
+                level: DemoTradingSafetyLevel::Blocked,
+                blockingErrors: array_values(array_unique($blockingErrors)),
+                warnings: $warnings,
+                policy: $policy,
+            );
+        }
+
+        if (!$policy->isWriteRequested()) {
+            if ($policy->environment->isDemoOrTestnet()) {
+                $warnings[] = 'dry_run_no_exchange_order';
+
+                return new DemoTradingSafetyDecision(
+                    allowed: true,
+                    level: DemoTradingSafetyLevel::DemoTestnetCandidate,
+                    blockingErrors: [],
+                    warnings: $warnings,
+                    policy: $policy,
+                );
+            }
+
+            return new DemoTradingSafetyDecision(
+                allowed: true,
+                level: DemoTradingSafetyLevel::LocalDryRun,
+                blockingErrors: [],
+                warnings: $warnings,
+                policy: $policy,
+            );
+        }
+
+        return new DemoTradingSafetyDecision(
+            allowed: true,
+            level: DemoTradingSafetyLevel::DemoTestnetEnabled,
+            blockingErrors: [],
+            warnings: $warnings,
+            policy: $policy,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function demoTestnetWriteErrors(DemoTradingSafetyPolicy $policy): array
+    {
+        $errors = [];
+
+        if (!$policy->demoTestnetWriteEnabled) {
+            $errors[] = 'demo_testnet_write_not_enabled';
+        }
+
+        if ($policy->killSwitchEnabled) {
+            $errors[] = 'kill_switch_enabled';
+        }
+
+        if (!$policy->requireStopLoss) {
+            $errors[] = 'stop_loss_required';
+        }
+
+        if ($policy->allowedSymbols === [] && $policy->allowedMarkets === []) {
+            $errors[] = 'allowed_symbols_or_markets_required';
+        }
+
+        if ($policy->maxNotional === null) {
+            $errors[] = 'max_notional_required';
+        }
+
+        return $errors;
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluator.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluator.php
@@ -94,8 +94,33 @@ final class DemoTradingSafetyPolicyEvaluator
 
         if ($policy->maxNotional === null) {
             $errors[] = 'max_notional_required';
+        } elseif ($policy->requestedNotional === null) {
+            $errors[] = 'requested_notional_required';
+        } elseif ($policy->requestedNotional > $policy->maxNotional) {
+            $errors[] = 'max_notional_exceeded';
+        }
+
+        if ($policy->requestedSymbol === null && $policy->requestedMarket === null) {
+            $errors[] = 'requested_symbol_or_market_required';
+        } elseif (!$this->matchesAllowedSymbolOrMarket($policy)) {
+            $errors[] = 'requested_symbol_or_market_not_allowed';
+        }
+
+        if ($policy->stopLossPresent === null) {
+            $errors[] = 'stop_loss_presence_required';
+        } elseif (!$policy->stopLossPresent) {
+            $errors[] = 'stop_loss_missing';
         }
 
         return $errors;
+    }
+
+    private function matchesAllowedSymbolOrMarket(DemoTradingSafetyPolicy $policy): bool
+    {
+        if ($policy->requestedSymbol !== null && in_array($policy->requestedSymbol, $policy->allowedSymbols, true)) {
+            return true;
+        }
+
+        return $policy->requestedMarket !== null && in_array($policy->requestedMarket, $policy->allowedMarkets, true);
     }
 }

--- a/trading-app/src/TradingCore/Execution/Safety/ExchangeRuntimeEnvironment.php
+++ b/trading-app/src/TradingCore/Execution/Safety/ExchangeRuntimeEnvironment.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+enum ExchangeRuntimeEnvironment: string
+{
+    case LOCAL_DRY_RUN = 'local_dry_run';
+    case DEMO = 'demo';
+    case TESTNET = 'testnet';
+    case MAINNET = 'mainnet';
+
+    public function isDemoOrTestnet(): bool
+    {
+        return $this === self::DEMO || $this === self::TESTNET;
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
@@ -1,0 +1,200 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution\Safety;
+
+use App\TradingCore\Execution\Safety\DemoTradingSafetyDecision;
+use App\TradingCore\Execution\Safety\DemoTradingSafetyLevel;
+use App\TradingCore\Execution\Safety\DemoTradingSafetyPolicy;
+use App\TradingCore\Execution\Safety\DemoTradingSafetyPolicyEvaluator;
+use App\TradingCore\Execution\Safety\ExchangeRuntimeEnvironment;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DemoTradingSafetyDecision::class)]
+#[CoversClass(DemoTradingSafetyLevel::class)]
+#[CoversClass(DemoTradingSafetyPolicy::class)]
+#[CoversClass(DemoTradingSafetyPolicyEvaluator::class)]
+#[CoversClass(ExchangeRuntimeEnvironment::class)]
+final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
+{
+    public function testMainnetWriteIsAlwaysBlockedEvenWhenFlagsAreEnabled(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(
+                environment: ExchangeRuntimeEnvironment::MAINNET,
+                mainnetWriteEnabled: true,
+                demoTestnetWriteEnabled: true,
+                killSwitchEnabled: false,
+            ),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::Blocked, $decision->level);
+        self::assertContains('mainnet_write_forbidden', $decision->blockingErrors);
+        self::assertContains('mainnet_write_enabled_must_remain_false', $decision->blockingErrors);
+    }
+
+    public function testMainnetWriteFlagIsBlockedEvenInDryRun(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            new DemoTradingSafetyPolicy(
+                environment: ExchangeRuntimeEnvironment::MAINNET,
+                mainnetWriteEnabled: true,
+            ),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::Blocked, $decision->level);
+        self::assertSame(['mainnet_write_enabled_must_remain_false'], $decision->blockingErrors);
+    }
+
+    public function testDemoWriteIsBlockedWhenKillSwitchIsActive(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(killSwitchEnabled: true),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::Blocked, $decision->level);
+        self::assertContains('kill_switch_enabled', $decision->blockingErrors);
+    }
+
+    public function testDemoWriteRequiresSymbolOrMarketWhitelist(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(
+                allowedSymbols: [],
+                allowedMarkets: [],
+                killSwitchEnabled: false,
+            ),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('allowed_symbols_or_markets_required', $decision->blockingErrors);
+    }
+
+    public function testDemoWriteRequiresMaxNotional(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(maxNotional: null, killSwitchEnabled: false),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('max_notional_required', $decision->blockingErrors);
+    }
+
+    public function testDemoWriteRequiresStopLoss(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(requireStopLoss: false, killSwitchEnabled: false),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('stop_loss_required', $decision->blockingErrors);
+    }
+
+    public function testDemoWriteRequiresExplicitDemoTestnetEnablement(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(demoTestnetWriteEnabled: false, killSwitchEnabled: false),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('demo_testnet_write_not_enabled', $decision->blockingErrors);
+    }
+
+    public function testLocalDryRunIsAllowedWithoutWritePrerequisites(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            new DemoTradingSafetyPolicy(
+                environment: ExchangeRuntimeEnvironment::LOCAL_DRY_RUN,
+            ),
+        );
+
+        self::assertTrue($decision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::LocalDryRun, $decision->level);
+        self::assertSame([], $decision->blockingErrors);
+    }
+
+    public function testTestnetDryRunIsADemoTestnetCandidateWithoutExchangeOrder(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            new DemoTradingSafetyPolicy(
+                environment: ExchangeRuntimeEnvironment::TESTNET,
+            ),
+        );
+
+        self::assertTrue($decision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::DemoTestnetCandidate, $decision->level);
+        self::assertSame(['dry_run_no_exchange_order'], $decision->warnings);
+    }
+
+    public function testDemoWriteCanReachEnabledLevelWhenAllGuardsPass(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(killSwitchEnabled: false),
+        );
+
+        self::assertTrue($decision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::DemoTestnetEnabled, $decision->level);
+        self::assertSame([], $decision->blockingErrors);
+    }
+
+    public function testSensitiveAuditFieldsAreRedacted(): void
+    {
+        $policy = $this->writePolicy(
+            killSwitchEnabled: false,
+            auditContext: [
+                'OKX_DEMO_API_KEY' => 'demo-key',
+                'passphrase' => 'demo-passphrase',
+                'nested' => [
+                    'private_key' => 'wallet-secret',
+                    'safe_value' => 'visible',
+                ],
+            ],
+        );
+
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate($policy);
+        $redacted = $decision->toRedactedArray();
+
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['OKX_DEMO_API_KEY']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['passphrase']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['private_key']);
+        self::assertSame('visible', $redacted['policy']['audit_context']['nested']['safe_value']);
+
+        $encoded = json_encode($redacted, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('demo-key', $encoded);
+        self::assertStringNotContainsString('wallet-secret', $encoded);
+    }
+
+    /**
+     * @param list<string> $allowedSymbols
+     * @param list<string> $allowedMarkets
+     * @param array<string,mixed> $auditContext
+     */
+    private function writePolicy(
+        ExchangeRuntimeEnvironment $environment = ExchangeRuntimeEnvironment::DEMO,
+        bool $mainnetWriteEnabled = false,
+        bool $demoTestnetWriteEnabled = true,
+        bool $killSwitchEnabled = true,
+        bool $requireStopLoss = true,
+        array $allowedSymbols = ['BTCUSDT'],
+        array $allowedMarkets = [],
+        ?float $maxNotional = 25.0,
+        array $auditContext = [],
+    ): DemoTradingSafetyPolicy {
+        return new DemoTradingSafetyPolicy(
+            environment: $environment,
+            dryRun: false,
+            mainnetWriteEnabled: $mainnetWriteEnabled,
+            demoTestnetWriteEnabled: $demoTestnetWriteEnabled,
+            killSwitchEnabled: $killSwitchEnabled,
+            requireStopLoss: $requireStopLoss,
+            allowedSymbols: $allowedSymbols,
+            allowedMarkets: $allowedMarkets,
+            maxNotional: $maxNotional,
+            auditContext: $auditContext,
+        );
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
@@ -163,6 +163,65 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
         self::assertSame([], $decision->blockingErrors);
     }
 
+    public function testDemoWriteBlocksRequestedSymbolOutsideWhitelist(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(
+                killSwitchEnabled: false,
+                requestedSymbol: 'ETHUSDT',
+            ),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('requested_symbol_or_market_not_allowed', $decision->blockingErrors);
+    }
+
+    public function testDemoWriteBlocksRequestedNotionalAboveCap(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(
+                killSwitchEnabled: false,
+                requestedNotional: 25.01,
+            ),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('max_notional_exceeded', $decision->blockingErrors);
+    }
+
+    public function testDemoWriteBlocksMissingConcreteStopLoss(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            $this->writePolicy(
+                killSwitchEnabled: false,
+                stopLossPresent: false,
+            ),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('stop_loss_missing', $decision->blockingErrors);
+    }
+
+    public function testDemoWriteRequiresConcreteOrderBeforeEnabled(): void
+    {
+        $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(
+            new DemoTradingSafetyPolicy(
+                environment: ExchangeRuntimeEnvironment::DEMO,
+                dryRun: false,
+                demoTestnetWriteEnabled: true,
+                killSwitchEnabled: false,
+                allowedSymbols: ['BTCUSDT'],
+                maxNotional: 25.0,
+            ),
+        );
+
+        self::assertFalse($decision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::Blocked, $decision->level);
+        self::assertContains('requested_symbol_or_market_required', $decision->blockingErrors);
+        self::assertContains('requested_notional_required', $decision->blockingErrors);
+        self::assertContains('stop_loss_presence_required', $decision->blockingErrors);
+    }
+
     public function testSensitiveAuditFieldsAreRedacted(): void
     {
         $policy = $this->writePolicy(
@@ -228,6 +287,10 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
         array $allowedSymbols = ['BTCUSDT'],
         array $allowedMarkets = [],
         ?float $maxNotional = 25.0,
+        ?string $requestedSymbol = 'BTCUSDT',
+        ?string $requestedMarket = null,
+        ?float $requestedNotional = 25.0,
+        ?bool $stopLossPresent = true,
         array $auditContext = [],
     ): DemoTradingSafetyPolicy {
         return new DemoTradingSafetyPolicy(
@@ -240,6 +303,10 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
             allowedSymbols: $allowedSymbols,
             allowedMarkets: $allowedMarkets,
             maxNotional: $maxNotional,
+            requestedSymbol: $requestedSymbol,
+            requestedMarket: $requestedMarket,
+            requestedNotional: $requestedNotional,
+            stopLossPresent: $stopLossPresent,
             auditContext: $auditContext,
         );
     }

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
@@ -150,6 +150,8 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
                 'passphrase' => 'demo-passphrase',
                 'nested' => [
                     'private_key' => 'wallet-secret',
+                    'apiKey' => 'camel-api-key',
+                    'privateKey' => 'camel-private-key',
                     'safe_value' => 'visible',
                 ],
             ],
@@ -161,11 +163,15 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['OKX_DEMO_API_KEY']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['passphrase']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['private_key']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['apiKey']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['privateKey']);
         self::assertSame('visible', $redacted['policy']['audit_context']['nested']['safe_value']);
 
         $encoded = json_encode($redacted, JSON_THROW_ON_ERROR);
         self::assertStringNotContainsString('demo-key', $encoded);
         self::assertStringNotContainsString('wallet-secret', $encoded);
+        self::assertStringNotContainsString('camel-api-key', $encoded);
+        self::assertStringNotContainsString('camel-private-key', $encoded);
     }
 
     /**

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
@@ -84,6 +84,28 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
         self::assertContains('max_notional_required', $decision->blockingErrors);
     }
 
+    public function testMaxNotionalMustBeFinite(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxNotional must be positive and finite when provided.');
+
+        new DemoTradingSafetyPolicy(
+            environment: ExchangeRuntimeEnvironment::DEMO,
+            maxNotional: NAN,
+        );
+    }
+
+    public function testMaxNotionalCannotBeInfinite(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxNotional must be positive and finite when provided.');
+
+        new DemoTradingSafetyPolicy(
+            environment: ExchangeRuntimeEnvironment::DEMO,
+            maxNotional: INF,
+        );
+    }
+
     public function testDemoWriteRequiresStopLoss(): void
     {
         $decision = (new DemoTradingSafetyPolicyEvaluator())->evaluate(

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
@@ -174,6 +174,8 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
                 'Cookie' => 'session=demo-cookie',
                 'OK-ACCESS-SIGN' => 'okx-signature',
                 'X-BM-SIGN' => 'bitmart-signature',
+                'BITMART_API_MEMO' => 'bitmart-memo',
+                'credentials' => 'serialized-credentials',
                 'nested' => [
                     'private_key' => 'wallet-secret',
                     'apiKey' => 'camel-api-key',
@@ -192,6 +194,8 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['Cookie']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['OK-ACCESS-SIGN']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['X-BM-SIGN']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['BITMART_API_MEMO']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['credentials']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['private_key']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['apiKey']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['privateKey']);
@@ -206,6 +210,8 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
         self::assertStringNotContainsString('session=demo-cookie', $encoded);
         self::assertStringNotContainsString('okx-signature', $encoded);
         self::assertStringNotContainsString('bitmart-signature', $encoded);
+        self::assertStringNotContainsString('bitmart-memo', $encoded);
+        self::assertStringNotContainsString('serialized-credentials', $encoded);
     }
 
     /**

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
@@ -148,6 +148,10 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
             auditContext: [
                 'OKX_DEMO_API_KEY' => 'demo-key',
                 'passphrase' => 'demo-passphrase',
+                'Authorization' => 'Bearer demo-token',
+                'Cookie' => 'session=demo-cookie',
+                'OK-ACCESS-SIGN' => 'okx-signature',
+                'X-BM-SIGN' => 'bitmart-signature',
                 'nested' => [
                     'private_key' => 'wallet-secret',
                     'apiKey' => 'camel-api-key',
@@ -162,6 +166,10 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
 
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['OKX_DEMO_API_KEY']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['passphrase']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['Authorization']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['Cookie']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['OK-ACCESS-SIGN']);
+        self::assertSame('[redacted]', $redacted['policy']['audit_context']['X-BM-SIGN']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['private_key']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['apiKey']);
         self::assertSame('[redacted]', $redacted['policy']['audit_context']['nested']['privateKey']);
@@ -172,6 +180,10 @@ final class DemoTradingSafetyPolicyEvaluatorTest extends TestCase
         self::assertStringNotContainsString('wallet-secret', $encoded);
         self::assertStringNotContainsString('camel-api-key', $encoded);
         self::assertStringNotContainsString('camel-private-key', $encoded);
+        self::assertStringNotContainsString('Bearer demo-token', $encoded);
+        self::assertStringNotContainsString('session=demo-cookie', $encoded);
+        self::assertStringNotContainsString('okx-signature', $encoded);
+        self::assertStringNotContainsString('bitmart-signature', $encoded);
     }
 
     /**


### PR DESCRIPTION
COMMON-001

## Summary
- add an explicit ExchangeRuntimeEnvironment enum for local dry-run, demo, testnet, and mainnet
- add a pure DemoTradingSafetyPolicy evaluator with blocked/local_dry_run/demo_testnet_candidate/demo_testnet_enabled decisions
- require explicit demo/testnet activation, symbol or market whitelist, max_notional, stop-loss requirement, and default kill switch before any demo/testnet write
- keep mainnet writes impossible through this policy by blocking mainnet_write_enabled and mainnet dry_run=false requests
- add redacted decision serialization and documentation for the demo/testnet safety envelope

## Safety
- no exchange call
- no runtime wiring
- no strategy, EntryZone, risk/leverage, SL/TP, MTF, Messenger, or Temporal change
- no real secrets in code, tests, fixtures, or docs
- “live demo” is documented as demo/testnet only, never mainnet

## Tests
- vendor/bin/phpunit tests/TradingCore/Execution/Safety/DemoTradingSafetyPolicyEvaluatorTest.php
- vendor/bin/phpstan analyse src/TradingCore/Execution/Safety tests/TradingCore/Execution/Safety --memory-limit=1G
- php bin/console lint:container --no-debug
- php bin/console lint:yaml config
- python3 -m mkdocs build --strict
- git diff --check

Note: lint:container returns OK, while emitting existing PHP 8.4 deprecation traces from EntryZoneStatsCommand unrelated to this PR.