### PR TITLE
COMMON-002 effective exchange runtime config

### DIFF
--- a/docs/handbook/technical/effective-trading-config-resolver.md
+++ b/docs/handbook/technical/effective-trading-config-resolver.md
@@ -102,11 +102,21 @@ Paires supportees par COMMON-002 :
 - `exchange=okx&env=demo` ;
 - `exchange=hyperliquid&env=testnet`.
 
+Modes supportes par l'API COMMON-002 :
+
+- `regular` ;
+- `scalper` ;
+- `scalper_micro`.
+
 Les paires croisees comme `exchange=okx&env=testnet` ou
 `exchange=hyperliquid&env=demo` sont refusees avant resolution pour eviter une
 config effective incoherente. Les exchanges inconnus et Bitmart via cet endpoint
 sont egalement refuses : Bitmart reste legacy et n'est pas re-route par l'API
 COMMON-002.
+
+Les modes inconnus sont refuses avant resolution. Les couches `mode/*` restent
+optionnelles pour le resolver bas niveau, mais l'API ne doit pas transformer une
+typo comme `scalperr` en config effective valide.
 
 L'API ne modifie aucun etat et ne contacte aucun exchange.
 

--- a/docs/handbook/technical/effective-trading-config-resolver.md
+++ b/docs/handbook/technical/effective-trading-config-resolver.md
@@ -104,7 +104,9 @@ Paires supportees par COMMON-002 :
 
 Les paires croisees comme `exchange=okx&env=testnet` ou
 `exchange=hyperliquid&env=demo` sont refusees avant resolution pour eviter une
-config effective incoherente.
+config effective incoherente. Les exchanges inconnus et Bitmart via cet endpoint
+sont egalement refuses : Bitmart reste legacy et n'est pas re-route par l'API
+COMMON-002.
 
 L'API ne modifie aucun etat et ne contacte aucun exchange.
 

--- a/docs/handbook/technical/effective-trading-config-resolver.md
+++ b/docs/handbook/technical/effective-trading-config-resolver.md
@@ -27,12 +27,20 @@ config/trading/env/dev.yaml
 
 ## Statut runtime
 
-Cette PR ne branche pas encore le resolver sur `mtf:run`, `POST /api/mtf/run`, TradeEntry, Temporal ou les gateways exchange.
+COMMON-002 ne branche pas encore le resolver sur `mtf:run`, `POST /api/mtf/run`,
+TradeEntry, Temporal ou les gateways exchange.
 
-Les fichiers sous `trading-app/config/trading/` sont des references inactives. Ils documentent la cible et gardent les protections suivantes :
+Les fichiers sous `trading-app/config/trading/` sont des references inactives. Ils
+documentent la cible et gardent les protections suivantes :
 
 - `dry_run: true` ;
 - `live_enabled: false` ;
+- `mainnet_write_enabled: false` ;
+- `demo_testnet_write_enabled: false` par defaut ;
+- `kill_switch_enabled: true` ;
+- `require_stop_loss: true` ;
+- `allowed_symbols` ou `allowed_markets` renseigne pour OKX demo et Hyperliquid testnet ;
+- `max_notional` renseigne ;
 - `runtime_check_required: true` pour OKX et Hyperliquid ;
 - Bitmart reste marque legacy tant que le runtime actuel en depend.
 
@@ -45,6 +53,83 @@ Les fichiers sous `trading-app/config/trading/` sont des references inactives. I
 - `env/{env}.yaml` est optionnel.
 
 Une couche optionnelle absente est ignoree et exposee dans `missing_optional_layers`. Une couche obligatoire absente leve `TradingConfigException`.
+
+Les couches demo/testnet ajoutees par COMMON-002 sont :
+
+- `env/demo.yaml` ;
+- `env/testnet.yaml` ;
+- `exchange/okx.yaml` ;
+- `exchange/hyperliquid.yaml` ;
+- `mode_exchange/{regular,scalper,scalper_micro}.okx.yaml` ;
+- `mode_exchange/{regular,scalper,scalper_micro}.hyperliquid.yaml`.
+
+Les secrets ne sont pas stockes dans ces fichiers. Les credentials demo/testnet
+restent des variables d'environnement dediees et ne sont pas serialisees dans la
+config effective.
+
+## API read-only
+
+COMMON-002 expose une surface read-only pour inspecter la config effective :
+
+```bash
+curl 'http://localhost:8082/api/trading/config/effective?mode=scalper&exchange=okx&env=demo'
+```
+
+Exemple Hyperliquid testnet :
+
+```bash
+curl 'http://localhost:8082/api/trading/config/effective?mode=scalper&exchange=hyperliquid&env=testnet'
+```
+
+La reponse contient :
+
+- `request` : couple `mode`, `exchange`, `env` demande ;
+- `config` : configuration effective resolue ;
+- `config_hash` : hash SHA-256 stable de la config normalisee ;
+- `layers` : couches utilisees dans l'ordre ;
+- `missing_optional_layers` : couches optionnelles absentes ;
+- `provenance` : provenance par chemin de valeur, par exemple
+  `trading.execution.max_notional`.
+
+Erreurs structurees :
+
+- `400 missing_query_parameter` si `mode`, `exchange` ou `env` manque ;
+- `400 invalid_config_request` si une couche est invalide ou non parseable.
+
+L'API ne modifie aucun etat et ne contacte aucun exchange.
+
+Le viewer Effective Config reste un follow-up separe : aucune integration runtime
+ou front n'est activee dans COMMON-002.
+
+## Exemples de resolution
+
+OKX demo scalper :
+
+```text
+base
+< mode/scalper
+< exchange/okx
+< mode_exchange/scalper.okx
+< env/demo
+= trading.environment: demo
+= trading.execution.mainnet_write_enabled: false
+= trading.execution.demo_testnet_write_enabled: false
+= trading.execution.kill_switch_enabled: true
+```
+
+Hyperliquid testnet scalper :
+
+```text
+base
+< mode/scalper
+< exchange/hyperliquid
+< mode_exchange/scalper.hyperliquid
+< env/testnet
+= trading.environment: testnet
+= trading.execution.mainnet_write_enabled: false
+= trading.execution.demo_testnet_write_enabled: false
+= trading.execution.kill_switch_enabled: true
+```
 
 ## YAML historiques actuellement utilises
 

--- a/docs/handbook/technical/effective-trading-config-resolver.md
+++ b/docs/handbook/technical/effective-trading-config-resolver.md
@@ -94,7 +94,17 @@ La reponse contient :
 Erreurs structurees :
 
 - `400 missing_query_parameter` si `mode`, `exchange` ou `env` manque ;
-- `400 invalid_config_request` si une couche est invalide ou non parseable.
+- `400 invalid_config_request` si une couche est invalide, non parseable ou si
+  la paire `exchange/env` est interdite.
+
+Paires supportees par COMMON-002 :
+
+- `exchange=okx&env=demo` ;
+- `exchange=hyperliquid&env=testnet`.
+
+Les paires croisees comme `exchange=okx&env=testnet` ou
+`exchange=hyperliquid&env=demo` sont refusees avant resolution pour eviter une
+config effective incoherente.
 
 L'API ne modifie aucun etat et ne contacte aucun exchange.
 

--- a/trading-app/config/trading/base.yaml
+++ b/trading-app/config/trading/base.yaml
@@ -4,14 +4,30 @@ trading:
   config_schema: effective_trading_config.v1
   runtime_status: inactive_reference
   exchange: fake
+  environment: local_dry_run
   market_type: perpetual
+  account_mode: local
+  margin_mode: isolated
+  rate_limit_profile:
+    name: local_reference
+    max_requests_per_second: 0
+  retry_policy:
+    max_attempts: 1
+    backoff_ms: 0
   execution:
     dry_run: true
     live_enabled: false
     runtime_check_required: true
+    mainnet_write_enabled: false
+    demo_testnet_write_enabled: false
+    allowed_symbols: []
+    allowed_markets: []
+    max_notional: null
+    kill_switch_enabled: true
     require_stop_loss: true
   risk:
     source: legacy_runtime_config
+    max_leverage_cap: 1
   leverage:
     policy: derived_from_risk_and_stop
   entry_zone:

--- a/trading-app/config/trading/env/demo.yaml
+++ b/trading-app/config/trading/env/demo.yaml
@@ -1,0 +1,13 @@
+version: '0.1.0-effective-config-demo-testnet'
+
+trading:
+  env: demo
+  environment: demo
+  execution:
+    dry_run: true
+    live_enabled: false
+    mainnet_write_enabled: false
+    demo_testnet_write_enabled: false
+    kill_switch_enabled: true
+    require_stop_loss: true
+

--- a/trading-app/config/trading/env/testnet.yaml
+++ b/trading-app/config/trading/env/testnet.yaml
@@ -1,0 +1,13 @@
+version: '0.1.0-effective-config-demo-testnet'
+
+trading:
+  env: testnet
+  environment: testnet
+  execution:
+    dry_run: true
+    live_enabled: false
+    mainnet_write_enabled: false
+    demo_testnet_write_enabled: false
+    kill_switch_enabled: true
+    require_stop_loss: true
+

--- a/trading-app/config/trading/exchange/hyperliquid.yaml
+++ b/trading-app/config/trading/exchange/hyperliquid.yaml
@@ -2,17 +2,33 @@ version: '0.1.0-effective-config-bootstrap'
 
 trading:
   exchange: hyperliquid
+  environment: testnet
   exchange_status: dry_run_runtime_check_only
+  account_mode: testnet
+  margin_mode: cross
+  rate_limit_profile:
+    name: hyperliquid_testnet_conservative
+    max_requests_per_second: 5
+  retry_policy:
+    max_attempts: 2
+    backoff_ms: 250
   execution:
     dry_run: true
     live_enabled: false
     runtime_check_required: true
+    mainnet_write_enabled: false
+    demo_testnet_write_enabled: false
+    allowed_symbols:
+      - BTCUSDT
+      - ETHUSDT
+    allowed_markets:
+      - perpetual
+    max_notional: 25.0
+    kill_switch_enabled: true
+    require_stop_loss: true
+  risk:
+    max_leverage_cap: 3
 
 compatibility:
-  env_template_keys:
-    - HYPERLIQUID_ENV
-    - HYPERLIQUID_PRIVATE_KEY
-    - HYPERLIQUID_ACCOUNT_ADDRESS
-    - HYPERLIQUID_API_BASE_URI
-    - HYPERLIQUID_WS_URI
-    - HYPERLIQUID_MAINNET_ENABLED
+  credential_scope: testnet_agent_wallet_only
+  secrets_external_only: true

--- a/trading-app/config/trading/exchange/okx.yaml
+++ b/trading-app/config/trading/exchange/okx.yaml
@@ -2,20 +2,34 @@ version: '0.1.0-effective-config-bootstrap'
 
 trading:
   exchange: okx
+  environment: demo
   exchange_status: dry_run_runtime_check_only
+  account_mode: demo
+  margin_mode: cross
+  rate_limit_profile:
+    name: okx_demo_conservative
+    max_requests_per_second: 5
+  retry_policy:
+    max_attempts: 2
+    backoff_ms: 250
   execution:
     dry_run: true
     live_enabled: false
     runtime_check_required: true
+    mainnet_write_enabled: false
+    demo_testnet_write_enabled: false
+    allowed_symbols:
+      - BTCUSDT
+      - ETHUSDT
+    allowed_markets:
+      - perpetual
+    max_notional: 25.0
+    kill_switch_enabled: true
+    require_stop_loss: true
+  risk:
+    max_leverage_cap: 3
 
 compatibility:
-  env_template_keys:
-    - OKX_ENV
-    - OKX_API_KEY
-    - OKX_API_SECRET
-    - OKX_API_PASSPHRASE
-    - OKX_API_BASE_URI
-    - OKX_WS_PUBLIC_URI
-    - OKX_WS_PRIVATE_URI
-    - OKX_DEMO_TRADING_ENABLED
-    - OKX_LIVE_ENABLED
+  credential_scope: demo_only
+  required_header: x-simulated-trading
+  secrets_external_only: true

--- a/trading-app/config/trading/mode_exchange/regular.hyperliquid.yaml
+++ b/trading-app/config/trading/mode_exchange/regular.hyperliquid.yaml
@@ -1,8 +1,8 @@
-version: '0.1.0-effective-config-bootstrap'
+version: '0.1.0-effective-config-demo-testnet'
 
 trading:
-  profile: scalper
-  exchange: okx
+  profile: regular
+  exchange: hyperliquid
   execution:
     dry_run: true
     live_enabled: false
@@ -11,14 +11,14 @@ trading:
     demo_testnet_write_enabled: false
     allowed_symbols:
       - BTCUSDT
-      - ETHUSDT
     allowed_markets:
       - perpetual
-    max_notional: 25.0
+    max_notional: 20.0
     kill_switch_enabled: true
     require_stop_loss: true
   risk:
-    max_leverage_cap: 3
+    max_leverage_cap: 2
 
 compatibility:
   reason: future_profile_exchange_override_placeholder
+

--- a/trading-app/config/trading/mode_exchange/regular.okx.yaml
+++ b/trading-app/config/trading/mode_exchange/regular.okx.yaml
@@ -1,7 +1,7 @@
-version: '0.1.0-effective-config-bootstrap'
+version: '0.1.0-effective-config-demo-testnet'
 
 trading:
-  profile: scalper
+  profile: regular
   exchange: okx
   execution:
     dry_run: true
@@ -11,14 +11,14 @@ trading:
     demo_testnet_write_enabled: false
     allowed_symbols:
       - BTCUSDT
-      - ETHUSDT
     allowed_markets:
       - perpetual
-    max_notional: 25.0
+    max_notional: 20.0
     kill_switch_enabled: true
     require_stop_loss: true
   risk:
-    max_leverage_cap: 3
+    max_leverage_cap: 2
 
 compatibility:
   reason: future_profile_exchange_override_placeholder
+

--- a/trading-app/config/trading/mode_exchange/scalper.hyperliquid.yaml
+++ b/trading-app/config/trading/mode_exchange/scalper.hyperliquid.yaml
@@ -1,8 +1,8 @@
-version: '0.1.0-effective-config-bootstrap'
+version: '0.1.0-effective-config-demo-testnet'
 
 trading:
   profile: scalper
-  exchange: okx
+  exchange: hyperliquid
   execution:
     dry_run: true
     live_enabled: false
@@ -22,3 +22,4 @@ trading:
 
 compatibility:
   reason: future_profile_exchange_override_placeholder
+

--- a/trading-app/config/trading/mode_exchange/scalper_micro.hyperliquid.yaml
+++ b/trading-app/config/trading/mode_exchange/scalper_micro.hyperliquid.yaml
@@ -1,8 +1,8 @@
-version: '0.1.0-effective-config-bootstrap'
+version: '0.1.0-effective-config-demo-testnet'
 
 trading:
-  profile: scalper
-  exchange: okx
+  profile: scalper_micro
+  exchange: hyperliquid
   execution:
     dry_run: true
     live_enabled: false
@@ -11,14 +11,14 @@ trading:
     demo_testnet_write_enabled: false
     allowed_symbols:
       - BTCUSDT
-      - ETHUSDT
     allowed_markets:
       - perpetual
-    max_notional: 25.0
+    max_notional: 10.0
     kill_switch_enabled: true
     require_stop_loss: true
   risk:
-    max_leverage_cap: 3
+    max_leverage_cap: 2
 
 compatibility:
   reason: future_profile_exchange_override_placeholder
+

--- a/trading-app/config/trading/mode_exchange/scalper_micro.okx.yaml
+++ b/trading-app/config/trading/mode_exchange/scalper_micro.okx.yaml
@@ -1,7 +1,7 @@
-version: '0.1.0-effective-config-bootstrap'
+version: '0.1.0-effective-config-demo-testnet'
 
 trading:
-  profile: scalper
+  profile: scalper_micro
   exchange: okx
   execution:
     dry_run: true
@@ -11,14 +11,14 @@ trading:
     demo_testnet_write_enabled: false
     allowed_symbols:
       - BTCUSDT
-      - ETHUSDT
     allowed_markets:
       - perpetual
-    max_notional: 25.0
+    max_notional: 10.0
     kill_switch_enabled: true
     require_stop_loss: true
   risk:
-    max_leverage_cap: 3
+    max_leverage_cap: 2
 
 compatibility:
   reason: future_profile_exchange_override_placeholder
+

--- a/trading-app/src/Trading/Controller/Api/EffectiveTradingConfigApiController.php
+++ b/trading-app/src/Trading/Controller/Api/EffectiveTradingConfigApiController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Trading\Controller\Api;
+
+use App\TradingCore\Config\EffectiveTradingConfigReadService;
+use App\TradingCore\Config\Exception\TradingConfigException;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class EffectiveTradingConfigApiController extends AbstractController
+{
+    public function __construct(
+        private readonly EffectiveTradingConfigReadService $readService,
+    ) {
+    }
+
+    #[Route('/api/trading/config/effective', name: 'api_trading_config_effective', methods: ['GET'])]
+    public function effective(Request $request): JsonResponse
+    {
+        $mode = $this->requiredQueryString($request, 'mode');
+        $exchange = $this->requiredQueryString($request, 'exchange');
+        $env = $this->requiredQueryString($request, 'env');
+
+        $missing = [];
+        foreach (['mode' => $mode, 'exchange' => $exchange, 'env' => $env] as $name => $value) {
+            if ($value === null) {
+                $missing[] = $name;
+            }
+        }
+
+        if ($missing !== []) {
+            return $this->json([
+                'error' => [
+                    'code' => 'missing_query_parameter',
+                    'message' => 'Query parameters "mode", "exchange" and "env" are required.',
+                    'missing' => $missing,
+                ],
+            ], Response::HTTP_BAD_REQUEST);
+        }
+
+        try {
+            return $this->json($this->readService->describe($mode, $exchange, $env));
+        } catch (TradingConfigException $exception) {
+            return $this->json([
+                'error' => [
+                    'code' => 'invalid_config_request',
+                    'message' => $exception->getMessage(),
+                ],
+            ], Response::HTTP_BAD_REQUEST);
+        }
+    }
+
+    private function requiredQueryString(Request $request, string $name): ?string
+    {
+        $value = $request->query->get($name);
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
+++ b/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
@@ -25,6 +25,10 @@ final readonly class EffectiveTradingConfigReadService
      */
     public function describe(string $mode, string $exchange, string $env): array
     {
+        $this->assertSafeLayerName('mode', $mode);
+        $this->assertSafeLayerName('exchange', $exchange);
+        $this->assertSafeLayerName('env', $env);
+        $this->assertSupportedMode($mode);
         $this->assertSupportedExchangeEnvironment($exchange, $env);
 
         $resolved = $this->resolver->resolve($mode, $exchange, $env);
@@ -43,6 +47,15 @@ final readonly class EffectiveTradingConfigReadService
         ];
     }
 
+    private function assertSupportedMode(string $mode): void
+    {
+        if (in_array($mode, ['regular', 'scalper', 'scalper_micro'], true)) {
+            return;
+        }
+
+        throw new TradingConfigException('Unsupported trading mode: COMMON-002 supports only regular, scalper and scalper_micro.');
+    }
+
     private function assertSupportedExchangeEnvironment(string $exchange, string $env): void
     {
         if (($exchange === 'okx' && $env === 'demo') || ($exchange === 'hyperliquid' && $env === 'testnet')) {
@@ -50,5 +63,18 @@ final readonly class EffectiveTradingConfigReadService
         }
 
         throw new TradingConfigException('Unsupported exchange/env pair: COMMON-002 supports only okx/demo and hyperliquid/testnet.');
+    }
+
+    private function assertSafeLayerName(string $type, string $name): void
+    {
+        if (preg_match('/^[a-z0-9][a-z0-9_-]*$/', $name) === 1) {
+            return;
+        }
+
+        throw new TradingConfigException(sprintf(
+            'Invalid trading config layer name for "%s": "%s"',
+            $type,
+            $name,
+        ));
     }
 }

--- a/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
+++ b/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\TradingCore\Config;
 
+use App\TradingCore\Config\Exception\TradingConfigException;
+
 final readonly class EffectiveTradingConfigReadService
 {
     public function __construct(
@@ -23,6 +25,8 @@ final readonly class EffectiveTradingConfigReadService
      */
     public function describe(string $mode, string $exchange, string $env): array
     {
+        $this->assertSupportedExchangeEnvironment($exchange, $env);
+
         $resolved = $this->resolver->resolve($mode, $exchange, $env);
 
         return [
@@ -37,5 +41,16 @@ final readonly class EffectiveTradingConfigReadService
             'missing_optional_layers' => $resolved['missing_optional_layers'],
             'provenance' => $resolved['provenance'],
         ];
+    }
+
+    private function assertSupportedExchangeEnvironment(string $exchange, string $env): void
+    {
+        if ($exchange === 'okx' && $env !== 'demo') {
+            throw new TradingConfigException('Unsupported exchange/env pair: OKX is available only with env=demo in this series.');
+        }
+
+        if ($exchange === 'hyperliquid' && $env !== 'testnet') {
+            throw new TradingConfigException('Unsupported exchange/env pair: Hyperliquid is available only with env=testnet in this series.');
+        }
     }
 }

--- a/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
+++ b/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
@@ -45,12 +45,10 @@ final readonly class EffectiveTradingConfigReadService
 
     private function assertSupportedExchangeEnvironment(string $exchange, string $env): void
     {
-        if ($exchange === 'okx' && $env !== 'demo') {
-            throw new TradingConfigException('Unsupported exchange/env pair: OKX is available only with env=demo in this series.');
+        if (($exchange === 'okx' && $env === 'demo') || ($exchange === 'hyperliquid' && $env === 'testnet')) {
+            return;
         }
 
-        if ($exchange === 'hyperliquid' && $env !== 'testnet') {
-            throw new TradingConfigException('Unsupported exchange/env pair: Hyperliquid is available only with env=testnet in this series.');
-        }
+        throw new TradingConfigException('Unsupported exchange/env pair: COMMON-002 supports only okx/demo and hyperliquid/testnet.');
     }
 }

--- a/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
+++ b/trading-app/src/TradingCore/Config/EffectiveTradingConfigReadService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TradingCore\Config;
+
+final readonly class EffectiveTradingConfigReadService
+{
+    public function __construct(
+        private EffectiveTradingConfigResolver $resolver,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     request: array{mode: string, exchange: string, env: string},
+     *     config: array<string, mixed>,
+     *     config_hash: string,
+     *     layers: list<array{type: string, name: string, path: string, required: bool}>,
+     *     missing_optional_layers: list<array{type: string, name: string, path: string, required: bool}>,
+     *     provenance: array<string, array{type: string, name: string, path: string, required: bool}>
+     * }
+     */
+    public function describe(string $mode, string $exchange, string $env): array
+    {
+        $resolved = $this->resolver->resolve($mode, $exchange, $env);
+
+        return [
+            'request' => [
+                'mode' => $mode,
+                'exchange' => $exchange,
+                'env' => $env,
+            ],
+            'config' => $resolved['config'],
+            'config_hash' => $resolved['config_hash'],
+            'layers' => $resolved['layers'],
+            'missing_optional_layers' => $resolved['missing_optional_layers'],
+            'provenance' => $resolved['provenance'],
+        ];
+    }
+}

--- a/trading-app/src/TradingCore/Config/EffectiveTradingConfigResolver.php
+++ b/trading-app/src/TradingCore/Config/EffectiveTradingConfigResolver.php
@@ -102,10 +102,25 @@ final readonly class EffectiveTradingConfigResolver
             }
 
             $base[$key] = $value;
+            $this->clearProvenanceForPath($provenance, $path);
             $this->recordProvenance($provenance, $path, $value, $layerContext);
         }
 
         return $base;
+    }
+
+    /**
+     * @param array<string, array{type: string, name: string, path: string, required: bool}> $provenance
+     */
+    private function clearProvenanceForPath(array &$provenance, string $path): void
+    {
+        unset($provenance[$path]);
+        $prefix = $path . '.';
+        foreach (array_keys($provenance) as $existingPath) {
+            if (str_starts_with($existingPath, $prefix)) {
+                unset($provenance[$existingPath]);
+            }
+        }
     }
 
     /**

--- a/trading-app/src/TradingCore/Config/EffectiveTradingConfigResolver.php
+++ b/trading-app/src/TradingCore/Config/EffectiveTradingConfigResolver.php
@@ -20,8 +20,10 @@ final readonly class EffectiveTradingConfigResolver
      *
      * @return array{
      *     config: array<string, mixed>,
+     *     config_hash: string,
      *     layers: list<array{type: string, name: string, path: string, required: bool}>,
-     *     missing_optional_layers: list<array{type: string, name: string, path: string, required: bool}>
+     *     missing_optional_layers: list<array{type: string, name: string, path: string, required: bool}>,
+     *     provenance: array<string, array{type: string, name: string, path: string, required: bool}>
      * }
      */
     public function resolve(string $mode, string $exchange, string $env): array
@@ -39,12 +41,14 @@ final readonly class EffectiveTradingConfigResolver
         $effectiveConfig = [];
         $usedLayers = [];
         $missingOptionalLayers = [];
+        $provenance = [];
 
         foreach ($candidates as $candidate) {
             $layer = $candidate['layer'];
             if ($layer instanceof TradingConfigLayer) {
-                $effectiveConfig = $this->mergeConfig($effectiveConfig, $layer->config);
-                $usedLayers[] = $layer->toLogContext();
+                $layerContext = $layer->toLogContext();
+                $effectiveConfig = $this->mergeConfig($effectiveConfig, $layer->config, $provenance, $layerContext);
+                $usedLayers[] = $layerContext;
                 continue;
             }
 
@@ -63,19 +67,25 @@ final readonly class EffectiveTradingConfigResolver
 
         return [
             'config' => $effectiveConfig,
+            'config_hash' => $this->hashConfig($effectiveConfig),
             'layers' => $usedLayers,
             'missing_optional_layers' => $missingOptionalLayers,
+            'provenance' => $provenance,
         ];
     }
 
     /**
      * @param array<string, mixed> $base
      * @param array<string, mixed> $override
+     * @param array<string, array{type: string, name: string, path: string, required: bool}> $provenance
+     * @param array{type: string, name: string, path: string, required: bool} $layerContext
      * @return array<string, mixed>
      */
-    private function mergeConfig(array $base, array $override): array
+    private function mergeConfig(array $base, array $override, array &$provenance, array $layerContext, string $prefix = ''): array
     {
         foreach ($override as $key => $value) {
+            $path = $prefix === '' ? $key : $prefix . '.' . $key;
+
             if (
                 array_key_exists($key, $base)
                 && is_array($base[$key])
@@ -87,14 +97,61 @@ final readonly class EffectiveTradingConfigResolver
                 $baseValue = $base[$key];
                 /** @var array<string, mixed> $overrideValue */
                 $overrideValue = $value;
-                $base[$key] = $this->mergeConfig($baseValue, $overrideValue);
+                $base[$key] = $this->mergeConfig($baseValue, $overrideValue, $provenance, $layerContext, $path);
                 continue;
             }
 
             $base[$key] = $value;
+            $this->recordProvenance($provenance, $path, $value, $layerContext);
         }
 
         return $base;
+    }
+
+    /**
+     * @param array<string, array{type: string, name: string, path: string, required: bool}> $provenance
+     * @param array{type: string, name: string, path: string, required: bool} $layerContext
+     */
+    private function recordProvenance(array &$provenance, string $path, mixed $value, array $layerContext): void
+    {
+        if (is_array($value) && $this->isAssociative($value)) {
+            /** @var array<string, mixed> $value */
+            foreach ($value as $childKey => $childValue) {
+                $this->recordProvenance($provenance, $path . '.' . $childKey, $childValue, $layerContext);
+            }
+
+            return;
+        }
+
+        $provenance[$path] = $layerContext;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private function hashConfig(array $config): string
+    {
+        $normalized = $this->sortRecursively($config);
+
+        return hash('sha256', json_encode($normalized, JSON_THROW_ON_ERROR));
+    }
+
+    private function sortRecursively(mixed $value): mixed
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if (!$this->isAssociative($value)) {
+            return array_map(fn (mixed $item): mixed => $this->sortRecursively($item), $value);
+        }
+
+        ksort($value);
+        foreach ($value as $key => $item) {
+            $value[$key] = $this->sortRecursively($item);
+        }
+
+        return $value;
     }
 
     /**

--- a/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
+++ b/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
@@ -80,6 +80,41 @@ final class EffectiveTradingConfigApiControllerTest extends TestCase
         self::assertStringContainsString('Unsupported exchange/env pair', $body['error']['message']);
     }
 
+    public function testRejectsUnknownExchangeEvenWhenEnvironmentLayerExists(): void
+    {
+        $this->writeYaml('base.yaml', "trading:\n  exchange: fake\n  execution:\n    dry_run: true\n");
+        $this->writeYaml('env/testnet.yaml', "trading:\n  environment: testnet\n");
+
+        $response = $this->controller()->effective(new Request([
+            'mode' => 'scalper',
+            'exchange' => 'okxx',
+            'env' => 'testnet',
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('invalid_config_request', $body['error']['code']);
+        self::assertStringContainsString('Unsupported exchange/env pair', $body['error']['message']);
+    }
+
+    public function testRejectsBitmartDemoBecauseCommon002ApiIsOnlyForDemoTestnetTargets(): void
+    {
+        $this->writeYaml('base.yaml', "trading:\n  exchange: fake\n  execution:\n    dry_run: true\n");
+        $this->writeYaml('exchange/bitmart.yaml', "trading:\n  exchange: bitmart\n  exchange_status: legacy_runtime_only\n");
+        $this->writeYaml('env/demo.yaml', "trading:\n  environment: demo\n");
+
+        $response = $this->controller()->effective(new Request([
+            'mode' => 'scalper',
+            'exchange' => 'bitmart',
+            'env' => 'demo',
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('invalid_config_request', $body['error']['code']);
+        self::assertStringContainsString('Unsupported exchange/env pair', $body['error']['message']);
+    }
+
     public function testReturnsEffectiveConfigWithHashAndProvenance(): void
     {
         $this->writeYaml('base.yaml', <<<YAML

--- a/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
+++ b/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
@@ -62,6 +62,24 @@ final class EffectiveTradingConfigApiControllerTest extends TestCase
         self::assertStringContainsString('Invalid trading config layer name', $body['error']['message']);
     }
 
+    public function testRejectsUnsupportedExchangeEnvironmentPair(): void
+    {
+        $this->writeYaml('base.yaml', "trading:\n  execution:\n    dry_run: true\n");
+        $this->writeYaml('exchange/okx.yaml', "trading:\n  exchange: okx\n  environment: demo\n");
+        $this->writeYaml('env/testnet.yaml', "trading:\n  environment: testnet\n");
+
+        $response = $this->controller()->effective(new Request([
+            'mode' => 'scalper',
+            'exchange' => 'okx',
+            'env' => 'testnet',
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('invalid_config_request', $body['error']['code']);
+        self::assertStringContainsString('Unsupported exchange/env pair', $body['error']['message']);
+    }
+
     public function testReturnsEffectiveConfigWithHashAndProvenance(): void
     {
         $this->writeYaml('base.yaml', <<<YAML

--- a/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
+++ b/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
@@ -115,6 +115,24 @@ final class EffectiveTradingConfigApiControllerTest extends TestCase
         self::assertStringContainsString('Unsupported exchange/env pair', $body['error']['message']);
     }
 
+    public function testRejectsUnsupportedModeBeforeOptionalLayersCanHideTypo(): void
+    {
+        $this->writeYaml('base.yaml', "trading:\n  exchange: fake\n  execution:\n    dry_run: true\n");
+        $this->writeYaml('exchange/okx.yaml', "trading:\n  exchange: okx\n  environment: demo\n");
+        $this->writeYaml('env/demo.yaml', "trading:\n  environment: demo\n");
+
+        $response = $this->controller()->effective(new Request([
+            'mode' => 'scalperr',
+            'exchange' => 'okx',
+            'env' => 'demo',
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('invalid_config_request', $body['error']['code']);
+        self::assertStringContainsString('Unsupported trading mode', $body['error']['message']);
+    }
+
     public function testReturnsEffectiveConfigWithHashAndProvenance(): void
     {
         $this->writeYaml('base.yaml', <<<YAML

--- a/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
+++ b/trading-app/tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Trading\Controller\Api;
+
+use App\Trading\Controller\Api\EffectiveTradingConfigApiController;
+use App\TradingCore\Config\EffectiveTradingConfigReadService;
+use App\TradingCore\Config\EffectiveTradingConfigResolver;
+use App\TradingCore\Config\Exception\TradingConfigException;
+use App\TradingCore\Config\TradingConfigLayer;
+use App\TradingCore\Config\TradingConfigLayerLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+#[CoversClass(EffectiveTradingConfigApiController::class)]
+#[CoversClass(EffectiveTradingConfigReadService::class)]
+final class EffectiveTradingConfigApiControllerTest extends TestCase
+{
+    private string $configRoot;
+
+    protected function setUp(): void
+    {
+        $this->configRoot = sys_get_temp_dir() . '/effective-config-api-' . bin2hex(random_bytes(6));
+        mkdir($this->configRoot . '/mode', 0777, true);
+        mkdir($this->configRoot . '/exchange', 0777, true);
+        mkdir($this->configRoot . '/mode_exchange', 0777, true);
+        mkdir($this->configRoot . '/env', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->configRoot);
+    }
+
+    public function testMissingQueryParametersReturnStructured400(): void
+    {
+        $response = $this->controller()->effective(new Request(['mode' => 'scalper']));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('missing_query_parameter', $body['error']['code']);
+        self::assertSame(['exchange', 'env'], $body['error']['missing']);
+    }
+
+    public function testInvalidLayerNameReturnsStructured400(): void
+    {
+        $this->writeYaml('base.yaml', "trading:\n  execution:\n    dry_run: true\n");
+
+        $response = $this->controller()->effective(new Request([
+            'mode' => '../../services',
+            'exchange' => 'okx',
+            'env' => 'demo',
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('invalid_config_request', $body['error']['code']);
+        self::assertStringContainsString('Invalid trading config layer name', $body['error']['message']);
+    }
+
+    public function testReturnsEffectiveConfigWithHashAndProvenance(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  exchange: fake
+  market_type: perpetual
+  execution:
+    dry_run: true
+    mainnet_write_enabled: false
+YAML);
+        $this->writeYaml('mode/scalper.yaml', <<<YAML
+trading:
+  profile: scalper
+YAML);
+        $this->writeYaml('exchange/okx.yaml', <<<YAML
+trading:
+  exchange: okx
+  environment: demo
+  execution:
+    demo_testnet_write_enabled: false
+YAML);
+        $this->writeYaml('env/demo.yaml', <<<YAML
+trading:
+  execution:
+    kill_switch_enabled: true
+YAML);
+
+        $response = $this->controller()->effective(new Request([
+            'mode' => 'scalper',
+            'exchange' => 'okx',
+            'env' => 'demo',
+        ]));
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $body = $this->json($response);
+        self::assertSame('scalper', $body['request']['mode']);
+        self::assertSame('okx', $body['request']['exchange']);
+        self::assertSame('demo', $body['request']['env']);
+        self::assertSame('okx', $body['config']['trading']['exchange']);
+        self::assertFalse($body['config']['trading']['execution']['mainnet_write_enabled']);
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $body['config_hash']);
+        self::assertSame('exchange', $body['provenance']['trading.exchange']['type']);
+        self::assertSame('env', $body['provenance']['trading.execution.kill_switch_enabled']['type']);
+        self::assertStringNotContainsString('SECRET', (string) $response->getContent());
+        self::assertStringNotContainsString('PRIVATE_KEY', (string) $response->getContent());
+    }
+
+    private function controller(): EffectiveTradingConfigApiController
+    {
+        $controller = new EffectiveTradingConfigApiController(
+            new EffectiveTradingConfigReadService(
+                new EffectiveTradingConfigResolver(new TradingConfigLayerLoader($this->configRoot)),
+            ),
+        );
+
+        $controller->setContainer(new class implements ContainerInterface {
+            public function get(string $id): mixed
+            {
+                throw new \RuntimeException('not available: ' . $id);
+            }
+
+            public function has(string $id): bool
+            {
+                return false;
+            }
+        });
+
+        return $controller;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function json(Response $response): array
+    {
+        return json_decode((string) $response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function writeYaml(string $relativePath, string $contents): void
+    {
+        $path = $this->configRoot . '/' . $relativePath;
+        $directory = dirname($path);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
+        file_put_contents($path, $contents . "\n");
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $entries = scandir($path);
+        self::assertIsArray($entries);
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $entryPath = $path . '/' . $entry;
+            if (is_dir($entryPath)) {
+                $this->removeDirectory($entryPath);
+                continue;
+            }
+
+            unlink($entryPath);
+        }
+
+        rmdir($path);
+    }
+}

--- a/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
+++ b/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
@@ -181,6 +181,28 @@ YAML);
         self::assertSame('base', $resolved['provenance']['trading.execution.mainnet_write_enabled']['type']);
     }
 
+    public function testReplacingSubtreeClearsStaleDescendantProvenance(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  execution:
+    dry_run: true
+    mainnet_write_enabled: false
+YAML);
+        $this->writeYaml('env/dev.yaml', <<<YAML
+trading:
+  execution: local_only
+YAML);
+
+        $resolved = $this->resolver()->resolve('missing-mode', 'missing-exchange', 'dev');
+
+        self::assertSame('local_only', $resolved['config']['trading']['execution']);
+        self::assertArrayHasKey('trading.execution', $resolved['provenance']);
+        self::assertSame('env', $resolved['provenance']['trading.execution']['type']);
+        self::assertArrayNotHasKey('trading.execution.dry_run', $resolved['provenance']);
+        self::assertArrayNotHasKey('trading.execution.mainnet_write_enabled', $resolved['provenance']);
+    }
+
     public function testThrowsClearErrorWhenBaseLayerIsMissing(): void
     {
         $this->expectException(TradingConfigException::class);

--- a/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
+++ b/trading-app/tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php
@@ -138,6 +138,49 @@ YAML);
         self::assertSame(['base', 'mode', 'exchange', 'mode_exchange', 'env'], array_column($resolved['layers'], 'type'));
     }
 
+    public function testExposesValueProvenanceAndStableConfigHash(): void
+    {
+        $this->writeYaml('base.yaml', <<<YAML
+trading:
+  exchange: fake
+  execution:
+    dry_run: true
+    mainnet_write_enabled: false
+  risk:
+    max_leverage_cap: 2
+YAML);
+        $this->writeYaml('mode/scalper.yaml', <<<YAML
+trading:
+  profile: scalper
+YAML);
+        $this->writeYaml('exchange/okx.yaml', <<<YAML
+trading:
+  exchange: okx
+  environment: demo
+  execution:
+    demo_testnet_write_enabled: false
+  risk:
+    max_leverage_cap: 5
+YAML);
+        $this->writeYaml('mode_exchange/scalper.okx.yaml', <<<YAML
+trading:
+  risk:
+    max_leverage_cap: 3
+YAML);
+
+        $resolved = $this->resolver()->resolve('scalper', 'okx', 'missing-env');
+
+        self::assertArrayHasKey('config_hash', $resolved);
+        self::assertIsString($resolved['config_hash']);
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $resolved['config_hash']);
+        self::assertArrayHasKey('provenance', $resolved);
+        self::assertSame('mode', $resolved['provenance']['trading.profile']['type']);
+        self::assertSame('exchange', $resolved['provenance']['trading.exchange']['type']);
+        self::assertSame('exchange', $resolved['provenance']['trading.environment']['type']);
+        self::assertSame('mode_exchange', $resolved['provenance']['trading.risk.max_leverage_cap']['type']);
+        self::assertSame('base', $resolved['provenance']['trading.execution.mainnet_write_enabled']['type']);
+    }
+
     public function testThrowsClearErrorWhenBaseLayerIsMissing(): void
     {
         $this->expectException(TradingConfigException::class);

--- a/trading-app/tests/TradingCore/Config/EffectiveTradingConfigRuntimeFilesTest.php
+++ b/trading-app/tests/TradingCore/Config/EffectiveTradingConfigRuntimeFilesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Config;
+
+use App\TradingCore\Config\EffectiveTradingConfigResolver;
+use App\TradingCore\Config\TradingConfigLayerLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EffectiveTradingConfigResolver::class)]
+#[CoversClass(TradingConfigLayerLoader::class)]
+final class EffectiveTradingConfigRuntimeFilesTest extends TestCase
+{
+    public function testOkxDemoScalperConfigIsSafeAndAuditable(): void
+    {
+        $resolved = $this->resolver()->resolve('scalper', 'okx', 'demo');
+        $trading = $resolved['config']['trading'];
+
+        self::assertSame('okx', $trading['exchange']);
+        self::assertArrayHasKey('environment', $trading);
+        self::assertSame('demo', $trading['environment']);
+        self::assertSame('perpetual', $trading['market_type']);
+        self::assertTrue($trading['execution']['dry_run']);
+        self::assertFalse($trading['execution']['mainnet_write_enabled']);
+        self::assertFalse($trading['execution']['demo_testnet_write_enabled']);
+        self::assertTrue($trading['execution']['kill_switch_enabled']);
+        self::assertTrue($trading['execution']['require_stop_loss']);
+        self::assertNotSame([], $trading['execution']['allowed_symbols']);
+        self::assertNotSame([], $trading['execution']['allowed_markets']);
+        self::assertIsFloat($trading['execution']['max_notional']);
+        self::assertGreaterThan(0.0, $trading['execution']['max_notional']);
+        self::assertIsInt($trading['risk']['max_leverage_cap']);
+        self::assertGreaterThan(0, $trading['risk']['max_leverage_cap']);
+        self::assertSame('demo', $trading['account_mode']);
+        self::assertArrayHasKey('rate_limit_profile', $trading);
+        self::assertArrayHasKey('retry_policy', $trading);
+        self::assertContains('mode_exchange', array_column($resolved['layers'], 'type'));
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $resolved['config_hash']);
+    }
+
+    public function testHyperliquidTestnetScalperConfigIsSafeAndAuditable(): void
+    {
+        $resolved = $this->resolver()->resolve('scalper', 'hyperliquid', 'testnet');
+        $trading = $resolved['config']['trading'];
+
+        self::assertSame('hyperliquid', $trading['exchange']);
+        self::assertArrayHasKey('environment', $trading);
+        self::assertSame('testnet', $trading['environment']);
+        self::assertSame('perpetual', $trading['market_type']);
+        self::assertTrue($trading['execution']['dry_run']);
+        self::assertFalse($trading['execution']['mainnet_write_enabled']);
+        self::assertFalse($trading['execution']['demo_testnet_write_enabled']);
+        self::assertTrue($trading['execution']['kill_switch_enabled']);
+        self::assertTrue($trading['execution']['require_stop_loss']);
+        self::assertNotSame([], $trading['execution']['allowed_symbols']);
+        self::assertNotSame([], $trading['execution']['allowed_markets']);
+        self::assertIsFloat($trading['execution']['max_notional']);
+        self::assertGreaterThan(0.0, $trading['execution']['max_notional']);
+        self::assertIsInt($trading['risk']['max_leverage_cap']);
+        self::assertGreaterThan(0, $trading['risk']['max_leverage_cap']);
+        self::assertSame('cross', $trading['margin_mode']);
+        self::assertArrayHasKey('rate_limit_profile', $trading);
+        self::assertArrayHasKey('retry_policy', $trading);
+        self::assertContains('mode_exchange', array_column($resolved['layers'], 'type'));
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $resolved['config_hash']);
+    }
+
+    public function testBitmartLegacyEffectiveConfigRemainsLegacyRuntimeOnly(): void
+    {
+        $resolved = $this->resolver()->resolve('scalper', 'bitmart', 'prod');
+        $trading = $resolved['config']['trading'];
+
+        self::assertSame('bitmart', $trading['exchange']);
+        self::assertSame('legacy_runtime_only', $trading['exchange_status']);
+        self::assertTrue($trading['execution']['dry_run']);
+        self::assertFalse($trading['execution']['live_enabled']);
+        self::assertTrue($resolved['config']['compatibility']['legacy_runtime_dependency']);
+    }
+
+    private function resolver(): EffectiveTradingConfigResolver
+    {
+        return new EffectiveTradingConfigResolver(new TradingConfigLayerLoader());
+    }
+}


### PR DESCRIPTION
COMMON-002

## Summary
- complete Effective Config layers for OKX demo and Hyperliquid testnet without wiring them into MTF, TradeEntry, Temporal, or exchange gateways
- add demo/testnet env layers plus mode/exchange overrides for regular, scalper, and scalper_micro
- enrich the resolver with deterministic `config_hash` and per-value `provenance`
- expose read-only `GET /api/trading/config/effective?mode=...&exchange=...&env=...` with structured 400 errors
- document examples, API response shape, rollback, and viewer follow-up

## Safety
- no exchange calls
- no runtime behavior change
- no mainnet write enablement
- OKX remains demo-only and Hyperliquid remains testnet-only in these configs
- `mainnet_write_enabled=false`, `demo_testnet_write_enabled=false`, `kill_switch_enabled=true`, `require_stop_loss=true` remain defaults
- Bitmart legacy effective config remains `legacy_runtime_only`
- no secrets or secret values added to config/docs/tests

## Tests
- `vendor/bin/phpunit tests/TradingCore/Config/EffectiveTradingConfigResolverTest.php tests/TradingCore/Config/EffectiveTradingConfigRuntimeFilesTest.php tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php`
- `vendor/bin/phpstan analyse src/TradingCore/Config src/Trading/Controller/Api/EffectiveTradingConfigApiController.php tests/TradingCore/Config tests/Trading/Controller/Api/EffectiveTradingConfigApiControllerTest.php --memory-limit=1G`
- `php bin/console lint:yaml config`
- `php bin/console lint:container --no-debug`
- `php bin/console debug:router api_trading_config_effective`
- `python3 -m mkdocs build --strict`
- `git diff --check`

Note: `lint:container` returns OK; it still emits existing PHP 8.4 deprecation traces from `EntryZoneStatsCommand`, unrelated to this PR.

Related to COMMON-001 / PR #221.