### PR TITLE
OKX-002 provider bundle registry skeleton

### DIFF
--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -287,6 +287,13 @@ services:
             $marketType: !php/const App\Common\Enum\MarketType::SPOT
         public: false
 
+    App\Provider\Context\ExchangeContext.okx_perpetual:
+        class: App\Provider\Context\ExchangeContext
+        arguments:
+            $exchange: !php/const App\Common\Enum\Exchange::OKX
+            $marketType: !php/const App\Common\Enum\MarketType::PERPETUAL
+        public: false
+
     # The fake provider classes themselves are autowired by the App\Provider\
     # resource block above; only the contexts and bundles need explicit wiring.
     App\Provider\Registry\ExchangeProviderBundle.fake_perpetual:
@@ -311,6 +318,21 @@ services:
             $systemProvider: '@App\Provider\Fake\FakeSystemProvider'
         public: false
 
+    # --- OKX provider bundle ---
+    # Skeleton-only provider bundle for OKX demo readiness. The bundle is
+    # intentionally registered for perpetual/SWAP only and every provider method
+    # fails explicitly until the read-only OKX PRs implement the actual gateways.
+    App\Provider\Registry\ExchangeProviderBundle.okx_perpetual:
+        class: App\Provider\Registry\ExchangeProviderBundle
+        arguments:
+            $context: '@App\Provider\Context\ExchangeContext.okx_perpetual'
+            $klineProvider: '@App\Provider\Okx\OkxMarketDataGateway'
+            $contractProvider: '@App\Provider\Okx\OkxMetadataProvider'
+            $orderProvider: '@App\Provider\Okx\OkxOrderGateway'
+            $accountProvider: '@App\Provider\Okx\OkxAccountGateway'
+            $systemProvider: '@App\Provider\Okx\OkxSystemProvider'
+        public: false
+
     App\Provider\Registry\ExchangeProviderRegistry:
         arguments:
             $bundles:
@@ -318,6 +340,7 @@ services:
                 - '@App\Provider\Registry\ExchangeProviderBundle.bitmart_spot'
                 - '@App\Provider\Registry\ExchangeProviderBundle.fake_perpetual'
                 - '@App\Provider\Registry\ExchangeProviderBundle.fake_spot'
+                - '@App\Provider\Registry\ExchangeProviderBundle.okx_perpetual'
             $defaultExchange: !php/const App\Common\Enum\Exchange::BITMART
             $defaultMarketType: !php/const App\Common\Enum\MarketType::PERPETUAL
 

--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -11,7 +11,10 @@ use App\Exchange\Contract\ExchangeAdapterInterface;
 use App\Exchange\Contract\ExchangeAdapterRegistryInterface;
 use App\Exchange\Hyperliquid\HyperliquidConfig;
 use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Readiness\ExchangeReadinessInput;
+use App\Exchange\Readiness\ExchangeReadinessLevel;
 use App\Provider\Context\ExchangeContext;
+use App\Provider\Okx\OkxRuntimeCheck;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -24,6 +27,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 )]
 final class ExchangeRuntimeCheckCommand extends Command
 {
+    /**
+     * @param array<string, string> $bitmartEnv
+     */
     public function __construct(
         private readonly ExchangeAdapterRegistryInterface $adapters,
         private readonly ExchangeProviderRegistryInterface $providers,
@@ -63,7 +69,7 @@ final class ExchangeRuntimeCheckCommand extends Command
         $credentials = $this->credentialsStatus($exchange);
         $liveTrading = $this->liveTradingStatus($exchange, $credentials);
         $privateWs = $this->privateWsStatus($adapter);
-        $scheduleReady = $adapterStatus === 'found' && $providerStatus === 'found';
+        $scheduleReady = $this->scheduleReady($exchange, $marketType, $adapterStatus, $providerStatus);
         $recommendedDryRun = !$scheduleReady || $credentials !== 'ok' || $liveTrading !== 'enabled';
 
         $output->writeln(sprintf('Exchange: %s', $exchange->value));
@@ -177,6 +183,29 @@ final class ExchangeRuntimeCheckCommand extends Command
         }
 
         return $adapter->capabilities()->supportsWebSocketPrivate ? 'enabled' : 'unsupported';
+    }
+
+    private function scheduleReady(
+        Exchange $exchange,
+        MarketType $marketType,
+        string $adapterStatus,
+        string $providerStatus,
+    ): bool {
+        if ($adapterStatus !== 'found' || $providerStatus !== 'found') {
+            return false;
+        }
+
+        if ($exchange === Exchange::OKX) {
+            $report = (new OkxRuntimeCheck())->check(new ExchangeReadinessInput(
+                exchange: $exchange,
+                marketType: $marketType,
+                environment: $this->okxConfig->normalizedEnvironment(),
+            ));
+
+            return $report->readyLevel !== ExchangeReadinessLevel::NotReady;
+        }
+
+        return true;
     }
 
     private function hasOkxCredentials(): bool

--- a/trading-app/src/Provider/Okx/OkxAccountGateway.php
+++ b/trading-app/src/Provider/Okx/OkxAccountGateway.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\Dto\AccountDto;
+use App\Contract\Provider\Dto\PositionDto;
+
+final class OkxAccountGateway implements AccountProviderInterface
+{
+    public function __construct(
+        private readonly OkxPositionGateway $positions = new OkxPositionGateway(),
+    ) {
+    }
+
+    public function getAccountInfo(): ?AccountDto
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function getAccountBalance(string $basicCurrency = 'USDT'): float
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return PositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        return $this->positions->getOpenPositions($symbol);
+    }
+
+    /**
+     * @return PositionDto[]
+     */
+    public function getOpenPositionsOrFail(?string $symbol = null): array
+    {
+        return $this->positions->getOpenPositionsOrFail($symbol);
+    }
+
+    public function getPosition(string $symbol): ?PositionDto
+    {
+        return $this->positions->getPosition($symbol);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getTradeHistory(string $symbol, int $limit = 100): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getTrades(
+        ?string $symbol = null,
+        int $limit = 100,
+        ?int $startTime = null,
+        ?int $endTime = null,
+    ): array {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getTransactionHistory(
+        ?string $symbol = null,
+        ?int $flowType = null,
+        int $limit = 100,
+        ?int $startTime = null,
+        ?int $endTime = null,
+    ): array {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getTradingFees(string $symbol): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function healthCheck(): bool
+    {
+        return false;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'OKX';
+    }
+
+    private function notImplemented(string $operation): OkxProviderNotReadyException
+    {
+        return new OkxProviderNotReadyException('okx_account_not_implemented', $operation);
+    }
+}

--- a/trading-app/src/Provider/Okx/OkxMarketDataGateway.php
+++ b/trading-app/src/Provider/Okx/OkxMarketDataGateway.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+use App\Common\Enum\Timeframe;
+use App\Contract\Provider\Dto\KlineDto;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Provider\Context\ExchangeContext;
+
+final class OkxMarketDataGateway implements KlineProviderInterface
+{
+    /**
+     * @return KlineDto[]
+     */
+    public function getKlines(
+        string $symbol,
+        Timeframe $timeframe,
+        int $limit = 490,
+        ?ExchangeContext $context = null,
+    ): array {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return KlineDto[]
+     */
+    public function getKlinesInWindow(
+        string $symbol,
+        Timeframe $timeframe,
+        \DateTimeImmutable $start,
+        \DateTimeImmutable $end,
+        int $limit = 500,
+        ?ExchangeContext $context = null,
+    ): array {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function getLastKline(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): ?KlineDto {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function saveKline(KlineDto $kline, ?ExchangeContext $context = null): void
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @param KlineDto[] $klines
+     */
+    public function saveKlines(
+        array $klines,
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): void {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function hasGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): bool {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getGaps(
+        string $symbol,
+        Timeframe $timeframe,
+        ?ExchangeContext $context = null,
+    ): array {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function healthCheck(): bool
+    {
+        return false;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'OKX';
+    }
+
+    private function notImplemented(string $operation): OkxProviderNotReadyException
+    {
+        return new OkxProviderNotReadyException('okx_market_data_not_implemented', $operation);
+    }
+}

--- a/trading-app/src/Provider/Okx/OkxMetadataProvider.php
+++ b/trading-app/src/Provider/Okx/OkxMetadataProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+use App\Contract\Provider\ContractProviderInterface;
+use App\Contract\Provider\Dto\ContractDto;
+
+final class OkxMetadataProvider implements ContractProviderInterface
+{
+    /**
+     * @return ContractDto[]
+     */
+    public function getContracts(): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function getContractDetails(string $symbol): ?ContractDto
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function getLastPrice(string $symbol): ?float
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOrderBook(string $symbol, int $limit = 50): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getRecentTrades(string $symbol, int $limit = 100): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getMarkPriceKline(
+        string $symbol,
+        int $step = 1,
+        int $limit = 1,
+        ?int $startTime = null,
+        ?int $endTime = null,
+    ): array {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    public function getLeverageBrackets(string $symbol): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @param array<string>|null $symbols
+     * @return array{upserted: int, total_fetched: int, errors: array<string>}
+     */
+    public function syncContracts(?array $symbols = null): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function healthCheck(): bool
+    {
+        return false;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'OKX';
+    }
+
+    private function notImplemented(string $operation): OkxProviderNotReadyException
+    {
+        return new OkxProviderNotReadyException('okx_metadata_not_implemented', $operation);
+    }
+}

--- a/trading-app/src/Provider/Okx/OkxOrderGateway.php
+++ b/trading-app/src/Provider/Okx/OkxOrderGateway.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Contract\Provider\Dto\OrderDto;
+use App\Contract\Provider\Dto\SymbolBidAskDto;
+use App\Contract\Provider\OrderProviderInterface;
+
+final class OkxOrderGateway implements OrderProviderInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function placeOrder(
+        string $symbol,
+        OrderSide $side,
+        OrderType $type,
+        float $quantity,
+        ?float $price = null,
+        ?float $stopPrice = null,
+        array $options = [],
+    ): ?OrderDto {
+        throw $this->writeNotImplemented(__METHOD__);
+    }
+
+    public function cancelOrder(string $symbol, string $orderId): bool
+    {
+        throw $this->writeNotImplemented(__METHOD__);
+    }
+
+    public function getOrder(string $symbol, string $orderId): ?OrderDto
+    {
+        throw $this->readNotImplemented(__METHOD__);
+    }
+
+    /**
+     * @return OrderDto[]
+     */
+    public function getOpenOrders(?string $symbol = null): array
+    {
+        throw $this->readNotImplemented(__METHOD__);
+    }
+
+    /**
+     * @return OrderDto[]
+     */
+    public function getOpenOrdersOrFail(?string $symbol = null): array
+    {
+        throw $this->readNotImplemented(__METHOD__);
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    public function getOrderHistory(string $symbol, int $limit = 100): array
+    {
+        throw $this->readNotImplemented(__METHOD__);
+    }
+
+    public function cancelAllOrders(string $symbol): bool
+    {
+        throw $this->writeNotImplemented(__METHOD__);
+    }
+
+    public function getOrderBookTop(string $symbol): SymbolBidAskDto
+    {
+        throw $this->readNotImplemented(__METHOD__);
+    }
+
+    public function submitLeverage(string $symbol, int $leverage, string $openType = 'isolated'): bool
+    {
+        throw $this->writeNotImplemented(__METHOD__);
+    }
+
+    public function getProviderName(): string
+    {
+        return 'OKX';
+    }
+
+    private function readNotImplemented(string $operation): OkxProviderNotReadyException
+    {
+        return new OkxProviderNotReadyException('okx_order_read_not_implemented', $operation);
+    }
+
+    private function writeNotImplemented(string $operation): OkxProviderNotReadyException
+    {
+        return new OkxProviderNotReadyException('okx_order_write_not_implemented', $operation);
+    }
+}

--- a/trading-app/src/Provider/Okx/OkxPositionGateway.php
+++ b/trading-app/src/Provider/Okx/OkxPositionGateway.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+use App\Contract\Provider\Dto\PositionDto;
+
+final class OkxPositionGateway
+{
+    /**
+     * @return PositionDto[]
+     */
+    public function getOpenPositions(?string $symbol = null): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    /**
+     * @return PositionDto[]
+     */
+    public function getOpenPositionsOrFail(?string $symbol = null): array
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    public function getPosition(string $symbol): ?PositionDto
+    {
+        throw $this->notImplemented(__METHOD__);
+    }
+
+    private function notImplemented(string $operation): OkxProviderNotReadyException
+    {
+        return new OkxProviderNotReadyException('okx_position_not_implemented', $operation);
+    }
+}

--- a/trading-app/src/Provider/Okx/OkxProviderNotReadyException.php
+++ b/trading-app/src/Provider/Okx/OkxProviderNotReadyException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+final class OkxProviderNotReadyException extends \RuntimeException
+{
+    public function __construct(
+        private readonly string $reason,
+        string $operation,
+    ) {
+        parent::__construct(sprintf('OKX provider skeleton is not ready for "%s": %s', $operation, $reason));
+    }
+
+    public function reason(): string
+    {
+        return $this->reason;
+    }
+}

--- a/trading-app/src/Provider/Okx/OkxRuntimeCheck.php
+++ b/trading-app/src/Provider/Okx/OkxRuntimeCheck.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+use App\Common\Enum\Exchange;
+use App\Exchange\Readiness\ExchangeReadinessEvaluator;
+use App\Exchange\Readiness\ExchangeReadinessInput;
+use App\Exchange\Readiness\ExchangeReadinessReport;
+use App\Exchange\Readiness\ExchangeRuntimeCheckInterface;
+
+final readonly class OkxRuntimeCheck implements ExchangeRuntimeCheckInterface
+{
+    public function __construct(
+        private ExchangeReadinessEvaluator $evaluator = new ExchangeReadinessEvaluator(),
+    ) {
+    }
+
+    public function check(ExchangeReadinessInput $input): ExchangeReadinessReport
+    {
+        if ($input->exchange !== Exchange::OKX) {
+            throw new \InvalidArgumentException('OkxRuntimeCheck only accepts exchange=okx.');
+        }
+
+        return $this->evaluator->evaluate(new ExchangeReadinessInput(
+            exchange: $input->exchange,
+            marketType: $input->marketType,
+            environment: $input->environment,
+            publicConnectivity: false,
+            privateReadConnectivity: false,
+            privateObservability: false,
+            privateObservabilityStatus: $input->privateObservabilityStatus,
+            instrumentsLoaded: false,
+            metadataValid: false,
+            precisionValid: false,
+            accountReadable: false,
+            permissionsRead: false,
+            permissionsTrade: false,
+            mainnetWriteGuard: $input->mainnetWriteGuard,
+            demoTestnetWriteGuard: $input->demoTestnetWriteGuard,
+            demoTestnetWriteEnabled: $input->demoTestnetWriteEnabled,
+            stopLossCapability: false,
+            killSwitch: $input->killSwitch,
+            dryRun: $input->dryRun,
+            allowedSymbols: $input->allowedSymbols,
+            allowedMarkets: $input->allowedMarkets,
+            maxNotional: $input->maxNotional,
+            configHash: $input->configHash,
+            blockingErrors: array_values(array_unique([
+                ...$input->blockingErrors,
+                'okx_provider_skeleton_not_ready',
+            ])),
+            warnings: $input->warnings,
+        ));
+    }
+}

--- a/trading-app/src/Provider/Okx/OkxSystemProvider.php
+++ b/trading-app/src/Provider/Okx/OkxSystemProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Okx;
+
+use App\Contract\Provider\SystemProviderInterface;
+
+final class OkxSystemProvider implements SystemProviderInterface
+{
+    public function getSystemTimeMs(): int
+    {
+        return (int) (microtime(true) * 1000);
+    }
+}

--- a/trading-app/src/Provider/README.md
+++ b/trading-app/src/Provider/README.md
@@ -18,6 +18,7 @@ Provider/
     ├── Registry/ExchangeProviderRegistry + ExchangeProviderBundle
     ├── MainProvider (#[AsAlias(MainProviderInterface::class)])
     ├── Bitmart/ (implémentation concrète)
+    ├── Okx/ (skeleton explicite, perpetual uniquement)
     └── CleanupProvider + services utilitaires
 ```
 
@@ -88,6 +89,29 @@ Chaque provider implémente son interface avec un accent sur :
 - `healthCheck()` (utilisé pour `/provider/health`),
 - `sync*()` (contrats, ordres, positions),
 - `Mapper`s internes pour convertir les structures Bitmart.
+
+## 4 bis. Bundle OKX skeleton
+
+OKX est enregistré explicitement dans la registry pour `exchange=okx` et
+`market_type=perpetual` :
+
+- `App\Provider\Registry\ExchangeProviderBundle.okx_perpetual`
+- `OkxMarketDataGateway`
+- `OkxAccountGateway`
+- `OkxOrderGateway`
+- `OkxPositionGateway`
+- `OkxMetadataProvider`
+- `OkxRuntimeCheck`
+
+Ce bundle est un skeleton OKX-002. Il ne fait aucun appel REST/WebSocket et
+n'expose aucun endpoint write. Les méthodes de lecture ou d'écriture non encore
+implémentées lèvent `OkxProviderNotReadyException` avec un reason explicite
+(`okx_market_data_not_implemented`, `okx_order_write_not_implemented`, etc.).
+
+Seul `okx/perpetual` est enregistré. `okx/spot` doit échouer avec
+`ProviderNotFoundException` et ne doit jamais retomber silencieusement sur
+Bitmart. Le contexte par défaut reste `bitmart/perpetual` tant que le runtime
+legacy en dépend.
 
 ---
 

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -61,10 +61,10 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('Schedule ready: no', $output);
     }
 
-    public function testOkxStaysDryRunOnlyEvenWithCredentialsProviderAndDemoFlag(): void
+    public function testOkxSkeletonStaysUnscheduledEvenWithCredentialsProviderAndDemoFlag(): void
     {
-        // PR11 hardening: a fully "ready" OKX runtime with demo trading enabled must still
-        // report live as forbidden and recommend dry-run. Demo capability != live trading.
+        // OKX-002 exposes an explicit provider bundle, but the provider read paths are still
+        // skeleton-only. Presence in the registry must not make the schedule preflight green.
         $command = new ExchangeRuntimeCheckCommand(
             $this->adapterRegistry($this->adapter(Exchange::OKX, MarketType::PERPETUAL, supportsPrivateWs: true)),
             $this->providerRegistry($this->providerBundle(Exchange::OKX, MarketType::PERPETUAL)),
@@ -98,7 +98,7 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('Live allowed: no', $output);
         self::assertStringContainsString('Demo trading enabled: yes', $output);
         self::assertStringContainsString('Recommended dry_run: true', $output);
-        self::assertStringContainsString('Schedule ready: yes', $output);
+        self::assertStringContainsString('Schedule ready: no', $output);
         // The Hyperliquid-specific lines must never leak into OKX output.
         self::assertStringNotContainsString('Network:', $output);
         self::assertStringNotContainsString('Mainnet enabled:', $output);

--- a/trading-app/tests/Provider/Okx/OkxExchangeBundleRegistryTest.php
+++ b/trading-app/tests/Provider/Okx/OkxExchangeBundleRegistryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Provider\Okx;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\Timeframe;
+use App\Contract\Provider\AccountProviderInterface;
+use App\Contract\Provider\ContractProviderInterface;
+use App\Contract\Provider\KlineProviderInterface;
+use App\Contract\Provider\OrderProviderInterface;
+use App\Contract\Provider\SystemProviderInterface;
+use App\Provider\Context\ExchangeContext;
+use App\Provider\MainProvider;
+use App\Provider\Okx\OkxAccountGateway;
+use App\Provider\Okx\OkxMarketDataGateway;
+use App\Provider\Okx\OkxMetadataProvider;
+use App\Provider\Okx\OkxOrderGateway;
+use App\Provider\Okx\OkxProviderNotReadyException;
+use App\Provider\Okx\OkxSystemProvider;
+use App\Provider\Registry\ExchangeProviderBundle;
+use App\Provider\Registry\ExchangeProviderRegistry;
+use App\Provider\Registry\Exception\ProviderNotFoundException;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class OkxExchangeBundleRegistryTest extends TestCase
+{
+    public function testRegistryResolvesOkxPerpetualBundle(): void
+    {
+        $registry = new ExchangeProviderRegistry(
+            [
+                $this->bitmartBundle(),
+                $this->okxBundle(),
+            ],
+            Exchange::BITMART,
+            MarketType::PERPETUAL,
+        );
+
+        $bundle = $registry->get(new ExchangeContext(Exchange::OKX, MarketType::PERPETUAL));
+
+        self::assertTrue($bundle->context()->equals(new ExchangeContext(Exchange::OKX, MarketType::PERPETUAL)));
+        self::assertInstanceOf(OkxMarketDataGateway::class, $bundle->kline());
+        self::assertInstanceOf(OkxMetadataProvider::class, $bundle->contract());
+        self::assertInstanceOf(OkxOrderGateway::class, $bundle->order());
+        self::assertInstanceOf(OkxAccountGateway::class, $bundle->account());
+        self::assertInstanceOf(OkxSystemProvider::class, $bundle->system());
+
+        self::assertTrue($registry->getDefaultContext()->equals(new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL)));
+    }
+
+    public function testOkxSpotDoesNotFallbackToBitmart(): void
+    {
+        $registry = new ExchangeProviderRegistry(
+            [
+                $this->bitmartBundle(),
+                $this->okxBundle(),
+            ],
+            Exchange::BITMART,
+            MarketType::PERPETUAL,
+        );
+
+        $this->expectException(ProviderNotFoundException::class);
+        $this->expectExceptionMessage('okx::spot');
+
+        $registry->get(new ExchangeContext(Exchange::OKX, MarketType::SPOT));
+    }
+
+    public function testMainProviderScopesToOkxPerpetualBundle(): void
+    {
+        $mainProvider = new MainProvider(new ExchangeProviderRegistry(
+            [
+                $this->bitmartBundle(),
+                $this->okxBundle(),
+            ],
+            Exchange::BITMART,
+            MarketType::PERPETUAL,
+        ));
+
+        $scoped = $mainProvider->forContext(new ExchangeContext(Exchange::OKX, MarketType::PERPETUAL));
+
+        $this->assertNotImplemented(
+            static fn (): array => $scoped->getKlineProvider()->getKlines('BTCUSDT', Timeframe::TF_1M),
+            'okx_market_data_not_implemented',
+        );
+        self::assertInstanceOf(OkxMetadataProvider::class, $scoped->getContractProvider());
+        $this->assertNotImplemented(
+            static fn (): array => $scoped->getOrderProvider()->getOpenOrdersOrFail('BTCUSDT'),
+            'okx_order_read_not_implemented',
+        );
+        self::assertInstanceOf(OkxAccountGateway::class, $scoped->getAccountProvider());
+        self::assertInstanceOf(OkxSystemProvider::class, $scoped->getSystemProvider());
+    }
+
+    private function okxBundle(): ExchangeProviderBundle
+    {
+        return new ExchangeProviderBundle(
+            new ExchangeContext(Exchange::OKX, MarketType::PERPETUAL),
+            new OkxMarketDataGateway(),
+            new OkxMetadataProvider(),
+            new OkxOrderGateway(),
+            new OkxAccountGateway(),
+            new OkxSystemProvider(),
+        );
+    }
+
+    private function bitmartBundle(): ExchangeProviderBundle
+    {
+        return new ExchangeProviderBundle(
+            new ExchangeContext(Exchange::BITMART, MarketType::PERPETUAL),
+            $this->createMock(KlineProviderInterface::class),
+            $this->createMock(ContractProviderInterface::class),
+            $this->createMock(OrderProviderInterface::class),
+            $this->createMock(AccountProviderInterface::class),
+            $this->createMock(SystemProviderInterface::class),
+        );
+    }
+
+    /**
+     * @param callable(): mixed $operation
+     */
+    private function assertNotImplemented(callable $operation, string $reason): void
+    {
+        try {
+            $operation();
+            self::fail('Expected OKX scoped provider operation to fail explicitly.');
+        } catch (OkxProviderNotReadyException $exception) {
+            self::assertSame($reason, $exception->reason());
+        }
+    }
+}

--- a/trading-app/tests/Provider/Okx/OkxProviderSkeletonTest.php
+++ b/trading-app/tests/Provider/Okx/OkxProviderSkeletonTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Provider\Okx;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Common\Enum\OrderSide;
+use App\Common\Enum\OrderType;
+use App\Common\Enum\Timeframe;
+use App\Exchange\Readiness\ExchangeReadinessInput;
+use App\Exchange\Readiness\ExchangeReadinessLevel;
+use App\Provider\Okx\OkxAccountGateway;
+use App\Provider\Okx\OkxMarketDataGateway;
+use App\Provider\Okx\OkxMetadataProvider;
+use App\Provider\Okx\OkxOrderGateway;
+use App\Provider\Okx\OkxPositionGateway;
+use App\Provider\Okx\OkxProviderNotReadyException;
+use App\Provider\Okx\OkxRuntimeCheck;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class OkxProviderSkeletonTest extends TestCase
+{
+    public function testReadSkeletonMethodsFailExplicitly(): void
+    {
+        $this->assertNotImplemented(
+            static fn (): array => (new OkxMarketDataGateway())->getKlines('BTCUSDT', Timeframe::TF_1M),
+            'okx_market_data_not_implemented',
+        );
+
+        $this->assertNotImplemented(
+            static fn (): array => (new OkxMetadataProvider())->getContracts(),
+            'okx_metadata_not_implemented',
+        );
+
+        $this->assertNotImplemented(
+            static fn (): array => (new OkxAccountGateway())->getOpenPositionsOrFail(),
+            'okx_position_not_implemented',
+        );
+
+        $this->assertNotImplemented(
+            static fn (): array => (new OkxPositionGateway())->getOpenPositionsOrFail(),
+            'okx_position_not_implemented',
+        );
+    }
+
+    public function testOrderSkeletonRejectsEveryMutativeMethodExplicitly(): void
+    {
+        $orderGateway = new OkxOrderGateway();
+
+        $this->assertNotImplemented(
+            static fn () => $orderGateway->placeOrder(
+                'BTCUSDT',
+                OrderSide::BUY,
+                OrderType::LIMIT,
+                1.0,
+                50000.0,
+            ),
+            'okx_order_write_not_implemented',
+        );
+
+        $this->assertNotImplemented(
+            static fn (): bool => $orderGateway->cancelOrder('BTCUSDT', 'ord-1'),
+            'okx_order_write_not_implemented',
+        );
+
+        $this->assertNotImplemented(
+            static fn (): bool => $orderGateway->submitLeverage('BTCUSDT', 2),
+            'okx_order_write_not_implemented',
+        );
+    }
+
+    public function testRuntimeCheckReturnsNotReadyForSkeleton(): void
+    {
+        $report = (new OkxRuntimeCheck())->check(new ExchangeReadinessInput(
+            exchange: Exchange::OKX,
+            marketType: MarketType::PERPETUAL,
+            environment: 'demo',
+            mainnetWriteGuard: true,
+            dryRun: true,
+        ));
+
+        self::assertSame(ExchangeReadinessLevel::NotReady, $report->readyLevel);
+        self::assertContains('okx_provider_skeleton_not_ready', $report->blockingErrors);
+        self::assertSame('okx', $report->toArray()['exchange']);
+        self::assertSame('perpetual', $report->toArray()['market_type']);
+    }
+
+    /**
+     * @param callable(): mixed $operation
+     */
+    private function assertNotImplemented(callable $operation, string $reason): void
+    {
+        try {
+            $operation();
+            self::fail('Expected OKX skeleton operation to fail explicitly.');
+        } catch (OkxProviderNotReadyException $exception) {
+            self::assertSame($reason, $exception->reason());
+            self::assertStringContainsString($reason, $exception->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add an explicit OKX provider skeleton bundle for `okx/perpetual`.
- Add OKX market data, metadata, account, position, order, system and runtime-check skeleton services.
- Fail closed with `OkxProviderNotReadyException` for unimplemented reads/writes; no network calls and no write endpoint implementation.
- Register `okx_perpetual` in the exchange provider registry without changing the Bitmart default or adding `okx/spot`.
- Update Provider README with the OKX registry behavior and no-fallback rule.

## Tests
- `docker-compose exec -T trading-app-php php bin/phpunit tests/Provider/Okx`
- `docker-compose exec -T trading-app-php ./vendor/bin/phpstan analyse src/Provider/Okx tests/Provider/Okx --no-progress`
- `docker-compose exec -T trading-app-php php bin/console lint:container --no-debug`
- `docker-compose exec -T trading-app-php php bin/console lint:yaml config`
- `python3 -m mkdocs build --strict`
- `git diff --check`
- Runtime smoke: `app:exchange:runtime-check okx perpetual` with Bitmart base URIs injected in the process env; output reports `Provider bundle: found`, `Live allowed: no`, `Recommended dry_run: true`.

## Scope guard
- No OKX REST/WS calls.
- No write endpoint implementation.
- No strategy, EntryZone, risk/leverage or SL/TP changes.
- No fallback to Bitmart for `exchange=okx`.

Part of OKX-002
Related to OKX-001 / #227
Related to #188
