### PR TITLE
COMMON-004 demo kill switch audit

### DIFF
--- a/docs/handbook/runbooks/demo-testnet-kill-switch.md
+++ b/docs/handbook/runbooks/demo-testnet-kill-switch.md
@@ -103,6 +103,7 @@ trading:
 | `hyperliquid_testnet_trading_disabled` | Gate Hyperliquid testnet ferme. |
 | `exchange_environment_pair_unsupported` | Paire hors scope : seules OKX/demo et Hyperliquid/testnet sont supportees. |
 | `effective_kill_switch_enabled` | Config effective encore en kill switch. |
+| `client_order_id_required` | Tentative sans client order id auditable/idempotent. |
 | `mainnet_write_forbidden` | Tentative mainnet mutative interdite. |
 | `audit_failed` | Audit non ecrit, mutation interdite. |
 

--- a/docs/handbook/runbooks/demo-testnet-kill-switch.md
+++ b/docs/handbook/runbooks/demo-testnet-kill-switch.md
@@ -101,6 +101,7 @@ trading:
 | `demo_trading_disabled` | Gate global `DEMO_TRADING_ENABLED=0`. |
 | `okx_demo_trading_disabled` | Gate OKX demo ferme. |
 | `hyperliquid_testnet_trading_disabled` | Gate Hyperliquid testnet ferme. |
+| `exchange_environment_pair_unsupported` | Paire hors scope : seules OKX/demo et Hyperliquid/testnet sont supportees. |
 | `effective_kill_switch_enabled` | Config effective encore en kill switch. |
 | `mainnet_write_forbidden` | Tentative mainnet mutative interdite. |
 | `audit_failed` | Audit non ecrit, mutation interdite. |

--- a/docs/handbook/runbooks/demo-testnet-kill-switch.md
+++ b/docs/handbook/runbooks/demo-testnet-kill-switch.md
@@ -1,0 +1,110 @@
+# Demo/Testnet Kill Switch Runbook
+
+## Objectif
+
+COMMON-004 ajoute un gate commun pour toute tentative mutative OKX demo ou
+Hyperliquid testnet. Le gate doit etre appele avant un futur envoi d'ordre
+`dry_run=false` en environnement fictif.
+
+Il ne rend pas le mainnet disponible. Une tentative mainnet reste bloquee meme si
+tous les switches demo/testnet sont ouverts.
+
+## Switches
+
+Les switches sont fail-closed par defaut :
+
+| Variable | Defaut | Effet |
+|---|---:|---|
+| `DEMO_TRADING_ENABLED` | `0` | Gate global. Si `0`, toute tentative demo/testnet est bloquee. |
+| `OKX_DEMO_TRADING_ENABLED` | `0` | Gate OKX demo. Si `0`, OKX/demo est bloque. |
+| `HYPERLIQUID_TESTNET_TRADING_ENABLED` | `0` | Gate Hyperliquid testnet. Si `0`, Hyperliquid/testnet est bloque. |
+| `trading.execution.kill_switch_enabled` | `true` | Kill switch de config effective. Si `true`, la tentative est bloquee. |
+
+Pour autoriser une future tentative demo/testnet, il faut donc :
+
+```bash
+DEMO_TRADING_ENABLED=1
+OKX_DEMO_TRADING_ENABLED=1              # OKX demo uniquement
+HYPERLIQUID_TESTNET_TRADING_ENABLED=1   # Hyperliquid testnet uniquement
+```
+
+et une config effective avec :
+
+```yaml
+trading:
+  execution:
+    mainnet_write_enabled: false
+    demo_testnet_write_enabled: true
+    kill_switch_enabled: false
+```
+
+Ces valeurs ne suffisent pas seules. La policy exige aussi une requete concrete :
+whitelist symbole ou marche, notional plafonne, notional demande, client order id
+auditable et stop loss present.
+
+## Audit obligatoire
+
+`DemoTradingKillSwitchService` produit une entree d'audit pour chaque tentative :
+
+- `exchange`
+- `environment`
+- `mode`
+- `profile`
+- `symbol`
+- `market`
+- `notional`
+- `client_order_id`
+- `action`
+- `allowed`
+- `outcome`
+- `reasons`
+- `correlation_ids`
+- `safety`
+- `audit_context`
+
+Les champs sensibles de `audit_context` sont redacted. Ne jamais placer de payload
+REST brut, signature, private key, token, cookie ou secret dans l'audit.
+
+Si l'audit ne peut pas etre ecrit, le service retourne une decision bloquee avec
+`audit_failed`. Une mutation ne doit jamais continuer sans audit ecrit.
+
+## Rollback immediat
+
+Pour stopper toute experimentation demo/testnet sans redeploy applicatif :
+
+```bash
+DEMO_TRADING_ENABLED=0
+OKX_DEMO_TRADING_ENABLED=0
+HYPERLIQUID_TESTNET_TRADING_ENABLED=0
+```
+
+Puis redemarrer les processus qui lisent l'environnement si necessaire :
+
+```bash
+docker-compose restart trading-app-php
+docker-compose restart trading-app-messenger-trading
+```
+
+Rollback de config effective :
+
+```yaml
+trading:
+  execution:
+    demo_testnet_write_enabled: false
+    kill_switch_enabled: true
+```
+
+## Raisons de blocage attendues
+
+| Raison | Interpretation |
+|---|---|
+| `demo_trading_disabled` | Gate global `DEMO_TRADING_ENABLED=0`. |
+| `okx_demo_trading_disabled` | Gate OKX demo ferme. |
+| `hyperliquid_testnet_trading_disabled` | Gate Hyperliquid testnet ferme. |
+| `effective_kill_switch_enabled` | Config effective encore en kill switch. |
+| `mainnet_write_forbidden` | Tentative mainnet mutative interdite. |
+| `audit_failed` | Audit non ecrit, mutation interdite. |
+
+Les raisons issues du safety envelope restent visibles, notamment
+`kill_switch_enabled`, `demo_testnet_write_not_enabled`, `max_notional_exceeded`
+ou `stop_loss_missing`.

--- a/docs/handbook/runbooks/demo-testnet-kill-switch.md
+++ b/docs/handbook/runbooks/demo-testnet-kill-switch.md
@@ -64,6 +64,13 @@ auditable et stop loss present.
 
 Les champs sensibles de `audit_context` sont redacted. Ne jamais placer de payload
 REST brut, signature, private key, token, cookie ou secret dans l'audit.
+Les identifiants non secrets comme `signal_id`, `signal_run_id`,
+`orchestration_run_id` et `correlation_run_id` doivent rester visibles pour la
+correlation.
+
+L'audit est ecrit sur le canal Monolog dedie `demo_trading_audit`, dans
+`var/log/demo-trading-audit.log`, avec un handler propre non pilote par
+`LOG_LEVEL_MAIN`.
 
 Si l'audit ne peut pas etre ecrit, le service retourne une decision bloquee avec
 `audit_failed`. Une mutation ne doit jamais continuer sans audit ecrit.

--- a/docs/handbook/technical/demo-testnet-safety-envelope.md
+++ b/docs/handbook/technical/demo-testnet-safety-envelope.md
@@ -105,6 +105,7 @@ Les erreurs sont explicites :
 - `hyperliquid_testnet_trading_disabled`
 - `exchange_environment_pair_unsupported`
 - `effective_kill_switch_enabled`
+- `client_order_id_required`
 - `mainnet_write_enabled_must_remain_false`
 - `mainnet_write_forbidden`
 - `local_dry_run_cannot_write`

--- a/docs/handbook/technical/demo-testnet-safety-envelope.md
+++ b/docs/handbook/technical/demo-testnet-safety-envelope.md
@@ -34,6 +34,10 @@ Le contrat est isole dans `App\TradingCore\Execution\Safety` :
 - `DemoTradingSafetyPolicy`
 - `DemoTradingSafetyDecision`
 - `DemoTradingSafetyPolicyEvaluator`
+- `DemoTradingMutationAttempt`
+- `DemoTradingKillSwitchService`
+- `DemoTradingKillSwitchDecision`
+- `DemoTradingAuditSinkInterface`
 
 `DemoTradingSafetyPolicyEvaluator` est pur :
 
@@ -42,6 +46,18 @@ Le contrat est isole dans `App\TradingCore\Execution\Safety` :
 - aucun acces a Symfony, Doctrine, Messenger ou Temporal ;
 - aucun secret requis ;
 - aucun effet de bord runtime.
+
+`DemoTradingKillSwitchService` est la facade runtime commune ajoutee par
+COMMON-004. Elle combine :
+
+- les switches d'environnement `DEMO_TRADING_ENABLED`,
+  `OKX_DEMO_TRADING_ENABLED`, `HYPERLIQUID_TESTNET_TRADING_ENABLED` ;
+- le `kill_switch_enabled` de la config effective ;
+- la policy pure `DemoTradingSafetyPolicyEvaluator` ;
+- un audit standardise via `DemoTradingAuditSinkInterface`.
+
+Le service reste fail-closed : si l'audit ne peut pas etre ecrit, la decision
+retournee est bloquee avec `audit_failed`.
 
 ## Niveaux de decision
 
@@ -64,6 +80,9 @@ Guards invariants :
 
 Guards obligatoires pour `demo|testnet` avec `dry_run=false` :
 
+- `DEMO_TRADING_ENABLED=true` ;
+- le switch exchange cible actif (`OKX_DEMO_TRADING_ENABLED=true` pour OKX demo
+  ou `HYPERLIQUID_TESTNET_TRADING_ENABLED=true` pour Hyperliquid testnet) ;
 - `demo_testnet_write_enabled=true` ;
 - `kill_switch_enabled=false` ;
 - `require_stop_loss=true` ;
@@ -79,6 +98,10 @@ a la policy respecte aussi la whitelist, le plafond notionnel et la presence SL.
 
 Les erreurs sont explicites :
 
+- `demo_trading_disabled`
+- `okx_demo_trading_disabled`
+- `hyperliquid_testnet_trading_disabled`
+- `effective_kill_switch_enabled`
 - `mainnet_write_enabled_must_remain_false`
 - `mainnet_write_forbidden`
 - `local_dry_run_cannot_write`
@@ -93,6 +116,31 @@ Les erreurs sont explicites :
 - `requested_symbol_or_market_not_allowed`
 - `stop_loss_presence_required`
 - `stop_loss_missing`
+- `audit_failed`
+
+## Audit COMMON-004
+
+Toute tentative mutative controlee par `DemoTradingKillSwitchService` produit une
+entree d'audit avec :
+
+- `exchange`
+- `environment`
+- `mode`
+- `profile`
+- `symbol`
+- `market`
+- `notional`
+- `client_order_id`
+- `action`
+- `allowed`
+- `outcome`
+- `reasons`
+- `correlation_ids`
+- `safety`
+- `audit_context`
+
+Les relations ambiguës ou blocages restent visibles dans `reasons`. Le service ne
+resout pas arbitrairement une tentative bloquee.
 
 ## Redaction
 
@@ -123,6 +171,14 @@ Cette PR ne fait pas :
 
 ## Rollback
 
+Rollback immediat demo/testnet : remettre `DEMO_TRADING_ENABLED=0`,
+`OKX_DEMO_TRADING_ENABLED=0`, `HYPERLIQUID_TESTNET_TRADING_ENABLED=0` et
+`trading.execution.kill_switch_enabled=true`, puis redemarrer les processus qui
+lisent l'environnement si necessaire.
+
 Rollback applicatif : supprimer l'usage futur du service ou revenir au commit
-precedent. Comme `COMMON-001` n'est pas branche au runtime existant, son rollback
-n'affecte pas les flux MTF, TradeEntry, OKX dry-run ou Hyperliquid dry-run actuels.
+precedent. Comme COMMON-004 ne branche pas encore de runtime mutatif reel, son
+rollback n'affecte pas les flux MTF, TradeEntry, OKX dry-run ou Hyperliquid
+dry-run actuels.
+
+Voir aussi : [Demo/Testnet Kill Switch Runbook](../runbooks/demo-testnet-kill-switch.md).

--- a/docs/handbook/technical/demo-testnet-safety-envelope.md
+++ b/docs/handbook/technical/demo-testnet-safety-envelope.md
@@ -146,6 +146,11 @@ entree d'audit avec :
 Les relations ambiguës ou blocages restent visibles dans `reasons`. Le service ne
 resout pas arbitrairement une tentative bloquee.
 
+L'audit COMMON-004 utilise un canal Monolog dedie `demo_trading_audit` et un
+fichier `var/log/demo-trading-audit.log`. Il ne depend pas de `LOG_LEVEL_MAIN`.
+Les IDs de correlation non secrets comme `signal_id` et `signal_run_id` restent
+visibles ; les cles de signature reelles comme `OK-ACCESS-SIGN` restent redacted.
+
 ## Redaction
 
 `DemoTradingSafetyDecision::toRedactedArray()` expose un payload d'audit sans secret.

--- a/docs/handbook/technical/demo-testnet-safety-envelope.md
+++ b/docs/handbook/technical/demo-testnet-safety-envelope.md
@@ -80,6 +80,8 @@ Guards invariants :
 
 Guards obligatoires pour `demo|testnet` avec `dry_run=false` :
 
+- la paire exchange/environnement doit etre supportee :
+  OKX/demo ou Hyperliquid/testnet ;
 - `DEMO_TRADING_ENABLED=true` ;
 - le switch exchange cible actif (`OKX_DEMO_TRADING_ENABLED=true` pour OKX demo
   ou `HYPERLIQUID_TESTNET_TRADING_ENABLED=true` pour Hyperliquid testnet) ;
@@ -101,6 +103,7 @@ Les erreurs sont explicites :
 - `demo_trading_disabled`
 - `okx_demo_trading_disabled`
 - `hyperliquid_testnet_trading_disabled`
+- `exchange_environment_pair_unsupported`
 - `effective_kill_switch_enabled`
 - `mainnet_write_enabled_must_remain_false`
 - `mainnet_write_forbidden`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Runbooks:
       - Exploitation: runbooks/operations.md
       - Investigation: runbooks/investigation.md
+      - Demo/Testnet kill switch: runbooks/demo-testnet-kill-switch.md
       - Recette orchestrateur R1-R16: runbooks/orchestrator-runtime-recipe-r1-r16.md
   - Rapports:
       - "Recette runtime orchestrateur #188": reports/orchestrator-runtime-final-report.md

--- a/trading-app/config/packages/monolog.yaml
+++ b/trading-app/config/packages/monolog.yaml
@@ -1,5 +1,5 @@
 monolog:
-  channels: ['mtf', 'signals', 'positions', 'provider', 'bitmart', 'indicators', 'runtime', 'pipeline_exec', 'deprecation', 'global-severity', 'ws_agent', 'conditionsLogger']
+  channels: ['mtf', 'signals', 'positions', 'provider', 'bitmart', 'indicators', 'runtime', 'pipeline_exec', 'deprecation', 'global-severity', 'ws_agent', 'conditionsLogger', 'demo_trading_audit']
   handlers:
     # =====================
     # --- Handler Temporal (Asynchrone) ---
@@ -62,6 +62,14 @@ monolog:
       max_files: 5
       level: info
       channels: ['conditionsLogger']
+      formatter: App\Logging\CustomLineFormatter
+
+    demo_trading_audit_rotating:
+      type: rotating_file
+      path: '%kernel.project_dir%/var/log/demo-trading-audit.log'
+      max_files: 30
+      level: debug
+      channels: ['demo_trading_audit']
       formatter: App\Logging\CustomLineFormatter
 
     # Canal Bitmart - Traçage des appels API Bitmart (REST/Privé)

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -48,6 +48,7 @@ parameters:
     env(HYPERLIQUID_API_BASE_URI): ''
     env(HYPERLIQUID_WS_URI): ''
     env(HYPERLIQUID_MAINNET_ENABLED): '0'
+    env(HYPERLIQUID_TESTNET_TRADING_ENABLED): '0'
     env(OKX_ENV): 'demo'
     env(OKX_API_KEY): ''
     env(OKX_API_SECRET): ''
@@ -55,6 +56,7 @@ parameters:
     env(OKX_API_BASE_URI): ''
     env(OKX_WS_PUBLIC_URI): ''
     env(OKX_WS_PRIVATE_URI): ''
+    env(DEMO_TRADING_ENABLED): '0'
     env(OKX_DEMO_TRADING_ENABLED): '0'
     env(OKX_LIVE_ENABLED): '0'
     env(MTF_VALIDATION_FALLBACK_ALERT_THRESHOLD): '1'
@@ -116,6 +118,15 @@ services:
     App\Trading\Reporting\PositionTradeAnalysisReportingService:
         arguments:
             $configuredSource: '%env(string:POSITION_TRADE_ANALYSIS_REPORTING_SOURCE)%'
+
+    App\TradingCore\Execution\Safety\DemoTradingAuditSinkInterface:
+        alias: App\TradingCore\Execution\Safety\PsrDemoTradingAuditSink
+
+    App\TradingCore\Execution\Safety\DemoTradingKillSwitchService:
+        arguments:
+            $globalDemoTradingEnabled: '%env(bool:DEMO_TRADING_ENABLED)%'
+            $okxDemoTradingEnabled: '%env(bool:OKX_DEMO_TRADING_ENABLED)%'
+            $hyperliquidTestnetTradingEnabled: '%env(bool:HYPERLIQUID_TESTNET_TRADING_ENABLED)%'
 
 
 

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -122,6 +122,10 @@ services:
     App\TradingCore\Execution\Safety\DemoTradingAuditSinkInterface:
         alias: App\TradingCore\Execution\Safety\PsrDemoTradingAuditSink
 
+    App\TradingCore\Execution\Safety\PsrDemoTradingAuditSink:
+        arguments:
+            $logger: '@monolog.logger.demo_trading_audit'
+
     App\TradingCore\Execution\Safety\DemoTradingKillSwitchService:
         arguments:
             $globalDemoTradingEnabled: '%env(bool:DEMO_TRADING_ENABLED)%'

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingAuditSinkInterface.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingAuditSinkInterface.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+interface DemoTradingAuditSinkInterface
+{
+    /**
+     * @param array<string,mixed> $event
+     */
+    public function recordDemoTradingAttempt(array $event): void;
+}

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchDecision.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchDecision.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+final readonly class DemoTradingKillSwitchDecision
+{
+    /**
+     * @param list<string> $reasons
+     * @param array<string,mixed> $auditEvent
+     */
+    public function __construct(
+        public bool $allowed,
+        public array $reasons,
+        public DemoTradingSafetyDecision $safetyDecision,
+        public array $auditEvent,
+    ) {
+    }
+
+    public function blocked(): bool
+    {
+        return !$this->allowed;
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+use App\Common\Enum\Exchange;
+
+final readonly class DemoTradingKillSwitchService
+{
+    public function __construct(
+        private DemoTradingSafetyPolicyEvaluator $evaluator,
+        private DemoTradingAuditSinkInterface $auditSink,
+        private bool $globalDemoTradingEnabled = false,
+        private bool $okxDemoTradingEnabled = false,
+        private bool $hyperliquidTestnetTradingEnabled = false,
+    ) {
+    }
+
+    public function evaluate(DemoTradingMutationAttempt $attempt): DemoTradingKillSwitchDecision
+    {
+        $switchReasons = $this->switchReasons($attempt);
+        $policy = new DemoTradingSafetyPolicy(
+            environment: $attempt->environment,
+            dryRun: false,
+            mainnetWriteEnabled: $attempt->mainnetWriteEnabled,
+            demoTestnetWriteEnabled: $attempt->demoTestnetWriteEnabled,
+            killSwitchEnabled: $attempt->effectiveKillSwitchEnabled || $switchReasons !== [],
+            requireStopLoss: $attempt->requireStopLoss,
+            allowedSymbols: $attempt->allowedSymbols,
+            allowedMarkets: $attempt->allowedMarkets,
+            maxNotional: $attempt->maxNotional,
+            requestedSymbol: $attempt->symbol,
+            requestedMarket: $attempt->market,
+            requestedNotional: $attempt->notional,
+            stopLossPresent: $attempt->stopLossPresent,
+            auditContext: $attempt->auditContext,
+        );
+
+        $safetyDecision = $this->evaluator->evaluate($policy);
+        $reasons = $this->mergeReasons($switchReasons, $safetyDecision->blockingErrors);
+        $allowed = $safetyDecision->allowed && $reasons === [];
+        $auditEvent = $this->auditEvent($attempt, $safetyDecision, $allowed, $reasons);
+
+        try {
+            $this->auditSink->recordDemoTradingAttempt($auditEvent);
+        } catch (\Throwable) {
+            $reasons = $this->mergeReasons($reasons, ['audit_failed']);
+            $auditEvent = array_merge($auditEvent, [
+                'allowed' => false,
+                'outcome' => 'blocked',
+                'reasons' => $reasons,
+            ]);
+
+            return new DemoTradingKillSwitchDecision(
+                allowed: false,
+                reasons: $reasons,
+                safetyDecision: $safetyDecision,
+                auditEvent: $auditEvent,
+            );
+        }
+
+        return new DemoTradingKillSwitchDecision(
+            allowed: $allowed,
+            reasons: $reasons,
+            safetyDecision: $safetyDecision,
+            auditEvent: $auditEvent,
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function switchReasons(DemoTradingMutationAttempt $attempt): array
+    {
+        $reasons = [];
+
+        if (!$this->globalDemoTradingEnabled && $attempt->environment->isDemoOrTestnet()) {
+            $reasons[] = 'demo_trading_disabled';
+        }
+
+        if ($attempt->exchange === Exchange::OKX
+            && $attempt->environment === ExchangeRuntimeEnvironment::DEMO
+            && !$this->okxDemoTradingEnabled
+        ) {
+            $reasons[] = 'okx_demo_trading_disabled';
+        }
+
+        if ($attempt->exchange === Exchange::HYPERLIQUID
+            && $attempt->environment === ExchangeRuntimeEnvironment::TESTNET
+            && !$this->hyperliquidTestnetTradingEnabled
+        ) {
+            $reasons[] = 'hyperliquid_testnet_trading_disabled';
+        }
+
+        if ($attempt->effectiveKillSwitchEnabled) {
+            $reasons[] = 'effective_kill_switch_enabled';
+        }
+
+        return $reasons;
+    }
+
+    /**
+     * @param list<string> $first
+     * @param list<string> $second
+     * @return list<string>
+     */
+    private function mergeReasons(array $first, array $second): array
+    {
+        return array_values(array_unique(array_merge($first, $second)));
+    }
+
+    /**
+     * @param list<string> $reasons
+     * @return array<string,mixed>
+     */
+    private function auditEvent(
+        DemoTradingMutationAttempt $attempt,
+        DemoTradingSafetyDecision $safetyDecision,
+        bool $allowed,
+        array $reasons,
+    ): array {
+        return [
+            'exchange' => $attempt->exchange->value,
+            'environment' => $attempt->environment->value,
+            'mode' => $attempt->mode,
+            'profile' => $attempt->profile,
+            'symbol' => $attempt->symbol,
+            'market' => $attempt->market,
+            'notional' => $attempt->notional,
+            'client_order_id' => $attempt->clientOrderId,
+            'action' => $attempt->action,
+            'allowed' => $allowed,
+            'outcome' => $allowed ? 'allowed' : 'blocked',
+            'reasons' => $reasons,
+            'correlation_ids' => self::redact($attempt->correlationIds),
+            'safety' => [
+                'level' => $safetyDecision->level->value,
+                'allowed' => $safetyDecision->allowed,
+                'blocking_errors' => $safetyDecision->blockingErrors,
+                'warnings' => $safetyDecision->warnings,
+            ],
+            'audit_context' => self::redact($attempt->auditContext),
+        ];
+    }
+
+    private static function redact(mixed $value, ?string $key = null): mixed
+    {
+        if ($key !== null && self::isSensitiveKey($key)) {
+            return '[redacted]';
+        }
+
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        $redacted = [];
+        foreach ($value as $childKey => $childValue) {
+            $redacted[$childKey] = self::redact(
+                $childValue,
+                is_string($childKey) ? $childKey : null,
+            );
+        }
+
+        return $redacted;
+    }
+
+    private static function isSensitiveKey(string $key): bool
+    {
+        $normalized = trim((string) preg_replace('/[^a-z0-9]+/', '_', strtolower($key)), '_');
+        $compacted = str_replace('_', '', $normalized);
+
+        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature', 'authorization', 'cookie', 'memo', 'credential', 'sign'] as $needle) {
+            if (str_contains($normalized, $needle) || str_contains($compacted, str_replace('_', '', $needle))) {
+                return true;
+            }
+        }
+
+        return $normalized === 'key'
+            || str_ends_with($normalized, '_key')
+            || str_ends_with($compacted, 'key');
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
@@ -183,14 +183,16 @@ final readonly class DemoTradingKillSwitchService
         $normalized = trim((string) preg_replace('/[^a-z0-9]+/', '_', strtolower($key)), '_');
         $compacted = str_replace('_', '', $normalized);
 
-        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature', 'authorization', 'cookie', 'memo', 'credential', 'sign'] as $needle) {
+        foreach (['secret', 'token', 'api_key', 'private_key', 'passphrase', 'password', 'signature', 'authorization', 'cookie', 'memo', 'credential'] as $needle) {
             if (str_contains($normalized, $needle) || str_contains($compacted, str_replace('_', '', $needle))) {
                 return true;
             }
         }
 
         return $normalized === 'key'
+            || $normalized === 'sign'
             || str_ends_with($normalized, '_key')
+            || str_ends_with($normalized, '_sign')
             || str_ends_with($compacted, 'key');
     }
 }

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
@@ -100,6 +100,10 @@ final readonly class DemoTradingKillSwitchService
             $reasons[] = 'effective_kill_switch_enabled';
         }
 
+        if ($attempt->clientOrderId === null) {
+            $reasons[] = 'client_order_id_required';
+        }
+
         return $reasons;
     }
 

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingKillSwitchService.php
@@ -78,6 +78,10 @@ final readonly class DemoTradingKillSwitchService
             $reasons[] = 'demo_trading_disabled';
         }
 
+        if ($attempt->environment->isDemoOrTestnet() && !$this->isSupportedDemoTestnetPair($attempt)) {
+            $reasons[] = 'exchange_environment_pair_unsupported';
+        }
+
         if ($attempt->exchange === Exchange::OKX
             && $attempt->environment === ExchangeRuntimeEnvironment::DEMO
             && !$this->okxDemoTradingEnabled
@@ -97,6 +101,12 @@ final readonly class DemoTradingKillSwitchService
         }
 
         return $reasons;
+    }
+
+    private function isSupportedDemoTestnetPair(DemoTradingMutationAttempt $attempt): bool
+    {
+        return ($attempt->exchange === Exchange::OKX && $attempt->environment === ExchangeRuntimeEnvironment::DEMO)
+            || ($attempt->exchange === Exchange::HYPERLIQUID && $attempt->environment === ExchangeRuntimeEnvironment::TESTNET);
     }
 
     /**

--- a/trading-app/src/TradingCore/Execution/Safety/DemoTradingMutationAttempt.php
+++ b/trading-app/src/TradingCore/Execution/Safety/DemoTradingMutationAttempt.php
@@ -1,0 +1,134 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+use App\Common\Enum\Exchange;
+
+final readonly class DemoTradingMutationAttempt
+{
+    /** @var list<string> */
+    public array $allowedSymbols;
+
+    /** @var list<string> */
+    public array $allowedMarkets;
+
+    public ?string $symbol;
+
+    public ?string $clientOrderId;
+
+    /** @var array<string,string> */
+    public array $correlationIds;
+
+    /** @var array<string,mixed> */
+    public array $auditContext;
+
+    /**
+     * @param list<string> $allowedSymbols
+     * @param list<string> $allowedMarkets
+     * @param array<mixed,mixed> $correlationIds
+     * @param array<string,mixed> $auditContext
+     */
+    public function __construct(
+        public Exchange $exchange,
+        public ExchangeRuntimeEnvironment $environment,
+        public string $mode,
+        public string $profile,
+        public string $market,
+        ?string $symbol,
+        public ?float $notional,
+        ?string $clientOrderId,
+        public string $action,
+        public bool $mainnetWriteEnabled = false,
+        public bool $demoTestnetWriteEnabled = false,
+        public bool $effectiveKillSwitchEnabled = true,
+        public bool $requireStopLoss = true,
+        public ?bool $stopLossPresent = null,
+        array $allowedSymbols = [],
+        array $allowedMarkets = [],
+        public ?float $maxNotional = null,
+        array $correlationIds = [],
+        array $auditContext = [],
+    ) {
+        $this->assertNonEmpty($mode, 'mode');
+        $this->assertNonEmpty($profile, 'profile');
+        $this->assertNonEmpty($market, 'market');
+        $this->assertNonEmpty($action, 'action');
+
+        if ($notional !== null && (!is_finite($notional) || $notional <= 0.0)) {
+            throw new \InvalidArgumentException('notional must be positive and finite when provided.');
+        }
+
+        if ($maxNotional !== null && (!is_finite($maxNotional) || $maxNotional <= 0.0)) {
+            throw new \InvalidArgumentException('maxNotional must be positive and finite when provided.');
+        }
+
+        $this->symbol = $this->normalizeNullableString($symbol);
+        $this->clientOrderId = $this->normalizeNullableString($clientOrderId);
+        $this->allowedSymbols = $this->normalizeStringList($allowedSymbols, 'allowedSymbols');
+        $this->allowedMarkets = $this->normalizeStringList($allowedMarkets, 'allowedMarkets');
+        $this->correlationIds = $this->normalizeStringMap($correlationIds, 'correlationIds');
+        $this->auditContext = $auditContext;
+    }
+
+    private function assertNonEmpty(string $value, string $field): void
+    {
+        if (trim($value) === '') {
+            throw new \InvalidArgumentException(sprintf('%s must not be blank.', $field));
+        }
+    }
+
+    /**
+     * @param list<string> $values
+     * @return list<string>
+     */
+    private function normalizeStringList(array $values, string $field): array
+    {
+        $normalized = [];
+        foreach ($values as $value) {
+            if (!is_string($value)) {
+                throw new \InvalidArgumentException(sprintf('%s must contain only strings.', $field));
+            }
+
+            $trimmed = trim($value);
+            if ($trimmed !== '') {
+                $normalized[] = $trimmed;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @param array<mixed,mixed> $values
+     * @return array<string,string>
+     */
+    private function normalizeStringMap(array $values, string $field): array
+    {
+        $normalized = [];
+        foreach ($values as $key => $value) {
+            if (!is_string($key) || !is_string($value)) {
+                throw new \InvalidArgumentException(sprintf('%s must be a string map.', $field));
+            }
+
+            $trimmedKey = trim($key);
+            $trimmedValue = trim($value);
+            if ($trimmedKey !== '' && $trimmedValue !== '') {
+                $normalized[$trimmedKey] = $trimmedValue;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeNullableString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Safety/PsrDemoTradingAuditSink.php
+++ b/trading-app/src/TradingCore/Execution/Safety/PsrDemoTradingAuditSink.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Safety;
+
+use Psr\Log\LoggerInterface;
+
+final readonly class PsrDemoTradingAuditSink implements DemoTradingAuditSinkInterface
+{
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function recordDemoTradingAttempt(array $event): void
+    {
+        $this->logger->info('[DemoTrading] mutation attempt', $event);
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
@@ -68,6 +68,7 @@ final class DemoTradingKillSwitchServiceTest extends TestCase
             auditContext: [
                 'OKX_DEMO_API_KEY' => 'demo-key',
                 'OK-ACCESS-SIGN' => 'raw-signature',
+                'signal_id' => 'signal-789',
                 'nested' => [
                     'private_key' => 'wallet-secret',
                     'safe_value' => 'visible',
@@ -76,6 +77,7 @@ final class DemoTradingKillSwitchServiceTest extends TestCase
             correlationIds: [
                 'orchestration_run_id' => 'run-123',
                 'correlation_run_id' => 'corr-456',
+                'signal_run_id' => 'signal-run-123',
             ],
         ));
 
@@ -96,8 +98,10 @@ final class DemoTradingKillSwitchServiceTest extends TestCase
         self::assertTrue($event['allowed']);
         self::assertSame([], $event['reasons']);
         self::assertSame('run-123', $event['correlation_ids']['orchestration_run_id']);
+        self::assertSame('signal-run-123', $event['correlation_ids']['signal_run_id']);
         self::assertSame('[redacted]', $event['audit_context']['OKX_DEMO_API_KEY']);
         self::assertSame('[redacted]', $event['audit_context']['OK-ACCESS-SIGN']);
+        self::assertSame('signal-789', $event['audit_context']['signal_id']);
         self::assertSame('[redacted]', $event['audit_context']['nested']['private_key']);
         self::assertSame('visible', $event['audit_context']['nested']['safe_value']);
 

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
@@ -1,0 +1,238 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution\Safety;
+
+use App\Common\Enum\Exchange;
+use App\TradingCore\Execution\Safety\DemoTradingAuditSinkInterface;
+use App\TradingCore\Execution\Safety\DemoTradingKillSwitchDecision;
+use App\TradingCore\Execution\Safety\DemoTradingKillSwitchService;
+use App\TradingCore\Execution\Safety\DemoTradingMutationAttempt;
+use App\TradingCore\Execution\Safety\DemoTradingSafetyDecision;
+use App\TradingCore\Execution\Safety\DemoTradingSafetyLevel;
+use App\TradingCore\Execution\Safety\DemoTradingSafetyPolicyEvaluator;
+use App\TradingCore\Execution\Safety\ExchangeRuntimeEnvironment;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DemoTradingKillSwitchDecision::class)]
+#[CoversClass(DemoTradingKillSwitchService::class)]
+#[CoversClass(DemoTradingMutationAttempt::class)]
+#[CoversClass(DemoTradingSafetyDecision::class)]
+#[CoversClass(DemoTradingSafetyPolicyEvaluator::class)]
+final class DemoTradingKillSwitchServiceTest extends TestCase
+{
+    public function testGlobalKillSwitchBlocksEveryDemoTestnetAttempt(): void
+    {
+        $sink = new CapturingDemoTradingAuditSink();
+        $decision = $this->service(
+            sink: $sink,
+            globalDemoTradingEnabled: false,
+            okxDemoTradingEnabled: true,
+            hyperliquidTestnetTradingEnabled: true,
+        )->evaluate($this->okxAttempt());
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('demo_trading_disabled', $decision->reasons);
+        self::assertContains('kill_switch_enabled', $decision->reasons);
+        self::assertSame('blocked', $sink->events[0]['outcome']);
+        self::assertSame(['demo_trading_disabled', 'kill_switch_enabled'], $sink->events[0]['reasons']);
+    }
+
+    public function testExchangeKillSwitchBlocksOnlyConcernedExchange(): void
+    {
+        $sink = new CapturingDemoTradingAuditSink();
+        $service = $this->service(
+            sink: $sink,
+            globalDemoTradingEnabled: true,
+            okxDemoTradingEnabled: false,
+            hyperliquidTestnetTradingEnabled: true,
+        );
+
+        $okxDecision = $service->evaluate($this->okxAttempt());
+        $hyperliquidDecision = $service->evaluate($this->hyperliquidAttempt());
+
+        self::assertFalse($okxDecision->allowed);
+        self::assertContains('okx_demo_trading_disabled', $okxDecision->reasons);
+
+        self::assertTrue($hyperliquidDecision->allowed);
+        self::assertSame(DemoTradingSafetyLevel::DemoTestnetEnabled, $hyperliquidDecision->safetyDecision->level);
+        self::assertSame('blocked', $sink->events[0]['outcome']);
+        self::assertSame('allowed', $sink->events[1]['outcome']);
+    }
+
+    public function testAuditEntryIsStandardizedAndRedacted(): void
+    {
+        $sink = new CapturingDemoTradingAuditSink();
+        $decision = $this->service($sink)->evaluate($this->okxAttempt(
+            auditContext: [
+                'OKX_DEMO_API_KEY' => 'demo-key',
+                'OK-ACCESS-SIGN' => 'raw-signature',
+                'nested' => [
+                    'private_key' => 'wallet-secret',
+                    'safe_value' => 'visible',
+                ],
+            ],
+            correlationIds: [
+                'orchestration_run_id' => 'run-123',
+                'correlation_run_id' => 'corr-456',
+            ],
+        ));
+
+        self::assertTrue($decision->allowed);
+        self::assertCount(1, $sink->events);
+
+        $event = $sink->events[0];
+        self::assertSame('okx', $event['exchange']);
+        self::assertSame('demo', $event['environment']);
+        self::assertSame('scalper_micro', $event['mode']);
+        self::assertSame('scalper_micro', $event['profile']);
+        self::assertSame('BTCUSDT', $event['symbol']);
+        self::assertSame('perpetual', $event['market']);
+        self::assertSame(12.5, $event['notional']);
+        self::assertSame('cid-001', $event['client_order_id']);
+        self::assertSame('place_order', $event['action']);
+        self::assertSame('allowed', $event['outcome']);
+        self::assertTrue($event['allowed']);
+        self::assertSame([], $event['reasons']);
+        self::assertSame('run-123', $event['correlation_ids']['orchestration_run_id']);
+        self::assertSame('[redacted]', $event['audit_context']['OKX_DEMO_API_KEY']);
+        self::assertSame('[redacted]', $event['audit_context']['OK-ACCESS-SIGN']);
+        self::assertSame('[redacted]', $event['audit_context']['nested']['private_key']);
+        self::assertSame('visible', $event['audit_context']['nested']['safe_value']);
+
+        $encoded = json_encode($event, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('demo-key', $encoded);
+        self::assertStringNotContainsString('raw-signature', $encoded);
+        self::assertStringNotContainsString('wallet-secret', $encoded);
+    }
+
+    public function testMainnetRemainsBlockedEvenWhenEverySwitchIsOff(): void
+    {
+        $sink = new CapturingDemoTradingAuditSink();
+        $decision = $this->service(
+            sink: $sink,
+            globalDemoTradingEnabled: true,
+            okxDemoTradingEnabled: true,
+            hyperliquidTestnetTradingEnabled: true,
+        )->evaluate($this->okxAttempt(
+            environment: ExchangeRuntimeEnvironment::MAINNET,
+            effectiveKillSwitchEnabled: false,
+            mainnetWriteEnabled: false,
+        ));
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('mainnet_write_forbidden', $decision->reasons);
+        self::assertSame('blocked', $sink->events[0]['outcome']);
+    }
+
+    public function testAllowedMutationAttemptIsAuditedBeforeCallerCanProceed(): void
+    {
+        $sink = new CapturingDemoTradingAuditSink();
+        $decision = $this->service($sink)->evaluate($this->okxAttempt());
+
+        self::assertTrue($decision->allowed);
+        self::assertCount(1, $sink->events);
+        self::assertSame('allowed', $sink->events[0]['outcome']);
+        self::assertSame($sink->events[0], $decision->auditEvent);
+    }
+
+    public function testAuditFailureBlocksMutation(): void
+    {
+        $decision = $this->service(new FailingDemoTradingAuditSink())->evaluate($this->okxAttempt());
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('audit_failed', $decision->reasons);
+        self::assertSame('blocked', $decision->auditEvent['outcome']);
+    }
+
+    /**
+     * @param array<string,mixed> $auditContext
+     * @param array<string,string> $correlationIds
+     */
+    private function okxAttempt(
+        ExchangeRuntimeEnvironment $environment = ExchangeRuntimeEnvironment::DEMO,
+        bool $effectiveKillSwitchEnabled = false,
+        bool $mainnetWriteEnabled = false,
+        array $auditContext = [],
+        array $correlationIds = [],
+    ): DemoTradingMutationAttempt {
+        return new DemoTradingMutationAttempt(
+            exchange: Exchange::OKX,
+            environment: $environment,
+            mode: 'scalper_micro',
+            profile: 'scalper_micro',
+            market: 'perpetual',
+            symbol: 'BTCUSDT',
+            notional: 12.5,
+            clientOrderId: 'cid-001',
+            action: 'place_order',
+            mainnetWriteEnabled: $mainnetWriteEnabled,
+            demoTestnetWriteEnabled: true,
+            effectiveKillSwitchEnabled: $effectiveKillSwitchEnabled,
+            requireStopLoss: true,
+            stopLossPresent: true,
+            allowedSymbols: ['BTCUSDT'],
+            allowedMarkets: ['perpetual'],
+            maxNotional: 25.0,
+            correlationIds: $correlationIds,
+            auditContext: $auditContext,
+        );
+    }
+
+    private function hyperliquidAttempt(): DemoTradingMutationAttempt
+    {
+        return new DemoTradingMutationAttempt(
+            exchange: Exchange::HYPERLIQUID,
+            environment: ExchangeRuntimeEnvironment::TESTNET,
+            mode: 'scalper_micro',
+            profile: 'scalper_micro',
+            market: 'perpetual',
+            symbol: 'BTC',
+            notional: 12.5,
+            clientOrderId: 'hl-cid-001',
+            action: 'place_order',
+            demoTestnetWriteEnabled: true,
+            effectiveKillSwitchEnabled: false,
+            requireStopLoss: true,
+            stopLossPresent: true,
+            allowedSymbols: ['BTC'],
+            allowedMarkets: ['perpetual'],
+            maxNotional: 25.0,
+        );
+    }
+
+    private function service(
+        DemoTradingAuditSinkInterface $sink,
+        bool $globalDemoTradingEnabled = true,
+        bool $okxDemoTradingEnabled = true,
+        bool $hyperliquidTestnetTradingEnabled = true,
+    ): DemoTradingKillSwitchService {
+        return new DemoTradingKillSwitchService(
+            evaluator: new DemoTradingSafetyPolicyEvaluator(),
+            auditSink: $sink,
+            globalDemoTradingEnabled: $globalDemoTradingEnabled,
+            okxDemoTradingEnabled: $okxDemoTradingEnabled,
+            hyperliquidTestnetTradingEnabled: $hyperliquidTestnetTradingEnabled,
+        );
+    }
+}
+
+final class CapturingDemoTradingAuditSink implements DemoTradingAuditSinkInterface
+{
+    /** @var list<array<string,mixed>> */
+    public array $events = [];
+
+    public function recordDemoTradingAttempt(array $event): void
+    {
+        $this->events[] = $event;
+    }
+}
+
+final class FailingDemoTradingAuditSink implements DemoTradingAuditSinkInterface
+{
+    public function recordDemoTradingAttempt(array $event): void
+    {
+        throw new \RuntimeException('audit sink unavailable');
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
@@ -157,6 +157,22 @@ final class DemoTradingKillSwitchServiceTest extends TestCase
         self::assertSame('blocked', $sink->events[1]['outcome']);
     }
 
+    public function testClientOrderIdIsRequiredBeforeAllowingMutation(): void
+    {
+        $sink = new CapturingDemoTradingAuditSink();
+        $decision = $this->service($sink)->evaluate($this->attempt(
+            exchange: Exchange::OKX,
+            environment: ExchangeRuntimeEnvironment::DEMO,
+            symbol: 'BTCUSDT',
+            clientOrderId: '',
+        ));
+
+        self::assertFalse($decision->allowed);
+        self::assertContains('client_order_id_required', $decision->reasons);
+        self::assertSame('blocked', $sink->events[0]['outcome']);
+        self::assertNull($sink->events[0]['client_order_id']);
+    }
+
     public function testAllowedMutationAttemptIsAuditedBeforeCallerCanProceed(): void
     {
         $sink = new CapturingDemoTradingAuditSink();

--- a/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
+++ b/trading-app/tests/TradingCore/Execution/Safety/DemoTradingKillSwitchServiceTest.php
@@ -126,6 +126,37 @@ final class DemoTradingKillSwitchServiceTest extends TestCase
         self::assertSame('blocked', $sink->events[0]['outcome']);
     }
 
+    public function testUnsupportedDemoTestnetPairsAreBlocked(): void
+    {
+        $sink = new CapturingDemoTradingAuditSink();
+        $service = $this->service(
+            sink: $sink,
+            globalDemoTradingEnabled: true,
+            okxDemoTradingEnabled: true,
+            hyperliquidTestnetTradingEnabled: true,
+        );
+
+        $bitmartDemo = $service->evaluate($this->attempt(
+            exchange: Exchange::BITMART,
+            environment: ExchangeRuntimeEnvironment::DEMO,
+            symbol: 'BTCUSDT',
+            clientOrderId: 'bitmart-cid-001',
+        ));
+        $okxTestnet = $service->evaluate($this->attempt(
+            exchange: Exchange::OKX,
+            environment: ExchangeRuntimeEnvironment::TESTNET,
+            symbol: 'BTCUSDT',
+            clientOrderId: 'okx-testnet-cid-001',
+        ));
+
+        self::assertFalse($bitmartDemo->allowed);
+        self::assertContains('exchange_environment_pair_unsupported', $bitmartDemo->reasons);
+        self::assertFalse($okxTestnet->allowed);
+        self::assertContains('exchange_environment_pair_unsupported', $okxTestnet->reasons);
+        self::assertSame('blocked', $sink->events[0]['outcome']);
+        self::assertSame('blocked', $sink->events[1]['outcome']);
+    }
+
     public function testAllowedMutationAttemptIsAuditedBeforeCallerCanProceed(): void
     {
         $sink = new CapturingDemoTradingAuditSink();
@@ -182,21 +213,40 @@ final class DemoTradingKillSwitchServiceTest extends TestCase
 
     private function hyperliquidAttempt(): DemoTradingMutationAttempt
     {
-        return new DemoTradingMutationAttempt(
+        return $this->attempt(
             exchange: Exchange::HYPERLIQUID,
             environment: ExchangeRuntimeEnvironment::TESTNET,
+            symbol: 'BTC',
+            clientOrderId: 'hl-cid-001',
+            allowedSymbols: ['BTC'],
+        );
+    }
+
+    /**
+     * @param list<string> $allowedSymbols
+     */
+    private function attempt(
+        Exchange $exchange,
+        ExchangeRuntimeEnvironment $environment,
+        string $symbol,
+        string $clientOrderId,
+        array $allowedSymbols = ['BTCUSDT'],
+    ): DemoTradingMutationAttempt {
+        return new DemoTradingMutationAttempt(
+            exchange: $exchange,
+            environment: $environment,
             mode: 'scalper_micro',
             profile: 'scalper_micro',
             market: 'perpetual',
-            symbol: 'BTC',
+            symbol: $symbol,
             notional: 12.5,
-            clientOrderId: 'hl-cid-001',
+            clientOrderId: $clientOrderId,
             action: 'place_order',
             demoTestnetWriteEnabled: true,
             effectiveKillSwitchEnabled: false,
             requireStopLoss: true,
             stopLossPresent: true,
-            allowedSymbols: ['BTC'],
+            allowedSymbols: $allowedSymbols,
             allowedMarkets: ['perpetual'],
             maxNotional: 25.0,
         );


### PR DESCRIPTION
## Summary
- Add `DemoTradingKillSwitchService` for future mutative demo/testnet attempts, combining env switches, effective kill switch config, the existing safety policy, and mandatory audit.
- Add standardized redacted audit payloads plus a PSR logger-backed audit sink; audit failure returns a blocked decision with `audit_failed`.
- Document the kill switch runbook, rollback procedure, env defaults, and COMMON-004 behavior in the safety envelope docs.

## Scope notes
- No mainnet write path is enabled.
- No exchange REST/WS calls are added.
- No strategy, EntryZone, Risk/Leverage, SL/TP, MTF, Temporal, or Bitmart behavior is changed.
- This is a common gate for later OKX demo / Hyperliquid testnet mutative PRs.

## Test plan
- `vendor/bin/phpunit tests/TradingCore/Execution/Safety`
- `vendor/bin/phpstan analyse src/TradingCore/Execution/Safety tests/TradingCore/Execution/Safety --memory-limit=1G`
- `php bin/console lint:yaml config`
- `php bin/console lint:container --no-debug`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Notes
- `lint:container` exits 0; it still prints the pre-existing PHP 8.4 deprecation in `EntryZoneStatsCommand::__construct()`.
- `mkdocs build --strict` exits 0; it still reports existing docs pages not included in nav.

Related to COMMON-001 / #221.
Related to COMMON-002 / #222.
Related to COMMON-003 / #223.
Part of the OKX demo / Hyperliquid testnet canonical PR sequence.
