### PR TITLE
COMMON-005 Fake/Paper demo recipe scenarios

### DIFF
--- a/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
+++ b/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
@@ -219,6 +219,35 @@ operateur. Les scenarios qui exigent ce type de controle, notamment R10 et le
 rollback effectif R16, restent `BLOCKED` jusqu'a execution sur une stack de
 recette dediee.
 
+## Preuve locale Fake/Paper COMMON-005
+
+Avant toute recette demo/testnet mutative OKX ou Hyperliquid, exercer le minimum
+Fake/Paper local :
+
+```bash
+cd trading-app
+php vendor/bin/phpunit tests/TradingCore/Execution/FakeExecutionPortTest.php
+```
+
+La fixture de scenarios est versionnee ici :
+
+```text
+trading-app/tests/fixtures/fake-paper/demo-recipe-scenarios.json
+```
+
+Les scenarios requis pour la protection sont :
+
+- fill complet + stop attache avec succes ;
+- fill complet + echec d'attache stop, avec fail-safe explicite ;
+- fill partiel + stop partiel refuse explicitement ;
+- duplicate `client_order_id`, sans creation d'un second fill ;
+- restart/resync simule via snapshot memoire ;
+- cancel et rejet d'ordre structures.
+
+Cette preuve reste locale : elle ne demarre pas OKX, Hyperliquid, Temporal ou un
+adapter exchange reel. Un resultat incomplet ou non protege doit rester `failed`
+ou `rejected`, jamais `PASS` pour une recette mutative.
+
 ## Commandes de recette guidee
 
 Run manuel :

--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -36,7 +36,7 @@ ou HTTP. Il ne passe aucun ordre.
 `FakeExecutionPort implements ExecutionPortInterface` est la gateway de test canonique.
 Elle respecte strictement l'interface existante : `execute(ExecutionRequest): ExecutionResult`.
 
-Comportement :
+Comportement par defaut, sans scenario explicite :
 
 | Cas | Résultat |
 | --- | --- |
@@ -56,6 +56,57 @@ Propriétés :
 
 Elle est distincte du fake exchange legacy `App\Exchange\Fake\*` (simulation au niveau
 adapter / websocket du provider) : la gateway PR10 vit dans le Core et reste pure.
+
+## Minimum COMMON-005 pour recette demo
+
+COMMON-005 ajoute un mode scenario optionnel au `FakeExecutionPort`. Ce mode reste
+local, en memoire et sans side effect exchange. Il sert uniquement a prouver les
+branches de protection avant une future recette demo/testnet OKX ou Hyperliquid.
+
+Le comportement historique ci-dessus reste inchange quand aucun scenario n'est
+passe au constructeur.
+
+Fixtures PHP :
+
+- `FakeExecutionScenarioFixtures::orderAccepted()`
+- `FakeExecutionScenarioFixtures::orderRejected()`
+- `FakeExecutionScenarioFixtures::fullFillStopAttachSuccess()`
+- `FakeExecutionScenarioFixtures::fullFillStopAttachFailure()`
+- `FakeExecutionScenarioFixtures::partialFillStopRejected()`
+- `FakeExecutionScenarioFixtures::cancelAcceptedOrder()`
+
+Fixture JSON de recette :
+
+```text
+trading-app/tests/fixtures/fake-paper/demo-recipe-scenarios.json
+```
+
+Scenarios couverts :
+
+| Scenario | Resultat attendu |
+| --- | --- |
+| `order_accepted` | Ordre accepte sans fill, aucune protection demandee. |
+| `order_rejected` | Refus structure avec `reject_reason=fake_exchange_rejected_order`. |
+| `full_fill_stop_attach_success` | Fill complet, stop attache full-size, aucun flag qualite. |
+| `full_fill_stop_attach_failure` | Fill complet, echec d'attache stop, `fail_safe.action=cancel_or_reduce_only_close_required`, resultat `failed`. |
+| `partial_fill_stop_rejected` | Fill partiel, stop partiel refuse explicitement, flags `partial_fill` et `partial_stop_rejected`, resultat `failed`. |
+| `cancel_accepted_order` | Annulation simulee sans fill, resultat `skipped`. |
+
+Pour les scenarios, `ExecutionResult::raw` expose `order`, `fills`,
+`protection` et, en cas d'echec de protection, `fail_safe`. Les flags qualite
+sont dans `ExecutionResult::metadata.quality_flags`. Un fill ou stop incomplet
+n'est jamais presente comme protege : `metadata.demo_recipe_protected=false`.
+
+Le port garde un etat memoire minimal par `client_order_id` en mode scenario :
+
+- rejoue le meme `client_order_id` => `duplicate_client_order_id`, aucun second fill ;
+- `snapshot()` exporte l'etat memoire ;
+- `FakeExecutionPort::fromSnapshot(..., scenario: ...)` recharge cet etat en
+  conservant le mode scenario necessaire aux gardes de replay ;
+- `resyncPosition(client_order_id)` reconstruit une position simulee depuis les fills.
+
+Cette resynchronisation est un outil de recette locale, pas une source de verite
+exchange.
 
 ## Pourquoi Fake / Paper avant OKX / Hyperliquid
 
@@ -83,9 +134,24 @@ reste legacy.
   « zone acceptée » n'est pas re-vérifié au build (le builder suppose la décision déjà prise en amont).
 - `entry_price = entryZone.center` simplifie le pricing legacy (carnet, hint, quantization) ;
   acceptable hors live, à rapprocher du legacy avant tout branchement.
-- Aucune persistance ni audit réel : la gateway est en mémoire.
+- Aucune persistance ni audit reel : la gateway est en memoire.
+- COMMON-005 ne couvre pas tout #196 : pas de carnet d'ordres, pas de latence,
+  pas de funding, pas de ledger persistant, pas de matching multi-ordres, pas de
+  websocket et pas de reconciliation exchange reelle.
+- Les scenarios Fake/Paper ne certifient ni OKX demo ni Hyperliquid testnet. Ils
+  prouvent seulement que les branches locales de protection sont visibles avant
+  toute tentative mutative.
+
+## Rollback
+
+Le rollback de COMMON-005 consiste a retirer le mode scenario et revenir au
+`FakeExecutionPort` par defaut. Aucun schema, aucun secret, aucune config runtime
+et aucun endpoint n'est modifie. Les tests de recette demo peuvent alors revenir
+au simple resultat `dry_run` deterministe.
 
 ## Suite
 
-PR11 : OKX dry-run + gate readiness live. PR12 : Hyperliquid dry-run. Le `FakeExecutionPort`
-servira de référence de comparaison pour ces adapters.
+Le Paper complet reste suivi par #196. OKX demo et Hyperliquid testnet doivent
+continuer a passer par leurs PR dediees avec activation explicite, sans mainnet
+et sans fallback silencieux vers Bitmart. Le `FakeExecutionPort` servira de
+reference de comparaison pour ces adapters.

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -82,6 +82,8 @@ services:
             - '../src/Kernel.php'
             - '../src/*/LookAtit'
             - '../src/Provider/'
+            - '../src/TradingCore/Execution/Fake/FakeExecutionScenario.php'
+            - '../src/TradingCore/Execution/Fake/FakeExecutionScenarioFixtures.php'
 
     # Loggers dedicated to the provider module
     App\Provider\:

--- a/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
+++ b/trading-app/src/TradingCore/Execution/Fake/FakeExecutionPort.php
@@ -24,9 +24,36 @@ use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
  */
 final class FakeExecutionPort implements ExecutionPortInterface
 {
+    /**
+     * @var array<string,array<string,mixed>>
+     */
+    private array $executionsByClientOrderId = [];
+
+    /**
+     * @param array<string,mixed> $state
+     */
     public function __construct(
         private readonly OrderPlanValidator $validator = new OrderPlanValidator(),
+        private readonly ?FakeExecutionScenario $scenario = null,
+        array $state = [],
     ) {
+        $this->executionsByClientOrderId = $state['executions_by_client_order_id'] ?? [];
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    public static function fromSnapshot(
+        array $snapshot,
+        ?FakeExecutionScenario $scenario = null,
+        ?OrderPlanValidator $validator = null,
+    ): self
+    {
+        return new self(
+            validator: $validator ?? new OrderPlanValidator(),
+            scenario: $scenario,
+            state: $snapshot,
+        );
     }
 
     public function execute(ExecutionRequest $request): ExecutionResult
@@ -70,12 +97,262 @@ final class FakeExecutionPort implements ExecutionPortInterface
             );
         }
 
+        if ($this->scenario !== null) {
+            return $this->executeScenario($request, $metadata);
+        }
+
         return new ExecutionResult(
             status: ExecutionStatus::DryRun,
             clientOrderId: $plan->clientOrderId,
             exchangeOrderId: $this->fakeOrderId($plan->clientOrderId),
             metadata: array_merge($metadata, ['dry_run' => true]),
         );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function snapshot(): array
+    {
+        return ['executions_by_client_order_id' => $this->executionsByClientOrderId];
+    }
+
+    public function fillCount(): int
+    {
+        $count = 0;
+        foreach ($this->executionsByClientOrderId as $record) {
+            $count += count($record['raw']['fills'] ?? []);
+        }
+
+        return $count;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function resyncPosition(string $clientOrderId): array
+    {
+        $record = $this->executionsByClientOrderId[$clientOrderId] ?? null;
+        if ($record === null) {
+            return [];
+        }
+
+        $fills = $record['raw']['fills'] ?? [];
+        $quantity = 0.0;
+        foreach ($fills as $fill) {
+            $quantity += (float) ($fill['quantity'] ?? 0.0);
+        }
+
+        $protectedQuantity = (float) ($record['raw']['protection']['protected_quantity'] ?? 0.0);
+
+        return [
+            'client_order_id' => $clientOrderId,
+            'exchange_order_id' => $record['exchange_order_id'] ?? null,
+            'symbol' => $record['raw']['order']['symbol'] ?? null,
+            'side' => $record['raw']['order']['side'] ?? null,
+            'quantity' => $quantity,
+            'protection_status' => $this->positionProtectionStatus($quantity, $protectedQuantity),
+            'source' => 'fake_paper_snapshot',
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function executeScenario(ExecutionRequest $request, array $metadata): ExecutionResult
+    {
+        \assert($this->scenario instanceof FakeExecutionScenario);
+
+        $plan = $request->orderPlan;
+        $clientOrderId = $plan->clientOrderId;
+        $exchangeOrderId = $this->fakeOrderId($clientOrderId);
+
+        if ($clientOrderId !== null && isset($this->executionsByClientOrderId[$clientOrderId])) {
+            return new ExecutionResult(
+                status: ExecutionStatus::Rejected,
+                clientOrderId: $clientOrderId,
+                metadata: array_merge($metadata, [
+                    'dry_run' => true,
+                    'scenario' => $this->scenario->name,
+                    'reject_reason' => 'duplicate_client_order_id',
+                    'previous_exchange_order_id' => $this->executionsByClientOrderId[$clientOrderId]['exchange_order_id'] ?? null,
+                    'quality_flags' => ['duplicate_client_order_id'],
+                    'simulated_replay_blocked' => true,
+                ]),
+            );
+        }
+
+        $raw = $this->scenarioRaw($request, $exchangeOrderId);
+        $qualityFlags = $this->scenario->qualityFlags;
+        $resultMetadata = array_merge($metadata, [
+            'dry_run' => true,
+            'scenario' => $this->scenario->name,
+            'quality_flags' => $qualityFlags,
+            'demo_recipe_protected' => $this->isFullyProtected($raw),
+            'cancelled' => $this->scenario->orderOutcome === 'cancelled',
+        ]);
+
+        if ($this->scenario->rejectReason !== null) {
+            $resultMetadata['reject_reason'] = $this->scenario->rejectReason;
+        }
+
+        $status = $this->scenarioStatus();
+        if ($clientOrderId !== null) {
+            $this->executionsByClientOrderId[$clientOrderId] = [
+                'exchange_order_id' => $exchangeOrderId,
+                'raw' => $raw,
+                'metadata' => $resultMetadata,
+            ];
+        }
+
+        return new ExecutionResult(
+            status: $status,
+            clientOrderId: $clientOrderId,
+            exchangeOrderId: $status === ExecutionStatus::Rejected ? null : $exchangeOrderId,
+            raw: $raw,
+            metadata: $resultMetadata,
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function scenarioRaw(ExecutionRequest $request, string $exchangeOrderId): array
+    {
+        \assert($this->scenario instanceof FakeExecutionScenario);
+
+        $plan = $request->orderPlan;
+        $filledQuantity = $this->filledQuantity($plan->quantity, $this->scenario->fillRatio);
+        $orderStatus = $this->orderStatus($filledQuantity, $plan->quantity);
+        $fills = [];
+        if ($filledQuantity > 0.0) {
+            $fills[] = [
+                'fill_id' => sprintf('FAKE-FILL-%s-001', $plan->clientOrderId ?? 'UNKNOWN'),
+                'exchange_fill_id' => sprintf('FAKE-EXFILL-%s-001', $plan->clientOrderId ?? 'UNKNOWN'),
+                'quantity' => $filledQuantity,
+                'price' => $plan->entryPrice,
+                'role' => 'entry',
+            ];
+        }
+
+        $raw = [
+            'order' => [
+                'exchange_order_id' => $exchangeOrderId,
+                'client_order_id' => $plan->clientOrderId,
+                'status' => $orderStatus,
+                'symbol' => $plan->symbol,
+                'side' => $plan->side,
+                'quantity' => $plan->quantity,
+                'filled_quantity' => $filledQuantity,
+            ],
+            'fills' => $fills,
+            'protection' => $this->protectionRaw($filledQuantity),
+        ];
+
+        if ($this->scenario->failSafeAction !== null) {
+            $raw['fail_safe'] = [
+                'action' => $this->scenario->failSafeAction,
+                'reason' => $this->scenario->protectionOutcome,
+            ];
+        }
+
+        return $raw;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function protectionRaw(float $filledQuantity): array
+    {
+        \assert($this->scenario instanceof FakeExecutionScenario);
+
+        $protectedQuantity = $this->scenario->protectionOutcome === 'attached' ? $filledQuantity : 0.0;
+
+        return [
+            'status' => $this->scenario->protectionOutcome,
+            'protected_quantity' => $protectedQuantity,
+        ];
+    }
+
+    private function scenarioStatus(): ExecutionStatus
+    {
+        \assert($this->scenario instanceof FakeExecutionScenario);
+
+        if ($this->scenario->orderOutcome === 'rejected') {
+            return ExecutionStatus::Rejected;
+        }
+
+        if ($this->scenario->orderOutcome === 'cancelled') {
+            return ExecutionStatus::Skipped;
+        }
+
+        if (in_array($this->scenario->protectionOutcome, ['failed', 'rejected'], true)) {
+            return ExecutionStatus::Failed;
+        }
+
+        return ExecutionStatus::Accepted;
+    }
+
+    private function orderStatus(float $filledQuantity, float $requestedQuantity): string
+    {
+        \assert($this->scenario instanceof FakeExecutionScenario);
+
+        if ($this->scenario->orderOutcome === 'rejected') {
+            return 'rejected';
+        }
+
+        if ($this->scenario->orderOutcome === 'cancelled') {
+            return 'cancelled';
+        }
+
+        if ($filledQuantity <= 0.0) {
+            return 'accepted';
+        }
+
+        if ($filledQuantity < $requestedQuantity) {
+            return 'partially_filled';
+        }
+
+        return 'filled';
+    }
+
+    private function filledQuantity(float $requestedQuantity, float $fillRatio): float
+    {
+        if ($fillRatio >= 1.0) {
+            return $requestedQuantity;
+        }
+
+        $filledQuantity = $requestedQuantity * $fillRatio;
+
+        return max(0.0, min($requestedQuantity, $filledQuantity));
+    }
+
+    /**
+     * @param array<string,mixed> $raw
+     */
+    private function isFullyProtected(array $raw): bool
+    {
+        $filledQuantity = (float) ($raw['order']['filled_quantity'] ?? 0.0);
+        $protectedQuantity = (float) ($raw['protection']['protected_quantity'] ?? 0.0);
+
+        return $filledQuantity > 0.0 && $protectedQuantity >= $filledQuantity;
+    }
+
+    private function positionProtectionStatus(float $quantity, float $protectedQuantity): string
+    {
+        if ($quantity <= 0.0) {
+            return 'flat';
+        }
+
+        if ($protectedQuantity >= $quantity) {
+            return 'protected';
+        }
+
+        if ($protectedQuantity > 0.0) {
+            return 'partially_protected';
+        }
+
+        return 'unprotected';
     }
 
     private function fakeOrderId(?string $clientOrderId): string

--- a/trading-app/src/TradingCore/Execution/Fake/FakeExecutionScenario.php
+++ b/trading-app/src/TradingCore/Execution/Fake/FakeExecutionScenario.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Fake;
+
+final readonly class FakeExecutionScenario
+{
+    private const ORDER_OUTCOMES = ['accepted', 'rejected', 'cancelled'];
+    private const PROTECTION_OUTCOMES = ['not_requested', 'attached', 'failed', 'rejected'];
+
+    /**
+     * @param list<string> $qualityFlags
+     */
+    public function __construct(
+        public string $name,
+        public string $orderOutcome,
+        public float $fillRatio,
+        public string $protectionOutcome,
+        public ?string $rejectReason = null,
+        public array $qualityFlags = [],
+        public ?string $failSafeAction = null,
+    ) {
+        if (!in_array($this->orderOutcome, self::ORDER_OUTCOMES, true)) {
+            throw new \InvalidArgumentException('Unsupported fake execution order outcome.');
+        }
+
+        if (!in_array($this->protectionOutcome, self::PROTECTION_OUTCOMES, true)) {
+            throw new \InvalidArgumentException('Unsupported fake execution protection outcome.');
+        }
+
+        if ($this->fillRatio < 0.0 || $this->fillRatio > 1.0) {
+            throw new \InvalidArgumentException('Fake execution fill ratio must be between 0 and 1.');
+        }
+    }
+}

--- a/trading-app/src/TradingCore/Execution/Fake/FakeExecutionScenarioFixtures.php
+++ b/trading-app/src/TradingCore/Execution/Fake/FakeExecutionScenarioFixtures.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace App\TradingCore\Execution\Fake;
+
+final class FakeExecutionScenarioFixtures
+{
+    public static function orderAccepted(): FakeExecutionScenario
+    {
+        return new FakeExecutionScenario(
+            name: 'order_accepted',
+            orderOutcome: 'accepted',
+            fillRatio: 0.0,
+            protectionOutcome: 'not_requested',
+        );
+    }
+
+    public static function orderRejected(): FakeExecutionScenario
+    {
+        return new FakeExecutionScenario(
+            name: 'order_rejected',
+            orderOutcome: 'rejected',
+            fillRatio: 0.0,
+            protectionOutcome: 'not_requested',
+            rejectReason: 'fake_exchange_rejected_order',
+        );
+    }
+
+    public static function fullFillStopAttachSuccess(): FakeExecutionScenario
+    {
+        return new FakeExecutionScenario(
+            name: 'full_fill_stop_attach_success',
+            orderOutcome: 'accepted',
+            fillRatio: 1.0,
+            protectionOutcome: 'attached',
+        );
+    }
+
+    public static function fullFillStopAttachFailure(): FakeExecutionScenario
+    {
+        return new FakeExecutionScenario(
+            name: 'full_fill_stop_attach_failure',
+            orderOutcome: 'accepted',
+            fillRatio: 1.0,
+            protectionOutcome: 'failed',
+            qualityFlags: ['protection_attach_failed'],
+            failSafeAction: 'cancel_or_reduce_only_close_required',
+        );
+    }
+
+    public static function partialFillStopRejected(): FakeExecutionScenario
+    {
+        return new FakeExecutionScenario(
+            name: 'partial_fill_stop_rejected',
+            orderOutcome: 'accepted',
+            fillRatio: 0.5,
+            protectionOutcome: 'rejected',
+            qualityFlags: ['partial_fill', 'partial_stop_rejected'],
+            failSafeAction: 'cancel_or_reduce_only_close_required',
+        );
+    }
+
+    public static function cancelAcceptedOrder(): FakeExecutionScenario
+    {
+        return new FakeExecutionScenario(
+            name: 'cancel_accepted_order',
+            orderOutcome: 'cancelled',
+            fillRatio: 0.0,
+            protectionOutcome: 'not_requested',
+        );
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
+++ b/trading-app/tests/TradingCore/Execution/FakeExecutionPortTest.php
@@ -7,6 +7,8 @@ use App\TradingCore\Execution\Dto\ExecutionRequest;
 use App\TradingCore\Execution\Enum\ExecutionMode;
 use App\TradingCore\Execution\Enum\ExecutionStatus;
 use App\TradingCore\Execution\Fake\FakeExecutionPort;
+use App\TradingCore\Execution\Fake\FakeExecutionScenario;
+use App\TradingCore\Execution\Fake\FakeExecutionScenarioFixtures;
 use App\TradingCore\OrderPlan\Dto\OrderPlan;
 use App\TradingCore\OrderPlan\Service\OrderPlanValidator;
 use App\TradingCore\SlTp\Dto\LiquidationCheckResult;
@@ -18,6 +20,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 #[CoversClass(FakeExecutionPort::class)]
+#[CoversClass(FakeExecutionScenario::class)]
 final class FakeExecutionPortTest extends TestCase
 {
     public function testDryRunValidPlanReturnsSimulatedDryRunResult(): void
@@ -131,9 +134,199 @@ final class FakeExecutionPortTest extends TestCase
         self::assertSame('live_not_supported_by_fake_gateway', $result->metadata['reject_reason']);
     }
 
+    public function testScenarioRejectsUnknownOrderOutcome(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported fake execution order outcome.');
+
+        new FakeExecutionScenario(
+            name: 'typo',
+            orderOutcome: 'acccepted',
+            fillRatio: 0.0,
+            protectionOutcome: 'not_requested',
+        );
+    }
+
+    public function testScenarioRejectsUnknownProtectionOutcome(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported fake execution protection outcome.');
+
+        new FakeExecutionScenario(
+            name: 'typo',
+            orderOutcome: 'accepted',
+            fillRatio: 0.0,
+            protectionOutcome: 'attched',
+        );
+    }
+
+    public function testDemoRecipeFullFillAttachesStopSuccessfully(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::fullFillStopAttachSuccess());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+
+        self::assertSame(ExecutionStatus::Accepted, $result->status);
+        self::assertSame('filled', $result->raw['order']['status']);
+        self::assertSame('FAKE-FILL-CID-ABC-001', $result->raw['fills'][0]['fill_id']);
+        self::assertSame(12.0, $result->raw['fills'][0]['quantity']);
+        self::assertSame('attached', $result->raw['protection']['status']);
+        self::assertSame(12.0, $result->raw['protection']['protected_quantity']);
+        self::assertSame([], $result->metadata['quality_flags']);
+    }
+
+    public function testFullFillScenarioDoesNotRoundAboveRequestedQuantity(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::fullFillStopAttachSuccess());
+        $request = ExecutionRequest::forPlan($this->executablePlan(quantity: 1.123456789), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+        $position = $port->resyncPosition('CID-ABC');
+
+        self::assertSame(1.123456789, $result->raw['order']['filled_quantity']);
+        self::assertSame(1.123456789, $result->raw['fills'][0]['quantity']);
+        self::assertSame(1.123456789, $result->raw['protection']['protected_quantity']);
+        self::assertSame(1.123456789, $position['quantity']);
+    }
+
+    public function testAcceptedScenarioReturnsAcceptedOrderWithoutFill(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::orderAccepted());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+
+        self::assertSame(ExecutionStatus::Accepted, $result->status);
+        self::assertSame('accepted', $result->raw['order']['status']);
+        self::assertSame([], $result->raw['fills']);
+        self::assertSame('not_requested', $result->raw['protection']['status']);
+        self::assertFalse($result->metadata['demo_recipe_protected']);
+    }
+
+    public function testFullFillWithStopAttachFailureRequiresFailSafe(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::fullFillStopAttachFailure());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+
+        self::assertSame(ExecutionStatus::Failed, $result->status);
+        self::assertSame('filled', $result->raw['order']['status']);
+        self::assertSame('failed', $result->raw['protection']['status']);
+        self::assertSame('cancel_or_reduce_only_close_required', $result->raw['fail_safe']['action']);
+        self::assertContains('protection_attach_failed', $result->metadata['quality_flags']);
+        self::assertFalse($result->metadata['demo_recipe_protected']);
+    }
+
+    public function testPartialFillWithRejectedPartialStopIsFlagged(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::partialFillStopRejected());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+
+        self::assertSame(ExecutionStatus::Failed, $result->status);
+        self::assertSame('partially_filled', $result->raw['order']['status']);
+        self::assertSame(6.0, $result->raw['fills'][0]['quantity']);
+        self::assertSame('rejected', $result->raw['protection']['status']);
+        self::assertSame(0.0, $result->raw['protection']['protected_quantity']);
+        self::assertContains('partial_fill', $result->metadata['quality_flags']);
+        self::assertContains('partial_stop_rejected', $result->metadata['quality_flags']);
+    }
+
+    public function testPartialFillScenarioDoesNotRoundTinyQuantityUpToFullSize(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::partialFillStopRejected());
+        $request = ExecutionRequest::forPlan($this->executablePlan(quantity: 0.00000001), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+
+        self::assertSame('partially_filled', $result->raw['order']['status']);
+        self::assertSame(0.000000005, $result->raw['order']['filled_quantity']);
+        self::assertSame(0.000000005, $result->raw['fills'][0]['quantity']);
+        self::assertLessThan($result->raw['order']['quantity'], $result->raw['order']['filled_quantity']);
+    }
+
+    public function testDuplicateClientOrderIdDoesNotCreateSecondFill(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::fullFillStopAttachSuccess());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $first = $port->execute($request);
+        $second = $port->execute($request);
+
+        self::assertSame(ExecutionStatus::Accepted, $first->status);
+        self::assertSame(ExecutionStatus::Rejected, $second->status);
+        self::assertSame('duplicate_client_order_id', $second->metadata['reject_reason']);
+        self::assertSame('FAKE-CID-ABC', $second->metadata['previous_exchange_order_id']);
+        self::assertSame(1, $port->fillCount());
+    }
+
+    public function testRestartResyncRestoresSimulatedOpenPosition(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::fullFillStopAttachSuccess());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $port->execute($request);
+        $restarted = FakeExecutionPort::fromSnapshot($port->snapshot());
+
+        $position = $restarted->resyncPosition('CID-ABC');
+
+        self::assertSame('BTCUSDT', $position['symbol']);
+        self::assertSame('long', $position['side']);
+        self::assertSame(12.0, $position['quantity']);
+        self::assertSame('protected', $position['protection_status']);
+        self::assertSame('FAKE-CID-ABC', $position['exchange_order_id']);
+    }
+
+    public function testRestartKeepsScenarioDuplicateGuardWhenReplayingSameClientOrderId(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::fullFillStopAttachSuccess());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $port->execute($request);
+        $restarted = FakeExecutionPort::fromSnapshot(
+            $port->snapshot(),
+            scenario: FakeExecutionScenarioFixtures::fullFillStopAttachSuccess(),
+        );
+
+        $result = $restarted->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertSame('duplicate_client_order_id', $result->metadata['reject_reason']);
+        self::assertSame(1, $restarted->fillCount());
+    }
+
+    public function testCancelScenarioReturnsCancelledOrderWithoutFill(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::cancelAcceptedOrder());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+
+        self::assertSame(ExecutionStatus::Skipped, $result->status);
+        self::assertSame('cancelled', $result->raw['order']['status']);
+        self::assertSame([], $result->raw['fills']);
+        self::assertTrue($result->metadata['cancelled']);
+    }
+
+    public function testRejectedScenarioReturnsStructuredRejectReason(): void
+    {
+        $port = new FakeExecutionPort(scenario: FakeExecutionScenarioFixtures::orderRejected());
+        $request = ExecutionRequest::forPlan($this->executablePlan(), ExecutionMode::DryRun);
+
+        $result = $port->execute($request);
+
+        self::assertSame(ExecutionStatus::Rejected, $result->status);
+        self::assertSame('rejected', $result->raw['order']['status']);
+        self::assertSame('fake_exchange_rejected_order', $result->metadata['reject_reason']);
+        self::assertSame([], $result->raw['fills']);
+    }
+
     // --- fixtures ---
 
-    private function executablePlan(): OrderPlan
+    private function executablePlan(float $quantity = 12.0): OrderPlan
     {
         $plan = new OrderPlan(
             symbol: 'BTCUSDT',
@@ -145,7 +338,7 @@ final class FakeExecutionPortTest extends TestCase
             marginMode: 'isolated',
             timeInForce: 'gtc',
             entryPrice: 100.0,
-            quantity: 12.0,
+            quantity: $quantity,
             leverage: 5,
             protectionPlan: $this->protectionPlan(),
             clientOrderId: 'CID-ABC',

--- a/trading-app/tests/fixtures/fake-paper/demo-recipe-scenarios.json
+++ b/trading-app/tests/fixtures/fake-paper/demo-recipe-scenarios.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "scope": "COMMON-005 local demo recipe only",
+  "scenarios": [
+    {
+      "name": "order_accepted",
+      "order_outcome": "accepted",
+      "fill_ratio": 0,
+      "protection_outcome": "not_requested",
+      "quality_flags": []
+    },
+    {
+      "name": "order_rejected",
+      "order_outcome": "rejected",
+      "fill_ratio": 0,
+      "protection_outcome": "not_requested",
+      "reject_reason": "fake_exchange_rejected_order",
+      "quality_flags": []
+    },
+    {
+      "name": "full_fill_stop_attach_success",
+      "order_outcome": "accepted",
+      "fill_ratio": 1,
+      "protection_outcome": "attached",
+      "quality_flags": []
+    },
+    {
+      "name": "full_fill_stop_attach_failure",
+      "order_outcome": "accepted",
+      "fill_ratio": 1,
+      "protection_outcome": "failed",
+      "fail_safe_action": "cancel_or_reduce_only_close_required",
+      "quality_flags": ["protection_attach_failed"]
+    },
+    {
+      "name": "partial_fill_stop_rejected",
+      "order_outcome": "accepted",
+      "fill_ratio": 0.5,
+      "protection_outcome": "rejected",
+      "fail_safe_action": "cancel_or_reduce_only_close_required",
+      "quality_flags": ["partial_fill", "partial_stop_rejected"]
+    },
+    {
+      "name": "cancel_accepted_order",
+      "order_outcome": "cancelled",
+      "fill_ratio": 0,
+      "protection_outcome": "not_requested",
+      "quality_flags": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

COMMON-005 adds the minimum Fake/Paper scenarios needed to prove local demo recipe protection paths before any OKX demo or Hyperliquid testnet mutation.

- Adds optional `FakeExecutionScenario` support to `FakeExecutionPort` while preserving the existing default dry-run behavior when no scenario is provided.
- Adds fixtures for accepted/rejected orders, full fill with stop attach success/failure, partial fill with explicit stop rejection, cancel, duplicate `client_order_id`, and restart/resync from snapshot.
- Documents limits, rollback, local recipe proof, and the follow-up boundary to #196 for complete Paper readiness.

## Scope guard

- No mainnet order path.
- No OKX/Hyperliquid mutative implementation.
- No strategy, EntryZone, Risk/Leverage, SL/TP business-rule change.
- No Symfony service wiring, DB schema, endpoint, YAML, or runtime runner mutation.
- No secrets or raw sensitive payloads.

## Tests

- `php vendor/bin/phpunit tests/TradingCore/Execution`
- `php vendor/bin/phpstan analyse --configuration=phpstan.dist.neon src/TradingCore/Execution/Fake/FakeExecutionPort.php src/TradingCore/Execution/Fake/FakeExecutionScenario.php src/TradingCore/Execution/Fake/FakeExecutionScenarioFixtures.php tests/TradingCore/Execution/FakeExecutionPortTest.php`
- `python3 -m mkdocs build --strict`
- `php bin/console lint:container --no-debug`
- `php bin/console lint:yaml config`
- `git diff --check`
- JSON fixture parse check

## References

Part of COMMON-005.
Related to #196.
Related to #188.
Related to #225.
