### PR TITLE
HL-008 Hyperliquid order fill position normalizers

### DIFF
--- a/docs/handbook/technical/hyperliquid-testnet-readiness.md
+++ b/docs/handbook/technical/hyperliquid-testnet-readiness.md
@@ -88,6 +88,7 @@ reutilisables.
 | Nonce manager | Livre HL-005 | `PersistentHyperliquidNonceManager` persiste `hyperliquid_nonce_state` par `environment + network + signer_address`, garde `account_address` en audit, rejette la reutilisation d'un signer sur un autre compte, et detecte les replays. | L'utiliser seulement dans une PR mutative future, apres signer crypto officiel et garde `/exchange`. |
 | Metadata / precision | Renforce HL-007 | Mapping `symbol -> coin -> asset_id`, `szDecimals`, tick prix, step quantite, max leverage, status marche et flags de qualite sont exposes dans `HyperliquidInstrumentMetadataDto`. Les collisions d'asset et metadata requises manquantes ne sont pas resolues arbitrairement. | Min-notional si Hyperliquid l'expose dans une surface officielle future. |
 | Fees / funding / costs | Renforce HL-007 | Funding public absent reste `null` avec `funding_rate_unknown`. `getTradingFees()` lit `userFees` read-only et expose maker/taker `null` + flags si absents. User fills et funding history sont lisibles via account read-only, redacted et non certifies PnL. | Ledger/certification dans les PRs dediees. |
+| Lifecycle normalizers | Livre HL-008 | `HyperliquidLifecycleNormalizer` normalise les requetes d'ordre sans broadcast, statuts ordre, fills, positions, funding et erreurs en DTOs stables. Les fills sans ordre passent en `unknown_requires_resync` avec quality flag. | Branchement mutatif testnet, reconciliation privee continue et consommation ledger/position-state complete. |
 | Local dry-run no broadcast | Partiel | `HyperliquidDryRunExecutionPort` simule sans HTTP ni `/exchange`. | Serialization future des payloads HL sans broadcast ni secret. |
 | Runtime-check candidate | Private-read possible HL-006 | `HyperliquidRuntimeCheck` peut retourner `private_read_only` quand les probes publiques et account sont bonnes. La commande runtime reste `Schedule ready: no` tant que les guards local dry-run/protection ne sont pas complets. | Niveaux `local_dry_run_ready`, puis `demo_testnet_candidate`. |
 | SL/TP / protection | A valider | Aucun attachement runtime Hyperliquid n'est prouve par HL-001. | Modele ordre/protection testnet avec SL immediat ou compensation fail-safe. |
@@ -219,6 +220,28 @@ Regles HL-006 :
   `flowType=null` ou `flowType=3`; les flux non-funding restent hors HL-006.
 - Les champs sensibles usuels (`secret`, `apiKey`, `privateKey`, `signature`,
   `passphrase`) sont retires des metadata/raw_reference.
+
+Regles HL-008 :
+
+- `HyperliquidLifecycleNormalizer::normalizeOrderRequest()` retourne le payload
+  action `order` construit localement a partir d'un `PlaceOrderRequest` et d'un
+  `asset_id`. Il ne signe pas, ne reserve pas de nonce et ne poste jamais vers
+  `/exchange`.
+- Les statuts internes stables sont `accepted`, `open`, `partially_filled`,
+  `filled`, `canceled`, `rejected`, `failed` et `unknown_requires_resync`.
+- Les evenements sont dedupliques puis tries par timestamp et rang de statut
+  pour que les replays out-of-order donnent un resultat deterministe.
+- Un fill present sans ligne d'ordre reste exploitable comme fill, mais le
+  lifecycle global devient `unknown_requires_resync` avec
+  `order_absent_fill_present`; aucun fallback par symbole ou fenetre temporelle
+  n'est autorise.
+- Les erreurs connues sont normalisees au minimum en
+  `insufficient_collateral` et `market_unavailable`; les payloads retournes sont
+  redacted.
+- Les positions zero-size restent visibles avec `position_closed_zero_size` afin
+  que les consommateurs position-state puissent enregistrer la fermeture.
+- Les rows funding sont exposees comme role `funding`, devise `USDC`, montant
+  signe preserve. Elles ne certifient pas encore un PnL net.
 
 Exemple operateur :
 

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -43,6 +43,9 @@ final readonly class HyperliquidLifecycleNormalizer
         $quantity = $this->orderQuantity($base, $fills);
         $remaining = $this->remainingQuantity($base, $quantity);
         $filled = max($this->sumFillQuantity($fills), max(0.0, $quantity - $remaining));
+        if ($this->isFillRow($latest) && $this->rowTimeMillis($latest) > $this->rowTimeMillis($base)) {
+            $remaining = max(0.0, $quantity - $filled);
+        }
         $status = $this->statusFromRows($base, $latestOrder !== [], $quantity, $filled, $remaining, $fills);
         if ($status === HyperliquidLifecycleStatus::FILLED && $filled <= 0.00000001 && $quantity > 0.0) {
             $filled = $quantity;
@@ -413,11 +416,11 @@ final readonly class HyperliquidLifecycleNormalizer
     private function status(mixed $status): HyperliquidLifecycleStatus
     {
         $normalized = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '', (string) $status));
-        if (str_contains($normalized, 'cancel')) {
-            return HyperliquidLifecycleStatus::CANCELED;
-        }
         if (str_contains($normalized, 'rejected')) {
             return HyperliquidLifecycleStatus::REJECTED;
+        }
+        if (str_contains($normalized, 'cancel')) {
+            return HyperliquidLifecycleStatus::CANCELED;
         }
 
         return match ($normalized) {

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -111,7 +111,9 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     public function normalizeFills(array $rows): array
     {
-        return $this->fillsFromRows($this->deduplicate($rows));
+        $normalizedRows = array_map(fn (array $row): array => $this->normalizeLifecycleRow($row), $rows);
+
+        return $this->fillsFromRows($this->deduplicate($normalizedRows));
     }
 
     /**
@@ -699,6 +701,13 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     private function normalizeLifecycleRow(array $row): array
     {
+        if (\is_array($row['fill'] ?? null)) {
+            /** @var array<string,mixed> $fill */
+            $fill = $row['fill'];
+
+            return array_merge($row, $fill);
+        }
+
         if (!\is_array($row['order'] ?? null)) {
             return $row;
         }

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -42,9 +42,15 @@ final readonly class HyperliquidLifecycleNormalizer
 
         $quantity = $this->orderQuantity($base, $fills);
         $remaining = $this->remainingQuantity($base, $quantity);
+        $fillQuantity = $this->sumFillQuantity($fills);
+        $baseStatus = $this->hasValue($base['status'] ?? $base['state'] ?? null)
+            ? $this->status($base['status'] ?? $base['state'] ?? null)
+            : null;
         $snapshotFilled = max(0.0, $quantity - $remaining);
-        $filled = max($this->sumFillQuantity($fills), $snapshotFilled);
-        if ($latestOrder !== [] && $this->isFillRow($latest) && $this->rowTimeMillis($latest) > $this->rowTimeMillis($base)) {
+        $filled = $this->isNonFilledTerminalStatus($baseStatus) ? $fillQuantity : max($fillQuantity, $snapshotFilled);
+        if ($this->isNonFilledTerminalStatus($baseStatus)) {
+            $remaining = 0.0;
+        } elseif ($latestOrder !== [] && $this->isFillRow($latest) && $this->rowTimeMillis($latest) > $this->rowTimeMillis($base)) {
             $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAfter($deduplicated, $base)));
             $remaining = max(0.0, $quantity - $filled);
         }
@@ -415,6 +421,9 @@ final readonly class HyperliquidLifecycleNormalizer
         }
 
         $status = $this->status($row['status'] ?? $row['state'] ?? null);
+        if ($this->isNonFilledTerminalStatus($status)) {
+            return $status;
+        }
         if ($status === HyperliquidLifecycleStatus::OPEN && $filled > 0.00000001 && $remaining > 0.00000001) {
             return HyperliquidLifecycleStatus::PARTIALLY_FILLED;
         }
@@ -443,6 +452,15 @@ final readonly class HyperliquidLifecycleNormalizer
             'failed', 'err', 'error' => HyperliquidLifecycleStatus::FAILED,
             default => HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC,
         };
+    }
+
+    private function isNonFilledTerminalStatus(?HyperliquidLifecycleStatus $status): bool
+    {
+        return \in_array($status, [
+            HyperliquidLifecycleStatus::CANCELED,
+            HyperliquidLifecycleStatus::REJECTED,
+            HyperliquidLifecycleStatus::FAILED,
+        ], true);
     }
 
     /**

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -171,8 +171,7 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     public function normalizeError(array $payload): HyperliquidNormalizedErrorDto
     {
-        $data = \is_array($payload['response'] ?? null) ? $payload['response'] : $payload;
-        /** @var array<string,mixed> $data */
+        $data = $this->errorDataRow($payload);
         $message = $this->firstNonEmpty($data['error'] ?? null, $data['message'] ?? null, $payload['error'] ?? null, $payload['message'] ?? null);
         $lower = strtolower($message);
         $code = match (true) {
@@ -499,7 +498,7 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     private function fillId(array $row): ?string
     {
-        $explicit = $this->firstNonEmpty($row['hash'] ?? null, $row['tid'] ?? null, $row['fillId'] ?? null, $row['exchangeFillId'] ?? null);
+        $explicit = $this->firstNonEmpty($row['tid'] ?? null, $row['fillId'] ?? null, $row['exchangeFillId'] ?? null, $row['hash'] ?? null);
         if ($explicit !== '') {
             return $explicit;
         }
@@ -710,6 +709,27 @@ final readonly class HyperliquidLifecycleNormalizer
     private function hasValue(mixed $value): bool
     {
         return $this->string($value) !== '';
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    private function errorDataRow(array $payload): array
+    {
+        $response = \is_array($payload['response'] ?? null) ? $payload['response'] : $payload;
+        /** @var array<string,mixed> $response */
+        $data = \is_array($response['data'] ?? null) ? $response['data'] : [];
+        /** @var array<string,mixed> $data */
+        $statuses = \is_array($data['statuses'] ?? null) ? $data['statuses'] : [];
+        foreach ($statuses as $status) {
+            if (\is_array($status) && $this->hasValue($status['error'] ?? null)) {
+                /** @var array<string,mixed> $status */
+                return $status;
+            }
+        }
+
+        return $response;
     }
 
     /**

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -460,7 +460,7 @@ final readonly class HyperliquidLifecycleNormalizer
     private function orderType(array $row): ExchangeOrderType
     {
         $type = strtolower($this->string($row['orderType'] ?? $row['type'] ?? ''));
-        if ($this->bool($row['isTrigger'] ?? false) || $this->hasValue($row['triggerPx'] ?? null)) {
+        if ($this->bool($row['isTrigger'] ?? false) || $this->float($row['triggerPx'] ?? null) > 0.0) {
             if (str_contains($type, 'take') || str_contains($type, 'profit') || str_contains($type, 'tp')) {
                 return ExchangeOrderType::TAKE_PROFIT;
             }

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -58,7 +58,7 @@ final readonly class HyperliquidLifecycleNormalizer
             && $this->rowTimeMillis($latest) >= $this->rowTimeMillis($base)
             && ($snapshotFilled <= 0.00000001 || $this->hasLifecycleUpdateTime($base))
         ) {
-            $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAfter($deduplicated, $base)));
+            $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAtOrAfter($deduplicated, $base)));
             $remaining = max(0.0, $quantity - $filled);
         }
         $status = $this->statusFromRows($base, $latestOrder !== [], $quantity, $filled, $remaining, $fills);
@@ -769,12 +769,12 @@ final readonly class HyperliquidLifecycleNormalizer
      * @param list<array<string,mixed>> $rows
      * @param array<string,mixed> $base
      */
-    private function sumFillQuantityAfter(array $rows, array $base): float
+    private function sumFillQuantityAtOrAfter(array $rows, array $base): float
     {
         $baseTime = $this->rowTimeMillis($base);
         $quantity = 0.0;
         foreach ($rows as $row) {
-            if (!$this->isFillRow($row) || $this->rowTimeMillis($row) <= $baseTime) {
+            if (!$this->isFillRow($row) || $this->rowTimeMillis($row) < $baseTime) {
                 continue;
             }
 

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -32,7 +32,8 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     public function normalizeOrderLifecycle(array $rows): HyperliquidNormalizedOrderLifecycleDto
     {
-        $supportedRows = array_values(array_filter($rows, fn (array $row): bool => $this->isSupportedLifecycleRow($row)));
+        $normalizedRows = array_map(fn (array $row): array => $this->normalizeLifecycleRow($row), $rows);
+        $supportedRows = array_values(array_filter($normalizedRows, fn (array $row): bool => $this->isSupportedLifecycleRow($row)));
         $deduplicated = $this->sortLifecycleRows($this->deduplicate($supportedRows));
         $fills = $this->fillsFromRows($deduplicated);
         $latest = $deduplicated[array_key_last($deduplicated)] ?? [];
@@ -210,7 +211,7 @@ final readonly class HyperliquidLifecycleNormalizer
                 $this->clientOrderId($row) ?? '',
                 $this->string($row['status'] ?? $row['state'] ?? ''),
                 $this->string($row['uTime'] ?? $row['updatedAt'] ?? $row['time'] ?? ''),
-                $this->string($row['hash'] ?? $row['tid'] ?? $row['fillId'] ?? ''),
+                $this->string($row['tid'] ?? $row['fillId'] ?? $row['exchangeFillId'] ?? $row['hash'] ?? ''),
                 $this->string($row['sz'] ?? ''),
                 $this->string($row['px'] ?? ''),
             ]);
@@ -302,7 +303,7 @@ final readonly class HyperliquidLifecycleNormalizer
             clientOrderId: $this->clientOrderId($row),
             fillId: $fillId,
             side: $this->orderSide($row['side'] ?? null),
-            positionSide: $this->positionSide(null, null, $row['side'] ?? null, $this->bool($row['reduceOnly'] ?? false)),
+            positionSide: $this->fillPositionSide($row),
             quantity: $quantity,
             price: $price,
             fee: $this->floatOrNull($row['fee'] ?? null),
@@ -411,15 +412,19 @@ final readonly class HyperliquidLifecycleNormalizer
 
     private function status(mixed $status): HyperliquidLifecycleStatus
     {
-        return match (strtolower(trim((string) $status))) {
+        $normalized = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '', (string) $status));
+        if (str_contains($normalized, 'canceled') || str_contains($normalized, 'cancelled')) {
+            return HyperliquidLifecycleStatus::CANCELED;
+        }
+        if (str_contains($normalized, 'rejected')) {
+            return HyperliquidLifecycleStatus::REJECTED;
+        }
+
+        return match ($normalized) {
             'accepted', 'resting', 'placed' => HyperliquidLifecycleStatus::ACCEPTED,
             'open', 'triggered' => HyperliquidLifecycleStatus::OPEN,
-            'partial', 'partially_filled', 'partially filled' => HyperliquidLifecycleStatus::PARTIALLY_FILLED,
+            'partial', 'partiallyfilled' => HyperliquidLifecycleStatus::PARTIALLY_FILLED,
             'filled', 'closed' => HyperliquidLifecycleStatus::FILLED,
-            'canceled', 'cancelled', 'margin_canceled', 'open_interest_cap_canceled', 'self_trade_canceled',
-            'vault_withdrawal_canceled', 'reduce_only_canceled', 'sibling_filled_canceled',
-            'delisted_canceled', 'liquidated_canceled', 'scheduled_cancel' => HyperliquidLifecycleStatus::CANCELED,
-            'rejected' => HyperliquidLifecycleStatus::REJECTED,
             'failed', 'err', 'error' => HyperliquidLifecycleStatus::FAILED,
             default => HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC,
         };
@@ -558,6 +563,22 @@ final readonly class HyperliquidLifecycleNormalizer
     /**
      * @param array<string,mixed> $row
      */
+    private function fillPositionSide(array $row): ?ExchangePositionSide
+    {
+        $direction = strtolower($this->string($row['dir'] ?? ''));
+        if (str_contains($direction, 'long')) {
+            return ExchangePositionSide::LONG;
+        }
+        if (str_contains($direction, 'short')) {
+            return ExchangePositionSide::SHORT;
+        }
+
+        return $this->positionSide(null, null, $row['side'] ?? null, $this->bool($row['reduceOnly'] ?? false));
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
     private function symbol(array $row): string
     {
         $coin = strtoupper($this->firstNonEmpty($row['coin'] ?? null, $row['symbol'] ?? null));
@@ -590,6 +611,35 @@ final readonly class HyperliquidLifecycleNormalizer
             || $this->hasValue($row['tid'] ?? null)
             || $this->hasValue($row['fillId'] ?? null)
             || ($this->hasValue($row['px'] ?? null) && $this->hasValue($row['fee'] ?? null));
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @return array<string,mixed>
+     */
+    private function normalizeLifecycleRow(array $row): array
+    {
+        if (!\is_array($row['order'] ?? null)) {
+            return $row;
+        }
+
+        /** @var array<string,mixed> $wrapper */
+        $wrapper = $row['order'];
+        $details = \is_array($wrapper['order'] ?? null) ? $wrapper['order'] : $wrapper;
+        /** @var array<string,mixed> $details */
+        $normalized = array_merge($details, [
+            'status' => $this->firstNonEmpty($wrapper['status'] ?? null, $details['status'] ?? null, $row['status'] ?? null),
+            'uTime' => $this->firstNonEmpty($wrapper['statusTimestamp'] ?? null, $wrapper['uTime'] ?? null, $details['uTime'] ?? null, $row['uTime'] ?? null),
+        ]);
+
+        if ($normalized['status'] === 'order') {
+            unset($normalized['status']);
+        }
+        if ($normalized['uTime'] === '') {
+            unset($normalized['uTime']);
+        }
+
+        return $normalized;
     }
 
     /**

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -401,6 +401,16 @@ final readonly class HyperliquidLifecycleNormalizer
         if (!$hasOrderRow && $fills !== []) {
             return HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC;
         }
+        if (!$this->hasValue($row['status'] ?? $row['state'] ?? null) && $hasOrderRow) {
+            if ($quantity > 0.0 && $filled >= $quantity - 0.00000001) {
+                return HyperliquidLifecycleStatus::FILLED;
+            }
+            if ($filled > 0.00000001 && $remaining > 0.00000001) {
+                return HyperliquidLifecycleStatus::PARTIALLY_FILLED;
+            }
+
+            return HyperliquidLifecycleStatus::OPEN;
+        }
 
         $status = $this->status($row['status'] ?? $row['state'] ?? null);
         if ($status === HyperliquidLifecycleStatus::OPEN && $filled > 0.00000001 && $remaining > 0.00000001) {

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -111,7 +111,7 @@ final readonly class HyperliquidLifecycleNormalizer
         foreach ($rows as $row) {
             $position = \is_array($row['position'] ?? null) ? $row['position'] : $row;
             /** @var array<string,mixed> $position */
-            if (!$this->hasValue($position['coin'] ?? null)) {
+            if (!$this->hasValue($position['coin'] ?? null) || !$this->isPerpetualInstrumentRow($position)) {
                 continue;
             }
 
@@ -149,7 +149,7 @@ final readonly class HyperliquidLifecycleNormalizer
         foreach ($rows as $row) {
             $delta = \is_array($row['delta'] ?? null) ? $row['delta'] : $row;
             /** @var array<string,mixed> $delta */
-            if (!$this->hasValue($delta['coin'] ?? null)) {
+            if (!$this->hasValue($delta['coin'] ?? null) || !$this->isPerpetualInstrumentRow($delta)) {
                 continue;
             }
 
@@ -291,7 +291,7 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     private function fillFromRow(array $row): ?HyperliquidNormalizedFillDto
     {
-        if (!$this->isFillRow($row)) {
+        if (!$this->isFillRow($row) || !$this->isPerpetualInstrumentRow($row)) {
             return null;
         }
 
@@ -612,6 +612,10 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     private function symbol(array $row): string
     {
+        if (!$this->isPerpetualInstrumentRow($row)) {
+            return '';
+        }
+
         $coin = strtoupper($this->firstNonEmpty($row['coin'] ?? null, $row['symbol'] ?? null));
         if ($coin === '') {
             return '';
@@ -625,12 +629,15 @@ final readonly class HyperliquidLifecycleNormalizer
      */
     private function isSupportedLifecycleRow(array $row): bool
     {
-        return $this->hasValue($row['oid'] ?? null)
-            || $this->hasValue($row['orderId'] ?? null)
-            || $this->hasValue($row['cloid'] ?? null)
-            || $this->hasValue($row['hash'] ?? null)
-            || $this->hasValue($row['status'] ?? null)
-            || $this->isFillRow($row);
+        return $this->isPerpetualInstrumentRow($row)
+            && (
+                $this->hasValue($row['oid'] ?? null)
+                || $this->hasValue($row['orderId'] ?? null)
+                || $this->hasValue($row['cloid'] ?? null)
+                || $this->hasValue($row['hash'] ?? null)
+                || $this->hasValue($row['status'] ?? null)
+                || $this->isFillRow($row)
+            );
     }
 
     /**
@@ -642,6 +649,16 @@ final readonly class HyperliquidLifecycleNormalizer
             || $this->hasValue($row['tid'] ?? null)
             || $this->hasValue($row['fillId'] ?? null)
             || ($this->hasValue($row['px'] ?? null) && $this->hasValue($row['fee'] ?? null));
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function isPerpetualInstrumentRow(array $row): bool
+    {
+        $coin = $this->firstNonEmpty($row['coin'] ?? null, $row['symbol'] ?? null);
+
+        return $coin === '' || !str_starts_with($coin, '@');
     }
 
     /**
@@ -753,7 +770,11 @@ final readonly class HyperliquidLifecycleNormalizer
 
         $millis = (int) $value;
         if ($millis > 9_999_999_999) {
-            return new \DateTimeImmutable('@' . intdiv($millis, 1000));
+            $seconds = intdiv($millis, 1000);
+            $milliseconds = $millis % 1000;
+            $time = \DateTimeImmutable::createFromFormat('U.u', sprintf('%d.%06d', $seconds, $milliseconds * 1000));
+
+            return $time instanceof \DateTimeImmutable ? $time : new \DateTimeImmutable('@' . $seconds);
         }
 
         return new \DateTimeImmutable('@' . $millis);

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -50,7 +50,7 @@ final readonly class HyperliquidLifecycleNormalizer
         $filled = $this->isNonFilledTerminalStatus($baseStatus) ? $fillQuantity : max($fillQuantity, $snapshotFilled);
         if ($this->isNonFilledTerminalStatus($baseStatus)) {
             $remaining = 0.0;
-        } elseif ($latestOrder !== [] && $this->isFillRow($latest) && $this->rowTimeMillis($latest) > $this->rowTimeMillis($base)) {
+        } elseif ($latestOrder !== [] && $this->isFillRow($latest) && $this->rowTimeMillis($latest) >= $this->rowTimeMillis($base)) {
             $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAfter($deduplicated, $base)));
             $remaining = max(0.0, $quantity - $filled);
         }

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -413,7 +413,7 @@ final readonly class HyperliquidLifecycleNormalizer
     private function status(mixed $status): HyperliquidLifecycleStatus
     {
         $normalized = strtolower((string) preg_replace('/[^a-zA-Z0-9]+/', '', (string) $status));
-        if (str_contains($normalized, 'canceled') || str_contains($normalized, 'cancelled')) {
+        if (str_contains($normalized, 'cancel')) {
             return HyperliquidLifecycleStatus::CANCELED;
         }
         if (str_contains($normalized, 'rejected')) {
@@ -457,6 +457,22 @@ final readonly class HyperliquidLifecycleNormalizer
     private function orderType(array $row): ExchangeOrderType
     {
         $type = strtolower($this->string($row['orderType'] ?? $row['type'] ?? ''));
+        if ($this->bool($row['isTrigger'] ?? false) || $this->hasValue($row['triggerPx'] ?? null)) {
+            if (str_contains($type, 'take') || str_contains($type, 'profit') || str_contains($type, 'tp')) {
+                return ExchangeOrderType::TAKE_PROFIT;
+            }
+            if (str_contains($type, 'stop') || str_contains($type, 'sl')) {
+                return ExchangeOrderType::STOP_LOSS;
+            }
+
+            return ExchangeOrderType::TRIGGER;
+        }
+        if (str_contains($type, 'take') || str_contains($type, 'profit')) {
+            return ExchangeOrderType::TAKE_PROFIT;
+        }
+        if (str_contains($type, 'stop')) {
+            return ExchangeOrderType::STOP_LOSS;
+        }
         if (str_contains($type, 'market')) {
             return ExchangeOrderType::MARKET;
         }
@@ -629,7 +645,13 @@ final readonly class HyperliquidLifecycleNormalizer
         /** @var array<string,mixed> $details */
         $normalized = array_merge($details, [
             'status' => $this->firstNonEmpty($wrapper['status'] ?? null, $details['status'] ?? null, $row['status'] ?? null),
-            'uTime' => $this->firstNonEmpty($wrapper['statusTimestamp'] ?? null, $wrapper['uTime'] ?? null, $details['uTime'] ?? null, $row['uTime'] ?? null),
+            'uTime' => $this->firstNonEmpty(
+                $wrapper['statusTimestamp'] ?? null,
+                $row['statusTimestamp'] ?? null,
+                $wrapper['uTime'] ?? null,
+                $details['uTime'] ?? null,
+                $row['uTime'] ?? null,
+            ),
         ]);
 
         if ($normalized['status'] === 'order') {

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -658,7 +658,7 @@ final readonly class HyperliquidLifecycleNormalizer
     {
         $coin = $this->firstNonEmpty($row['coin'] ?? null, $row['symbol'] ?? null);
 
-        return $coin === '' || !str_starts_with($coin, '@');
+        return $coin === '' || (!str_starts_with($coin, '@') && !str_contains($coin, '/'));
     }
 
     /**

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -1,0 +1,739 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid\Lifecycle;
+
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Hyperliquid\HyperliquidActionFactory;
+
+final readonly class HyperliquidLifecycleNormalizer
+{
+    private const SENSITIVE_KEY_PATTERN = '/(api[_-]?key|access[_-]?key|secret|private[_-]?key|passphrase|password|authorization|cookie|token|signature|sign|credentials?|memo)/i';
+
+    public function __construct(
+        private HyperliquidActionFactory $actions = new HyperliquidActionFactory(),
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function normalizeOrderRequest(int $assetId, PlaceOrderRequest $request): array
+    {
+        return $this->actions->order($assetId, $request);
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     */
+    public function normalizeOrderLifecycle(array $rows): HyperliquidNormalizedOrderLifecycleDto
+    {
+        $supportedRows = array_values(array_filter($rows, fn (array $row): bool => $this->isSupportedLifecycleRow($row)));
+        $deduplicated = $this->sortLifecycleRows($this->deduplicate($supportedRows));
+        $fills = $this->fillsFromRows($deduplicated);
+        $latest = $deduplicated[array_key_last($deduplicated)] ?? [];
+        $latestOrder = $this->latestOrderRow($deduplicated);
+        $base = $latestOrder === [] ? $latest : $latestOrder;
+
+        $quantity = $this->orderQuantity($base, $fills);
+        $remaining = $this->remainingQuantity($base, $quantity);
+        $filled = max($this->sumFillQuantity($fills), max(0.0, $quantity - $remaining));
+        $status = $this->statusFromRows($base, $latestOrder !== [], $quantity, $filled, $remaining, $fills);
+        if ($status === HyperliquidLifecycleStatus::FILLED && $filled <= 0.00000001 && $quantity > 0.0) {
+            $filled = $quantity;
+            $remaining = 0.0;
+        }
+
+        $qualityFlags = [];
+        if ($latestOrder === [] && $fills !== []) {
+            $qualityFlags[] = 'order_absent_fill_present';
+        }
+        if ($status === HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC) {
+            $qualityFlags[] = 'unknown_order_state';
+        }
+        if (count($deduplicated) < count($supportedRows)) {
+            $qualityFlags[] = 'duplicate_event';
+        }
+        if (count($supportedRows) < count($rows)) {
+            $qualityFlags[] = 'unsupported_lifecycle_row_ignored';
+        }
+
+        return new HyperliquidNormalizedOrderLifecycleDto(
+            status: $status,
+            symbol: $this->symbol($base),
+            exchangeOrderId: $this->orderId($base),
+            clientOrderId: $this->clientOrderId($base),
+            side: $this->orderSideOrNull($base['side'] ?? null),
+            positionSide: $this->positionSide(null, null, $base['side'] ?? null, $this->bool($base['reduceOnly'] ?? false)),
+            orderType: $this->orderType($base),
+            quantity: $quantity,
+            filledQuantity: $filled,
+            remainingQuantity: max(0.0, $remaining),
+            price: $this->orderPrice($base),
+            averageFillPrice: $this->averageFillPrice($base, $fills),
+            createdAt: $this->time($base['timestamp'] ?? $base['time'] ?? null),
+            updatedAt: $this->time($base['uTime'] ?? $base['updatedAt'] ?? $base['time'] ?? $latest['time'] ?? null),
+            fills: $fills,
+            requiresResync: \in_array('order_absent_fill_present', $qualityFlags, true)
+                || $status === HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC,
+            deduplicatedEventCount: count($deduplicated),
+            qualityFlags: array_values(array_unique($qualityFlags)),
+            redactedPayload: $this->redacted($base),
+        );
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return list<HyperliquidNormalizedFillDto>
+     */
+    public function normalizeFills(array $rows): array
+    {
+        return $this->fillsFromRows($this->deduplicate($rows));
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return list<HyperliquidNormalizedPositionDto>
+     */
+    public function normalizePositions(array $rows): array
+    {
+        $positions = [];
+        foreach ($rows as $row) {
+            $position = \is_array($row['position'] ?? null) ? $row['position'] : $row;
+            /** @var array<string,mixed> $position */
+            if (!$this->hasValue($position['coin'] ?? null)) {
+                continue;
+            }
+
+            $size = $this->float($position['szi'] ?? $position['position'] ?? $position['size'] ?? null);
+            $flags = [];
+            if (abs($size) <= 0.00000001) {
+                $flags[] = 'position_closed_zero_size';
+            }
+
+            $positions[] = new HyperliquidNormalizedPositionDto(
+                symbol: $this->symbol($position),
+                side: $size < -0.00000001 ? ExchangePositionSide::SHORT : ExchangePositionSide::LONG,
+                size: abs($size),
+                entryPrice: $this->float($position['entryPx'] ?? null),
+                markPrice: $this->floatOrNull($position['markPx'] ?? null),
+                unrealizedPnl: $this->floatOrNull($position['unrealizedPnl'] ?? null),
+                marginUsed: $this->floatOrNull($position['marginUsed'] ?? null),
+                leverage: $this->leverage($position),
+                updatedAt: $this->timeOrNull($position['time'] ?? $position['uTime'] ?? null),
+                qualityFlags: $flags,
+                redactedPayload: $this->redacted($position),
+            );
+        }
+
+        return $positions;
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return list<HyperliquidNormalizedFundingDto>
+     */
+    public function normalizeFunding(array $rows): array
+    {
+        $funding = [];
+        foreach ($rows as $row) {
+            $delta = \is_array($row['delta'] ?? null) ? $row['delta'] : $row;
+            /** @var array<string,mixed> $delta */
+            if (!$this->hasValue($delta['coin'] ?? null)) {
+                continue;
+            }
+
+            $amount = $this->floatOrNull($delta['usdc'] ?? $delta['funding'] ?? $delta['amount'] ?? null);
+            if ($amount === null) {
+                continue;
+            }
+
+            $funding[] = new HyperliquidNormalizedFundingDto(
+                symbol: $this->symbol($delta),
+                amount: $amount,
+                currency: 'USDC',
+                role: 'funding',
+                fundingRate: $this->floatOrNull($delta['fundingRate'] ?? null),
+                occurredAt: $this->time($row['time'] ?? $delta['time'] ?? null),
+                redactedPayload: $this->redacted($row),
+            );
+        }
+
+        return $funding;
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public function normalizeError(array $payload): HyperliquidNormalizedErrorDto
+    {
+        $data = \is_array($payload['response'] ?? null) ? $payload['response'] : $payload;
+        /** @var array<string,mixed> $data */
+        $message = $this->firstNonEmpty($data['error'] ?? null, $data['message'] ?? null, $payload['error'] ?? null, $payload['message'] ?? null);
+        $lower = strtolower($message);
+        $code = match (true) {
+            str_contains($lower, 'insufficient')
+                || str_contains($lower, 'margin')
+                || str_contains($lower, 'collateral') => 'insufficient_collateral',
+            str_contains($lower, 'market')
+                || str_contains($lower, 'not open')
+                || str_contains($lower, 'unavailable')
+                || str_contains($lower, 'delist') => 'market_unavailable',
+            default => $this->firstNonEmpty($data['code'] ?? null, $payload['code'] ?? null, 'exchange_error'),
+        };
+
+        return new HyperliquidNormalizedErrorDto(
+            status: HyperliquidLifecycleStatus::FAILED,
+            code: $code,
+            message: $message,
+            exchangeOrderId: $this->stringOrNull($this->firstNonEmpty($data['oid'] ?? null, $payload['oid'] ?? null)),
+            clientOrderId: $this->stringOrNull($this->firstNonEmpty($data['cloid'] ?? null, $payload['cloid'] ?? null)),
+            qualityFlags: $message === '' ? ['missing_error_message'] : [],
+            redactedPayload: $this->redacted($payload),
+        );
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return list<array<string,mixed>>
+     */
+    private function deduplicate(array $rows): array
+    {
+        $seen = [];
+        $deduplicated = [];
+        foreach ($rows as $row) {
+            $key = implode('|', [
+                $this->orderId($row),
+                $this->clientOrderId($row) ?? '',
+                $this->string($row['status'] ?? $row['state'] ?? ''),
+                $this->string($row['uTime'] ?? $row['updatedAt'] ?? $row['time'] ?? ''),
+                $this->string($row['hash'] ?? $row['tid'] ?? $row['fillId'] ?? ''),
+                $this->string($row['sz'] ?? ''),
+                $this->string($row['px'] ?? ''),
+            ]);
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $deduplicated[] = $row;
+        }
+
+        return $deduplicated;
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return list<array<string,mixed>>
+     */
+    private function sortLifecycleRows(array $rows): array
+    {
+        $indexed = [];
+        foreach ($rows as $index => $row) {
+            $indexed[] = ['index' => $index, 'row' => $row];
+        }
+
+        usort(
+            $indexed,
+            function (array $left, array $right): int {
+                /** @var array<string,mixed> $leftRow */
+                $leftRow = $left['row'];
+                /** @var array<string,mixed> $rightRow */
+                $rightRow = $right['row'];
+
+                return [$this->rowTimeMillis($leftRow), $this->stateRank($leftRow), $left['index']]
+                    <=> [$this->rowTimeMillis($rightRow), $this->stateRank($rightRow), $right['index']];
+            },
+        );
+
+        $sorted = [];
+        foreach ($indexed as $entry) {
+            /** @var array<string,mixed> $row */
+            $row = $entry['row'];
+            $sorted[] = $row;
+        }
+
+        return $sorted;
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return list<HyperliquidNormalizedFillDto>
+     */
+    private function fillsFromRows(array $rows): array
+    {
+        $fills = [];
+        $seen = [];
+        foreach ($rows as $row) {
+            $fill = $this->fillFromRow($row);
+            if (!$fill instanceof HyperliquidNormalizedFillDto || isset($seen[$fill->fillId])) {
+                continue;
+            }
+
+            $seen[$fill->fillId] = true;
+            $fills[] = $fill;
+        }
+
+        return $fills;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function fillFromRow(array $row): ?HyperliquidNormalizedFillDto
+    {
+        if (!$this->isFillRow($row)) {
+            return null;
+        }
+
+        $quantity = $this->float($row['sz'] ?? $row['quantity'] ?? null);
+        $price = $this->float($row['px'] ?? $row['price'] ?? null);
+        $fillId = $this->fillId($row);
+        if ($fillId === null || $quantity <= 0.0 || $price <= 0.0) {
+            return null;
+        }
+
+        return new HyperliquidNormalizedFillDto(
+            symbol: $this->symbol($row),
+            exchangeOrderId: $this->orderId($row),
+            clientOrderId: $this->clientOrderId($row),
+            fillId: $fillId,
+            side: $this->orderSide($row['side'] ?? null),
+            positionSide: $this->positionSide(null, null, $row['side'] ?? null, $this->bool($row['reduceOnly'] ?? false)),
+            quantity: $quantity,
+            price: $price,
+            fee: $this->floatOrNull($row['fee'] ?? null),
+            feeCurrency: $this->hasValue($row['feeToken'] ?? null) ? $this->string($row['feeToken']) : 'USDC',
+            occurredAt: $this->time($row['time'] ?? $row['timestamp'] ?? null),
+            redactedPayload: $this->redacted($row),
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @param list<HyperliquidNormalizedFillDto> $fills
+     */
+    private function averageFillPrice(array $row, array $fills): ?float
+    {
+        $average = $this->floatOrNull($row['avgPx'] ?? $row['avgPrice'] ?? null);
+        if ($average !== null && $average > 0.0) {
+            return $average;
+        }
+
+        $quantity = 0.0;
+        $notional = 0.0;
+        foreach ($fills as $fill) {
+            $quantity += $fill->quantity;
+            $notional += $fill->quantity * $fill->price;
+        }
+
+        return $quantity > 0.0 ? $notional / $quantity : null;
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @return array<string,mixed>
+     */
+    private function latestOrderRow(array $rows): array
+    {
+        $latest = [];
+        foreach ($rows as $row) {
+            if (!$this->isFillRow($row)) {
+                $latest = $row;
+            }
+        }
+
+        return $latest;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @param list<HyperliquidNormalizedFillDto> $fills
+     */
+    private function orderQuantity(array $row, array $fills): float
+    {
+        $quantity = $this->float($row['origSz'] ?? $row['originalSz'] ?? $row['orderSz'] ?? null);
+        if ($quantity > 0.0) {
+            return $quantity;
+        }
+
+        $rowQuantity = $this->float($row['sz'] ?? null);
+        if ($rowQuantity > 0.0 && !$this->isFillRow($row)) {
+            return $rowQuantity;
+        }
+
+        return $this->sumFillQuantity($fills);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function remainingQuantity(array $row, float $quantity): float
+    {
+        if ($this->hasValue($row['origSz'] ?? null) || $this->hasValue($row['originalSz'] ?? null)) {
+            return $this->float($row['sz'] ?? $row['remainingSz'] ?? null);
+        }
+
+        $remaining = $this->floatOrNull($row['remainingSz'] ?? $row['remaining'] ?? null);
+
+        return $remaining ?? $quantity;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     * @param list<HyperliquidNormalizedFillDto> $fills
+     */
+    private function statusFromRows(
+        array $row,
+        bool $hasOrderRow,
+        float $quantity,
+        float $filled,
+        float $remaining,
+        array $fills,
+    ): HyperliquidLifecycleStatus {
+        if (!$hasOrderRow && $fills !== []) {
+            return HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC;
+        }
+
+        $status = $this->status($row['status'] ?? $row['state'] ?? null);
+        if ($status === HyperliquidLifecycleStatus::OPEN && $filled > 0.00000001 && $remaining > 0.00000001) {
+            return HyperliquidLifecycleStatus::PARTIALLY_FILLED;
+        }
+        if ($quantity > 0.0 && $filled >= $quantity - 0.00000001) {
+            return HyperliquidLifecycleStatus::FILLED;
+        }
+
+        return $status;
+    }
+
+    private function status(mixed $status): HyperliquidLifecycleStatus
+    {
+        return match (strtolower(trim((string) $status))) {
+            'accepted', 'resting', 'placed' => HyperliquidLifecycleStatus::ACCEPTED,
+            'open', 'triggered' => HyperliquidLifecycleStatus::OPEN,
+            'partial', 'partially_filled', 'partially filled' => HyperliquidLifecycleStatus::PARTIALLY_FILLED,
+            'filled', 'closed' => HyperliquidLifecycleStatus::FILLED,
+            'canceled', 'cancelled', 'margin_canceled', 'open_interest_cap_canceled', 'self_trade_canceled',
+            'vault_withdrawal_canceled', 'reduce_only_canceled', 'sibling_filled_canceled',
+            'delisted_canceled', 'liquidated_canceled', 'scheduled_cancel' => HyperliquidLifecycleStatus::CANCELED,
+            'rejected' => HyperliquidLifecycleStatus::REJECTED,
+            'failed', 'err', 'error' => HyperliquidLifecycleStatus::FAILED,
+            default => HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC,
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function stateRank(array $row): int
+    {
+        if ($this->isFillRow($row)) {
+            return 45;
+        }
+
+        return match ($this->status($row['status'] ?? $row['state'] ?? null)) {
+            HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC => 0,
+            HyperliquidLifecycleStatus::ACCEPTED => 20,
+            HyperliquidLifecycleStatus::OPEN => 30,
+            HyperliquidLifecycleStatus::PARTIALLY_FILLED => 40,
+            HyperliquidLifecycleStatus::CANCELED,
+            HyperliquidLifecycleStatus::REJECTED,
+            HyperliquidLifecycleStatus::FAILED => 60,
+            HyperliquidLifecycleStatus::FILLED => 70,
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderType(array $row): ExchangeOrderType
+    {
+        $type = strtolower($this->string($row['orderType'] ?? $row['type'] ?? ''));
+        if (str_contains($type, 'market')) {
+            return ExchangeOrderType::MARKET;
+        }
+        if (str_contains($type, 'trigger')) {
+            return ExchangeOrderType::TRIGGER;
+        }
+
+        return ExchangeOrderType::LIMIT;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderPrice(array $row): ?float
+    {
+        foreach ([$row['limitPx'] ?? null, $row['px'] ?? null, $row['price'] ?? null, $row['avgPx'] ?? null] as $candidate) {
+            $price = $this->floatOrNull($candidate);
+            if ($price !== null && $price > 0.0) {
+                return $price;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function orderId(array $row): string
+    {
+        return $this->firstNonEmpty($row['oid'] ?? null, $row['orderId'] ?? null, $row['exchangeOrderId'] ?? null);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function clientOrderId(array $row): ?string
+    {
+        return $this->stringOrNull($this->firstNonEmpty($row['cloid'] ?? null, $row['clientOrderId'] ?? null));
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function fillId(array $row): ?string
+    {
+        $explicit = $this->firstNonEmpty($row['hash'] ?? null, $row['tid'] ?? null, $row['fillId'] ?? null, $row['exchangeFillId'] ?? null);
+        if ($explicit !== '') {
+            return $explicit;
+        }
+
+        $fallback = implode('|', [
+            $this->orderId($row),
+            $this->string($row['time'] ?? $row['timestamp'] ?? ''),
+            $this->string($row['sz'] ?? ''),
+            $this->string($row['px'] ?? ''),
+        ]);
+
+        return trim($fallback, '|') === '' ? null : 'hl:' . substr(hash('sha256', $fallback), 0, 24);
+    }
+
+    private function orderSide(mixed $side): ExchangeOrderSide
+    {
+        $value = strtolower((string) $side);
+
+        return \in_array($value, ['a', 'ask', 'sell', 's'], true) ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY;
+    }
+
+    private function orderSideOrNull(mixed $side): ?ExchangeOrderSide
+    {
+        return $this->hasValue($side) ? $this->orderSide($side) : null;
+    }
+
+    private function positionSide(
+        mixed $side,
+        ?float $size = null,
+        mixed $orderSide = null,
+        bool $reduceOnly = false,
+    ): ?ExchangePositionSide {
+        $positionSide = strtolower((string) $side);
+        if ($positionSide === 'long') {
+            return ExchangePositionSide::LONG;
+        }
+        if ($positionSide === 'short') {
+            return ExchangePositionSide::SHORT;
+        }
+        if ($reduceOnly) {
+            return $this->orderSide($orderSide) === ExchangeOrderSide::SELL
+                ? ExchangePositionSide::LONG
+                : ExchangePositionSide::SHORT;
+        }
+        if ($size !== null && $size < -0.00000001) {
+            return ExchangePositionSide::SHORT;
+        }
+        if ($size !== null && $size > 0.00000001) {
+            return ExchangePositionSide::LONG;
+        }
+
+        return $this->hasValue($orderSide)
+            ? ($this->orderSide($orderSide) === ExchangeOrderSide::BUY ? ExchangePositionSide::LONG : ExchangePositionSide::SHORT)
+            : null;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function symbol(array $row): string
+    {
+        $coin = strtoupper($this->firstNonEmpty($row['coin'] ?? null, $row['symbol'] ?? null));
+        if ($coin === '') {
+            return '';
+        }
+
+        return str_ends_with($coin, 'USDT') || str_ends_with($coin, 'USDC') ? $coin : $coin . 'USDT';
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function isSupportedLifecycleRow(array $row): bool
+    {
+        return $this->hasValue($row['oid'] ?? null)
+            || $this->hasValue($row['orderId'] ?? null)
+            || $this->hasValue($row['cloid'] ?? null)
+            || $this->hasValue($row['hash'] ?? null)
+            || $this->hasValue($row['status'] ?? null)
+            || $this->isFillRow($row);
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function isFillRow(array $row): bool
+    {
+        return $this->hasValue($row['hash'] ?? null)
+            || $this->hasValue($row['tid'] ?? null)
+            || $this->hasValue($row['fillId'] ?? null)
+            || ($this->hasValue($row['px'] ?? null) && $this->hasValue($row['fee'] ?? null));
+    }
+
+    /**
+     * @param array<string,mixed> $position
+     */
+    private function leverage(array $position): ?float
+    {
+        if (\is_array($position['leverage'] ?? null)) {
+            /** @var array<string,mixed> $leverage */
+            $leverage = $position['leverage'];
+
+            return $this->floatOrNull($leverage['value'] ?? null);
+        }
+
+        return $this->floatOrNull($position['leverage'] ?? null);
+    }
+
+    /**
+     * @param list<HyperliquidNormalizedFillDto> $fills
+     */
+    private function sumFillQuantity(array $fills): float
+    {
+        $quantity = 0.0;
+        foreach ($fills as $fill) {
+            $quantity += $fill->quantity;
+        }
+
+        return $quantity;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function rowTimeMillis(array $row): int
+    {
+        foreach ([$row['uTime'] ?? null, $row['updatedAt'] ?? null, $row['time'] ?? null, $row['timestamp'] ?? null] as $candidate) {
+            if (is_numeric($candidate)) {
+                return (int) $candidate;
+            }
+        }
+
+        return 0;
+    }
+
+    private function time(mixed $value): \DateTimeImmutable
+    {
+        return $this->timeOrNull($value) ?? new \DateTimeImmutable('@0');
+    }
+
+    private function timeOrNull(mixed $value): ?\DateTimeImmutable
+    {
+        if (!is_numeric($value)) {
+            return null;
+        }
+
+        $millis = (int) $value;
+        if ($millis > 9_999_999_999) {
+            return new \DateTimeImmutable('@' . intdiv($millis, 1000));
+        }
+
+        return new \DateTimeImmutable('@' . $millis);
+    }
+
+    private function float(mixed $value): float
+    {
+        return $this->floatOrNull($value) ?? 0.0;
+    }
+
+    private function floatOrNull(mixed $value): ?float
+    {
+        if (is_int($value) || is_float($value) || (is_string($value) && is_numeric($value))) {
+            return (float) $value;
+        }
+
+        return null;
+    }
+
+    private function bool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        return \in_array(strtolower((string) $value), ['1', 'true', 'yes'], true);
+    }
+
+    private function firstNonEmpty(mixed ...$values): string
+    {
+        foreach ($values as $value) {
+            if ($this->hasValue($value)) {
+                return $this->string($value);
+            }
+        }
+
+        return '';
+    }
+
+    private function string(mixed $value): string
+    {
+        if ($value instanceof \Stringable) {
+            return trim((string) $value);
+        }
+        if (is_scalar($value)) {
+            return trim((string) $value);
+        }
+
+        return '';
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        $string = $this->string($value);
+
+        return $string === '' ? null : $string;
+    }
+
+    private function hasValue(mixed $value): bool
+    {
+        return $this->string($value) !== '';
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     * @return array<string,mixed>
+     */
+    private function redacted(array $payload): array
+    {
+        $redacted = [];
+        foreach ($payload as $key => $value) {
+            $keyString = (string) $key;
+            if (preg_match(self::SENSITIVE_KEY_PATTERN, $keyString) === 1) {
+                $redacted[$keyString] = '[redacted]';
+                continue;
+            }
+            if (\is_array($value)) {
+                /** @var array<string,mixed> $value */
+                $redacted[$keyString] = $this->redacted($value);
+                continue;
+            }
+
+            $redacted[$keyString] = $value;
+        }
+
+        return $redacted;
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -77,7 +77,7 @@ final readonly class HyperliquidLifecycleNormalizer
             price: $this->orderPrice($base),
             averageFillPrice: $this->averageFillPrice($base, $fills),
             createdAt: $this->time($base['timestamp'] ?? $base['time'] ?? null),
-            updatedAt: $this->time($base['uTime'] ?? $base['updatedAt'] ?? $base['time'] ?? $latest['time'] ?? null),
+            updatedAt: $this->time($latest['uTime'] ?? $latest['updatedAt'] ?? $latest['time'] ?? $latest['timestamp'] ?? $base['uTime'] ?? $base['updatedAt'] ?? $base['time'] ?? null),
             fills: $fills,
             requiresResync: \in_array('order_absent_fill_present', $qualityFlags, true)
                 || $status === HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC,

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -52,7 +52,12 @@ final readonly class HyperliquidLifecycleNormalizer
             : max($fillQuantity, $snapshotFilled);
         if ($this->isNonFilledTerminalStatus($baseStatus)) {
             $remaining = $filled > 0.00000001 && $remaining > 0.00000001 ? $remaining : 0.0;
-        } elseif ($latestOrder !== [] && $this->isFillRow($latest) && $this->rowTimeMillis($latest) >= $this->rowTimeMillis($base)) {
+        } elseif (
+            $latestOrder !== []
+            && $this->isFillRow($latest)
+            && $this->rowTimeMillis($latest) >= $this->rowTimeMillis($base)
+            && ($snapshotFilled <= 0.00000001 || $this->hasLifecycleUpdateTime($base))
+        ) {
             $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAfter($deduplicated, $base)));
             $remaining = max(0.0, $quantity - $filled);
         }
@@ -467,14 +472,9 @@ final readonly class HyperliquidLifecycleNormalizer
 
     private function terminalFilledQuantity(float $fillQuantity, float $snapshotFilled, float $remaining): float
     {
-        if ($fillQuantity > 0.00000001) {
-            return $fillQuantity;
-        }
-        if ($snapshotFilled > 0.00000001 && $remaining > 0.00000001) {
-            return $snapshotFilled;
-        }
+        $snapshotPartialFilled = $snapshotFilled > 0.00000001 && $remaining > 0.00000001 ? $snapshotFilled : 0.0;
 
-        return 0.0;
+        return max($fillQuantity, $snapshotPartialFilled);
     }
 
     /**
@@ -787,6 +787,14 @@ final readonly class HyperliquidLifecycleNormalizer
         }
 
         return 0;
+    }
+
+    /**
+     * @param array<string,mixed> $row
+     */
+    private function hasLifecycleUpdateTime(array $row): bool
+    {
+        return $this->hasValue($row['uTime'] ?? null) || $this->hasValue($row['updatedAt'] ?? null);
     }
 
     private function time(mixed $value): \DateTimeImmutable

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -42,8 +42,10 @@ final readonly class HyperliquidLifecycleNormalizer
 
         $quantity = $this->orderQuantity($base, $fills);
         $remaining = $this->remainingQuantity($base, $quantity);
-        $filled = max($this->sumFillQuantity($fills), max(0.0, $quantity - $remaining));
-        if ($this->isFillRow($latest) && $this->rowTimeMillis($latest) > $this->rowTimeMillis($base)) {
+        $snapshotFilled = max(0.0, $quantity - $remaining);
+        $filled = max($this->sumFillQuantity($fills), $snapshotFilled);
+        if ($latestOrder !== [] && $this->isFillRow($latest) && $this->rowTimeMillis($latest) > $this->rowTimeMillis($base)) {
+            $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAfter($deduplicated, $base)));
             $remaining = max(0.0, $quantity - $filled);
         }
         $status = $this->statusFromRows($base, $latestOrder !== [], $quantity, $filled, $remaining, $fills);
@@ -700,6 +702,25 @@ final readonly class HyperliquidLifecycleNormalizer
         $quantity = 0.0;
         foreach ($fills as $fill) {
             $quantity += $fill->quantity;
+        }
+
+        return $quantity;
+    }
+
+    /**
+     * @param list<array<string,mixed>> $rows
+     * @param array<string,mixed> $base
+     */
+    private function sumFillQuantityAfter(array $rows, array $base): float
+    {
+        $baseTime = $this->rowTimeMillis($base);
+        $quantity = 0.0;
+        foreach ($rows as $row) {
+            if (!$this->isFillRow($row) || $this->rowTimeMillis($row) <= $baseTime) {
+                continue;
+            }
+
+            $quantity += $this->float($row['sz'] ?? $row['quantity'] ?? null);
         }
 
         return $quantity;

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -47,9 +47,11 @@ final readonly class HyperliquidLifecycleNormalizer
             ? $this->status($base['status'] ?? $base['state'] ?? null)
             : null;
         $snapshotFilled = max(0.0, $quantity - $remaining);
-        $filled = $this->isNonFilledTerminalStatus($baseStatus) ? $fillQuantity : max($fillQuantity, $snapshotFilled);
+        $filled = $this->isNonFilledTerminalStatus($baseStatus)
+            ? $this->terminalFilledQuantity($fillQuantity, $snapshotFilled, $remaining)
+            : max($fillQuantity, $snapshotFilled);
         if ($this->isNonFilledTerminalStatus($baseStatus)) {
-            $remaining = 0.0;
+            $remaining = $filled > 0.00000001 && $remaining > 0.00000001 ? $remaining : 0.0;
         } elseif ($latestOrder !== [] && $this->isFillRow($latest) && $this->rowTimeMillis($latest) >= $this->rowTimeMillis($base)) {
             $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAfter($deduplicated, $base)));
             $remaining = max(0.0, $quantity - $filled);
@@ -461,6 +463,18 @@ final readonly class HyperliquidLifecycleNormalizer
             HyperliquidLifecycleStatus::REJECTED,
             HyperliquidLifecycleStatus::FAILED,
         ], true);
+    }
+
+    private function terminalFilledQuantity(float $fillQuantity, float $snapshotFilled, float $remaining): float
+    {
+        if ($fillQuantity > 0.00000001) {
+            return $fillQuantity;
+        }
+        if ($snapshotFilled > 0.00000001 && $remaining > 0.00000001) {
+            return $snapshotFilled;
+        }
+
+        return 0.0;
     }
 
     /**

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleNormalizer.php
@@ -58,7 +58,7 @@ final readonly class HyperliquidLifecycleNormalizer
             && $this->rowTimeMillis($latest) >= $this->rowTimeMillis($base)
             && ($snapshotFilled <= 0.00000001 || $this->hasLifecycleUpdateTime($base))
         ) {
-            $filled = min($quantity, max($filled, $snapshotFilled + $this->sumFillQuantityAtOrAfter($deduplicated, $base)));
+            $filled = min($quantity, max($filled, $snapshotFilled + $this->sumIncrementalFillQuantity($deduplicated, $base, $snapshotFilled, $remaining)));
             $remaining = max(0.0, $quantity - $filled);
         }
         $status = $this->statusFromRows($base, $latestOrder !== [], $quantity, $filled, $remaining, $fills);
@@ -769,19 +769,36 @@ final readonly class HyperliquidLifecycleNormalizer
      * @param list<array<string,mixed>> $rows
      * @param array<string,mixed> $base
      */
-    private function sumFillQuantityAtOrAfter(array $rows, array $base): float
+    private function sumIncrementalFillQuantity(array $rows, array $base, float $snapshotFilled, float $remaining): float
     {
         $baseTime = $this->rowTimeMillis($base);
-        $quantity = 0.0;
+        $sameMillisecondQuantity = 0.0;
+        $laterQuantity = 0.0;
         foreach ($rows as $row) {
             if (!$this->isFillRow($row) || $this->rowTimeMillis($row) < $baseTime) {
                 continue;
             }
 
-            $quantity += $this->float($row['sz'] ?? $row['quantity'] ?? null);
+            if ($this->rowTimeMillis($row) === $baseTime) {
+                $sameMillisecondQuantity += $this->float($row['sz'] ?? $row['quantity'] ?? null);
+
+                continue;
+            }
+
+            $laterQuantity += $this->float($row['sz'] ?? $row['quantity'] ?? null);
         }
 
-        return $quantity;
+        if ($sameMillisecondQuantity <= 0.00000001) {
+            return $laterQuantity;
+        }
+        if ($snapshotFilled <= 0.00000001) {
+            return $laterQuantity + $sameMillisecondQuantity;
+        }
+        if ($sameMillisecondQuantity + 0.00000001 >= $remaining) {
+            return $laterQuantity + min($sameMillisecondQuantity, $remaining);
+        }
+
+        return $laterQuantity;
     }
 
     /**

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleStatus.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidLifecycleStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid\Lifecycle;
+
+enum HyperliquidLifecycleStatus: string
+{
+    case ACCEPTED = 'accepted';
+    case OPEN = 'open';
+    case PARTIALLY_FILLED = 'partially_filled';
+    case FILLED = 'filled';
+    case CANCELED = 'canceled';
+    case REJECTED = 'rejected';
+    case FAILED = 'failed';
+    case UNKNOWN_REQUIRES_RESYNC = 'unknown_requires_resync';
+}

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedErrorDto.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedErrorDto.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid\Lifecycle;
+
+final readonly class HyperliquidNormalizedErrorDto
+{
+    /**
+     * @param list<string> $qualityFlags
+     * @param array<string,mixed> $redactedPayload
+     */
+    public function __construct(
+        public HyperliquidLifecycleStatus $status,
+        public string $code,
+        public string $message,
+        public ?string $exchangeOrderId,
+        public ?string $clientOrderId,
+        public array $qualityFlags,
+        public array $redactedPayload,
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedFillDto.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedFillDto.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid\Lifecycle;
+
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangePositionSide;
+
+final readonly class HyperliquidNormalizedFillDto
+{
+    /**
+     * @param array<string,mixed> $redactedPayload
+     */
+    public function __construct(
+        public string $symbol,
+        public string $exchangeOrderId,
+        public ?string $clientOrderId,
+        public string $fillId,
+        public ExchangeOrderSide $side,
+        public ?ExchangePositionSide $positionSide,
+        public float $quantity,
+        public float $price,
+        public ?float $fee,
+        public ?string $feeCurrency,
+        public \DateTimeImmutable $occurredAt,
+        public array $redactedPayload,
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedFundingDto.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedFundingDto.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid\Lifecycle;
+
+final readonly class HyperliquidNormalizedFundingDto
+{
+    /**
+     * @param array<string,mixed> $redactedPayload
+     */
+    public function __construct(
+        public string $symbol,
+        public float $amount,
+        public string $currency,
+        public string $role,
+        public ?float $fundingRate,
+        public \DateTimeImmutable $occurredAt,
+        public array $redactedPayload,
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedOrderLifecycleDto.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedOrderLifecycleDto.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid\Lifecycle;
+
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+
+final readonly class HyperliquidNormalizedOrderLifecycleDto
+{
+    /**
+     * @param list<HyperliquidNormalizedFillDto> $fills
+     * @param list<string> $qualityFlags
+     * @param array<string,mixed> $redactedPayload
+     */
+    public function __construct(
+        public HyperliquidLifecycleStatus $status,
+        public string $symbol,
+        public string $exchangeOrderId,
+        public ?string $clientOrderId,
+        public ?ExchangeOrderSide $side,
+        public ?ExchangePositionSide $positionSide,
+        public ExchangeOrderType $orderType,
+        public float $quantity,
+        public float $filledQuantity,
+        public float $remainingQuantity,
+        public ?float $price,
+        public ?float $averageFillPrice,
+        public \DateTimeImmutable $createdAt,
+        public \DateTimeImmutable $updatedAt,
+        public array $fills,
+        public bool $requiresResync,
+        public int $deduplicatedEventCount,
+        public array $qualityFlags,
+        public array $redactedPayload,
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedPositionDto.php
+++ b/trading-app/src/Exchange/Hyperliquid/Lifecycle/HyperliquidNormalizedPositionDto.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Hyperliquid\Lifecycle;
+
+use App\Exchange\Enum\ExchangePositionSide;
+
+final readonly class HyperliquidNormalizedPositionDto
+{
+    /**
+     * @param list<string> $qualityFlags
+     * @param array<string,mixed> $redactedPayload
+     */
+    public function __construct(
+        public string $symbol,
+        public ExchangePositionSide $side,
+        public float $size,
+        public float $entryPrice,
+        public ?float $markPrice,
+        public ?float $unrealizedPnl,
+        public ?float $marginUsed,
+        public ?float $leverage,
+        public ?\DateTimeImmutable $updatedAt,
+        public array $qualityFlags,
+        public array $redactedPayload,
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Hyperliquid/README.md
+++ b/trading-app/src/Exchange/Hyperliquid/README.md
@@ -42,6 +42,12 @@ First API-first Hyperliquid integration slice.
   maker=`userAddRate`, taker=`userCrossRate`, fee currency `USDC`. Missing fee
   data remains `null` with `maker_fee_unknown`, `taker_fee_unknown` and/or
   `fee_schedule_unknown`; no absent fee is converted to zero.
+- HL-008 adds read-only lifecycle normalizers for order requests, order status
+  rows, fills, positions, funding rows, and exchange errors. These normalizers
+  only transform local/request or `/info` payloads; they do not sign, allocate a
+  nonce, or broadcast `/exchange`. Ambiguous streams, such as fills without an
+  order row, are returned as `unknown_requires_resync` with quality flags instead
+  of being resolved from symbol or time alone.
 - Mutative execution provider methods remain fail-closed with
   `HyperliquidProviderNotReadyException`.
 - `HyperliquidRuntimeCheck` may reach `private_read_only` when public and
@@ -92,3 +98,10 @@ Rollback for HL-007: revert the metadata strictness and `userFees` read-only
 mapping changes. Public/account reads from HL-003/HL-006 remain available, but
 cost model consumers must treat Hyperliquid fees and incomplete metadata as
 unknown until this slice is restored.
+
+Rollback for HL-008: remove consumers of
+`App\Exchange\Hyperliquid\Lifecycle\HyperliquidLifecycleNormalizer` and revert
+the lifecycle DTOs. Public/account reads from HL-003/HL-006 and metadata/cost
+reads from HL-007 remain available, but ledger and position-state consumers must
+not ingest Hyperliquid order/fill/position lifecycle payloads until the
+normalizer slice is restored.

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -129,6 +129,18 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testDoesNotDoubleCountSameMillisecondFillAlreadyReflectedByPartialSnapshot(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '0.6', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $this->fillRow(quantity: '0.4', price: '25010', hash: 'same-ms-reflected-fill', time: 1_767_225_600_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::PARTIALLY_FILLED, $lifecycle->status);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+    }
+
     public function testCountsFillThatCompletesPartialOrderSnapshot(): void
     {
         $lifecycle = $this->normalizer->normalizeOrderLifecycle([

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -159,13 +159,49 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.7, $lifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testPreservesTopLevelHistoricalOrderStatusTimestamp(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([[
+            'status' => 'filled',
+            'statusTimestamp' => 1_767_225_700_000,
+            'order' => [
+                'coin' => 'BTC',
+                'oid' => 1004,
+                'side' => 'B',
+                'sz' => '0',
+                'origSz' => '1',
+                'limitPx' => '25020',
+                'orderType' => 'Limit',
+                'timestamp' => 1_767_225_600_000,
+            ],
+        ]]);
+
+        self::assertSame(HyperliquidLifecycleStatus::FILLED, $lifecycle->status);
+        self::assertSame(1_767_225_700, $lifecycle->updatedAt->getTimestamp());
+    }
+
     public function testNormalizesCamelCaseTerminalOrderStatuses(): void
     {
         $canceled = $this->orderRow(remaining: '1', original: '1', status: 'marginCanceled', updatedAt: 1_767_225_606_000);
         $rejected = $this->orderRow(remaining: '1', original: '1', status: 'badAloPxRejected', updatedAt: 1_767_225_607_000);
+        $scheduled = $this->orderRow(remaining: '1', original: '1', status: 'scheduledCancel', updatedAt: 1_767_225_608_000);
 
         self::assertSame(HyperliquidLifecycleStatus::CANCELED, $this->normalizer->normalizeOrderLifecycle([$canceled])->status);
         self::assertSame(HyperliquidLifecycleStatus::REJECTED, $this->normalizer->normalizeOrderLifecycle([$rejected])->status);
+        self::assertSame(HyperliquidLifecycleStatus::CANCELED, $this->normalizer->normalizeOrderLifecycle([$scheduled])->status);
+    }
+
+    public function testNormalizesStopOrdersAsTriggerProtectionTypes(): void
+    {
+        $stop = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_609_000);
+        $stop['orderType'] = 'Stop Market';
+        $stop['triggerPx'] = '24900';
+        $takeProfit = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_610_000);
+        $takeProfit['orderType'] = 'Take Profit Limit';
+        $takeProfit['triggerPx'] = '26000';
+
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $this->normalizer->normalizeOrderLifecycle([$stop])->orderType);
+        self::assertSame(ExchangeOrderType::TAKE_PROFIT, $this->normalizer->normalizeOrderLifecycle([$takeProfit])->orderType);
     }
 
     public function testNormalizesPositionSnapshotAndZeroClose(): void

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -176,6 +176,26 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertSame('1767225601.456000', $fills[1]->occurredAt->format('U.u'));
     }
 
+    public function testUnwrapsTwapSliceFillRowsBeforeDeduplication(): void
+    {
+        $first = ['twapId' => 'twap-a', 'fill' => $this->fillRow(quantity: '0.1', price: '25010', hash: 'twap-fill-1', time: 1_767_225_601_000)];
+        $second = ['twapId' => 'twap-b', 'fill' => $this->fillRow(quantity: '0.3', price: '25020', hash: 'twap-fill-2', time: 1_767_225_602_000)];
+
+        $fills = $this->normalizer->normalizeFills([$first, $second]);
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $first,
+            $second,
+        ]);
+
+        self::assertCount(2, $fills);
+        self::assertSame('twap-fill-1', $fills[0]->fillId);
+        self::assertSame('twap-fill-2', $fills[1]->fillId);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+        self::assertCount(2, $lifecycle->fills);
+    }
+
     public function testTreatsOpenOrderSnapshotWithoutStatusAsOpen(): void
     {
         $row = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -292,6 +292,17 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.0, $rejectedLifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testPreservesSnapshotPartialFillOnTerminalCancel(): void
+    {
+        $canceled = $this->orderRow(remaining: '0.6', original: '1', status: 'marginCanceled', updatedAt: 1_767_225_610_000);
+
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([$canceled]);
+
+        self::assertSame(HyperliquidLifecycleStatus::CANCELED, $lifecycle->status);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+    }
+
     public function testNormalizesStopOrdersAsTriggerProtectionTypes(): void
     {
         $stop = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_609_000);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -102,6 +102,17 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testTreatsOpenOrderSnapshotWithoutStatusAsOpen(): void
+    {
+        $row = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000);
+        unset($row['status']);
+
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([$row]);
+
+        self::assertSame(HyperliquidLifecycleStatus::OPEN, $lifecycle->status);
+        self::assertFalse($lifecycle->requiresResync);
+    }
+
     public function testKeepsDistinctFillsSharingTransactionHash(): void
     {
         $first = $this->fillRow(quantity: '0.2', price: '25000', hash: 'shared-tx-hash', time: 1_767_225_601_000);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -219,6 +219,16 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertSame(ExchangeOrderType::TAKE_PROFIT, $this->normalizer->normalizeOrderLifecycle([$takeProfit])->orderType);
     }
 
+    public function testIgnoresZeroTriggerPriceOnStandardOrders(): void
+    {
+        $limit = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_611_000);
+        $limit['orderType'] = 'Limit';
+        $limit['triggerPx'] = '0.0';
+        $limit['isTrigger'] = false;
+
+        self::assertSame(ExchangeOrderType::LIMIT, $this->normalizer->normalizeOrderLifecycle([$limit])->orderType);
+    }
+
     public function testNormalizesPositionSnapshotAndZeroClose(): void
     {
         $positions = $this->normalizer->normalizePositions([

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -141,6 +141,18 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.0, $lifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testCountsSameMillisecondFillThatCompletesPartialOrderSnapshot(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '0.1', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $this->fillRow(quantity: '0.1', price: '25010', hash: 'remaining-fill-same-ms', time: 1_767_225_600_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::FILLED, $lifecycle->status);
+        self::assertEqualsWithDelta(1.0, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.0, $lifecycle->remainingQuantity, 0.000001);
+    }
+
     public function testIgnoresSpotCoinFillsInPerpetualLifecycle(): void
     {
         $spotFill = $this->fillRow(quantity: '1', price: '10', hash: 'spot-fill', time: 1_767_225_601_000);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -118,11 +118,14 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
     {
         $spotFill = $this->fillRow(quantity: '1', price: '10', hash: 'spot-fill', time: 1_767_225_601_000);
         $spotFill['coin'] = '@107';
+        $slashSpotFill = $this->fillRow(quantity: '1', price: '10', hash: 'slash-spot-fill', time: 1_767_225_602_000);
+        $slashSpotFill['coin'] = 'PURR/USDC';
 
-        $fills = $this->normalizer->normalizeFills([$spotFill]);
+        $fills = $this->normalizer->normalizeFills([$spotFill, $slashSpotFill]);
         $lifecycle = $this->normalizer->normalizeOrderLifecycle([
             $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
             $spotFill,
+            $slashSpotFill,
         ]);
 
         self::assertSame([], $fills);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -69,6 +69,7 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(1.0, $lifecycle->quantity, 0.000001);
         self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
         self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+        self::assertSame(1_767_225_601, $lifecycle->updatedAt->getTimestamp());
         self::assertCount(1, $lifecycle->fills);
         self::assertSame('fill-1', $lifecycle->fills[0]->fillId);
         self::assertSame('USDC', $lifecycle->fills[0]->feeCurrency);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -90,6 +90,18 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertContains('duplicate_event', $lifecycle->qualityFlags);
     }
 
+    public function testRecomputesRemainingWhenNewerFillFollowsOrderSnapshot(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $this->fillRow(quantity: '0.4', price: '25010', hash: 'newer-fill', time: 1_767_225_601_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::PARTIALLY_FILLED, $lifecycle->status);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+    }
+
     public function testKeepsDistinctFillsSharingTransactionHash(): void
     {
         $first = $this->fillRow(quantity: '0.2', price: '25000', hash: 'shared-tx-hash', time: 1_767_225_601_000);
@@ -186,10 +198,12 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         $canceled = $this->orderRow(remaining: '1', original: '1', status: 'marginCanceled', updatedAt: 1_767_225_606_000);
         $rejected = $this->orderRow(remaining: '1', original: '1', status: 'badAloPxRejected', updatedAt: 1_767_225_607_000);
         $scheduled = $this->orderRow(remaining: '1', original: '1', status: 'scheduledCancel', updatedAt: 1_767_225_608_000);
+        $iocRejected = $this->orderRow(remaining: '1', original: '1', status: 'iocCancelRejected', updatedAt: 1_767_225_609_000);
 
         self::assertSame(HyperliquidLifecycleStatus::CANCELED, $this->normalizer->normalizeOrderLifecycle([$canceled])->status);
         self::assertSame(HyperliquidLifecycleStatus::REJECTED, $this->normalizer->normalizeOrderLifecycle([$rejected])->status);
         self::assertSame(HyperliquidLifecycleStatus::CANCELED, $this->normalizer->normalizeOrderLifecycle([$scheduled])->status);
+        self::assertSame(HyperliquidLifecycleStatus::REJECTED, $this->normalizer->normalizeOrderLifecycle([$iocRejected])->status);
     }
 
     public function testNormalizesStopOrdersAsTriggerProtectionTypes(): void

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -264,6 +264,22 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertSame(HyperliquidLifecycleStatus::REJECTED, $this->normalizer->normalizeOrderLifecycle([$iocRejected])->status);
     }
 
+    public function testDoesNotTreatTerminalZeroSizeCancelOrRejectAsFill(): void
+    {
+        $canceled = $this->orderRow(remaining: '0', original: '1', status: 'marginCanceled', updatedAt: 1_767_225_610_000);
+        $rejected = $this->orderRow(remaining: '0', original: '1', status: 'badAloPxRejected', updatedAt: 1_767_225_611_000);
+
+        $canceledLifecycle = $this->normalizer->normalizeOrderLifecycle([$canceled]);
+        $rejectedLifecycle = $this->normalizer->normalizeOrderLifecycle([$rejected]);
+
+        self::assertSame(HyperliquidLifecycleStatus::CANCELED, $canceledLifecycle->status);
+        self::assertEqualsWithDelta(0.0, $canceledLifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.0, $canceledLifecycle->remainingQuantity, 0.000001);
+        self::assertSame(HyperliquidLifecycleStatus::REJECTED, $rejectedLifecycle->status);
+        self::assertEqualsWithDelta(0.0, $rejectedLifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.0, $rejectedLifecycle->remainingQuantity, 0.000001);
+    }
+
     public function testNormalizesStopOrdersAsTriggerProtectionTypes(): void
     {
         $stop = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_609_000);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -93,7 +93,7 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
     {
         $first = $this->fillRow(quantity: '0.2', price: '25000', hash: 'shared-tx-hash', time: 1_767_225_601_000);
         $first['tid'] = 10_001;
-        $second = $this->fillRow(quantity: '0.3', price: '25010', hash: 'shared-tx-hash', time: 1_767_225_601_000);
+        $second = $this->fillRow(quantity: '0.2', price: '25000', hash: 'shared-tx-hash', time: 1_767_225_601_000);
         $second['tid'] = 10_002;
 
         $fills = $this->normalizer->normalizeFills([$first, $second]);
@@ -101,6 +101,21 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertCount(2, $fills);
         self::assertSame('10001', $fills[0]->fillId);
         self::assertSame('10002', $fills[1]->fillId);
+    }
+
+    public function testUsesFillDirectionForClosePositionSide(): void
+    {
+        $closeLong = $this->fillRow(quantity: '0.2', price: '25000', hash: 'close-long', time: 1_767_225_601_000);
+        $closeLong['side'] = 'A';
+        $closeLong['dir'] = 'Close Long';
+        $closeShort = $this->fillRow(quantity: '0.2', price: '25000', hash: 'close-short', time: 1_767_225_602_000);
+        $closeShort['side'] = 'B';
+        $closeShort['dir'] = 'Close Short';
+
+        $fills = $this->normalizer->normalizeFills([$closeLong, $closeShort]);
+
+        self::assertSame(ExchangePositionSide::LONG, $fills[0]->positionSide);
+        self::assertSame(ExchangePositionSide::SHORT, $fills[1]->positionSide);
     }
 
     public function testOrderAbsentButFillPresentRequiresResyncAndKeepsFill(): void
@@ -113,6 +128,44 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertTrue($lifecycle->requiresResync);
         self::assertContains('order_absent_fill_present', $lifecycle->qualityFlags);
         self::assertCount(1, $lifecycle->fills);
+    }
+
+    public function testNormalizesNestedOrderStatusWrapper(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([[
+            'status' => 'order',
+            'order' => [
+                'status' => 'open',
+                'statusTimestamp' => 1_767_225_606_000,
+                'order' => [
+                    'coin' => 'BTC',
+                    'oid' => 1003,
+                    'cloid' => 'client-nested',
+                    'side' => 'B',
+                    'sz' => '0.7',
+                    'origSz' => '1',
+                    'limitPx' => '25020',
+                    'orderType' => 'Limit',
+                    'timestamp' => 1_767_225_600_000,
+                ],
+            ],
+        ]]);
+
+        self::assertSame(HyperliquidLifecycleStatus::PARTIALLY_FILLED, $lifecycle->status);
+        self::assertSame('BTCUSDT', $lifecycle->symbol);
+        self::assertSame('1003', $lifecycle->exchangeOrderId);
+        self::assertSame('client-nested', $lifecycle->clientOrderId);
+        self::assertEqualsWithDelta(1.0, $lifecycle->quantity, 0.000001);
+        self::assertEqualsWithDelta(0.7, $lifecycle->remainingQuantity, 0.000001);
+    }
+
+    public function testNormalizesCamelCaseTerminalOrderStatuses(): void
+    {
+        $canceled = $this->orderRow(remaining: '1', original: '1', status: 'marginCanceled', updatedAt: 1_767_225_606_000);
+        $rejected = $this->orderRow(remaining: '1', original: '1', status: 'badAloPxRejected', updatedAt: 1_767_225_607_000);
+
+        self::assertSame(HyperliquidLifecycleStatus::CANCELED, $this->normalizer->normalizeOrderLifecycle([$canceled])->status);
+        self::assertSame(HyperliquidLifecycleStatus::REJECTED, $this->normalizer->normalizeOrderLifecycle([$rejected])->status);
     }
 
     public function testNormalizesPositionSnapshotAndZeroClose(): void

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -59,7 +59,7 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
     public function testNormalizesPartialFillLifecycleWithFee(): void
     {
         $lifecycle = $this->normalizer->normalizeOrderLifecycle([
-            $this->orderRow(remaining: '0.6', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $this->orderRow(remaining: '0.6', original: '1', status: 'open', updatedAt: 1_767_225_602_000),
             $this->fillRow(quantity: '0.4', price: '25010', hash: 'fill-1', time: 1_767_225_601_000),
         ]);
 
@@ -69,7 +69,7 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(1.0, $lifecycle->quantity, 0.000001);
         self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
         self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
-        self::assertSame(1_767_225_601, $lifecycle->updatedAt->getTimestamp());
+        self::assertSame(1_767_225_602, $lifecycle->updatedAt->getTimestamp());
         self::assertCount(1, $lifecycle->fills);
         self::assertSame('fill-1', $lifecycle->fills[0]->fillId);
         self::assertSame('USDC', $lifecycle->fills[0]->feeCurrency);
@@ -100,6 +100,18 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertSame(HyperliquidLifecycleStatus::PARTIALLY_FILLED, $lifecycle->status);
         self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
         self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+    }
+
+    public function testCountsFillThatCompletesPartialOrderSnapshot(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '0.1', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $this->fillRow(quantity: '0.1', price: '25010', hash: 'remaining-fill', time: 1_767_225_601_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::FILLED, $lifecycle->status);
+        self::assertEqualsWithDelta(1.0, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.0, $lifecycle->remainingQuantity, 0.000001);
     }
 
     public function testTreatsOpenOrderSnapshotWithoutStatusAsOpen(): void

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -102,6 +102,18 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testRecomputesRemainingWhenSameMillisecondFillFollowsOrderSnapshot(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $this->fillRow(quantity: '0.4', price: '25010', hash: 'same-ms-fill', time: 1_767_225_600_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::PARTIALLY_FILLED, $lifecycle->status);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+    }
+
     public function testCountsFillThatCompletesPartialOrderSnapshot(): void
     {
         $lifecycle = $this->normalizer->normalizeOrderLifecycle([

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -89,6 +89,20 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertContains('duplicate_event', $lifecycle->qualityFlags);
     }
 
+    public function testKeepsDistinctFillsSharingTransactionHash(): void
+    {
+        $first = $this->fillRow(quantity: '0.2', price: '25000', hash: 'shared-tx-hash', time: 1_767_225_601_000);
+        $first['tid'] = 10_001;
+        $second = $this->fillRow(quantity: '0.3', price: '25010', hash: 'shared-tx-hash', time: 1_767_225_601_000);
+        $second['tid'] = 10_002;
+
+        $fills = $this->normalizer->normalizeFills([$first, $second]);
+
+        self::assertCount(2, $fills);
+        self::assertSame('10001', $fills[0]->fillId);
+        self::assertSame('10002', $fills[1]->fillId);
+    }
+
     public function testOrderAbsentButFillPresentRequiresResyncAndKeepsFill(): void
     {
         $lifecycle = $this->normalizer->normalizeOrderLifecycle([
@@ -153,6 +167,18 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
             'error' => 'Market is not open for this asset',
             'cloid' => 'cid-market',
         ]);
+        $batched = $this->normalizer->normalizeError([
+            'response' => [
+                'type' => 'order',
+                'data' => [
+                    'statuses' => [[
+                        'error' => 'Insufficient collateral available',
+                        'oid' => 1002,
+                        'cloid' => 'cid-batched',
+                    ]],
+                ],
+            ],
+        ]);
 
         self::assertSame(HyperliquidLifecycleStatus::FAILED, $insufficient->status);
         self::assertSame('insufficient_collateral', $insufficient->code);
@@ -160,6 +186,9 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertSame('[redacted]', $insufficient->redactedPayload['response']['signature']);
         self::assertSame('market_unavailable', $marketUnavailable->code);
         self::assertSame('cid-market', $marketUnavailable->clientOrderId);
+        self::assertSame('insufficient_collateral', $batched->code);
+        self::assertSame('1002', $batched->exchangeOrderId);
+        self::assertSame('cid-batched', $batched->clientOrderId);
     }
 
     /**

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -114,6 +114,38 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.0, $lifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testIgnoresSpotCoinFillsInPerpetualLifecycle(): void
+    {
+        $spotFill = $this->fillRow(quantity: '1', price: '10', hash: 'spot-fill', time: 1_767_225_601_000);
+        $spotFill['coin'] = '@107';
+
+        $fills = $this->normalizer->normalizeFills([$spotFill]);
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $spotFill,
+        ]);
+
+        self::assertSame([], $fills);
+        self::assertSame(HyperliquidLifecycleStatus::OPEN, $lifecycle->status);
+        self::assertSame('BTCUSDT', $lifecycle->symbol);
+        self::assertSame([], $lifecycle->fills);
+        self::assertEqualsWithDelta(0.0, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(1.0, $lifecycle->remainingQuantity, 0.000001);
+        self::assertContains('unsupported_lifecycle_row_ignored', $lifecycle->qualityFlags);
+    }
+
+    public function testPreservesMillisecondPrecisionOnFillTimestamps(): void
+    {
+        $fills = $this->normalizer->normalizeFills([
+            $this->fillRow(quantity: '0.1', price: '25010', hash: 'fill-ms-1', time: 1_767_225_601_123),
+            $this->fillRow(quantity: '0.1', price: '25011', hash: 'fill-ms-2', time: 1_767_225_601_456),
+        ]);
+
+        self::assertCount(2, $fills);
+        self::assertSame('1767225601.123000', $fills[0]->occurredAt->format('U.u'));
+        self::assertSame('1767225601.456000', $fills[1]->occurredAt->format('U.u'));
+    }
+
     public function testTreatsOpenOrderSnapshotWithoutStatusAsOpen(): void
     {
         $row = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000);

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Hyperliquid;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Hyperliquid\HyperliquidActionFactory;
+use App\Exchange\Hyperliquid\Lifecycle\HyperliquidLifecycleNormalizer;
+use App\Exchange\Hyperliquid\Lifecycle\HyperliquidLifecycleStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HyperliquidLifecycleNormalizer::class)]
+#[CoversClass(HyperliquidLifecycleStatus::class)]
+#[CoversClass(HyperliquidActionFactory::class)]
+final class HyperliquidLifecycleNormalizerTest extends TestCase
+{
+    private HyperliquidLifecycleNormalizer $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new HyperliquidLifecycleNormalizer(new HyperliquidActionFactory());
+    }
+
+    public function testNormalizesOrderRequestWithoutBroadcast(): void
+    {
+        $action = $this->normalizer->normalizeOrderRequest(0, new PlaceOrderRequest(
+            exchange: Exchange::HYPERLIQUID,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::LIMIT,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.01,
+            price: 25000.0,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'cid-hl-normalized',
+        ));
+
+        self::assertSame('order', $action['type']);
+        self::assertSame(0, $action['orders'][0]['a']);
+        self::assertSame('25000', $action['orders'][0]['p']);
+        self::assertSame('Alo', $action['orders'][0]['t']['limit']['tif']);
+        self::assertArrayNotHasKey('secret', $action);
+    }
+
+    public function testNormalizesPartialFillLifecycleWithFee(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->orderRow(remaining: '0.6', original: '1', status: 'open', updatedAt: 1_767_225_600_000),
+            $this->fillRow(quantity: '0.4', price: '25010', hash: 'fill-1', time: 1_767_225_601_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::PARTIALLY_FILLED, $lifecycle->status);
+        self::assertSame('BTCUSDT', $lifecycle->symbol);
+        self::assertSame('1001', $lifecycle->exchangeOrderId);
+        self::assertEqualsWithDelta(1.0, $lifecycle->quantity, 0.000001);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+        self::assertCount(1, $lifecycle->fills);
+        self::assertSame('fill-1', $lifecycle->fills[0]->fillId);
+        self::assertSame('USDC', $lifecycle->fills[0]->feeCurrency);
+        self::assertEqualsWithDelta(0.12, $lifecycle->fills[0]->fee ?? 0.0, 0.000001);
+    }
+
+    public function testDeduplicatesAndUsesNewestOutOfOrderStatus(): void
+    {
+        $open = $this->orderRow(remaining: '1', original: '1', status: 'open', updatedAt: 1_767_225_600_000);
+        $filled = $this->orderRow(remaining: '0', original: '1', status: 'filled', updatedAt: 1_767_225_603_000);
+        $filled['avgPx'] = '25005';
+
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([$filled, $open, $filled]);
+
+        self::assertSame(HyperliquidLifecycleStatus::FILLED, $lifecycle->status);
+        self::assertEqualsWithDelta(1.0, $lifecycle->filledQuantity, 0.000001);
+        self::assertSame(2, $lifecycle->deduplicatedEventCount);
+        self::assertContains('duplicate_event', $lifecycle->qualityFlags);
+    }
+
+    public function testOrderAbsentButFillPresentRequiresResyncAndKeepsFill(): void
+    {
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $this->fillRow(quantity: '0.25', price: '25001', hash: 'standalone-fill', time: 1_767_225_604_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::UNKNOWN_REQUIRES_RESYNC, $lifecycle->status);
+        self::assertTrue($lifecycle->requiresResync);
+        self::assertContains('order_absent_fill_present', $lifecycle->qualityFlags);
+        self::assertCount(1, $lifecycle->fills);
+    }
+
+    public function testNormalizesPositionSnapshotAndZeroClose(): void
+    {
+        $positions = $this->normalizer->normalizePositions([
+            ['position' => [
+                'coin' => 'BTC',
+                'szi' => '0.5',
+                'entryPx' => '25000',
+                'markPx' => '25100',
+                'unrealizedPnl' => '50',
+                'marginUsed' => '100',
+                'leverage' => ['value' => '3'],
+                'time' => 1_767_225_604_000,
+            ]],
+            ['position' => ['coin' => 'ETH', 'szi' => '0', 'time' => 1_767_225_605_000]],
+        ]);
+
+        self::assertCount(2, $positions);
+        self::assertSame(ExchangePositionSide::LONG, $positions[0]->side);
+        self::assertEqualsWithDelta(0.5, $positions[0]->size, 0.000001);
+        self::assertSame(ExchangePositionSide::LONG, $positions[1]->side);
+        self::assertEqualsWithDelta(0.0, $positions[1]->size, 0.000001);
+        self::assertContains('position_closed_zero_size', $positions[1]->qualityFlags);
+    }
+
+    public function testNormalizesFundingRow(): void
+    {
+        $funding = $this->normalizer->normalizeFunding([[
+            'time' => 1_767_225_606_000,
+            'delta' => ['coin' => 'BTC', 'usdc' => '-0.42', 'fundingRate' => '0.0001'],
+        ]]);
+
+        self::assertCount(1, $funding);
+        self::assertSame('BTCUSDT', $funding[0]->symbol);
+        self::assertEqualsWithDelta(-0.42, $funding[0]->amount, 0.000001);
+        self::assertSame('USDC', $funding[0]->currency);
+        self::assertSame('funding', $funding[0]->role);
+    }
+
+    public function testNormalizesInsufficientCollateralAndMarketUnavailableErrors(): void
+    {
+        $insufficient = $this->normalizer->normalizeError([
+            'status' => 'err',
+            'response' => [
+                'error' => 'Insufficient margin to place order',
+                'oid' => 1001,
+                'signature' => 'must-not-leak',
+            ],
+        ]);
+        $marketUnavailable = $this->normalizer->normalizeError([
+            'error' => 'Market is not open for this asset',
+            'cloid' => 'cid-market',
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::FAILED, $insufficient->status);
+        self::assertSame('insufficient_collateral', $insufficient->code);
+        self::assertSame('1001', $insufficient->exchangeOrderId);
+        self::assertSame('[redacted]', $insufficient->redactedPayload['response']['signature']);
+        self::assertSame('market_unavailable', $marketUnavailable->code);
+        self::assertSame('cid-market', $marketUnavailable->clientOrderId);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function orderRow(string $remaining, string $original, string $status, int $updatedAt): array
+    {
+        return [
+            'coin' => 'BTC',
+            'oid' => 1001,
+            'cloid' => 'client-a',
+            'side' => 'B',
+            'sz' => $remaining,
+            'origSz' => $original,
+            'limitPx' => '25000',
+            'orderType' => 'Limit',
+            'status' => $status,
+            'timestamp' => 1_767_225_599_000,
+            'uTime' => $updatedAt,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fillRow(string $quantity, string $price, string $hash, int $time): array
+    {
+        return [
+            'coin' => 'BTC',
+            'oid' => 1001,
+            'cloid' => 'client-a',
+            'side' => 'B',
+            'sz' => $quantity,
+            'px' => $price,
+            'fee' => '0.12',
+            'hash' => $hash,
+            'time' => $time,
+        ];
+    }
+}

--- a/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
+++ b/trading-app/tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
@@ -114,6 +114,21 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
     }
 
+    public function testDoesNotDoubleCountFillsAlreadyReflectedByCurrentSnapshot(): void
+    {
+        $snapshot = $this->orderRow(remaining: '0.6', original: '1', status: 'open', updatedAt: 1_767_225_600_000);
+        unset($snapshot['uTime']);
+
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $snapshot,
+            $this->fillRow(quantity: '0.4', price: '25010', hash: 'snapshot-fill', time: 1_767_225_601_000),
+        ]);
+
+        self::assertSame(HyperliquidLifecycleStatus::PARTIALLY_FILLED, $lifecycle->status);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+    }
+
     public function testCountsFillThatCompletesPartialOrderSnapshot(): void
     {
         $lifecycle = $this->normalizer->normalizeOrderLifecycle([
@@ -297,6 +312,20 @@ final class HyperliquidLifecycleNormalizerTest extends TestCase
         $canceled = $this->orderRow(remaining: '0.6', original: '1', status: 'marginCanceled', updatedAt: 1_767_225_610_000);
 
         $lifecycle = $this->normalizer->normalizeOrderLifecycle([$canceled]);
+
+        self::assertSame(HyperliquidLifecycleStatus::CANCELED, $lifecycle->status);
+        self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);
+        self::assertEqualsWithDelta(0.6, $lifecycle->remainingQuantity, 0.000001);
+    }
+
+    public function testDoesNotDowngradeTerminalSnapshotPartialFillWithIncompleteFillPage(): void
+    {
+        $canceled = $this->orderRow(remaining: '0.6', original: '1', status: 'marginCanceled', updatedAt: 1_767_225_610_000);
+
+        $lifecycle = $this->normalizer->normalizeOrderLifecycle([
+            $canceled,
+            $this->fillRow(quantity: '0.1', price: '25010', hash: 'incomplete-fill-page', time: 1_767_225_601_000),
+        ]);
 
         self::assertSame(HyperliquidLifecycleStatus::CANCELED, $lifecycle->status);
         self::assertEqualsWithDelta(0.4, $lifecycle->filledQuantity, 0.000001);


### PR DESCRIPTION
Part of Hyperliquid demo/testnet canonical sequence.

Summary:
- add read-only Hyperliquid lifecycle normalizer and stable lifecycle DTOs/status enum
- normalize order requests without broadcast, order lifecycle rows, fills, positions, funding rows and exchange errors
- preserve ambiguous fill-only streams as requires-resync with quality flags and redact sensitive payload fields
- document lifecycle mapping and rollback for HL-008

References:
- Related to HL-007 metadata/precision/fees/funding
- Related to Hyperliquid demo/testnet readiness sequence

Validation:
- docker-compose exec -T trading-app-php ./vendor/bin/phpunit tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php
- docker-compose exec -T trading-app-php ./vendor/bin/phpunit tests/Exchange/Hyperliquid tests/Provider/Hyperliquid tests/Command/ExchangeRuntimeCheckCommandTest.php --filter 'Hyperliquid|RuntimeCheck'\n- docker-compose exec -T trading-app-php ./vendor/bin/phpstan analyse --memory-limit=1G src/Exchange/Hyperliquid/Lifecycle tests/Exchange/Hyperliquid/HyperliquidLifecycleNormalizerTest.php\n- docker-compose exec -T trading-app-php php bin/console lint:container --no-debug\n- docker-compose exec -T trading-app-php php bin/console lint:yaml config\n- python3 -m mkdocs build --strict\n- git diff --check