### PR TITLE
HL-005: Add Hyperliquid persistent nonce manager

### DIFF
--- a/docs/handbook/technical/hyperliquid-testnet-readiness.md
+++ b/docs/handbook/technical/hyperliquid-testnet-readiness.md
@@ -84,7 +84,7 @@ reutilisables.
 | WebSocket prive / equivalent | A livrer | State compte lisible via `info`, streams a valider. | Policy de snapshot initial + delta, ou justification equivalente avant mutation. |
 | Signer fake/local | Livre HL-004 | `FakeHyperliquidSigner` produit une signature deterministe de fixture, sans secret et sans HTTP. `HyperliquidDryRunExecutionPort` ne signe pas et ne broadcast pas. | Conserver le fake pour les recettes local dry-run et les tests de payload. |
 | Signer testnet | Encapsule HL-004 | `HyperliquidAgentSigner` valide `HYPERLIQUID_ENV=testnet`, `HYPERLIQUID_NETWORK=testnet` et les variables agent/account testnet, puis delegue a un backend de signature injecte. Aucun backend crypto n'est cable au client `/exchange` par defaut. | Ajouter le backend crypto officiel/valide par vecteurs dans une PR ulterieure avant tout broadcast. |
-| Nonce manager | Skeleton HL-002 | `HyperliquidNonceManagerInterface` existe sans implementation concrete. | Compteur persistant par signer, monotone, restart-safe et auditable. |
+| Nonce manager | Livre HL-005 | `PersistentHyperliquidNonceManager` persiste `hyperliquid_nonce_state` par `environment + network + signer_address`, garde `account_address` en audit, rejette la reutilisation d'un signer sur un autre compte, et detecte les replays. | L'utiliser seulement dans une PR mutative future, apres signer crypto officiel et garde `/exchange`. |
 | Metadata / precision | Partiel HL-003 | Mapping `symbol -> coin -> asset_id`, `szDecimals`, max leverage et precision derivee sont exposes dans `HyperliquidInstrumentMetadataDto`. | Precision complete fees/min-notional en HL-007. |
 | Fees / funding / costs | Partiel HL-003 | Funding public absent reste `null` avec `funding_rate_unknown`, jamais converti en zero dans le DTO metadata. | User fills/funding/couts complets en PR account/ledger dediees. |
 | Local dry-run no broadcast | Partiel | `HyperliquidDryRunExecutionPort` simule sans HTTP ni `/exchange`. | Serialization future des payloads HL sans broadcast ni secret. |
@@ -192,12 +192,41 @@ HL-004 ajoute la frontiere de signature sans activer de broadcast :
 - le client REST `/exchange` par defaut continue de refuser, meme si les
   variables de signer sont presentes.
 
+### Nonce manager et replay
+
+HL-005 ajoute un compteur nonce persistant sans activer de broadcast :
+
+- `HyperliquidNonceManagerInterface` expose `nextNonce()` et
+  `recordObservedNonce()` ;
+- `HyperliquidNonceScope` transporte `environment`, `network`,
+  `account_address` et `signer_address` ;
+- `PersistentHyperliquidNonceManager` reserve `max(now_ms, last_nonce + 1)` ;
+- `hyperliquid_nonce_state` porte la cle unique
+  `environment + network + signer_address` ;
+- `account_address` reste stocke pour audit et pour detecter une tentative de
+  reutiliser le meme signer sur un autre compte ;
+- la reservation utilise un upsert atomique `ON CONFLICT ... RETURNING`, ce qui
+  couvre le premier insert concurrent et les reservations suivantes ;
+- un signer deja associe a un autre compte leve
+  `hyperliquid_nonce_scope_conflict` ;
+- un nonce observe inferieur ou egal au dernier nonce connu leve
+  `hyperliquid_nonce_replay_detected` ;
+- le compteur survit aux restarts et peut etre resynchronise par un nonce
+  observe plus haut ;
+- ce compteur n'est pas une cle d'idempotence metier et ne remplace pas les
+  `client_order_id`/Cloid applicatifs.
+
+Le signer est l'axe de serialization anti-replay. Le compte reste visible dans
+la ligne persistante, mais il ne cree pas un compteur independant pour un meme
+signer. Aucun fallback par symbole, horodatage seul ou ordre metier n'est
+autorise pour determiner un nonce.
+
 Les actions `POST /exchange` restent hors perimetre. Une future PR mutative
 testnet devra prouver :
 
 - API wallet testnet dedie au bot, jamais private key du wallet principal ;
 - signer crypto officiel valide par vecteurs non secrets ;
-- nonce manager persistant par signer ;
+- utilisation explicite du nonce manager persistant par signer ;
 - payloads redacted et hashables pour audit ;
 - whitelist symbole/marche, notional minimal, leverage cap et SL obligatoire ;
 - fail-safe si le SL ne peut pas etre attache ou relu ;
@@ -317,6 +346,17 @@ HL-003 ajoute la lecture publique. Son rollback doit aussi retirer :
   `HyperliquidMetadataProvider` ;
 - le passage `public_read_only` de `HyperliquidRuntimeCheck` ;
 - les tests `HyperliquidPublicReadProviderTest`.
+
+HL-005 ajoute le compteur nonce persistant. Son rollback doit aussi retirer :
+
+- la table `hyperliquid_nonce_state` via la migration inverse ;
+- `HyperliquidNonceScope`, `HyperliquidNonceReplayException`,
+  `HyperliquidNonceScopeConflictException`, `PersistentHyperliquidNonceManager`
+  et `HyperliquidNonceStateRepository` ;
+- l'entite `HyperliquidNonceState` ;
+- l'alias DI `HyperliquidNonceManagerInterface` vers
+  `PersistentHyperliquidNonceManager` ;
+- les tests `HyperliquidNonceManagerTest`.
 
 Le rollback operationnel a conserver pour les PRs suivantes reste :
 

--- a/trading-app/config/services.yaml
+++ b/trading-app/config/services.yaml
@@ -114,6 +114,9 @@ services:
     App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportServiceInterface:
         alias: App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportService
 
+    App\Provider\Hyperliquid\HyperliquidNonceManagerInterface:
+        alias: App\Provider\Hyperliquid\PersistentHyperliquidNonceManager
+
     App\Trading\Reporting\PositionTradeAnalysisLegacyReaderInterface:
         alias: App\Repository\PositionTradeAnalysisRepository
 

--- a/trading-app/migrations/Version20260630000000.php
+++ b/trading-app/migrations/Version20260630000000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260630000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add persistent Hyperliquid nonce state table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+        CREATE TABLE IF NOT EXISTS hyperliquid_nonce_state (
+            id BIGSERIAL NOT NULL,
+            environment VARCHAR(32) NOT NULL,
+            network VARCHAR(32) NOT NULL,
+            account_address VARCHAR(128) NOT NULL,
+            signer_address VARCHAR(128) NOT NULL,
+            last_nonce BIGINT NOT NULL,
+            created_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+            updated_at TIMESTAMP(0) WITH TIME ZONE NOT NULL,
+            PRIMARY KEY(id)
+        )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX IF NOT EXISTS ux_hyperliquid_nonce_signer_scope ON hyperliquid_nonce_state (environment, network, signer_address)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_hyperliquid_nonce_account ON hyperliquid_nonce_state (environment, network, account_address)');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_hyperliquid_nonce_updated_at ON hyperliquid_nonce_state (updated_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_hyperliquid_nonce_updated_at');
+        $this->addSql('DROP INDEX IF EXISTS idx_hyperliquid_nonce_account');
+        $this->addSql('DROP INDEX IF EXISTS ux_hyperliquid_nonce_signer_scope');
+        $this->addSql('DROP TABLE IF EXISTS hyperliquid_nonce_state');
+    }
+}

--- a/trading-app/src/Entity/HyperliquidNonceState.php
+++ b/trading-app/src/Entity/HyperliquidNonceState.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Provider\Hyperliquid\HyperliquidNonceScope;
+use App\Repository\HyperliquidNonceStateRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: HyperliquidNonceStateRepository::class)]
+#[ORM\Table(name: 'hyperliquid_nonce_state')]
+#[ORM\UniqueConstraint(name: 'ux_hyperliquid_nonce_signer_scope', columns: ['environment', 'network', 'signer_address'])]
+#[ORM\Index(name: 'idx_hyperliquid_nonce_account', columns: ['environment', 'network', 'account_address'])]
+#[ORM\Index(name: 'idx_hyperliquid_nonce_updated_at', columns: ['updated_at'])]
+final class HyperliquidNonceState
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::BIGINT)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::STRING, length: 32)]
+    private string $environment;
+
+    #[ORM\Column(type: Types::STRING, length: 32)]
+    private string $network;
+
+    #[ORM\Column(name: 'account_address', type: Types::STRING, length: 128)]
+    private string $accountAddress;
+
+    #[ORM\Column(name: 'signer_address', type: Types::STRING, length: 128)]
+    private string $signerAddress;
+
+    #[ORM\Column(name: 'last_nonce', type: Types::BIGINT)]
+    private int $lastNonce;
+
+    #[ORM\Column(name: 'created_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    #[ORM\Column(name: 'updated_at', type: Types::DATETIMETZ_IMMUTABLE)]
+    private \DateTimeImmutable $updatedAt;
+
+    public function __construct(HyperliquidNonceScope $scope, int $lastNonce, \DateTimeImmutable $now)
+    {
+        $this->environment = $scope->environment;
+        $this->network = $scope->network;
+        $this->accountAddress = $scope->accountAddress;
+        $this->signerAddress = $scope->signerAddress;
+        $this->lastNonce = $lastNonce;
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getEnvironment(): string
+    {
+        return $this->environment;
+    }
+
+    public function getNetwork(): string
+    {
+        return $this->network;
+    }
+
+    public function getAccountAddress(): string
+    {
+        return $this->accountAddress;
+    }
+
+    public function getSignerAddress(): string
+    {
+        return $this->signerAddress;
+    }
+
+    public function getLastNonce(): int
+    {
+        return $this->lastNonce;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): \DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function advanceTo(int $nonce, \DateTimeImmutable $now): void
+    {
+        if ($nonce <= $this->lastNonce) {
+            return;
+        }
+
+        $this->lastNonce = $nonce;
+        $this->updatedAt = $now;
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/README.md
+++ b/trading-app/src/Exchange/Hyperliquid/README.md
@@ -30,12 +30,18 @@ First API-first Hyperliquid integration slice.
   `/exchange`.
 - `HyperliquidRuntimeCheck` may reach `public_read_only` when public probes are
   supplied as good, but `app:exchange:runtime-check hyperliquid perpetual`
-  remains `Schedule ready: no` until account read, signer, nonce, local dry-run,
-  and protection readiness are implemented.
+  remains `Schedule ready: no` until account read, local dry-run, protection
+  readiness, and future controlled `/exchange` wiring are implemented.
 - `HyperliquidAgentSigner` only accepts `HYPERLIQUID_NETWORK=testnet` and
   `HYPERLIQUID_ENV=testnet`. The application never accepts the wallet principal
   private key; only a dedicated testnet agent key is allowed, and signer outputs
   are redacted.
+- `PersistentHyperliquidNonceManager` stores monotonic nonces in
+  `hyperliquid_nonce_state`, scoped by
+  `environment + network + signer_address`. It keeps `account_address` for audit,
+  rejects signer reuse across accounts with `hyperliquid_nonce_scope_conflict`,
+  rejects replay with `hyperliquid_nonce_replay_detected`, and is not a business
+  idempotency key.
 
 Environment:
 
@@ -54,3 +60,8 @@ HYPERLIQUID_TESTNET_TRADING_ENABLED=0
 Rollback for HL-004: unset the three `HYPERLIQUID_TESTNET_*` signer/account
 variables and keep `HYPERLIQUID_TESTNET_TRADING_ENABLED=0`. Public read-only
 HL-003 remains available; no `/exchange` broadcast path is enabled by this slice.
+
+Rollback for HL-005: migrate down `hyperliquid_nonce_state`, remove the
+`PersistentHyperliquidNonceManager` DI alias, and keep
+`HYPERLIQUID_TESTNET_TRADING_ENABLED=0`. Signer boundaries remain available, but
+no `/exchange` broadcast path is enabled by this slice.

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidNonceManagerInterface.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidNonceManagerInterface.php
@@ -6,5 +6,7 @@ namespace App\Provider\Hyperliquid;
 
 interface HyperliquidNonceManagerInterface
 {
-    public function nextNonce(string $signerAddress): int;
+    public function nextNonce(HyperliquidNonceScope $scope): int;
+
+    public function recordObservedNonce(HyperliquidNonceScope $scope, int $nonce): void;
 }

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidNonceReplayException.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidNonceReplayException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Hyperliquid;
+
+final class HyperliquidNonceReplayException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('hyperliquid_nonce_replay_detected');
+    }
+}

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidNonceScope.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidNonceScope.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Hyperliquid;
+
+final readonly class HyperliquidNonceScope
+{
+    public string $environment;
+    public string $network;
+    public string $accountAddress;
+    public string $signerAddress;
+
+    public function __construct(
+        string $environment,
+        string $network,
+        string $accountAddress,
+        string $signerAddress,
+    ) {
+        $this->environment = $this->normalizeRequired($environment, 'environment');
+        $this->network = $this->normalizeRequired($network, 'network');
+        $this->accountAddress = $this->normalizeRequired($accountAddress, 'account_address');
+        $this->signerAddress = $this->normalizeRequired($signerAddress, 'signer_address');
+    }
+
+    private function normalizeRequired(string $value, string $name): string
+    {
+        $normalized = strtolower(trim($value));
+        if ($normalized === '') {
+            throw new \InvalidArgumentException(sprintf('hyperliquid_nonce_scope_missing_%s', $name));
+        }
+
+        return $normalized;
+    }
+}

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidNonceScopeConflictException.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidNonceScopeConflictException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Hyperliquid;
+
+final class HyperliquidNonceScopeConflictException extends \RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('hyperliquid_nonce_scope_conflict');
+    }
+}

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidRuntimeCheck.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidRuntimeCheck.php
@@ -29,7 +29,6 @@ final readonly class HyperliquidRuntimeCheck implements ExchangeRuntimeCheckInte
         if (!$input->permissionsTrade) {
             $warnings[] = 'hyperliquid_api_wallet_not_ready';
         }
-        $warnings[] = 'hyperliquid_nonce_manager_not_ready';
 
         $report = (new ExchangeReadinessEvaluator())->evaluate(new ExchangeReadinessInput(
             exchange: $input->exchange,

--- a/trading-app/src/Provider/Hyperliquid/PersistentHyperliquidNonceManager.php
+++ b/trading-app/src/Provider/Hyperliquid/PersistentHyperliquidNonceManager.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Provider\Hyperliquid;
+
+use App\Repository\HyperliquidNonceStateRepository;
+use Psr\Clock\ClockInterface;
+
+final readonly class PersistentHyperliquidNonceManager implements HyperliquidNonceManagerInterface
+{
+    public function __construct(
+        private HyperliquidNonceStateRepository $repository,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function nextNonce(HyperliquidNonceScope $scope): int
+    {
+        $now = $this->clock->now();
+
+        return $this->repository->reserveNext($scope, $this->toMilliseconds($now), $now);
+    }
+
+    public function recordObservedNonce(HyperliquidNonceScope $scope, int $nonce): void
+    {
+        $this->repository->recordObserved($scope, $nonce, $this->clock->now());
+    }
+
+    private function toMilliseconds(\DateTimeImmutable $now): int
+    {
+        return ((int) $now->format('U') * 1000) + ((int) floor(((int) $now->format('u')) / 1000));
+    }
+}

--- a/trading-app/src/Repository/HyperliquidNonceStateRepository.php
+++ b/trading-app/src/Repository/HyperliquidNonceStateRepository.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\HyperliquidNonceState;
+use App\Provider\Hyperliquid\HyperliquidNonceReplayException;
+use App\Provider\Hyperliquid\HyperliquidNonceScope;
+use App\Provider\Hyperliquid\HyperliquidNonceScopeConflictException;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<HyperliquidNonceState>
+ */
+final class HyperliquidNonceStateRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, HyperliquidNonceState::class);
+    }
+
+    public function reserveNext(HyperliquidNonceScope $scope, int $candidateNonce, \DateTimeImmutable $now): int
+    {
+        $result = $this->getEntityManager()->getConnection()->executeQuery(
+            <<<'SQL'
+INSERT INTO hyperliquid_nonce_state (
+    environment,
+    network,
+    account_address,
+    signer_address,
+    last_nonce,
+    created_at,
+    updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (environment, network, signer_address)
+DO UPDATE SET
+    last_nonce = CASE
+        WHEN hyperliquid_nonce_state.last_nonce + 1 > EXCLUDED.last_nonce THEN hyperliquid_nonce_state.last_nonce + 1
+        ELSE EXCLUDED.last_nonce
+    END,
+    updated_at = EXCLUDED.updated_at
+WHERE hyperliquid_nonce_state.account_address = EXCLUDED.account_address
+RETURNING last_nonce
+SQL,
+            $this->parameters($scope, $candidateNonce, $now),
+            $this->parameterTypes(),
+        );
+
+        $reserved = $result->fetchOne();
+        if ($reserved === false) {
+            throw new HyperliquidNonceScopeConflictException();
+        }
+
+        return (int) $reserved;
+    }
+
+    public function recordObserved(HyperliquidNonceScope $scope, int $observedNonce, \DateTimeImmutable $now): void
+    {
+        $result = $this->getEntityManager()->getConnection()->executeQuery(
+            <<<'SQL'
+INSERT INTO hyperliquid_nonce_state (
+    environment,
+    network,
+    account_address,
+    signer_address,
+    last_nonce,
+    created_at,
+    updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT (environment, network, signer_address)
+DO UPDATE SET
+    last_nonce = EXCLUDED.last_nonce,
+    updated_at = EXCLUDED.updated_at
+WHERE hyperliquid_nonce_state.account_address = EXCLUDED.account_address
+  AND hyperliquid_nonce_state.last_nonce < EXCLUDED.last_nonce
+RETURNING last_nonce
+SQL,
+            $this->parameters($scope, $observedNonce, $now),
+            $this->parameterTypes(),
+        );
+
+        if ($result->fetchOne() !== false) {
+            return;
+        }
+
+        $accountAddress = $this->accountAddressForSigner($scope);
+        if ($accountAddress !== null && $accountAddress !== $scope->accountAddress) {
+            throw new HyperliquidNonceScopeConflictException();
+        }
+
+        throw new HyperliquidNonceReplayException();
+    }
+
+    private function accountAddressForSigner(HyperliquidNonceScope $scope): ?string
+    {
+        $accountAddress = $this->createQueryBuilder('state')
+            ->select('state.accountAddress')
+            ->andWhere('state.environment = :environment')
+            ->andWhere('state.network = :network')
+            ->andWhere('state.signerAddress = :signerAddress')
+            ->setParameter('environment', $scope->environment)
+            ->setParameter('network', $scope->network)
+            ->setParameter('signerAddress', $scope->signerAddress)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($accountAddress === null) {
+            return null;
+        }
+
+        if (!is_array($accountAddress) || !isset($accountAddress['accountAddress']) || !is_string($accountAddress['accountAddress'])) {
+            throw new HyperliquidNonceReplayException();
+        }
+
+        return $accountAddress['accountAddress'];
+    }
+
+    /**
+     * @return array{0:string,1:string,2:string,3:string,4:int,5:\DateTimeImmutable,6:\DateTimeImmutable}
+     */
+    private function parameters(HyperliquidNonceScope $scope, int $nonce, \DateTimeImmutable $now): array
+    {
+        return [
+            $scope->environment,
+            $scope->network,
+            $scope->accountAddress,
+            $scope->signerAddress,
+            $nonce,
+            $now,
+            $now,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function parameterTypes(): array
+    {
+        return [
+            Types::STRING,
+            Types::STRING,
+            Types::STRING,
+            Types::STRING,
+            Types::BIGINT,
+            Types::DATETIMETZ_IMMUTABLE,
+            Types::DATETIMETZ_IMMUTABLE,
+        ];
+    }
+}

--- a/trading-app/tests/Provider/Hyperliquid/HyperliquidExchangeBundleRegistryTest.php
+++ b/trading-app/tests/Provider/Hyperliquid/HyperliquidExchangeBundleRegistryTest.php
@@ -174,7 +174,7 @@ final class HyperliquidExchangeBundleRegistryTest extends TestCase
         self::assertContains('hyperliquid_provider_bundle_skeleton_not_ready', $report->blockingErrors);
     }
 
-    public function testSignerAndNonceContractsArePresentButNotImplemented(): void
+    public function testSignerAndNonceContractsArePresent(): void
     {
         self::assertTrue(interface_exists(HyperliquidSignerInterface::class));
         self::assertTrue(interface_exists(HyperliquidNonceManagerInterface::class));

--- a/trading-app/tests/Provider/Hyperliquid/HyperliquidNonceManagerTest.php
+++ b/trading-app/tests/Provider/Hyperliquid/HyperliquidNonceManagerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Provider\Hyperliquid;
+
+use App\Entity\HyperliquidNonceState;
+use App\Provider\Hyperliquid\HyperliquidNonceReplayException;
+use App\Provider\Hyperliquid\HyperliquidNonceScope;
+use App\Provider\Hyperliquid\HyperliquidNonceScopeConflictException;
+use App\Provider\Hyperliquid\PersistentHyperliquidNonceManager;
+use App\Repository\HyperliquidNonceStateRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Clock\MockClock;
+
+#[CoversClass(PersistentHyperliquidNonceManager::class)]
+#[CoversClass(HyperliquidNonceScope::class)]
+#[CoversClass(HyperliquidNonceState::class)]
+final class HyperliquidNonceManagerTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private HyperliquidNonceStateRepository $repository;
+
+    protected static function getKernelClass(): string
+    {
+        return \App\Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $em */
+        $em = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+        $this->em = $em;
+
+        $tool = new SchemaTool($this->em);
+        $metadata = [$this->em->getClassMetadata(HyperliquidNonceState::class)];
+        $tool->dropSchema($metadata);
+        $tool->createSchema($metadata);
+
+        /** @var HyperliquidNonceStateRepository $repository */
+        $repository = $this->em->getRepository(HyperliquidNonceState::class);
+        $this->repository = $repository;
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->em)) {
+            (new SchemaTool($this->em))->dropSchema([
+                $this->em->getClassMetadata(HyperliquidNonceState::class),
+            ]);
+            $this->em->close();
+        }
+
+        parent::tearDown();
+    }
+
+    public function testNextNonceIsMonotonicAndSurvivesRestart(): void
+    {
+        $clock = new MockClock('2026-06-30 00:00:00.123 UTC');
+        $scope = $this->scope();
+
+        $manager = new PersistentHyperliquidNonceManager($this->repository, $clock);
+
+        $first = $manager->nextNonce($scope);
+        $second = $manager->nextNonce($scope);
+        $afterRestart = (new PersistentHyperliquidNonceManager($this->repository, $clock))->nextNonce($scope);
+
+        self::assertSame(1_782_777_600_123, $first);
+        self::assertSame($first + 1, $second);
+        self::assertSame($second + 1, $afterRestart);
+        self::assertSame(1, $this->repository->count([]));
+    }
+
+    public function testScopesAreSeparatedByEnvironmentAccountAndSigner(): void
+    {
+        $clock = new MockClock('2026-06-30 00:00:00.500 UTC');
+        $manager = new PersistentHyperliquidNonceManager($this->repository, $clock);
+
+        $base = $manager->nextNonce($this->scope());
+        $sameScopeAgain = $manager->nextNonce($this->scope());
+        $otherEnvironment = $manager->nextNonce($this->scope(environment: 'testnet-alt'));
+        $otherAccount = $manager->nextNonce($this->scope(
+            account: '0x00000000000000000000000000000000000000aa',
+            signer: '0x00000000000000000000000000000000000000ab',
+        ));
+        $otherSigner = $manager->nextNonce($this->scope(signer: '0x00000000000000000000000000000000000000bb'));
+
+        self::assertSame(1_782_777_600_500, $base);
+        self::assertSame($base + 1, $sameScopeAgain);
+        self::assertSame($base, $otherEnvironment);
+        self::assertSame($base, $otherAccount);
+        self::assertSame($base, $otherSigner);
+        self::assertSame(4, $this->repository->count([]));
+    }
+
+    public function testSameSignerCannotBeReusedAcrossAccounts(): void
+    {
+        $clock = new MockClock('2026-06-30 00:00:00.700 UTC');
+        $manager = new PersistentHyperliquidNonceManager($this->repository, $clock);
+        $scope = $this->scope();
+
+        $first = $manager->nextNonce($scope);
+
+        $this->expectException(HyperliquidNonceScopeConflictException::class);
+        $this->expectExceptionMessage('hyperliquid_nonce_scope_conflict');
+
+        try {
+            $manager->nextNonce($this->scope(account: '0x00000000000000000000000000000000000000aa'));
+        } finally {
+            self::assertSame($first + 1, $manager->nextNonce($scope));
+        }
+    }
+
+    public function testObservedNonceReplayIsRejectedAndHigherObservedNonceAdvancesState(): void
+    {
+        $clock = new MockClock('2026-06-30 00:00:00.000 UTC');
+        $manager = new PersistentHyperliquidNonceManager($this->repository, $clock);
+        $scope = $this->scope();
+
+        $first = $manager->nextNonce($scope);
+
+        try {
+            $manager->recordObservedNonce($scope, $first);
+            self::fail('Expected replayed nonce to be rejected.');
+        } catch (HyperliquidNonceReplayException $exception) {
+            self::assertSame('hyperliquid_nonce_replay_detected', $exception->getMessage());
+        }
+
+        $manager->recordObservedNonce($scope, $first + 100);
+
+        self::assertSame($first + 101, $manager->nextNonce($scope));
+    }
+
+    public function testIndependentManagersReserveDistinctNoncesOnSameStorage(): void
+    {
+        $clock = new MockClock('2026-06-30 00:00:00.000 UTC');
+        $scope = $this->scope();
+
+        $firstManager = new PersistentHyperliquidNonceManager($this->repository, $clock);
+        $secondManager = new PersistentHyperliquidNonceManager($this->repository, $clock);
+
+        self::assertSame(1_782_777_600_000, $firstManager->nextNonce($scope));
+        self::assertSame(1_782_777_600_001, $secondManager->nextNonce($scope));
+    }
+
+    private function scope(
+        string $environment = 'testnet',
+        string $network = 'testnet',
+        string $account = '0x0000000000000000000000000000000000000001',
+        string $signer = '0x0000000000000000000000000000000000000002',
+    ): HyperliquidNonceScope {
+        return new HyperliquidNonceScope(
+            environment: $environment,
+            network: $network,
+            accountAddress: $account,
+            signerAddress: $signer,
+        );
+    }
+}


### PR DESCRIPTION
Part of HL-005
Related to HL-004
Related to Hyperliquid testnet readiness sequence

## Summary
- add a persistent Hyperliquid nonce state table scoped by environment, network, account address, and signer address
- implement a monotonic nonce manager with atomic `ON CONFLICT ... RETURNING` reservations and replay rejection
- wire the nonce manager through DI while keeping Hyperliquid execution fail-closed/no broadcast
- document nonce/replay policy and rollback

## Tests
- `docker-compose exec -T trading-app-php php bin/phpunit tests/Provider/Hyperliquid/HyperliquidNonceManagerTest.php`
- `docker-compose exec -T trading-app-php php bin/phpunit tests/Provider/Hyperliquid/HyperliquidNonceManagerTest.php tests/Provider/Hyperliquid/HyperliquidExchangeBundleRegistryTest.php tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php tests/Exchange/Hyperliquid/HyperliquidSignerTest.php tests/Exchange/Hyperliquid/HyperliquidRestClientTest.php tests/Command/ExchangeRuntimeCheckCommandTest.php`
- `docker-compose exec -T trading-app-php vendor/bin/phpstan analyse --configuration=phpstan.dist.neon src/Entity/HyperliquidNonceState.php src/Provider/Hyperliquid/HyperliquidNonceManagerInterface.php src/Provider/Hyperliquid/HyperliquidNonceReplayException.php src/Provider/Hyperliquid/HyperliquidNonceScope.php src/Provider/Hyperliquid/PersistentHyperliquidNonceManager.php src/Provider/Hyperliquid/HyperliquidRuntimeCheck.php src/Repository/HyperliquidNonceStateRepository.php tests/Provider/Hyperliquid/HyperliquidNonceManagerTest.php tests/Provider/Hyperliquid/HyperliquidExchangeBundleRegistryTest.php`
- `docker-compose exec -T trading-app-php php bin/console lint:container --no-debug`
- `docker-compose exec -T trading-app-php php bin/console lint:yaml config`
- `docker-compose exec -T trading-app-php php bin/console doctrine:migrations:migrate --dry-run --no-interaction`
- `python3 -m mkdocs build --strict`
- `git diff --check`

## Safety
- no `/exchange` broadcast path enabled
- no mainnet support added
- nonce remains separate from business idempotency/client order IDs
- no secrets or raw signed payloads added
