### PR TITLE
HL-007 Hyperliquid metadata precision fees funding

### DIFF
--- a/docs/handbook/technical/hyperliquid-testnet-readiness.md
+++ b/docs/handbook/technical/hyperliquid-testnet-readiness.md
@@ -86,8 +86,8 @@ reutilisables.
 | Signer fake/local | Livre HL-004 | `FakeHyperliquidSigner` produit une signature deterministe de fixture, sans secret et sans HTTP. `HyperliquidDryRunExecutionPort` ne signe pas et ne broadcast pas. | Conserver le fake pour les recettes local dry-run et les tests de payload. |
 | Signer testnet | Encapsule HL-004 | `HyperliquidAgentSigner` valide `HYPERLIQUID_ENV=testnet`, `HYPERLIQUID_NETWORK=testnet` et les variables agent/account testnet, puis delegue a un backend de signature injecte. Aucun backend crypto n'est cable au client `/exchange` par defaut. | Ajouter le backend crypto officiel/valide par vecteurs dans une PR ulterieure avant tout broadcast. |
 | Nonce manager | Livre HL-005 | `PersistentHyperliquidNonceManager` persiste `hyperliquid_nonce_state` par `environment + network + signer_address`, garde `account_address` en audit, rejette la reutilisation d'un signer sur un autre compte, et detecte les replays. | L'utiliser seulement dans une PR mutative future, apres signer crypto officiel et garde `/exchange`. |
-| Metadata / precision | Partiel HL-003 | Mapping `symbol -> coin -> asset_id`, `szDecimals`, max leverage et precision derivee sont exposes dans `HyperliquidInstrumentMetadataDto`. | Precision complete fees/min-notional en HL-007. |
-| Fees / funding / costs | Partiel HL-006 | Funding public absent reste `null` avec `funding_rate_unknown`. User fills et funding history sont lisibles via account read-only, redacted et non certifies PnL. | Fees/min-notional complets et couts ledger/certification dans les PRs dediees. |
+| Metadata / precision | Renforce HL-007 | Mapping `symbol -> coin -> asset_id`, `szDecimals`, tick prix, step quantite, max leverage, status marche et flags de qualite sont exposes dans `HyperliquidInstrumentMetadataDto`. Les collisions d'asset et metadata requises manquantes ne sont pas resolues arbitrairement. | Min-notional si Hyperliquid l'expose dans une surface officielle future. |
+| Fees / funding / costs | Renforce HL-007 | Funding public absent reste `null` avec `funding_rate_unknown`. `getTradingFees()` lit `userFees` read-only et expose maker/taker `null` + flags si absents. User fills et funding history sont lisibles via account read-only, redacted et non certifies PnL. | Ledger/certification dans les PRs dediees. |
 | Local dry-run no broadcast | Partiel | `HyperliquidDryRunExecutionPort` simule sans HTTP ni `/exchange`. | Serialization future des payloads HL sans broadcast ni secret. |
 | Runtime-check candidate | Private-read possible HL-006 | `HyperliquidRuntimeCheck` peut retourner `private_read_only` quand les probes publiques et account sont bonnes. La commande runtime reste `Schedule ready: no` tant que les guards local dry-run/protection ne sont pas complets. | Niveaux `local_dry_run_ready`, puis `demo_testnet_candidate`. |
 | SL/TP / protection | A valider | Aucun attachement runtime Hyperliquid n'est prouve par HL-001. | Modele ordre/protection testnet avec SL immediat ou compensation fail-safe. |
@@ -138,6 +138,24 @@ HL-003 normalise :
   `qualityFlags` quand le funding public est absent ;
 - les erreurs publiques 429 en `hyperliquid_public_rate_limited`.
 
+HL-007 renforce ce mapping :
+
+- `BTCUSDT` interne est normalise en coin Hyperliquid `BTC`; l'`asset_id`
+  reste l'index de `meta.universe`/`metaAndAssetCtxs` et n'est jamais hardcode ;
+- `price_tick` est derive de la regle Hyperliquid `max_decimals = 6 -
+  szDecimals`, en respectant aussi la limite de 5 chiffres significatifs pour
+  les prix non entiers ;
+- `quantity_step` et `min_size` viennent de `szDecimals`; si `szDecimals` est
+  absent ou invalide, le DTO porte `missing_size_decimals` ou
+  `invalid_size_decimals` et `isCompleteForSizing()` vaut false ;
+- `max_leverage` vient de `meta.universe[].maxLeverage`; absence ou valeur
+  invalide donne `missing_max_leverage` ou `invalid_max_leverage`, sans fallback
+  optimiste ;
+- un marche `isDelisted=true` est expose avec `status=suspend`,
+  `market_suspended`, et n'est pas considere complet pour sizing ;
+- deux assets resolus vers le meme coin provoquent `hyperliquid_asset_collision`
+  afin d'eviter une resolution arbitraire.
+
 Configuration testnet public cible :
 
 ```dotenv
@@ -162,6 +180,7 @@ touchent jamais a `/exchange`.
 | User fills | `POST /info` user fills / fills by time | Prix, quantite, fees, side, oid, timestamps et pagination. |
 | Historical orders | `POST /info` historical orders | Statuts terminaux et reconciliation apres restart. |
 | User funding | `POST /info` user funding | Funding utilisateur, couts et quality flags. |
+| User fees | `POST /info` user fees | Fee schedule compte, maker=`userAddRate`, taker=`userCrossRate`, devise USDC, flags `*_fee_unknown` si absent. |
 | WebSocket account | WS testnet si retenu | Deltas ordres/fills/positions, ou justification d'un polling read-only borne. |
 
 Configuration account read-only cible :
@@ -352,7 +371,7 @@ Les elements suivants restent explicitement non supportes :
 | Confusion testnet/mainnet | Endpoints testnet obligatoires, `mainnet_write_enabled=false`, `HYPERLIQUID_MAINNET_ENABLED=0` dans les templates de recette. |
 | Secret de wallet principal expose | API wallet dediee obligatoire pour toute future mutation, redaction defensive, aucun secret dans Git. |
 | Collision de nonce | Nonce manager persistant par signer avant tout broadcast. |
-| Asset id divergent | Mapping issu de metadata testnet, jamais hardcode depuis mainnet. |
+| Asset id divergent | Mapping issu de metadata testnet, jamais hardcode depuis mainnet ; collision d'asset rejetee avec `hyperliquid_asset_collision`. |
 | Frais/funding absents | Flags de qualite et PnL non certifie, jamais zero implicite. |
 | Private stream incomplet | `demo_testnet_enabled` bloque par private observability policy. |
 | Partial fill ou SL attach failure | Scenario Fake/Paper d'abord, compensation fail-safe avant toute ecriture testnet. |

--- a/trading-app/src/Exchange/Hyperliquid/HyperliquidAssetResolver.php
+++ b/trading-app/src/Exchange/Hyperliquid/HyperliquidAssetResolver.php
@@ -31,6 +31,10 @@ final class HyperliquidAssetResolver
                 continue;
             }
             $name = $this->normalizeSymbol((string) $asset['name']);
+            if (isset($this->assetIds[$name])) {
+                throw new \RuntimeException(sprintf('hyperliquid_asset_collision:%s', $name));
+            }
+
             $this->assetIds[$name] = (int) $index;
         }
 

--- a/trading-app/src/Exchange/Hyperliquid/HyperliquidAssetResolver.php
+++ b/trading-app/src/Exchange/Hyperliquid/HyperliquidAssetResolver.php
@@ -26,17 +26,20 @@ final class HyperliquidAssetResolver
             throw new \RuntimeException('Hyperliquid meta response missing universe');
         }
 
+        $assetIds = [];
         foreach (array_values($universe) as $index => $asset) {
             if (!\is_array($asset) || !isset($asset['name'])) {
                 continue;
             }
             $name = $this->normalizeSymbol((string) $asset['name']);
-            if (isset($this->assetIds[$name])) {
+            if (isset($assetIds[$name])) {
                 throw new \RuntimeException(sprintf('hyperliquid_asset_collision:%s', $name));
             }
 
-            $this->assetIds[$name] = (int) $index;
+            $assetIds[$name] = (int) $index;
         }
+
+        $this->assetIds = array_replace($this->assetIds, $assetIds);
 
         if (!isset($this->assetIds[$normalized])) {
             throw new \InvalidArgumentException(sprintf('Unknown Hyperliquid asset "%s"', $symbol));

--- a/trading-app/src/Exchange/Hyperliquid/README.md
+++ b/trading-app/src/Exchange/Hyperliquid/README.md
@@ -5,8 +5,9 @@ First API-first Hyperliquid integration slice.
 - Official docs used:
   - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint
   - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
+  - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/tick-and-lot-size
 - Defaults to testnet. Mainnet requires `HYPERLIQUID_ENV=mainnet` and `HYPERLIQUID_MAINNET_ENABLED=1`.
-- REST public/account reads use the official `/info` endpoint (`meta`, `l2Book`, `clearinghouseState`, `frontendOpenOrders`, `userFills`, `userFillsByTime`, `userFunding`).
+- REST public/account reads use the official `/info` endpoint (`meta`, `l2Book`, `clearinghouseState`, `frontendOpenOrders`, `userFills`, `userFillsByTime`, `userFunding`, `userFees`).
 - Open-order reconciliation uses `frontendOpenOrders` so standalone trigger protection orders expose `triggerPx`, `reduceOnly`, and frontend order type metadata.
 - Trading actions are built in official `/exchange` wire format (`order`, `cancel`, `cancelByCloid`, `updateLeverage`).
 - Market orders are sent as IOC limit orders with a 5% slippage cap derived from the current L2 top. Stop-loss/take-profit trigger market orders use the same 5% cap around `stopPrice`.
@@ -32,6 +33,15 @@ First API-first Hyperliquid integration slice.
   `HYPERLIQUID_TESTNET_ACCOUNT_ADDRESS`, reject using the agent address as the
   account address, redact sensitive metadata, do not sign, and do not broadcast
   `/exchange`.
+- HL-007 strengthens market metadata and costs. `HyperliquidInstrumentMetadataDto`
+  exposes derived price tick, quantity step, max leverage, funding, status and
+  quality flags. Missing required sizing fields or suspended markets make
+  `isCompleteForSizing()` false. Duplicate asset names are rejected with
+  `hyperliquid_asset_collision` instead of resolving one arbitrarily.
+- HL-007 also reads user fee schedule through `/info` `userFees`:
+  maker=`userAddRate`, taker=`userCrossRate`, fee currency `USDC`. Missing fee
+  data remains `null` with `maker_fee_unknown`, `taker_fee_unknown` and/or
+  `fee_schedule_unknown`; no absent fee is converted to zero.
 - Mutative execution provider methods remain fail-closed with
   `HyperliquidProviderNotReadyException`.
 - `HyperliquidRuntimeCheck` may reach `private_read_only` when public and
@@ -77,3 +87,8 @@ Rollback for HL-006: unset `HYPERLIQUID_TESTNET_ACCOUNT_ADDRESS` or remove the
 account/execution provider read-only wiring to the Hyperliquid `/info` client.
 Public read-only HL-003 and nonce HL-005 remain available; mutative paths stay
 fail-closed and no `/exchange` broadcast path is enabled by this slice.
+
+Rollback for HL-007: revert the metadata strictness and `userFees` read-only
+mapping changes. Public/account reads from HL-003/HL-006 remain available, but
+cost model consumers must treat Hyperliquid fees and incomplete metadata as
+unknown until this slice is restored.

--- a/trading-app/src/Provider/Hyperliquid/Dto/HyperliquidInstrumentMetadataDto.php
+++ b/trading-app/src/Provider/Hyperliquid/Dto/HyperliquidInstrumentMetadataDto.php
@@ -25,13 +25,14 @@ final readonly class HyperliquidInstrumentMetadataDto
         public ?string $fundingRate,
         public ?\DateTimeImmutable $fundingTime,
         public array $qualityFlags,
+        public string $status = 'live',
     ) {
     }
 
     public function isCompleteForSizing(): bool
     {
         foreach ($this->qualityFlags as $flag) {
-            if (str_starts_with($flag, 'missing_') || str_starts_with($flag, 'invalid_')) {
+            if (str_starts_with($flag, 'missing_') || str_starts_with($flag, 'invalid_') || $flag === 'market_suspended') {
                 return false;
             }
         }
@@ -72,7 +73,12 @@ final readonly class HyperliquidInstrumentMetadataDto
 
     private function isMultipleOf(string $value, string $step): bool
     {
-        return BigDecimal::of($value)->remainder(BigDecimal::of($step))->isZero();
+        $stepDecimal = BigDecimal::of($step);
+        if ($stepDecimal->isLessThanOrEqualTo(BigDecimal::zero())) {
+            return false;
+        }
+
+        return BigDecimal::of($value)->remainder($stepDecimal)->isZero();
     }
 
     private function isAllowedHyperliquidPrice(string $price): bool
@@ -105,6 +111,10 @@ final readonly class HyperliquidInstrumentMetadataDto
     private function quantizeDown(string $value, string $step): string
     {
         $stepDecimal = BigDecimal::of($step);
+        if ($stepDecimal->isLessThanOrEqualTo(BigDecimal::zero())) {
+            return $value;
+        }
+
         $units = BigDecimal::of($value)->dividedBy($stepDecimal, 0, RoundingMode::DOWN);
 
         return (string) $units

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidAccountGateway.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidAccountGateway.php
@@ -157,7 +157,13 @@ final class HyperliquidAccountGateway implements AccountProviderInterface
      */
     public function getTradingFees(string $symbol): array
     {
-        throw $this->notReady(__METHOD__);
+        $coin = $this->coin($symbol);
+        $payload = $this->assoc($this->info([
+            'type' => 'userFees',
+            'user' => $this->accountAddress(__METHOD__),
+        ], __METHOD__));
+
+        return $this->mapper->tradingFees($payload, strtoupper($symbol), $coin);
     }
 
     public function healthCheck(): bool

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidMetadataProvider.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidMetadataProvider.php
@@ -230,11 +230,32 @@ final class HyperliquidMetadataProvider implements ContractProviderInterface
         $meta = $payload[0] ?? [];
         $assets = \is_array($meta) && \is_array($meta['universe'] ?? null) ? array_values($meta['universe']) : [];
         $contexts = \is_array($payload[1] ?? null) ? array_values($payload[1]) : [];
+        $assets = array_values(array_filter($assets, static fn (mixed $row): bool => \is_array($row)));
+        $this->assertUniqueAssets($assets, $operation);
 
         return [
-            array_values(array_filter($assets, static fn (mixed $row): bool => \is_array($row))),
+            $assets,
             array_values(array_filter($contexts, static fn (mixed $row): bool => \is_array($row))),
         ];
+    }
+
+    /**
+     * @param list<array<string,mixed>> $assets
+     */
+    private function assertUniqueAssets(array $assets, string $operation): void
+    {
+        $seen = [];
+        foreach ($assets as $asset) {
+            $coin = $this->mapper->coin($asset);
+            if ($coin === '') {
+                continue;
+            }
+            if (isset($seen[$coin])) {
+                throw new HyperliquidProviderUnavailableException('hyperliquid_asset_collision', $operation);
+            }
+
+            $seen[$coin] = true;
+        }
     }
 
     /**

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidPrivateReadMapper.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidPrivateReadMapper.php
@@ -172,6 +172,38 @@ final readonly class HyperliquidPrivateReadMapper
         ];
     }
 
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    public function tradingFees(array $payload, string $symbol, string $coin): array
+    {
+        $maker = $this->numberOrNull($payload['userAddRate'] ?? null);
+        $taker = $this->numberOrNull($payload['userCrossRate'] ?? null);
+        $qualityFlags = [];
+
+        if ($maker === null) {
+            $qualityFlags[] = 'maker_fee_unknown';
+        }
+        if ($taker === null) {
+            $qualityFlags[] = 'taker_fee_unknown';
+        }
+        if (!\is_array($payload['feeSchedule'] ?? null)) {
+            $qualityFlags[] = 'fee_schedule_unknown';
+        }
+
+        return [
+            'exchange' => 'hyperliquid',
+            'symbol' => strtoupper($symbol),
+            'coin' => strtoupper($coin),
+            'fee_currency' => 'USDC',
+            'maker' => $maker,
+            'taker' => $taker,
+            'quality_flags' => array_values(array_unique($qualityFlags)),
+            'raw_reference' => $this->redacted($payload),
+        ];
+    }
+
     public function symbol(mixed $coin): string
     {
         $coin = strtoupper($this->string($coin));
@@ -282,6 +314,11 @@ final readonly class HyperliquidPrivateReadMapper
         }
 
         return '0';
+    }
+
+    private function numberOrNull(mixed $value): ?string
+    {
+        return $this->isUsableNumber($value) ? (string) $value : null;
     }
 
     private function isUsableNumber(mixed $value): bool

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidPublicReadMapper.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidPublicReadMapper.php
@@ -23,6 +23,7 @@ final readonly class HyperliquidPublicReadMapper
         $prevDay = $this->string($context['prevDayPx'] ?? '0') ?: '0';
         $openInterest = $this->string($context['openInterest'] ?? '0') ?: '0';
         $priceMaxDecimals = $this->priceMaxDecimals($asset);
+        $quantityStep = $this->quantityStep($asset);
 
         return new ContractDto(
             symbol: $this->symbol($coin),
@@ -39,11 +40,11 @@ final readonly class HyperliquidPublicReadMapper
             indexName: $coin,
             contractSize: BigDecimal::of('1'),
             minLeverage: BigDecimal::of('1'),
-            maxLeverage: BigDecimal::of($this->string($asset['maxLeverage'] ?? '1') ?: '1'),
+            maxLeverage: BigDecimal::of($this->maxLeverage($asset) ?? '0'),
             pricePrecision: BigDecimal::of((string) $priceMaxDecimals),
-            volPrecision: BigDecimal::of((string) $this->decimalPlaces($this->quantityStep($asset))),
+            volPrecision: BigDecimal::of((string) $this->decimalPlaces($quantityStep)),
             maxVolume: BigDecimal::of('0'),
-            minVolume: BigDecimal::of($this->quantityStep($asset)),
+            minVolume: BigDecimal::of($quantityStep === '0' ? '0' : $quantityStep),
             fundingRate: BigDecimal::of($this->string($context['funding'] ?? '0') ?: '0'),
             expectedFundingRate: BigDecimal::of($this->string($context['funding'] ?? '0') ?: '0'),
             openInterest: BigDecimal::of($openInterest),
@@ -75,9 +76,22 @@ final readonly class HyperliquidPublicReadMapper
         $coin = $this->coin($asset);
         $fundingRate = $this->nullableNumericString($funding['fundingRate'] ?? $context['funding'] ?? null);
         $priceMaxDecimals = $this->priceMaxDecimals($asset);
+        $quantityStep = $this->quantityStep($asset);
+        $maxLeverage = $this->maxLeverage($asset);
+        $status = $this->status($asset);
 
         if ($fundingRate === null) {
             $qualityFlags[] = 'funding_rate_unknown';
+        }
+        if (!$this->hasValidSizeDecimals($asset)) {
+            $qualityFlags[] = array_key_exists('szDecimals', $asset) ? 'invalid_size_decimals' : 'missing_size_decimals';
+        }
+        if ($maxLeverage === null) {
+            $qualityFlags[] = array_key_exists('maxLeverage', $asset) ? 'invalid_max_leverage' : 'missing_max_leverage';
+            $maxLeverage = '0';
+        }
+        if ($status !== 'live') {
+            $qualityFlags[] = 'market_suspended';
         }
 
         return new HyperliquidInstrumentMetadataDto(
@@ -86,13 +100,14 @@ final readonly class HyperliquidPublicReadMapper
             assetId: $assetId,
             priceTick: $this->stepFromDecimalPlaces($priceMaxDecimals),
             priceMaxDecimals: $priceMaxDecimals,
-            quantityStep: $this->quantityStep($asset),
-            minSize: $this->quantityStep($asset),
+            quantityStep: $quantityStep,
+            minSize: $quantityStep,
             maxSize: '0',
-            maxLeverage: $this->string($asset['maxLeverage'] ?? '1') ?: '1',
+            maxLeverage: $maxLeverage,
             fundingRate: $fundingRate,
             fundingTime: $this->time($funding['time'] ?? null),
             qualityFlags: array_values(array_unique($qualityFlags)),
+            status: $status,
         );
     }
 
@@ -197,7 +212,11 @@ final readonly class HyperliquidPublicReadMapper
      */
     private function quantityStep(array $asset): string
     {
-        $decimals = max(0, (int) ($asset['szDecimals'] ?? 0));
+        if (!$this->hasValidSizeDecimals($asset)) {
+            return '0';
+        }
+
+        $decimals = (int) $asset['szDecimals'];
 
         return $decimals === 0 ? '1' : '0.' . str_repeat('0', $decimals - 1) . '1';
     }
@@ -207,9 +226,45 @@ final readonly class HyperliquidPublicReadMapper
      */
     private function priceMaxDecimals(array $asset): int
     {
-        $sizeDecimals = max(0, (int) ($asset['szDecimals'] ?? 0));
+        if (!$this->hasValidSizeDecimals($asset)) {
+            return 0;
+        }
+
+        $sizeDecimals = (int) $asset['szDecimals'];
 
         return max(0, 6 - $sizeDecimals);
+    }
+
+    /**
+     * @param array<string,mixed> $asset
+     */
+    private function hasValidSizeDecimals(array $asset): bool
+    {
+        if (!array_key_exists('szDecimals', $asset) || !\is_scalar($asset['szDecimals'])) {
+            return false;
+        }
+
+        $value = trim((string) $asset['szDecimals']);
+        if ($value === '' || !ctype_digit($value)) {
+            return false;
+        }
+
+        $decimals = (int) $value;
+
+        return $decimals >= 0 && $decimals <= 6;
+    }
+
+    /**
+     * @param array<string,mixed> $asset
+     */
+    private function maxLeverage(array $asset): ?string
+    {
+        $value = $this->nullableNumericString($asset['maxLeverage'] ?? null);
+        if ($value === null || (float) $value <= 0.0) {
+            return null;
+        }
+
+        return $value;
     }
 
     private function stepFromDecimalPlaces(int $places): string

--- a/trading-app/src/Provider/Hyperliquid/HyperliquidPublicReadMapper.php
+++ b/trading-app/src/Provider/Hyperliquid/HyperliquidPublicReadMapper.php
@@ -19,6 +19,11 @@ final readonly class HyperliquidPublicReadMapper
     public function contract(array $asset, int $assetId, ?array $context = null): ContractDto
     {
         $coin = $this->coin($asset);
+        $maxLeverage = $this->maxLeverage($asset);
+        if (!$this->hasValidSizeDecimals($asset) || $maxLeverage === null) {
+            throw new \InvalidArgumentException(sprintf('hyperliquid_contract_metadata_incomplete:%s', $coin));
+        }
+
         $last = $this->string($context['markPx'] ?? $context['midPx'] ?? '0') ?: '0';
         $prevDay = $this->string($context['prevDayPx'] ?? '0') ?: '0';
         $openInterest = $this->string($context['openInterest'] ?? '0') ?: '0';
@@ -40,7 +45,7 @@ final readonly class HyperliquidPublicReadMapper
             indexName: $coin,
             contractSize: BigDecimal::of('1'),
             minLeverage: BigDecimal::of('1'),
-            maxLeverage: BigDecimal::of($this->maxLeverage($asset) ?? '0'),
+            maxLeverage: BigDecimal::of($maxLeverage),
             pricePrecision: BigDecimal::of((string) $priceMaxDecimals),
             volPrecision: BigDecimal::of((string) $this->decimalPlaces($quantityStep)),
             maxVolume: BigDecimal::of('0'),

--- a/trading-app/tests/Provider/Hyperliquid/HyperliquidPrivateReadProviderTest.php
+++ b/trading-app/tests/Provider/Hyperliquid/HyperliquidPrivateReadProviderTest.php
@@ -236,6 +236,44 @@ final class HyperliquidPrivateReadProviderTest extends TestCase
         self::assertSame([], $client->requests);
     }
 
+    public function testReadsTradingFeesReadOnly(): void
+    {
+        $client = new FakeHyperliquidPrivateReadClient();
+        $gateway = $this->accountGateway($client);
+
+        $fees = $gateway->getTradingFees('BTCUSDT');
+
+        self::assertSame('hyperliquid', $fees['exchange']);
+        self::assertSame('BTCUSDT', $fees['symbol']);
+        self::assertSame('BTC', $fees['coin']);
+        self::assertSame('USDC', $fees['fee_currency']);
+        self::assertSame('0.0002', $fees['maker']);
+        self::assertSame('0.0005', $fees['taker']);
+        self::assertSame([], $fees['quality_flags']);
+        self::assertArrayNotHasKey('apiSecret', $fees['raw_reference']);
+
+        $request = $client->requests[array_key_last($client->requests)];
+        self::assertSame('userFees', $request['type']);
+        self::assertSame('0xaccount', $request['user']);
+        self::assertSame(0, $client->exchangeCalls);
+    }
+
+    public function testMissingTradingFeesAreUnknownNotZero(): void
+    {
+        $client = new FakeHyperliquidPrivateReadClient();
+        $client->hideFees = true;
+        $gateway = $this->accountGateway($client);
+
+        $fees = $gateway->getTradingFees('BTCUSDT');
+
+        self::assertNull($fees['maker']);
+        self::assertNull($fees['taker']);
+        self::assertContains('maker_fee_unknown', $fees['quality_flags']);
+        self::assertContains('taker_fee_unknown', $fees['quality_flags']);
+        self::assertContains('fee_schedule_unknown', $fees['quality_flags']);
+        self::assertSame(0, $client->exchangeCalls);
+    }
+
     private function accountGateway(
         FakeHyperliquidPrivateReadClient $client,
         ?HyperliquidConfig $config = null,
@@ -274,6 +312,7 @@ final class FakeHyperliquidPrivateReadClient implements HyperliquidRestClientInt
     public bool $unknownAccount = false;
     public bool $unavailable = false;
     public bool $noPositions = false;
+    public bool $hideFees = false;
     public int $exchangeCalls = 0;
 
     /** @var list<array<string,mixed>> */
@@ -302,6 +341,7 @@ final class FakeHyperliquidPrivateReadClient implements HyperliquidRestClientInt
             'frontendOpenOrders' => $this->openOrders(),
             'userFills', 'userFillsByTime' => $this->fills(),
             'userFunding' => $this->funding(),
+            'userFees' => $this->fees(),
             default => throw new \LogicException('Unexpected Hyperliquid info type: ' . (string) ($request['type'] ?? '')),
         };
     }
@@ -455,6 +495,30 @@ final class FakeHyperliquidPrivateReadClient implements HyperliquidRestClientInt
                     'usdc' => '0.11',
                 ],
             ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fees(): array
+    {
+        if ($this->hideFees) {
+            return [
+                'dailyUserVlm' => [],
+                'apiSecret' => 'must-not-leak',
+            ];
+        }
+
+        return [
+            'userAddRate' => '0.0002',
+            'userCrossRate' => '0.0005',
+            'activeReferralDiscount' => '0.04',
+            'feeSchedule' => [
+                'cross' => '0.00045',
+                'add' => '0.00015',
+            ],
+            'apiSecret' => 'must-not-leak',
         ];
     }
 }

--- a/trading-app/tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php
+++ b/trading-app/tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php
@@ -114,6 +114,18 @@ final class HyperliquidPublicReadProviderTest extends TestCase
         $provider->getInstrumentMetadata('BTCUSDT');
     }
 
+    public function testAssetResolverDoesNotDetectCollisionAgainstItsCache(): void
+    {
+        $resolver = new HyperliquidAssetResolver($this->client());
+
+        self::assertSame(0, $resolver->assetId('BTCUSDT'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown Hyperliquid asset "DOGEUSDT"');
+
+        $resolver->assetId('DOGEUSDT');
+    }
+
     public function testHyperliquidPriceRulesEnforceSignificantFiguresAndMaxDecimals(): void
     {
         $provider = new HyperliquidMetadataProvider($this->client(), new HyperliquidAssetResolver($this->client()));

--- a/trading-app/tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php
+++ b/trading-app/tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php
@@ -90,6 +90,18 @@ final class HyperliquidPublicReadProviderTest extends TestCase
         self::assertFalse($metadata->isCompleteForSizing());
     }
 
+    public function testContractsFailClosedWhenRequiredMetadataIsMissing(): void
+    {
+        $client = $this->client();
+        $client->missingMaxLeverage = true;
+        $provider = new HyperliquidMetadataProvider($client, new HyperliquidAssetResolver($client));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('hyperliquid_contract_metadata_incomplete:BTC');
+
+        $provider->getContracts();
+    }
+
     public function testSuspendedMarketIsVisibleAndNotCompleteForSizing(): void
     {
         $provider = new HyperliquidMetadataProvider($this->client(), new HyperliquidAssetResolver($this->client()));

--- a/trading-app/tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php
+++ b/trading-app/tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php
@@ -76,6 +76,44 @@ final class HyperliquidPublicReadProviderTest extends TestCase
         self::assertTrue($metadata->isCompleteForSizing());
     }
 
+    public function testRejectsIncompleteMetadataForSizing(): void
+    {
+        $client = $this->client();
+        $client->missingMaxLeverage = true;
+        $provider = new HyperliquidMetadataProvider($client, new HyperliquidAssetResolver($client));
+
+        $metadata = $provider->getInstrumentMetadata('BTCUSDT');
+
+        self::assertNotNull($metadata);
+        self::assertSame('0', $metadata->maxLeverage);
+        self::assertContains('missing_max_leverage', $metadata->qualityFlags);
+        self::assertFalse($metadata->isCompleteForSizing());
+    }
+
+    public function testSuspendedMarketIsVisibleAndNotCompleteForSizing(): void
+    {
+        $provider = new HyperliquidMetadataProvider($this->client(), new HyperliquidAssetResolver($this->client()));
+
+        $metadata = $provider->getInstrumentMetadata('ETHUSDT');
+
+        self::assertNotNull($metadata);
+        self::assertSame('suspend', $metadata->status);
+        self::assertContains('market_suspended', $metadata->qualityFlags);
+        self::assertFalse($metadata->isCompleteForSizing());
+    }
+
+    public function testAssetCollisionIsRejected(): void
+    {
+        $client = $this->client();
+        $client->duplicateAsset = true;
+        $provider = new HyperliquidMetadataProvider($client, new HyperliquidAssetResolver($client));
+
+        $this->expectException(HyperliquidProviderUnavailableException::class);
+        $this->expectExceptionMessage('hyperliquid_asset_collision');
+
+        $provider->getInstrumentMetadata('BTCUSDT');
+    }
+
     public function testHyperliquidPriceRulesEnforceSignificantFiguresAndMaxDecimals(): void
     {
         $provider = new HyperliquidMetadataProvider($this->client(), new HyperliquidAssetResolver($this->client()));
@@ -183,6 +221,8 @@ final class FakeHyperliquidPublicReadClient implements HyperliquidRestClientInte
 {
     public bool $rateLimited = false;
     public bool $hideFunding = false;
+    public bool $missingMaxLeverage = false;
+    public bool $duplicateAsset = false;
 
     /** @var list<array<string,mixed>> */
     public array $requests = [];
@@ -224,12 +264,20 @@ final class FakeHyperliquidPublicReadClient implements HyperliquidRestClientInte
      */
     private function meta(): array
     {
-        return [
-            'universe' => [
-                ['name' => 'BTC', 'szDecimals' => 5, 'maxLeverage' => 50],
-                ['name' => 'ETH', 'szDecimals' => 4, 'maxLeverage' => 25, 'isDelisted' => true],
-            ],
+        $btc = ['name' => 'BTC', 'szDecimals' => 5, 'maxLeverage' => 50];
+        if ($this->missingMaxLeverage) {
+            unset($btc['maxLeverage']);
+        }
+
+        $universe = [
+            $btc,
+            ['name' => 'ETH', 'szDecimals' => 4, 'maxLeverage' => 25, 'isDelisted' => true],
         ];
+        if ($this->duplicateAsset) {
+            $universe[] = ['name' => 'BTC', 'szDecimals' => 3, 'maxLeverage' => 10];
+        }
+
+        return ['universe' => $universe];
     }
 
     /**
@@ -255,6 +303,14 @@ final class FakeHyperliquidPublicReadClient implements HyperliquidRestClientInte
                     'dayNtlVlm' => '500000',
                     'funding' => '0.0002',
                     'openInterest' => '42',
+                ],
+                [
+                    'markPx' => '25100',
+                    'midPx' => '25100',
+                    'prevDayPx' => '25000',
+                    'dayNtlVlm' => '1000',
+                    'funding' => '0.0003',
+                    'openInterest' => '1',
                 ],
             ],
         ];
@@ -304,15 +360,18 @@ final class FakeHyperliquidPublicReadClient implements HyperliquidRestClientInte
      */
     private function funding(array $request): array
     {
-        $this->assertRequestValue($request, 'coin', 'BTC');
+        $coin = (string) ($request['coin'] ?? '');
+        if (!in_array($coin, ['BTC', 'ETH'], true)) {
+            throw new \RuntimeException(sprintf('Expected Hyperliquid funding coin BTC or ETH, got %s.', $coin));
+        }
 
         if ($this->hideFunding) {
             return [];
         }
 
         return [[
-            'coin' => 'BTC',
-            'fundingRate' => '0.0001',
+            'coin' => $coin,
+            'fundingRate' => $coin === 'ETH' ? '0.0002' : '0.0001',
             'premium' => '0.00001',
             'time' => 1767225600000,
         ]];


### PR DESCRIPTION
## Summary
- strengthen Hyperliquid market metadata with strict sizing completeness, market status flags, and asset collision rejection
- add read-only user fee schedule mapping via /info userFees with unknown flags instead of zero fallbacks
- document HL-007 market/asset mapping, fee semantics, rollback, and no-broadcast constraints

## Validation
- docker-compose exec -T trading-app-php ./vendor/bin/phpunit tests/Provider/Hyperliquid tests/Command/ExchangeRuntimeCheckCommandTest.php --filter 'Hyperliquid|RuntimeCheck'
- docker-compose exec -T trading-app-php ./vendor/bin/phpstan analyse src/Exchange/Hyperliquid/HyperliquidAssetResolver.php src/Provider/Hyperliquid/Dto/HyperliquidInstrumentMetadataDto.php src/Provider/Hyperliquid/HyperliquidAccountGateway.php src/Provider/Hyperliquid/HyperliquidMetadataProvider.php src/Provider/Hyperliquid/HyperliquidPrivateReadMapper.php src/Provider/Hyperliquid/HyperliquidPublicReadMapper.php tests/Provider/Hyperliquid/HyperliquidPublicReadProviderTest.php tests/Provider/Hyperliquid/HyperliquidPrivateReadProviderTest.php --memory-limit=1G
- docker-compose exec -T trading-app-php php bin/console lint:container --no-debug
- docker-compose exec -T trading-app-php php bin/console lint:yaml config
- python3 -m mkdocs build --strict
- git diff --check

## Notes
- HL-007
- Related to HL-006 / PR #241
- No /exchange broadcast path added; mutative methods remain fail-closed.