### PR TITLE
docs: add TradingV3 roadmap waves

### DIFF
--- a/docs/roadmap/01-okx-hyperliquid-demo-testnet.md
+++ b/docs/roadmap/01-okx-hyperliquid-demo-testnet.md
@@ -1,0 +1,122 @@
+# TradingV3 — Vague 1 — OKX / Hyperliquid demo-testnet
+
+**Issue parent :** #173  
+**Statut :** en cours avancé  
+**Objectif :** fiabiliser OKX demo et Hyperliquid testnet sans aucune écriture mainnet.
+
+Cette vague remplace la logique “dry-run uniquement” par une cible plus précise :
+
+- `dry_run=true` : simulation locale, aucun ordre envoyé à l’exchange ;
+- `dry_run=false + environment=demo|testnet` : exécution mutative autorisée uniquement après gates explicites ;
+- `dry_run=false + mainnet` : interdit dans toute cette vague.
+
+## Règles permanentes
+
+- Ne jamais utiliser, demander, stocker ou logger de secret mainnet.
+- OKX est autorisé uniquement en Demo Trading.
+- Hyperliquid est autorisé uniquement en testnet.
+- Toute exécution mutative demo/testnet nécessite whitelist, notional minimal, kill switch, runtime-check, audit et rollback.
+- Aucune position, même fictive, sans SL immédiat ou compensation fail-safe documentée.
+- Aucun fallback silencieux vers Bitmart quand `exchange=okx` ou `exchange=hyperliquid`.
+- Aucune optimisation stratégie, fréquence, EntryZone ou SL/TP métier dans cette vague.
+- Toute PR doit être atomique, testée, documentée et rollbackable.
+- Surveiller chaque PR jusqu’à validation Codex ; traiter les retours pertinents ; marquer résolu ; compresser le contexte si 80%.
+
+## Déjà livré / à cocher dans #173
+
+- [x] COMMON-001 — Safety envelope demo/testnet — #221 / `45ff518`.
+- [x] COMMON-002 — Effective Config runtime exchange/env — #222 / `9cb132f`.
+- [x] COMMON-003 — Exchange readiness contract commun — #223 / `b801a6b`.
+- [x] COMMON-004 — Kill switch demo/testnet commun — #224 / `0e61c01`.
+- [x] COMMON-006 — Private observability policy — #225 / `49d45fb`.
+- [x] COMMON-005 — Fake/Paper scenarios pour recette demo — #226 / `280837e`.
+- [x] OKX-001 — Capability matrix OKX + ADR readiness demo — #227 / `6313c55`.
+- [x] OKX-002 — Provider bundle OKX skeleton — #228 / `06b275c`.
+- [x] OKX-003 — Public REST read-only OKX — #229 / `4e5919c`.
+- [x] OKX-004 — Auth + private read-only OKX demo — #230 / `fb902e7`.
+- [x] OKX-005 — Metadata / precision / fees / funding OKX — #231 / `5d7f399`.
+- [x] OKX-006 — Normalizers lifecycle OKX — #232 / `bf8c1fb`.
+- [x] OKX-007 — Local dry-run write serialization OKX — #233 / `18ef164`.
+- [x] OKX-008 — Runtime-check demo/testnet candidate OKX — #234 / `4e5919c`.
+- [x] OKX-009 — Orchestrator dry-run recipe OKX — #235 / `c103c1b`.
+- [x] HL-001 — Capability matrix + ADR Hyperliquid testnet — #236 / `5724aab`.
+- [x] HL-002 — Provider bundle skeleton Hyperliquid — #237 / `ac8e1d2`.
+- [x] HL-003 — Public read-only Hyperliquid — #238 / `3e89691`.
+- [x] HL-004 — Signer Hyperliquid isolé — #239 / `27ec03a`.
+- [x] HL-005 — Nonce manager Hyperliquid persistant — #240 / `932d686`.
+- [x] HL-006 — Account read-only Hyperliquid — #241 / `7bfad8f`.
+- [x] HL-007 — Metadata / precision / fees / funding Hyperliquid — #242 / `b0ce547`.
+
+## Restant vague 1
+
+- [ ] HL-008 — Order/fill/position normalizers Hyperliquid.
+- [ ] HL-009 — Local dry-run no broadcast Hyperliquid.
+- [ ] HL-010 — Runtime-check `demo_testnet_candidate` Hyperliquid.
+- [ ] HL-011 — Orchestrator dry-run recipe Hyperliquid.
+- [ ] DEMO-001 — Fixtures demo OKX + Hyperliquid.
+- [ ] DEMO-002 — Recette R1-R16 double exchange en dry-run.
+- [ ] DEMO-003 — Demo ops runbook + rollback.
+- [ ] DEMO-004 — Enable demo schedule guarded.
+- [ ] DEMO-005 — Pre-mutative demo readiness decision.
+- [ ] OKX-010 — Demo trading controlled avec SL.
+- [ ] HL-012 — Testnet trading controlled avec SL.
+- [ ] DEMO-006 — Final demo/testnet execution evidence report.
+
+## Ordre strict recommandé
+
+```text
+HL-008
+HL-009
+HL-010
+HL-011
+
+DEMO-001
+DEMO-002
+DEMO-003
+DEMO-004
+DEMO-005
+
+OKX-010
+HL-012
+
+DEMO-006
+```
+
+## Prompt type pour chaque PR restante
+
+```text
+Tu travailles sur le repo pivox/tradingV3.
+Langue : français.
+
+Objectif : créer la PR <ID> de la vague 1 OKX/Hyperliquid demo-testnet.
+
+Contraintes :
+- PR atomique.
+- Aucun mainnet mutatif.
+- Aucun secret mainnet.
+- Aucun fonds réel.
+- Aucun tuning stratégie.
+- Tests ciblés obligatoires.
+- Documentation et rollback si runtime/config/ops touchés.
+- Surveiller la PR jusqu’à validation Codex.
+- Corriger les retours pertinents, répondre et marquer comme résolu.
+- Si contexte 80%, compresser en gardant objectif, fichiers modifiés, décisions, tests, retours ouverts, risques, rollback, prochaine action.
+
+Definition of Done :
+- tests ciblés verts ;
+- `git diff --check` ;
+- `mkdocs build --strict` si docs touchées ;
+- pas de secret ;
+- body PR complet ;
+- rollback documenté.
+```
+
+## Critère de sortie vague 1
+
+La vague 1 est terminée uniquement si :
+
+- OKX demo et Hyperliquid testnet ont une recette dry-run complète ;
+- la décision pre-mutative est documentée ;
+- OKX-010 et HL-012 n’autorisent des ordres que sur environnements fictifs ;
+- un rapport final prouve ou bloque la readiness demo/testnet ;
+- aucune formulation ne laisse croire que le mainnet est prêt.

--- a/docs/roadmap/02-data-yaml-cockpit-profitability-foundation.md
+++ b/docs/roadmap/02-data-yaml-cockpit-profitability-foundation.md
@@ -1,0 +1,126 @@
+# TradingV3 — Vague 2 — Data, YAML, Cockpit & Profitability Foundation
+
+**Issue parent :** #173  
+**Dépendance :** vague 1 suffisamment stabilisée en dry-run/demo-testnet  
+**Objectif :** préparer la base data/config/ops qui permettra de décider par données, pas par intuition.
+
+Cette vague ne cherche pas à optimiser une stratégie. Elle construit la fondation pour mesurer correctement les modes `regular`, `scalper` et `scalper_micro`.
+
+## Cap produit
+
+TradingV3 doit être piloté par :
+
+- moins de mauvais trades ;
+- expectancy nette positive ;
+- frais, spread, slippage et funding intégrés ;
+- analyse via `position_trade_analysis` ;
+- refus de desserrer les EntryZones sans preuve PnL.
+
+## Règles permanentes
+
+- Ne pas ajouter de fréquence.
+- Ne pas ajouter de capital réel.
+- Ne pas activer mainnet.
+- Ne pas supprimer Bitmart brutalement.
+- Ne pas créer un cockpit décoratif : chaque écran doit remplacer une recherche manuelle dans les logs.
+- Toute config effective doit être traçable : source files, overrides, hash, env, mode, exchange.
+- Toute métrique PnL doit préciser brut/net et qualité des données.
+- Toute PR doit être atomique, testée, documentée et rollbackable.
+- Surveiller la PR jusqu’à validation Codex ; corriger les retours pertinents ; marquer résolu ; compresser le contexte si 80%.
+
+## PR proposées
+
+### Bloc 2A — `position_trade_analysis` et vérité PnL
+
+- [ ] PTA-001 — Inventaire de `position_trade_analysis` : colonnes, sources, hypothèses, trous de données.
+- [ ] PTA-002 — Vérifier le rapprochement entrée/sortie et documenter les cas ambigus.
+- [ ] PTA-003 — Ajouter/normaliser `pnl_R`, `MFE_R`, `MAE_R`, holding time et drawdown par trade.
+- [ ] PTA-004 — Ajouter les coûts nets : fees, spread, slippage, funding si applicable.
+- [ ] PTA-005 — Ajouter un rapport par mode/exchange/symbol/env.
+- [ ] PTA-006 — Ajouter un rapport mauvais trades : entrée tardive, SL trop serré, TP irréaliste, EntryZone faible, coût excessif.
+- [ ] PTA-007 — Ajouter un export JSON/CSV redacted pour analyse offline.
+- [ ] PTA-008 — Documenter les critères “donnée fiable / donnée incomplète / résultat non certifié”.
+
+### Bloc 2B — YAML layered resolver
+
+- [ ] YAML-001 — ADR structure cible : `base + mode + exchange + mode_exchange + env = effective config`.
+- [ ] YAML-002 — Inventaire des YAML actuels `regular`, `scalper`, `scalper_micro`, Bitmart, OKX, Hyperliquid.
+- [ ] YAML-003 — Implémenter resolver en lecture seule avec provenance, hash et ordre de merge.
+- [ ] YAML-004 — Exposer l’effective config via commande CLI ou endpoint read-only.
+- [ ] YAML-005 — Ajouter validation fail-closed : types, bornes, champs inconnus, env incohérent.
+- [ ] YAML-006 — Migrer Bitmart en compatibilité progressive sans casser le runtime.
+- [ ] YAML-007 — Préparer overlays OKX demo et Hyperliquid testnet sans activation mutative.
+- [ ] YAML-008 — Ajouter documentation opérateur et exemples de config effective.
+
+### Bloc 2C — Cockpit opérateur / front ops
+
+- [ ] OPS-001 — Décider surface canonique cockpit : Symfony/Twig existant, React, ou séparation progressive.
+- [ ] OPS-002 — Écran runtime-check : état exchange/env/mode, readiness, raisons de blocage.
+- [ ] OPS-003 — Écran kill switch : global, exchange, env, mode, état et audit.
+- [ ] OPS-004 — Écran effective config viewer : fichiers chargés, overrides, hash, risk effectif.
+- [ ] OPS-005 — Écran exchange health : public/private read, stale data, rate limit, erreurs normalisées.
+- [ ] OPS-006 — Écran positions/orders demo-testnet : positions, SL attaché, cancels, incidents.
+- [ ] OPS-007 — Écran trade lifecycle : décision → order plan → ordre → fill → SL/TP → clôture.
+- [ ] OPS-008 — Écran bad trades : lecture exploitable de `position_trade_analysis`.
+- [ ] OPS-009 — Écran comparaison modes : regular/scalper/scalper_micro sur expectancy nette.
+- [ ] OPS-010 — Runbook front ops : quelles actions faire avant d’ouvrir les logs.
+
+### Bloc 2D — Recette et gouvernance data
+
+- [ ] DATA-001 — Data quality flags : données manquantes, stale, approximées, non certifiées.
+- [ ] DATA-002 — Lineage `run_id`, `set_id`, exchange, symbol, mode jusqu’au trade analysé.
+- [ ] DATA-003 — Baseline analytics report avant toute optimisation.
+- [ ] DATA-004 — Tests de non-régression sur les métriques critiques.
+- [ ] DATA-005 — Gate “pas d’optimisation sans baseline”.
+
+## Ordre recommandé
+
+```text
+PTA-001 → PTA-004
+YAML-001 → YAML-005
+OPS-001 → OPS-005
+DATA-001 → DATA-003
+PTA-005 → PTA-008
+YAML-006 → YAML-008
+OPS-006 → OPS-010
+DATA-004 → DATA-005
+```
+
+## Prompt type
+
+```text
+Tu travailles sur le repo pivox/tradingV3.
+Langue : français.
+
+Objectif : créer la PR <ID> de la vague 2 Data/YAML/Cockpit/Profitability Foundation.
+
+Contraintes :
+- PR atomique.
+- Aucune activation mainnet.
+- Aucun ordre réel.
+- Aucun tuning stratégie.
+- La vérité de décision doit passer par position_trade_analysis.
+- Les résultats incomplets doivent rester flagged, jamais certifiés.
+- Les YAML doivent être traçables et rollbackables.
+- Les écrans cockpit doivent aider l’exploitation, pas remplacer les tests.
+- Surveiller la PR jusqu’à validation Codex.
+- Traiter les retours pertinents et marquer résolu.
+- Si contexte 80%, compresser en gardant objectif, fichiers modifiés, décisions, tests, retours ouverts, risques, rollback, prochaine action.
+
+Tests attendus selon périmètre :
+- PHPUnit ciblé ;
+- PHPStan ciblé si logique PHP ;
+- lint YAML si config ;
+- mkdocs build --strict si docs ;
+- git diff --check.
+```
+
+## Critère de sortie vague 2
+
+La vague 2 est terminée si TradingV3 permet de répondre clairement :
+
+- quelle config effective a produit une décision ;
+- quel run/set/mode/exchange/symbol a produit un trade ;
+- quel PnL net est mesuré ;
+- pourquoi un trade est classé mauvais ;
+- quel mode est meilleur ou pire sur expectancy nette, pas seulement winrate.

--- a/docs/roadmap/03-mtf-backstaging-config-mining.md
+++ b/docs/roadmap/03-mtf-backstaging-config-mining.md
@@ -1,0 +1,191 @@
+# TradingV3 — Vague 3 — MTF Backstaging Config Mining
+
+**Issue parent :** #173  
+**Dépendance :** vague 2 utilisable : `position_trade_analysis`, effective config, coûts nets, lineage  
+**Objectif :** optimiser les configs par mode via backstaging chronologique, puis valider hors période.
+
+Cette vague sert à augmenter la probabilité de rentabilité en cherchant des configs robustes par mode, pas en ajoutant des trades.
+
+## Définition
+
+Dans TradingV3, le backstaging signifie :
+
+```text
+rejouer l’historique chronologiquement
+→ tester des configs candidates par mode
+→ enregistrer signaux, trades, no-trades et échecs
+→ calculer MFE/MAE/pnl_R/frais/spread/slippage
+→ classer les configs
+→ figer les meilleures
+→ valider hors période / walk-forward
+→ exporter des YAML candidates ou rejeter le mode
+```
+
+Ce n’est pas :
+
+```text
+chercher un trade gagnant dans le passé
+→ remonter pour trouver le 4H/1H/15m qui l’explique
+→ fabriquer une config qui colle au résultat connu
+```
+
+## Règles anti-biais
+
+- À chaque instant `T`, n’utiliser que les bougies clôturées avant `T`.
+- Le futur ne sert qu’à mesurer le résultat après coup, jamais à décider l’entrée.
+- Les no-trades doivent être stockés.
+- Les contextes valides sans confirmation doivent être stockés.
+- Les signaux perdants doivent être stockés.
+- La période de discovery ne doit pas servir de validation finale.
+- Une config optimisée doit être figée avant out-of-sample.
+- Le scoring doit pénaliser l’overfitting, le drawdown, la dépendance à un symbole ou à une semaine.
+
+## Modes à optimiser séparément
+
+### `regular`
+
+- Contexte probable : 4H + 1H.
+- Setup probable : 15m.
+- Trigger probable : 5m.
+- Objectif : peu de trades, mouvements propres, drawdown limité.
+
+### `scalper`
+
+- Contexte probable : 1H + 15m.
+- Setup probable : 5m.
+- Trigger probable : 1m.
+- Objectif : trades courts mais encore robustes aux coûts.
+
+### `scalper_micro`
+
+- Contexte probable : 15m + 5m.
+- Setup/trigger probable : 1m.
+- Objectif : vérifier s’il mérite d’exister ; rejet si frais/spread/slippage détruisent l’edge.
+
+## PR proposées
+
+### Bloc 3A — Modèle et moteur backstaging
+
+- [ ] BSM-001 — ADR MTF Backstaging Config Mining : termes, biais, discovery, validation.
+- [ ] BSM-002 — Modèle `BackstageRun`, `BackstageCandidate`, `BackstageResult`, `BackstageNoTrade`.
+- [ ] BSM-003 — Générateur de configs candidates à partir des YAML effectifs.
+- [ ] BSM-004 — Builder contexte MTF configurable par mode.
+- [ ] BSM-005 — Moteur de simulation chronologique sans look-ahead.
+- [ ] BSM-006 — Stockage des no-trades et contextes invalidés.
+- [ ] BSM-007 — Replay déterministe d’une fenêtre historique.
+- [ ] BSM-008 — Tests anti-look-ahead et fixtures minimales.
+
+### Bloc 3B — Mesures et scoring
+
+- [ ] BSM-009 — Calcul MFE/MAE/pnl_R par candidat.
+- [ ] BSM-010 — Intégrer fees/spread/slippage/funding dans le scoring net.
+- [ ] BSM-011 — Score de robustesse : expectancy nette, profit factor, drawdown, stabilité.
+- [ ] BSM-012 — Pénalités : trop de trades, dépendance à un symbole, dépendance à un outlier.
+- [ ] BSM-013 — Rapport par mode/config/symbol/timeframe/régime marché.
+- [ ] BSM-014 — Export CSV/JSON redacted des résultats.
+
+### Bloc 3C — Optimisation par mode
+
+- [ ] MODE-REG-001 — Définir l’espace de recherche `regular`.
+- [ ] MODE-REG-002 — Backstaging `regular` et short-list configs candidates.
+- [ ] MODE-REG-003 — Validation out-of-sample `regular`.
+- [ ] MODE-REG-004 — Export `regular_config_candidate.yaml` ou rejet documenté.
+- [ ] MODE-SCALP-001 — Définir l’espace de recherche `scalper`.
+- [ ] MODE-SCALP-002 — Backstaging `scalper` et short-list configs candidates.
+- [ ] MODE-SCALP-003 — Validation out-of-sample `scalper`.
+- [ ] MODE-SCALP-004 — Export `scalper_config_candidate.yaml` ou rejet documenté.
+- [ ] MODE-MICRO-001 — Définir l’espace de recherche `scalper_micro` avec spread/frais stricts.
+- [ ] MODE-MICRO-002 — Backstaging `scalper_micro` et décision de survie.
+- [ ] MODE-MICRO-003 — Validation out-of-sample ou rejet définitif.
+
+### Bloc 3D — Régimes marché et no-trade
+
+- [ ] REGIME-001 — Classifier simple : trend_up, trend_down, range, high_volatility, low_volatility, chop.
+- [ ] REGIME-002 — Associer chaque résultat à un régime marché.
+- [ ] REGIME-003 — Rapport expectancy par mode/config/régime.
+- [ ] ENTRY-001 — Entry quality score configurable.
+- [ ] ENTRY-002 — No-trade threshold par mode.
+- [ ] ENTRY-003 — Rapport trades évités vs trades pris.
+
+### Bloc 3E — Walk-forward et décision
+
+- [ ] WFO-001 — Découpage train/test/out-of-sample configurable.
+- [ ] WFO-002 — Walk-forward runner déterministe.
+- [ ] WFO-003 — Rapport stabilité inter-fenêtres.
+- [ ] WFO-004 — Go/no-go config report par mode.
+- [ ] WFO-005 — Export YAML suggested_config avec statut `candidate`, `validated`, `rejected`.
+
+## Critères d’optimisation
+
+Ne jamais choisir la config au PnL max seul. Le score doit favoriser :
+
+- expectancy_R nette positive ;
+- profit factor robuste ;
+- drawdown acceptable ;
+- résultats hors période cohérents ;
+- MFE/MAE sain ;
+- coûts d’exécution supportables ;
+- peu de dépendance à un seul symbole ou outlier ;
+- capacité à dire no-trade.
+
+Exemple de verdict attendu :
+
+```yaml
+regular:
+  status: validated_candidate
+  best_config: regular_v07
+  expectancy_R_net: 0.16
+  profit_factor: 1.23
+  drawdown_R: acceptable
+
+scalper:
+  status: candidate
+  best_config: scalper_v03
+  expectancy_R_net: 0.05
+  warning: fragile_after_fees
+
+scalper_micro:
+  status: rejected
+  reason: spread_and_fees_destroy_edge
+```
+
+## Prompt type
+
+```text
+Tu travailles sur le repo pivox/tradingV3.
+Langue : français.
+
+Objectif : créer la PR <ID> de la vague 3 MTF Backstaging Config Mining.
+
+Contraintes :
+- PR atomique.
+- Aucun mainnet.
+- Aucun ordre réel.
+- Aucune config promue sans validation hors période.
+- Aucun look-ahead : n’utiliser que les données disponibles à T pour décider.
+- Enregistrer les no-trades, les échecs et les signaux perdants.
+- Mesurer en net : fees, spread, slippage, funding si applicable.
+- Comparer les modes sur expectancy nette, pas winrate seul.
+- Surveiller la PR jusqu’à validation Codex.
+- Corriger les retours pertinents, répondre et marquer comme résolu.
+- Si contexte 80%, compresser en gardant objectif, fichiers modifiés, décisions, tests, retours ouverts, risques, rollback, prochaine action.
+
+Tests attendus :
+- tests anti-look-ahead ;
+- tests déterminisme replay ;
+- tests scoring ;
+- tests YAML si config ;
+- mkdocs build --strict si docs ;
+- git diff --check.
+```
+
+## Critère de sortie vague 3
+
+La vague 3 est terminée quand chaque mode a un verdict :
+
+- `validated_candidate` ;
+- `candidate_needs_shadow` ;
+- `rejected` ;
+- `disabled_until_new_evidence`.
+
+Aucune config ne doit être considérée prête pour capital réel sans vague 4.

--- a/docs/roadmap/04-shadow-capital-protection-live-readiness.md
+++ b/docs/roadmap/04-shadow-capital-protection-live-readiness.md
@@ -1,0 +1,149 @@
+# TradingV3 — Vague 4 — Shadow, Capital Protection & Live-readiness
+
+**Issue parent :** #173  
+**Dépendance :** au moins une config candidate validée par la vague 3  
+**Objectif :** vérifier que l’edge survit aux conditions de marché réelles, puis préparer une gouvernance de risque sans activer le mainnet.
+
+Cette vague ne signifie pas “trader en réel”. Elle prépare la décision. Toute activation réelle éventuelle doit rester manuelle, séparée et explicitement validée.
+
+## Règles permanentes
+
+- Pas de secrets mainnet dans l’application tant que la décision humaine finale n’est pas prise.
+- Pas d’ordre réel dans les PR de live-readiness.
+- Shadow production avant capital réel.
+- Risque et capital protection avant scaling.
+- Un seul mode, peu de symboles, un exchange stable avant toute extension.
+- Tout incident déclenche pause, audit et rollback.
+- Toute PR doit être atomique, testée, documentée et rollbackable.
+- Surveiller chaque PR jusqu’à validation Codex ; traiter les retours pertinents ; marquer résolu ; compresser le contexte si 80%.
+
+## PR proposées
+
+### Bloc 4A — Shadow production réaliste
+
+- [ ] SHADOW-001 — ADR Shadow Production : objectifs, limites, données nécessaires, no-mainnet.
+- [ ] SHADOW-002 — Shadow signal runner : générer les signaux live sans envoyer d’ordre.
+- [ ] SHADOW-003 — Capture bid/ask/spread/orderbook au moment du signal.
+- [ ] SHADOW-004 — Simulateur fill réaliste : market, limit, non-fill, TTL, slippage pessimiste.
+- [ ] SHADOW-005 — Comparaison signal théorique vs fill réaliste.
+- [ ] SHADOW-006 — Rapport quotidien shadow : PnL brut, PnL net, fills, non-fills, slippage.
+- [ ] SHADOW-007 — Rapport par mode/config/symbol/exchange en shadow.
+- [ ] SHADOW-008 — Gate : rejet config si edge disparaît en shadow.
+
+### Bloc 4B — Capital protection layer
+
+- [ ] RISKCAP-001 — ADR Capital Protection : limites journalières, hebdomadaires, exposition, pause.
+- [ ] RISKCAP-002 — `risk_per_trade` strict : 0.25% à 0.5% par défaut en pilot.
+- [ ] RISKCAP-003 — Daily loss limit et weekly loss limit.
+- [ ] RISKCAP-004 — Max consecutive losses → pause automatique.
+- [ ] RISKCAP-005 — Max open positions et max exposure par exchange/symbol/mode.
+- [ ] RISKCAP-006 — Circuit breaker volatilité/spread/stale data.
+- [ ] RISKCAP-007 — Confirmation humaine pour changement config critique.
+- [ ] RISKCAP-008 — Audit capital protection dans cockpit et logs redacted.
+
+### Bloc 4C — Mainnet-readiness sans activation
+
+- [ ] READY-001 — ADR mainnet-readiness sans activation mainnet.
+- [ ] READY-002 — Strategy secrets/vault future : aucun secret mainnet en Git/env par défaut.
+- [ ] READY-003 — Runtime gate `mainnet_write_enabled=false` impossible à contourner silencieusement.
+- [ ] READY-004 — Mainnet read-only éventuel, séparé des permissions write.
+- [ ] READY-005 — Double confirmation humaine pour toute future activation.
+- [ ] READY-006 — Runbook incident : kill switch, close/cancel, rollback, postmortem.
+- [ ] READY-007 — Alerting Telegram/email pour incidents, drawdown, stale data, stop attach failure.
+- [ ] READY-008 — Audit complet des décisions, configs et hash de version.
+
+### Bloc 4D — Controlled live pilot éventuel
+
+Ce bloc reste documentaire tant qu’aucune décision humaine finale n’autorise le réel.
+
+- [ ] PILOT-001 — Critères go/no-go pour petit live pilot.
+- [ ] PILOT-002 — Plan pilot : 1 exchange, 1 mode, 1 à 3 symboles, capital ridicule.
+- [ ] PILOT-003 — Checklist pré-pilot : shadow positif, risk caps, runbook, rollback.
+- [ ] PILOT-004 — Rapport pilot quotidien : PnL net, drawdown, incidents, décisions.
+- [ ] PILOT-005 — Stop criteria : premier incident critique, drawdown, SL attach fail, data stale.
+- [ ] PILOT-006 — Live pilot extended si et seulement si pilot initial positif et stable.
+
+### Bloc 4E — Production risk governance et scaling contrôlé
+
+- [ ] GOV-001 — Budget de perte mensuel.
+- [ ] GOV-002 — Capital allocation par mode/exchange/symbol.
+- [ ] GOV-003 — Versioning et approbation des configs.
+- [ ] GOV-004 — Rapport mensuel expectancy nette et drawdown.
+- [ ] GOV-005 — Décision : source rentable, pause, refonte, ou projet R&D/portfolio.
+- [ ] SCALE-001 — Règles de scaling lent : capital avant fréquence, un axe à la fois.
+
+## Gates obligatoires
+
+### Gate Shadow
+
+```text
+GO shadow-to-pilot si :
+- expectancy_R nette positive ;
+- profit factor robuste ;
+- slippage pessimiste encore acceptable ;
+- pas de dépendance à un seul trade ;
+- config stable plusieurs semaines ;
+- aucun incident safety critique.
+```
+
+### Gate Capital
+
+```text
+NO-GO si :
+- edge shadow négatif ;
+- frais/spread détruisent le résultat ;
+- drawdown supérieur au budget ;
+- SL attach/fail-safe non prouvé ;
+- runtime-check ou kill switch douteux ;
+- données incomplètes certifiées à tort.
+```
+
+## Prompt type
+
+```text
+Tu travailles sur le repo pivox/tradingV3.
+Langue : français.
+
+Objectif : créer la PR <ID> de la vague 4 Shadow/Capital Protection/Live-readiness.
+
+Contraintes :
+- PR atomique.
+- Aucun ordre mainnet.
+- Aucun secret mainnet.
+- Aucun scaling.
+- Aucun live pilot implicite.
+- Shadow avant capital réel.
+- Risk caps avant toute expérimentation live future.
+- Toute décision doit être fondée sur position_trade_analysis + shadow report.
+- Surveiller la PR jusqu’à validation Codex.
+- Corriger les retours pertinents, répondre et marquer comme résolu.
+- Si contexte 80%, compresser en gardant objectif, fichiers modifiés, décisions, tests, retours ouverts, risques, rollback, prochaine action.
+
+Tests attendus selon périmètre :
+- tests risk caps ;
+- tests circuit breaker ;
+- tests no-mainnet ;
+- tests alerting/fail-closed ;
+- mkdocs build --strict si docs ;
+- git diff --check.
+```
+
+## Critère de sortie vague 4
+
+La vague 4 est terminée si TradingV3 peut produire une décision claire :
+
+```text
+- go small pilot
+- no-go, continuer shadow
+- no-go, rejeter config/mode
+- no-go, refonte stratégie
+```
+
+Le résultat attendu n’est pas “trader gros”. Le résultat attendu est :
+
+```text
+un système qui sait dire non,
+perdre peu,
+s’arrêter seul,
+et prouver ou invalider son edge avec des données.
+```


### PR DESCRIPTION
## Résumé

Cette PR documentaire ajoute les 4 fichiers de pilotage demandés pour la suite de la roadmap TradingV3 :

- `docs/roadmap/01-okx-hyperliquid-demo-testnet.md`
- `docs/roadmap/02-data-yaml-cockpit-profitability-foundation.md`
- `docs/roadmap/03-mtf-backstaging-config-mining.md`
- `docs/roadmap/04-shadow-capital-protection-live-readiness.md`

## Contenu

- Vague 1 : état OKX/Hyperliquid demo-testnet, avec les PR déjà livrées cochées jusqu’à `HL-007`.
- Vague 2 : fondations data, YAML layered resolver, cockpit opérateur et `position_trade_analysis`.
- Vague 3 : MTF Backstaging Config Mining et optimisation des configs par mode.
- Vague 4 : Shadow Production, Capital Protection, mainnet-readiness sans activation et pilot éventuel.

## Règles conservées

- Ne pas piloter par “plus de trades”.
- Prioriser moins de mauvais trades + expectancy nette positive.
- Décider via `position_trade_analysis`.
- Aucun mainnet mutatif.
- Aucun secret mainnet.
- PR atomiques, testées, traçables.

## Tests

- Non lancés : documentation uniquement.

Closes/Refs: #173