### PR TITLE
COMMON-003 exchange readiness contract

### DIFF
--- a/docs/handbook/technical/exchange-readiness-matrix.md
+++ b/docs/handbook/technical/exchange-readiness-matrix.md
@@ -63,8 +63,8 @@ Le rapport expose une forme stable pour le cockpit :
 
 Les champs `blocking_errors` et `warnings` sont serialises avec redaction defensive
 des messages contenant des termes de secret (`api_key`, `secret`, `private_key`,
-`passphrase`, `authorization`, `cookie`, `token`, `signature`, `credentials`).
-Les implementations ne doivent pas y placer de payload brut.
+`passphrase`, `password`, `authorization`, `cookie`, `token`, `signature`, `sign`,
+`credentials`, `memo`). Les implementations ne doivent pas y placer de payload brut.
 
 ## Niveaux readiness COMMON-003
 
@@ -86,8 +86,10 @@ Regles fail-closed :
 - absence de guard mainnet => `not_ready` avec `mainnet_write_guard_missing` ;
 - absence de `stop_loss_capability` => impossible d'atteindre `demo_testnet_candidate` ;
 - kill switch actif => impossible d'atteindre `demo_testnet_enabled` ;
-- `demo_testnet_enabled` exige aussi `demo_testnet_write_enabled=true`,
-  `permissions_trade=true`, whitelist symbole/marche et `max_notional`.
+- `demo_testnet_candidate` et `demo_testnet_enabled` exigent `environment=demo|testnet` ;
+- `demo_testnet_enabled` exige aussi `dry_run=false`,
+  `demo_testnet_write_enabled=true`, `permissions_trade=true`, whitelist
+  symbole/marche et `max_notional`.
 
 Les configs effectives OKX demo et Hyperliquid testnet livrees par `COMMON-002`
 peuvent produire un rapport `demo_testnet_candidate` en fixture si les signaux

--- a/docs/handbook/technical/exchange-readiness-matrix.md
+++ b/docs/handbook/technical/exchange-readiness-matrix.md
@@ -86,7 +86,10 @@ Regles fail-closed :
 - absence de guard mainnet => `not_ready` avec `mainnet_write_guard_missing` ;
 - absence de `stop_loss_capability` => impossible d'atteindre `demo_testnet_candidate` ;
 - kill switch actif => impossible d'atteindre `demo_testnet_enabled` ;
-- `demo_testnet_candidate` et `demo_testnet_enabled` exigent `environment=demo|testnet` ;
+- `demo_testnet_candidate` et `demo_testnet_enabled` exigent une paire supportee :
+  OKX/demo ou Hyperliquid/testnet ;
+- les paires croisees comme OKX/testnet ou Hyperliquid/demo restent bloquees avec
+  `exchange_environment_pair_unsupported` ;
 - `demo_testnet_enabled` exige aussi `dry_run=false`,
   `demo_testnet_write_enabled=true`, `permissions_trade=true`, whitelist
   symbole/marche utilisable et `max_notional`.

--- a/docs/handbook/technical/exchange-readiness-matrix.md
+++ b/docs/handbook/technical/exchange-readiness-matrix.md
@@ -95,6 +95,9 @@ Regles fail-closed :
   symbole/marche utilisable et `max_notional`.
 - les whitelists sont normalisees avant decision : les valeurs non string ou vides
   apres trim ne satisfont pas le guard.
+- une whitelist marche ne satisfait le guard que si elle contient le `market_type`
+  evalue ; par exemple `allowed_markets: [spot]` ne valide pas un rapport
+  `market_type=perpetual`.
 
 Les configs effectives OKX demo et Hyperliquid testnet livrees par `COMMON-002`
 peuvent produire un rapport `demo_testnet_candidate` en fixture si les signaux

--- a/docs/handbook/technical/exchange-readiness-matrix.md
+++ b/docs/handbook/technical/exchange-readiness-matrix.md
@@ -89,7 +89,9 @@ Regles fail-closed :
 - `demo_testnet_candidate` et `demo_testnet_enabled` exigent `environment=demo|testnet` ;
 - `demo_testnet_enabled` exige aussi `dry_run=false`,
   `demo_testnet_write_enabled=true`, `permissions_trade=true`, whitelist
-  symbole/marche et `max_notional`.
+  symbole/marche utilisable et `max_notional`.
+- les whitelists sont normalisees avant decision : les valeurs non string ou vides
+  apres trim ne satisfont pas le guard.
 
 Les configs effectives OKX demo et Hyperliquid testnet livrees par `COMMON-002`
 peuvent produire un rapport `demo_testnet_candidate` en fixture si les signaux

--- a/docs/handbook/technical/exchange-readiness-matrix.md
+++ b/docs/handbook/technical/exchange-readiness-matrix.md
@@ -20,6 +20,80 @@ Elle ne rend aucun exchange prêt au live. Elle sert à éviter les confusions e
 | `legacy_runtime_only` | Présent parce que le runtime historique en dépend encore, mais à retirer plus tard. |
 | `not_ready` | Ne doit pas être utilisé par le runtime. |
 
+## Contrat runtime COMMON-003
+
+`COMMON-003` ajoute un contrat PHP pur dans `App\Exchange\Readiness` :
+
+- `ExchangeReadinessLevel` ;
+- `ExchangeReadinessInput` ;
+- `ExchangeReadinessReport` ;
+- `ExchangeReadinessEvaluator` ;
+- `ExchangeRuntimeCheckInterface`.
+
+Ce contrat ne fait aucun appel REST, WebSocket, Doctrine, Messenger ou Temporal. Les
+implementations OKX et Hyperliquid futures devront alimenter `ExchangeReadinessInput`
+avec des preuves deja collectees ou des fixtures de test, puis retourner le meme
+`ExchangeReadinessReport`.
+
+Le rapport expose une forme stable pour le cockpit :
+
+- `exchange` ;
+- `market_type` ;
+- `environment` ;
+- `ready_level` ;
+- `public_connectivity` ;
+- `private_read_connectivity` ;
+- `private_observability` ;
+- `instruments_loaded` ;
+- `metadata_valid` ;
+- `precision_valid` ;
+- `account_readable` ;
+- `permissions_read` ;
+- `permissions_trade` ;
+- `mainnet_write_guard` ;
+- `demo_testnet_write_guard` ;
+- `stop_loss_capability` ;
+- `kill_switch` ;
+- `allowed_symbols` ;
+- `allowed_markets` ;
+- `max_notional` ;
+- `config_hash` ;
+- `blocking_errors` ;
+- `warnings`.
+
+Les champs `blocking_errors` et `warnings` sont serialises avec redaction defensive
+des messages contenant des termes de secret (`api_key`, `secret`, `private_key`,
+`passphrase`, `authorization`, `cookie`, `token`, `signature`, `credentials`).
+Les implementations ne doivent pas y placer de payload brut.
+
+## Niveaux readiness COMMON-003
+
+| Niveau | Sens | Ecriture exchange |
+|---|---|---|
+| `not_ready` | Un pre-requis bloquant manque. | Non |
+| `public_read_only` | Connectivite publique, instruments et metadata exploitables. | Non |
+| `private_read_only` | Lecture privee/account possible en plus du public. | Non |
+| `local_dry_run_ready` | Config et guards suffisants pour construire une simulation locale auditable. | Non |
+| `demo_testnet_candidate` | Candidat demo/testnet avec SL capability, mais ecriture non autorisee. | Non |
+| `demo_testnet_enabled` | Ecriture demo/testnet autorisee par guards explicites. | Demo/testnet uniquement |
+
+`mainnet_ready` et `live_ready` sont interdits dans cette serie et ne sont pas des
+valeurs de l'enum.
+
+Regles fail-closed :
+
+- absence d'instruments charges => `not_ready` avec `instruments_not_loaded` ;
+- absence de guard mainnet => `not_ready` avec `mainnet_write_guard_missing` ;
+- absence de `stop_loss_capability` => impossible d'atteindre `demo_testnet_candidate` ;
+- kill switch actif => impossible d'atteindre `demo_testnet_enabled` ;
+- `demo_testnet_enabled` exige aussi `demo_testnet_write_enabled=true`,
+  `permissions_trade=true`, whitelist symbole/marche et `max_notional`.
+
+Les configs effectives OKX demo et Hyperliquid testnet livrees par `COMMON-002`
+peuvent produire un rapport `demo_testnet_candidate` en fixture si les signaux
+public/private read sont verts. Elles restent non mutatives par defaut :
+`demo_testnet_write_enabled=false` et `kill_switch_enabled=true`.
+
 ## Matrice synthétique
 
 | Exchange | Statut cible | Runtime actuel | Dry-run autorisé | Live autorisé | Rôle |

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
@@ -129,7 +129,7 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
     private function hasGuardedReadiness(ExchangeReadinessInput $input): bool
     {
         return $input->demoTestnetWriteGuard
-            && ($input->allowedSymbols !== [] || $input->allowedMarkets !== [])
+            && ($this->normalizedList($input->allowedSymbols) !== [] || $this->normalizedList($input->allowedMarkets) !== [])
             && $input->maxNotional !== null;
     }
 
@@ -166,12 +166,35 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
             demoTestnetWriteGuard: $input->demoTestnetWriteGuard,
             stopLossCapability: $input->stopLossCapability,
             killSwitch: $input->killSwitch,
-            allowedSymbols: $input->allowedSymbols,
-            allowedMarkets: $input->allowedMarkets,
+            allowedSymbols: $this->normalizedList($input->allowedSymbols),
+            allowedMarkets: $this->normalizedList($input->allowedMarkets),
             maxNotional: $input->maxNotional,
             configHash: $input->configHash,
             blockingErrors: array_values(array_unique($blockingErrors)),
             warnings: array_values(array_unique($warnings)),
         );
+    }
+
+    /**
+     * @param array<mixed> $values
+     * @return list<string>
+     */
+    private function normalizedList(array $values): array
+    {
+        $normalized = [];
+        foreach ($values as $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+
+            $value = trim($value);
+            if ($value === '') {
+                continue;
+            }
+
+            $normalized[] = $value;
+        }
+
+        return array_values(array_unique($normalized));
     }
 }

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Exchange\Readiness;
 
+use App\Common\Enum\Exchange;
+
 final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
 {
     public function check(ExchangeReadinessInput $input): ExchangeReadinessReport
@@ -20,8 +22,11 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
             $blockingErrors[] = $error;
         }
 
-        if (!$input->dryRun && !$this->isDemoOrTestnet($input->environment)) {
+        if (!$input->dryRun && !$this->isSupportedDemoTestnetPair($input)) {
             $blockingErrors[] = 'demo_testnet_environment_required';
+            if ($this->isDemoOrTestnet($input->environment)) {
+                $blockingErrors[] = 'exchange_environment_pair_unsupported';
+            }
         }
 
         if ($blockingErrors !== []) {
@@ -46,8 +51,11 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
 
         $readyLevel = ExchangeReadinessLevel::LocalDryRunReady;
 
-        if (!$this->isDemoOrTestnet($input->environment)) {
+        if (!$this->isSupportedDemoTestnetPair($input)) {
             $warnings[] = 'demo_testnet_environment_required';
+            if ($this->isDemoOrTestnet($input->environment)) {
+                $warnings[] = 'exchange_environment_pair_unsupported';
+            }
 
             return $this->report($input, $readyLevel, [], $warnings);
         }
@@ -136,6 +144,14 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
     private function isDemoOrTestnet(string $environment): bool
     {
         return in_array(strtolower($environment), ['demo', 'testnet'], true);
+    }
+
+    private function isSupportedDemoTestnetPair(ExchangeReadinessInput $input): bool
+    {
+        $environment = strtolower($input->environment);
+
+        return ($input->exchange === Exchange::OKX && $environment === 'demo')
+            || ($input->exchange === Exchange::HYPERLIQUID && $environment === 'testnet');
     }
 
     /**

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
@@ -137,8 +137,17 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
     private function hasGuardedReadiness(ExchangeReadinessInput $input): bool
     {
         return $input->demoTestnetWriteGuard
-            && ($this->normalizedList($input->allowedSymbols) !== [] || $this->normalizedList($input->allowedMarkets) !== [])
+            && $this->hasUsableWhitelist($input)
             && $input->maxNotional !== null;
+    }
+
+    private function hasUsableWhitelist(ExchangeReadinessInput $input): bool
+    {
+        if ($this->normalizedList($input->allowedSymbols) !== []) {
+            return true;
+        }
+
+        return in_array($input->marketType->value, $this->normalizedList($input->allowedMarkets), true);
     }
 
     private function isDemoOrTestnet(string $environment): bool

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Readiness;
+
+final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
+{
+    public function check(ExchangeReadinessInput $input): ExchangeReadinessReport
+    {
+        return $this->evaluate($input);
+    }
+
+    public function evaluate(ExchangeReadinessInput $input): ExchangeReadinessReport
+    {
+        $blockingErrors = $input->blockingErrors;
+        $warnings = $input->warnings;
+
+        foreach ($this->notReadyErrors($input) as $error) {
+            $blockingErrors[] = $error;
+        }
+
+        if ($blockingErrors !== []) {
+            return $this->report($input, ExchangeReadinessLevel::NotReady, $blockingErrors, $warnings);
+        }
+
+        $readyLevel = ExchangeReadinessLevel::PublicReadOnly;
+
+        if (!$this->hasPrivateRead($input)) {
+            $warnings[] = 'private_read_not_ready';
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
+
+        $readyLevel = ExchangeReadinessLevel::PrivateReadOnly;
+
+        if (!$this->hasLocalDryRunReadiness($input)) {
+            $warnings[] = 'local_dry_run_prerequisites_missing';
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
+
+        $readyLevel = ExchangeReadinessLevel::LocalDryRunReady;
+
+        if (!$input->stopLossCapability) {
+            $warnings[] = 'stop_loss_capability_required_for_demo_testnet_candidate';
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
+
+        $readyLevel = ExchangeReadinessLevel::DemoTestnetCandidate;
+
+        if (!$input->demoTestnetWriteEnabled) {
+            $warnings[] = 'demo_testnet_write_not_enabled';
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
+
+        if ($input->killSwitch) {
+            $warnings[] = 'kill_switch_enabled_blocks_demo_testnet_enabled';
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
+
+        if (!$input->permissionsTrade) {
+            $warnings[] = 'trade_permission_required_for_demo_testnet_enabled';
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
+
+        return $this->report($input, ExchangeReadinessLevel::DemoTestnetEnabled, [], $warnings);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function notReadyErrors(ExchangeReadinessInput $input): array
+    {
+        $errors = [];
+
+        if (!$input->mainnetWriteGuard) {
+            $errors[] = 'mainnet_write_guard_missing';
+        }
+
+        if (!$input->publicConnectivity) {
+            $errors[] = 'public_connectivity_unavailable';
+        }
+
+        if (!$input->instrumentsLoaded) {
+            $errors[] = 'instruments_not_loaded';
+        }
+
+        if (!$input->metadataValid) {
+            $errors[] = 'metadata_invalid';
+        }
+
+        if (!$input->precisionValid) {
+            $errors[] = 'precision_invalid';
+        }
+
+        return $errors;
+    }
+
+    private function hasPrivateRead(ExchangeReadinessInput $input): bool
+    {
+        return $input->privateReadConnectivity
+            && $input->accountReadable
+            && $input->permissionsRead;
+    }
+
+    private function hasLocalDryRunReadiness(ExchangeReadinessInput $input): bool
+    {
+        return $input->dryRun
+            && $input->demoTestnetWriteGuard
+            && ($input->allowedSymbols !== [] || $input->allowedMarkets !== [])
+            && $input->maxNotional !== null;
+    }
+
+    /**
+     * @param list<string> $blockingErrors
+     * @param list<string> $warnings
+     */
+    private function report(
+        ExchangeReadinessInput $input,
+        ExchangeReadinessLevel $readyLevel,
+        array $blockingErrors,
+        array $warnings,
+    ): ExchangeReadinessReport {
+        return new ExchangeReadinessReport(
+            exchange: $input->exchange,
+            marketType: $input->marketType,
+            environment: $input->environment,
+            readyLevel: $readyLevel,
+            publicConnectivity: $input->publicConnectivity,
+            privateReadConnectivity: $input->privateReadConnectivity,
+            privateObservability: $input->privateObservability,
+            instrumentsLoaded: $input->instrumentsLoaded,
+            metadataValid: $input->metadataValid,
+            precisionValid: $input->precisionValid,
+            accountReadable: $input->accountReadable,
+            permissionsRead: $input->permissionsRead,
+            permissionsTrade: $input->permissionsTrade,
+            mainnetWriteGuard: $input->mainnetWriteGuard,
+            demoTestnetWriteGuard: $input->demoTestnetWriteGuard,
+            stopLossCapability: $input->stopLossCapability,
+            killSwitch: $input->killSwitch,
+            allowedSymbols: $input->allowedSymbols,
+            allowedMarkets: $input->allowedMarkets,
+            maxNotional: $input->maxNotional,
+            configHash: $input->configHash,
+            blockingErrors: array_values(array_unique($blockingErrors)),
+            warnings: array_values(array_unique($warnings)),
+        );
+    }
+}

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessEvaluator.php
@@ -20,6 +20,10 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
             $blockingErrors[] = $error;
         }
 
+        if (!$input->dryRun && !$this->isDemoOrTestnet($input->environment)) {
+            $blockingErrors[] = 'demo_testnet_environment_required';
+        }
+
         if ($blockingErrors !== []) {
             return $this->report($input, ExchangeReadinessLevel::NotReady, $blockingErrors, $warnings);
         }
@@ -34,13 +38,19 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
 
         $readyLevel = ExchangeReadinessLevel::PrivateReadOnly;
 
-        if (!$this->hasLocalDryRunReadiness($input)) {
+        if (!$this->hasGuardedReadiness($input)) {
             $warnings[] = 'local_dry_run_prerequisites_missing';
 
             return $this->report($input, $readyLevel, [], $warnings);
         }
 
         $readyLevel = ExchangeReadinessLevel::LocalDryRunReady;
+
+        if (!$this->isDemoOrTestnet($input->environment)) {
+            $warnings[] = 'demo_testnet_environment_required';
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
 
         if (!$input->stopLossCapability) {
             $warnings[] = 'stop_loss_capability_required_for_demo_testnet_candidate';
@@ -49,6 +59,14 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
         }
 
         $readyLevel = ExchangeReadinessLevel::DemoTestnetCandidate;
+
+        if ($input->dryRun) {
+            if (!$input->demoTestnetWriteEnabled) {
+                $warnings[] = 'demo_testnet_write_not_enabled';
+            }
+
+            return $this->report($input, $readyLevel, [], $warnings);
+        }
 
         if (!$input->demoTestnetWriteEnabled) {
             $warnings[] = 'demo_testnet_write_not_enabled';
@@ -108,12 +126,16 @@ final class ExchangeReadinessEvaluator implements ExchangeRuntimeCheckInterface
             && $input->permissionsRead;
     }
 
-    private function hasLocalDryRunReadiness(ExchangeReadinessInput $input): bool
+    private function hasGuardedReadiness(ExchangeReadinessInput $input): bool
     {
-        return $input->dryRun
-            && $input->demoTestnetWriteGuard
+        return $input->demoTestnetWriteGuard
             && ($input->allowedSymbols !== [] || $input->allowedMarkets !== [])
             && $input->maxNotional !== null;
+    }
+
+    private function isDemoOrTestnet(string $environment): bool
+    {
+        return in_array(strtolower($environment), ['demo', 'testnet'], true);
     }
 
     /**

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessInput.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessInput.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Readiness;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+final readonly class ExchangeReadinessInput
+{
+    /**
+     * @param list<string> $allowedSymbols
+     * @param list<string> $allowedMarkets
+     * @param list<string> $blockingErrors
+     * @param list<string> $warnings
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $environment,
+        public bool $publicConnectivity = false,
+        public bool $privateReadConnectivity = false,
+        public bool $privateObservability = false,
+        public bool $instrumentsLoaded = false,
+        public bool $metadataValid = false,
+        public bool $precisionValid = false,
+        public bool $accountReadable = false,
+        public bool $permissionsRead = false,
+        public bool $permissionsTrade = false,
+        public bool $mainnetWriteGuard = false,
+        public bool $demoTestnetWriteGuard = false,
+        public bool $demoTestnetWriteEnabled = false,
+        public bool $stopLossCapability = false,
+        public bool $killSwitch = true,
+        public bool $dryRun = true,
+        public array $allowedSymbols = [],
+        public array $allowedMarkets = [],
+        public ?float $maxNotional = null,
+        public ?string $configHash = null,
+        public array $blockingErrors = [],
+        public array $warnings = [],
+    ) {
+        if ($this->maxNotional !== null && (!is_finite($this->maxNotional) || $this->maxNotional <= 0.0)) {
+            throw new \InvalidArgumentException('maxNotional must be positive and finite when provided.');
+        }
+    }
+}

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessLevel.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessLevel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Readiness;
+
+enum ExchangeReadinessLevel: string
+{
+    case NotReady = 'not_ready';
+    case PublicReadOnly = 'public_read_only';
+    case PrivateReadOnly = 'private_read_only';
+    case LocalDryRunReady = 'local_dry_run_ready';
+    case DemoTestnetCandidate = 'demo_testnet_candidate';
+    case DemoTestnetEnabled = 'demo_testnet_enabled';
+}

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessReport.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessReport.php
@@ -9,7 +9,7 @@ use App\Common\Enum\MarketType;
 
 final readonly class ExchangeReadinessReport
 {
-    private const SENSITIVE_PATTERN = '/(api[_-]?key|secret|private[_-]?key|passphrase|authorization|cookie|token|signature|credentials?)/i';
+    private const SENSITIVE_PATTERN = '/(api[_-]?key|secret|private[_-]?key|passphrase|password|authorization|cookie|token|signature|sign|credentials?|memo)/i';
 
     /**
      * @param list<string> $allowedSymbols

--- a/trading-app/src/Exchange/Readiness/ExchangeReadinessReport.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeReadinessReport.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Readiness;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+
+final readonly class ExchangeReadinessReport
+{
+    private const SENSITIVE_PATTERN = '/(api[_-]?key|secret|private[_-]?key|passphrase|authorization|cookie|token|signature|credentials?)/i';
+
+    /**
+     * @param list<string> $allowedSymbols
+     * @param list<string> $allowedMarkets
+     * @param list<string> $blockingErrors
+     * @param list<string> $warnings
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public MarketType $marketType,
+        public string $environment,
+        public ExchangeReadinessLevel $readyLevel,
+        public bool $publicConnectivity,
+        public bool $privateReadConnectivity,
+        public bool $privateObservability,
+        public bool $instrumentsLoaded,
+        public bool $metadataValid,
+        public bool $precisionValid,
+        public bool $accountReadable,
+        public bool $permissionsRead,
+        public bool $permissionsTrade,
+        public bool $mainnetWriteGuard,
+        public bool $demoTestnetWriteGuard,
+        public bool $stopLossCapability,
+        public bool $killSwitch,
+        public array $allowedSymbols,
+        public array $allowedMarkets,
+        public ?float $maxNotional,
+        public ?string $configHash,
+        public array $blockingErrors,
+        public array $warnings,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     exchange: string,
+     *     market_type: string,
+     *     environment: string,
+     *     ready_level: string,
+     *     public_connectivity: bool,
+     *     private_read_connectivity: bool,
+     *     private_observability: bool,
+     *     instruments_loaded: bool,
+     *     metadata_valid: bool,
+     *     precision_valid: bool,
+     *     account_readable: bool,
+     *     permissions_read: bool,
+     *     permissions_trade: bool,
+     *     mainnet_write_guard: bool,
+     *     demo_testnet_write_guard: bool,
+     *     stop_loss_capability: bool,
+     *     kill_switch: bool,
+     *     allowed_symbols: list<string>,
+     *     allowed_markets: list<string>,
+     *     max_notional: ?float,
+     *     config_hash: ?string,
+     *     blocking_errors: list<string>,
+     *     warnings: list<string>
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'exchange' => $this->exchange->value,
+            'market_type' => $this->marketType->value,
+            'environment' => $this->environment,
+            'ready_level' => $this->readyLevel->value,
+            'public_connectivity' => $this->publicConnectivity,
+            'private_read_connectivity' => $this->privateReadConnectivity,
+            'private_observability' => $this->privateObservability,
+            'instruments_loaded' => $this->instrumentsLoaded,
+            'metadata_valid' => $this->metadataValid,
+            'precision_valid' => $this->precisionValid,
+            'account_readable' => $this->accountReadable,
+            'permissions_read' => $this->permissionsRead,
+            'permissions_trade' => $this->permissionsTrade,
+            'mainnet_write_guard' => $this->mainnetWriteGuard,
+            'demo_testnet_write_guard' => $this->demoTestnetWriteGuard,
+            'stop_loss_capability' => $this->stopLossCapability,
+            'kill_switch' => $this->killSwitch,
+            'allowed_symbols' => $this->allowedSymbols,
+            'allowed_markets' => $this->allowedMarkets,
+            'max_notional' => $this->maxNotional,
+            'config_hash' => $this->configHash,
+            'blocking_errors' => $this->redactMessages($this->blockingErrors),
+            'warnings' => $this->redactMessages($this->warnings),
+        ];
+    }
+
+    /**
+     * @param list<string> $messages
+     * @return list<string>
+     */
+    private function redactMessages(array $messages): array
+    {
+        return array_map(
+            static fn (string $message): string => preg_match(self::SENSITIVE_PATTERN, $message) === 1 ? '[redacted]' : $message,
+            $messages,
+        );
+    }
+}

--- a/trading-app/src/Exchange/Readiness/ExchangeRuntimeCheckInterface.php
+++ b/trading-app/src/Exchange/Readiness/ExchangeRuntimeCheckInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Readiness;
+
+interface ExchangeRuntimeCheckInterface
+{
+    public function check(ExchangeReadinessInput $input): ExchangeReadinessReport;
+}

--- a/trading-app/tests/Exchange/Readiness/ExchangeReadinessEffectiveConfigTest.php
+++ b/trading-app/tests/Exchange/Readiness/ExchangeReadinessEffectiveConfigTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Readiness;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Readiness\ExchangeReadinessEvaluator;
+use App\Exchange\Readiness\ExchangeReadinessInput;
+use App\Exchange\Readiness\ExchangeReadinessLevel;
+use App\Exchange\Readiness\ExchangeReadinessReport;
+use App\Exchange\Readiness\ExchangeRuntimeCheckInterface;
+use App\TradingCore\Config\EffectiveTradingConfigResolver;
+use App\TradingCore\Config\TradingConfigLayerLoader;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExchangeReadinessEvaluator::class)]
+#[CoversClass(ExchangeReadinessInput::class)]
+#[CoversClass(ExchangeReadinessLevel::class)]
+#[CoversClass(ExchangeReadinessReport::class)]
+#[CoversClass(ExchangeRuntimeCheckInterface::class)]
+#[CoversClass(EffectiveTradingConfigResolver::class)]
+#[CoversClass(TradingConfigLayerLoader::class)]
+final class ExchangeReadinessEffectiveConfigTest extends TestCase
+{
+    public function testOkxDemoEffectiveConfigCanProduceCandidateReadinessReport(): void
+    {
+        $resolved = (new EffectiveTradingConfigResolver(new TradingConfigLayerLoader()))
+            ->resolve('scalper', 'okx', 'demo');
+
+        $report = (new ExchangeReadinessEvaluator())->evaluate($this->inputFromConfig(
+            exchange: Exchange::OKX,
+            env: 'demo',
+            resolved: $resolved,
+        ));
+
+        self::assertSame(ExchangeReadinessLevel::DemoTestnetCandidate, $report->readyLevel);
+        self::assertSame('okx', $report->toArray()['exchange']);
+        self::assertSame('demo', $report->toArray()['environment']);
+        self::assertSame($resolved['config_hash'], $report->toArray()['config_hash']);
+        self::assertTrue($report->mainnetWriteGuard);
+        self::assertTrue($report->demoTestnetWriteGuard);
+        self::assertTrue($report->killSwitch);
+        self::assertSame(['demo_testnet_write_not_enabled'], $report->warnings);
+    }
+
+    public function testHyperliquidTestnetEffectiveConfigCanProduceCandidateReadinessReport(): void
+    {
+        $resolved = (new EffectiveTradingConfigResolver(new TradingConfigLayerLoader()))
+            ->resolve('scalper', 'hyperliquid', 'testnet');
+
+        $report = (new ExchangeReadinessEvaluator())->evaluate($this->inputFromConfig(
+            exchange: Exchange::HYPERLIQUID,
+            env: 'testnet',
+            resolved: $resolved,
+        ));
+
+        self::assertSame(ExchangeReadinessLevel::DemoTestnetCandidate, $report->readyLevel);
+        self::assertSame('hyperliquid', $report->toArray()['exchange']);
+        self::assertSame('testnet', $report->toArray()['environment']);
+        self::assertSame($resolved['config_hash'], $report->toArray()['config_hash']);
+        self::assertTrue($report->mainnetWriteGuard);
+        self::assertTrue($report->demoTestnetWriteGuard);
+        self::assertTrue($report->killSwitch);
+        self::assertSame(['demo_testnet_write_not_enabled'], $report->warnings);
+    }
+
+    /**
+     * @param array{
+     *     config: array<string,mixed>,
+     *     config_hash: string,
+     *     layers: list<array{type: string, name: string, path: string, required: bool}>,
+     *     missing_optional_layers: list<array{type: string, name: string, path: string, required: bool}>,
+     *     provenance: array<string, array{type: string, name: string, path: string, required: bool}>
+     * } $resolved
+     */
+    private function inputFromConfig(Exchange $exchange, string $env, array $resolved): ExchangeReadinessInput
+    {
+        $trading = $resolved['config']['trading'];
+        self::assertIsArray($trading);
+        $execution = $trading['execution'];
+        self::assertIsArray($execution);
+
+        return new ExchangeReadinessInput(
+            exchange: $exchange,
+            marketType: MarketType::PERPETUAL,
+            environment: $env,
+            publicConnectivity: true,
+            privateReadConnectivity: true,
+            privateObservability: false,
+            instrumentsLoaded: true,
+            metadataValid: true,
+            precisionValid: true,
+            accountReadable: true,
+            permissionsRead: true,
+            permissionsTrade: false,
+            mainnetWriteGuard: ($execution['mainnet_write_enabled'] ?? true) === false,
+            demoTestnetWriteGuard: array_key_exists('demo_testnet_write_enabled', $execution),
+            demoTestnetWriteEnabled: ($execution['demo_testnet_write_enabled'] ?? false) === true,
+            stopLossCapability: ($execution['require_stop_loss'] ?? false) === true,
+            killSwitch: ($execution['kill_switch_enabled'] ?? true) === true,
+            allowedSymbols: $this->stringList($execution['allowed_symbols'] ?? []),
+            allowedMarkets: $this->stringList($execution['allowed_markets'] ?? []),
+            maxNotional: is_float($execution['max_notional'] ?? null) ? $execution['max_notional'] : null,
+            configHash: $resolved['config_hash'],
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, static fn (mixed $item): bool => is_string($item)));
+    }
+}

--- a/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
+++ b/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Readiness;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Readiness\ExchangeReadinessEvaluator;
+use App\Exchange\Readiness\ExchangeReadinessInput;
+use App\Exchange\Readiness\ExchangeReadinessLevel;
+use App\Exchange\Readiness\ExchangeReadinessReport;
+use App\Exchange\Readiness\ExchangeRuntimeCheckInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExchangeReadinessEvaluator::class)]
+#[CoversClass(ExchangeReadinessInput::class)]
+#[CoversClass(ExchangeReadinessLevel::class)]
+#[CoversClass(ExchangeReadinessReport::class)]
+#[CoversClass(ExchangeRuntimeCheckInterface::class)]
+final class ExchangeReadinessEvaluatorTest extends TestCase
+{
+    public function testReportsNotReadyWhenInstrumentsAreAbsent(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(instrumentsLoaded: false),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::NotReady, $report->readyLevel);
+        self::assertContains('instruments_not_loaded', $report->blockingErrors);
+        self::assertSame('okx', $report->toArray()['exchange']);
+        self::assertSame('not_ready', $report->toArray()['ready_level']);
+    }
+
+    public function testReportsNotReadyWhenMainnetWriteGuardIsAbsent(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(mainnetWriteGuard: false),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::NotReady, $report->readyLevel);
+        self::assertContains('mainnet_write_guard_missing', $report->blockingErrors);
+    }
+
+    public function testDemoTestnetCandidateIsImpossibleWithoutStopLossCapability(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(stopLossCapability: false),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::LocalDryRunReady, $report->readyLevel);
+        self::assertContains('stop_loss_capability_required_for_demo_testnet_candidate', $report->warnings);
+    }
+
+    public function testDemoTestnetEnabledIsImpossibleWhenKillSwitchIsActive(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(
+                demoTestnetWriteEnabled: true,
+                killSwitch: true,
+            ),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::DemoTestnetCandidate, $report->readyLevel);
+        self::assertContains('kill_switch_enabled_blocks_demo_testnet_enabled', $report->warnings);
+    }
+
+    public function testReportsDemoTestnetEnabledOnlyWhenAllGuardsPass(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(
+                demoTestnetWriteEnabled: true,
+                killSwitch: false,
+            ),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::DemoTestnetEnabled, $report->readyLevel);
+        self::assertSame([], $report->blockingErrors);
+        self::assertSame('demo_testnet_enabled', $report->toArray()['ready_level']);
+    }
+
+    public function testReadinessLevelsNeverExposeMainnetOrLiveReady(): void
+    {
+        $values = array_map(
+            static fn (ExchangeReadinessLevel $level): string => $level->value,
+            ExchangeReadinessLevel::cases(),
+        );
+
+        self::assertNotContains('mainnet_ready', $values);
+        self::assertNotContains('live_ready', $values);
+        self::assertSame([
+            'not_ready',
+            'public_read_only',
+            'private_read_only',
+            'local_dry_run_ready',
+            'demo_testnet_candidate',
+            'demo_testnet_enabled',
+        ], $values);
+    }
+
+    public function testRedactsSensitiveWarningOutput(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(warnings: [
+                'private_key=wallet-secret',
+                'safe_fixture_warning',
+            ]),
+        );
+
+        $encoded = json_encode($report->toArray(), JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('wallet-secret', $encoded);
+        self::assertStringContainsString('[redacted]', $encoded);
+        self::assertStringContainsString('safe_fixture_warning', $encoded);
+    }
+
+    /**
+     * @param list<string> $warnings
+     */
+    private function readyInput(
+        bool $publicConnectivity = true,
+        bool $privateReadConnectivity = true,
+        bool $privateObservability = false,
+        bool $instrumentsLoaded = true,
+        bool $metadataValid = true,
+        bool $precisionValid = true,
+        bool $accountReadable = true,
+        bool $permissionsRead = true,
+        bool $permissionsTrade = true,
+        bool $mainnetWriteGuard = true,
+        bool $demoTestnetWriteGuard = true,
+        bool $demoTestnetWriteEnabled = false,
+        bool $stopLossCapability = true,
+        bool $killSwitch = true,
+        array $warnings = [],
+    ): ExchangeReadinessInput {
+        return new ExchangeReadinessInput(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            environment: 'demo',
+            publicConnectivity: $publicConnectivity,
+            privateReadConnectivity: $privateReadConnectivity,
+            privateObservability: $privateObservability,
+            instrumentsLoaded: $instrumentsLoaded,
+            metadataValid: $metadataValid,
+            precisionValid: $precisionValid,
+            accountReadable: $accountReadable,
+            permissionsRead: $permissionsRead,
+            permissionsTrade: $permissionsTrade,
+            mainnetWriteGuard: $mainnetWriteGuard,
+            demoTestnetWriteGuard: $demoTestnetWriteGuard,
+            demoTestnetWriteEnabled: $demoTestnetWriteEnabled,
+            stopLossCapability: $stopLossCapability,
+            killSwitch: $killSwitch,
+            allowedSymbols: ['BTCUSDT'],
+            allowedMarkets: ['perpetual'],
+            maxNotional: 25.0,
+            configHash: str_repeat('a', 64),
+            warnings: $warnings,
+        );
+    }
+}

--- a/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
+++ b/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
@@ -144,6 +144,23 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
         self::assertSame([], $report->toArray()['allowed_symbols']);
     }
 
+    public function testAllowedMarketMustMatchCheckedMarketType(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(
+                marketType: MarketType::PERPETUAL,
+                dryRun: false,
+                demoTestnetWriteEnabled: true,
+                killSwitch: false,
+                allowedSymbols: [],
+                allowedMarkets: ['spot'],
+            ),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::PrivateReadOnly, $report->readyLevel);
+        self::assertContains('local_dry_run_prerequisites_missing', $report->warnings);
+    }
+
     public function testReadinessLevelsNeverExposeMainnetOrLiveReady(): void
     {
         $values = array_map(
@@ -191,6 +208,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
      */
     private function readyInput(
         Exchange $exchange = Exchange::OKX,
+        MarketType $marketType = MarketType::PERPETUAL,
         string $environment = 'demo',
         bool $publicConnectivity = true,
         bool $privateReadConnectivity = true,
@@ -213,7 +231,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
     ): ExchangeReadinessInput {
         return new ExchangeReadinessInput(
             exchange: $exchange,
-            marketType: MarketType::PERPETUAL,
+            marketType: $marketType,
             environment: $environment,
             publicConnectivity: $publicConnectivity,
             privateReadConnectivity: $privateReadConnectivity,

--- a/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
+++ b/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
@@ -110,6 +110,24 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
         self::assertContains('demo_testnet_environment_required', $report->blockingErrors);
     }
 
+    public function testBlankWhitelistEntriesDoNotSatisfyGuardedReadiness(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(
+                dryRun: false,
+                demoTestnetWriteEnabled: true,
+                killSwitch: false,
+                allowedSymbols: ['', '   '],
+                allowedMarkets: [],
+            ),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::PrivateReadOnly, $report->readyLevel);
+        self::assertContains('local_dry_run_prerequisites_missing', $report->warnings);
+        self::assertSame([], $report->allowedSymbols);
+        self::assertSame([], $report->toArray()['allowed_symbols']);
+    }
+
     public function testReadinessLevelsNeverExposeMainnetOrLiveReady(): void
     {
         $values = array_map(
@@ -151,6 +169,8 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
     }
 
     /**
+     * @param array<mixed> $allowedSymbols
+     * @param array<mixed> $allowedMarkets
      * @param list<string> $warnings
      */
     private function readyInput(
@@ -170,6 +190,8 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
         bool $stopLossCapability = true,
         bool $killSwitch = true,
         bool $dryRun = true,
+        array $allowedSymbols = ['BTCUSDT'],
+        array $allowedMarkets = ['perpetual'],
         array $warnings = [],
     ): ExchangeReadinessInput {
         return new ExchangeReadinessInput(
@@ -191,8 +213,8 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
             stopLossCapability: $stopLossCapability,
             killSwitch: $killSwitch,
             dryRun: $dryRun,
-            allowedSymbols: ['BTCUSDT'],
-            allowedMarkets: ['perpetual'],
+            allowedSymbols: $allowedSymbols,
+            allowedMarkets: $allowedMarkets,
             maxNotional: 25.0,
             configHash: str_repeat('a', 64),
             warnings: $warnings,

--- a/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
+++ b/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
@@ -110,6 +110,22 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
         self::assertContains('demo_testnet_environment_required', $report->blockingErrors);
     }
 
+    public function testMismatchedExchangeEnvironmentPairCannotReachDemoTestnetEnabled(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(
+                exchange: Exchange::HYPERLIQUID,
+                environment: 'demo',
+                dryRun: false,
+                demoTestnetWriteEnabled: true,
+                killSwitch: false,
+            ),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::NotReady, $report->readyLevel);
+        self::assertContains('exchange_environment_pair_unsupported', $report->blockingErrors);
+    }
+
     public function testBlankWhitelistEntriesDoNotSatisfyGuardedReadiness(): void
     {
         $report = (new ExchangeReadinessEvaluator())->evaluate(
@@ -174,6 +190,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
      * @param list<string> $warnings
      */
     private function readyInput(
+        Exchange $exchange = Exchange::OKX,
         string $environment = 'demo',
         bool $publicConnectivity = true,
         bool $privateReadConnectivity = true,
@@ -195,7 +212,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
         array $warnings = [],
     ): ExchangeReadinessInput {
         return new ExchangeReadinessInput(
-            exchange: Exchange::OKX,
+            exchange: $exchange,
             marketType: MarketType::PERPETUAL,
             environment: $environment,
             publicConnectivity: $publicConnectivity,

--- a/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
+++ b/trading-app/tests/Exchange/Readiness/ExchangeReadinessEvaluatorTest.php
@@ -57,6 +57,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
     {
         $report = (new ExchangeReadinessEvaluator())->evaluate(
             $this->readyInput(
+                dryRun: false,
                 demoTestnetWriteEnabled: true,
                 killSwitch: true,
             ),
@@ -70,6 +71,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
     {
         $report = (new ExchangeReadinessEvaluator())->evaluate(
             $this->readyInput(
+                dryRun: false,
                 demoTestnetWriteEnabled: true,
                 killSwitch: false,
             ),
@@ -78,6 +80,34 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
         self::assertSame(ExchangeReadinessLevel::DemoTestnetEnabled, $report->readyLevel);
         self::assertSame([], $report->blockingErrors);
         self::assertSame('demo_testnet_enabled', $report->toArray()['ready_level']);
+    }
+
+    public function testDryRunTrueNeverReportsDemoTestnetEnabled(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(
+                dryRun: true,
+                demoTestnetWriteEnabled: true,
+                killSwitch: false,
+            ),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::DemoTestnetCandidate, $report->readyLevel);
+    }
+
+    public function testDemoTestnetEnabledIsRejectedOutsideDemoTestnetEnvironment(): void
+    {
+        $report = (new ExchangeReadinessEvaluator())->evaluate(
+            $this->readyInput(
+                environment: 'mainnet',
+                dryRun: false,
+                demoTestnetWriteEnabled: true,
+                killSwitch: false,
+            ),
+        );
+
+        self::assertSame(ExchangeReadinessLevel::NotReady, $report->readyLevel);
+        self::assertContains('demo_testnet_environment_required', $report->blockingErrors);
     }
 
     public function testReadinessLevelsNeverExposeMainnetOrLiveReady(): void
@@ -103,12 +133,18 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
     {
         $report = (new ExchangeReadinessEvaluator())->evaluate(
             $this->readyInput(warnings: [
+                'password=demo-password',
+                'BITMART_API_MEMO=demo-memo',
+                'OK-ACCESS-SIGN=demo-signature',
                 'private_key=wallet-secret',
                 'safe_fixture_warning',
             ]),
         );
 
         $encoded = json_encode($report->toArray(), JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('demo-password', $encoded);
+        self::assertStringNotContainsString('demo-memo', $encoded);
+        self::assertStringNotContainsString('demo-signature', $encoded);
         self::assertStringNotContainsString('wallet-secret', $encoded);
         self::assertStringContainsString('[redacted]', $encoded);
         self::assertStringContainsString('safe_fixture_warning', $encoded);
@@ -118,6 +154,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
      * @param list<string> $warnings
      */
     private function readyInput(
+        string $environment = 'demo',
         bool $publicConnectivity = true,
         bool $privateReadConnectivity = true,
         bool $privateObservability = false,
@@ -132,12 +169,13 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
         bool $demoTestnetWriteEnabled = false,
         bool $stopLossCapability = true,
         bool $killSwitch = true,
+        bool $dryRun = true,
         array $warnings = [],
     ): ExchangeReadinessInput {
         return new ExchangeReadinessInput(
             exchange: Exchange::OKX,
             marketType: MarketType::PERPETUAL,
-            environment: 'demo',
+            environment: $environment,
             publicConnectivity: $publicConnectivity,
             privateReadConnectivity: $privateReadConnectivity,
             privateObservability: $privateObservability,
@@ -152,6 +190,7 @@ final class ExchangeReadinessEvaluatorTest extends TestCase
             demoTestnetWriteEnabled: $demoTestnetWriteEnabled,
             stopLossCapability: $stopLossCapability,
             killSwitch: $killSwitch,
+            dryRun: $dryRun,
             allowedSymbols: ['BTCUSDT'],
             allowedMarkets: ['perpetual'],
             maxNotional: 25.0,


### PR DESCRIPTION
## Summary
- add the pure `App\Exchange\Readiness` contract: readiness levels, input/report DTOs, evaluator, and runtime check interface
- enforce fail-closed readiness rules for missing instruments, missing mainnet guard, missing SL capability, kill switch, and demo/testnet enablement
- document the COMMON-003 readiness levels and report shape in the exchange readiness matrix

## Scope
- no REST, WebSocket, Doctrine, Messenger, Temporal, or runtime trading calls
- no mainnet/live readiness level
- no strategy, EntryZone, Risk/Leverage, SL/TP behavior changes

## References
- COMMON-003 — Exchange readiness contract
- Depends on COMMON-002 / PR #222

## Tests
- `vendor/bin/phpunit tests/Exchange/Readiness tests/TradingCore/Config/EffectiveTradingConfigRuntimeFilesTest.php`
- `vendor/bin/phpstan analyse src/Exchange/Readiness tests/Exchange/Readiness --memory-limit=1G`
- `php bin/console lint:container --no-debug` (passes; existing PHP 8.4 deprecation from `EntryZoneStatsCommand`)
- `python3 -m mkdocs build --strict`
- `git diff --cached --check`