### PR TITLE
docs: align roadmap v2 with roadmap waves

### DIFF
--- a/docs/roadmap/tradingv3-roadmap-v2.md
+++ b/docs/roadmap/tradingv3-roadmap-v2.md
@@ -119,6 +119,8 @@ Document : [`02-data-yaml-cockpit-profitability-foundation.md`](./02-data-yaml-c
 
 Objectif : construire la base data/config/ops nécessaire pour décider par données.
 
+Dépendance : la vague 2 complète démarre après stabilisation suffisante de la vague 1. Avant cela, seules les tâches préparatoires sans dépendance demo/testnet peuvent être traitées, par exemple inventaires, ADR, audits de données et docs.
+
 Axes principaux :
 
 - fiabiliser `position_trade_analysis` ;
@@ -133,6 +135,8 @@ Axes principaux :
 Document : [`03-mtf-backstaging-config-mining.md`](./03-mtf-backstaging-config-mining.md)
 
 Objectif : optimiser les configs par mode via backstaging chronologique, puis valider hors période.
+
+Dépendance : ne pas lancer les PR de moteur/scoring backstaging avant que la vague 2 fournisse une base fiable : `position_trade_analysis`, coûts nets, lineage et effective config.
 
 Axes principaux :
 
@@ -149,6 +153,8 @@ Axes principaux :
 Document : [`04-shadow-capital-protection-live-readiness.md`](./04-shadow-capital-protection-live-readiness.md)
 
 Objectif : vérifier que l’edge survit aux conditions de marché réelles sans capital réel, puis préparer la gouvernance de risque.
+
+Dépendance : ne pas lancer la vague 4 avant qu’au moins une config ait un verdict exploitable après vague 3.
 
 Axes principaux :
 
@@ -191,46 +197,55 @@ Les nouvelles vagues issues de #244 peuvent ensuite donner lieu à des issues fi
 
 ## 7. Ordre de priorité recommandé
 
-### P0 — Fiabiliser l’exécution et la donnée
+Cet ordre est séquentiel. Les vagues 2 et 3 ne doivent pas contourner les gates de la vague 1. Les seules tâches autorisées en parallèle sont les tâches préparatoires sans dépendance runtime : inventaires, ADR, docs, audits et lectures read-only.
+
+### P0 — Terminer l’exécution demo/testnet sûre — Vague 1
+
+1. Inventorier les dépendances Bitmart via [#195](https://github.com/pivox/tradingV3/issues/195), sans suppression brutale.
+2. Stabiliser Fake/Paper via [#196](https://github.com/pivox/tradingV3/issues/196) pour conserver un filet de sécurité représentatif.
+3. Finaliser Hyperliquid dry-run/testnet : `HL-008` à `HL-011`.
+4. Finaliser les fixtures et recettes double exchange : `DEMO-001` à `DEMO-005`.
+5. Valider OKX en dry-run puis OKX Demo Trading contrôlé via [#197](https://github.com/pivox/tradingV3/issues/197) et la vague 1.
+6. Valider Hyperliquid en dry-run puis testnet contrôlé via [#198](https://github.com/pivox/tradingV3/issues/198) et la vague 1.
+7. Produire `DEMO-006` : rapport final demo/testnet.
+8. Garder le mainnet impossible : aucun secret mainnet, aucun fallback, aucun write non explicitement demo/testnet.
+
+### P1 — Fiabiliser la donnée et la config — Vague 2 socle
 
 1. Finaliser le lineage complet via [#189](https://github.com/pivox/tradingV3/issues/189).
 2. Fiabiliser `position_trade_analysis` et le PnL net via [#190](https://github.com/pivox/tradingV3/issues/190).
 3. Exécuter la recette runtime via [#188](https://github.com/pivox/tradingV3/issues/188).
 4. Tester reprise, replay, idempotence et rollback dans #188.
-5. Ne basculer aucun legacy avant validation de ces trois issues.
+5. Brancher l’effective config progressivement via [#133](https://github.com/pivox/tradingV3/issues/133).
+6. Ajouter le viewer via [#192](https://github.com/pivox/tradingV3/issues/192).
+7. Ne basculer aucun legacy avant validation de ces fondations.
 
-### P1 — Comprendre les pertes
+### P2 — Comprendre les pertes et produire une baseline nette
 
 1. Produire la baseline par profil dans [#132](https://github.com/pivox/tradingV3/issues/132).
 2. Classer les causes de trades perdants.
-3. Vérifier l’impact réel des frais et du slippage à partir des données certifiées de #190.
+3. Vérifier l’impact réel des frais, spread, slippage et funding à partir des données certifiées de #190.
 4. Proposer des corrections atomiques, sans tuning de fréquence prématuré.
 
-### P2 — Backtesting net et fondations profitabilité
+### P3 — Backtesting net, Front Ops et fondations profitabilité
 
 1. Construire le moteur et le modèle de coûts dans [#191](https://github.com/pivox/tradingV3/issues/191).
 2. Rejouer chaque profil séparément.
 3. Comparer expectancy, drawdown et profit factor.
-4. Préparer un forward test ou shadow test lorsque les données le permettent.
-5. Exécuter la vague 2 pour fiabiliser les métriques, YAML et cockpit.
+4. Décider la surface Front Ops canonique via [#193](https://github.com/pivox/tradingV3/issues/193).
+5. Construire la roadmap d’investigation via [#194](https://github.com/pivox/tradingV3/issues/194).
+6. Exécuter la vague 2 complète pour fiabiliser les métriques, YAML et cockpit.
 
-### P3 — Config effective, Front Ops et backstaging
+### P4 — MTF Backstaging Config Mining — Vague 3
 
-1. Brancher l’Effective Config progressivement via [#133](https://github.com/pivox/tradingV3/issues/133).
-2. Ajouter le viewer via [#192](https://github.com/pivox/tradingV3/issues/192).
-3. Décider la surface canonique via [#193](https://github.com/pivox/tradingV3/issues/193).
-4. Construire la roadmap d’investigation via [#194](https://github.com/pivox/tradingV3/issues/194).
-5. Exécuter la vague 3 MTF Backstaging Config Mining.
+1. Construire le MTF Backstaging Config Mining sans look-ahead.
+2. Optimiser `regular`.
+3. Optimiser `scalper`.
+4. Valider ou rejeter `scalper_micro`.
+5. Valider hors période / walk-forward.
+6. Exporter les YAML avec statut `candidate`, `validated`, `rejected` ou `disabled`.
 
-### P4 — Exchanges demo/testnet puis shadow/readiness
-
-1. Inventorier Bitmart via [#195](https://github.com/pivox/tradingV3/issues/195).
-2. Stabiliser Fake/Paper via [#196](https://github.com/pivox/tradingV3/issues/196).
-3. Valider OKX en dry-run puis demo trading contrôlé via [#197](https://github.com/pivox/tradingV3/issues/197) et la vague 1.
-4. Valider Hyperliquid en dry-run puis testnet contrôlé via [#198](https://github.com/pivox/tradingV3/issues/198) et la vague 1.
-5. N’envisager le mainnet qu’après runtime-check, recette, rollback, shadow et go/no-go explicite.
-
-### P5 — Shadow, capital protection et décision business
+### P5 — Shadow, capital protection et décision business — Vague 4
 
 1. Exécuter la vague 4 Shadow Production.
 2. Ajouter le capital protection layer.
@@ -264,28 +279,29 @@ Construire un moteur de trading modulaire, observable et testable, piloté par l
 
 ## État global
 
+- Vague 1 — OKX/Hyperliquid demo-testnet : **priorité immédiate**.
 - Orchestrateur Python / Temporal : **en finalisation runtime**.
-- Lineage et analytics : **à fiabiliser**.
+- Lineage et analytics : **à fiabiliser après gates demo/testnet**.
 - TradingCore : **fondations présentes, branchement incomplet**.
 - Effective Config : **resolver présent, intégration runtime à poursuivre**.
 - Front Ops : **surface canonique à décider**.
 - Analytics « bad trades first » : **priorité produit**.
 - Backtesting net : **à compléter**.
+- Backstaging MTF : **nouveau chantier config mining après vague 2**.
+- Shadow / Capital Protection : **chantier pre-live après vague 3**.
 - OKX / Hyperliquid : **demo/testnet uniquement, jamais mainnet**.
-- Backstaging MTF : **nouveau chantier config mining**.
-- Shadow / Capital Protection : **nouveau chantier pre-live**.
 - Bitmart : **legacy encore nécessaire**.
 
 ## Priorités
 
-1. Fiabilité orchestration et données.
-2. Baseline des pertes par profil.
-3. Backtesting net et coûts réels.
-4. Effective Config et Front Ops.
-5. OKX/Hyperliquid demo-testnet.
-6. MTF Backstaging Config Mining.
-7. Shadow Production et Capital Protection.
-8. Décision go/no-go business.
+1. Terminer l’exécution OKX/Hyperliquid demo-testnet sûre.
+2. Fiabiliser orchestration, données, `position_trade_analysis` et config effective.
+3. Produire la baseline nette des pertes par profil.
+4. Construire le backtesting net et les coûts réels.
+5. Industrialiser Effective Config et Front Ops.
+6. Optimiser les configs par mode via MTF Backstaging Config Mining.
+7. Passer en Shadow Production avec Capital Protection.
+8. Décider : go/no-go business, pause, refonte ou projet R&D/portfolio.
 
 ## Suivi
 
@@ -311,6 +327,7 @@ La roadmap détaillée est maintenue dans :
 
 Cette issue sera clôturée lorsque :
 
+- l’exécution demo/testnet sera sûre et rollbackable ;
 - le pipeline cible sera validé de bout en bout ;
 - les données PnL seront fiables ;
 - une baseline nette sera disponible pour les trois profils ;

--- a/docs/roadmap/tradingv3-roadmap-v2.md
+++ b/docs/roadmap/tradingv3-roadmap-v2.md
@@ -1,32 +1,39 @@
-# TradingV3 — Relecture de l’issue #173 et découpage recommandé
+# TradingV3 — Roadmap V2 parent et vagues de pilotage
 
-**Date de relecture : 22 juin 2026**  
-**Issue concernée :** [#173 — Roadmap globale TradingV3](https://github.com/pivox/tradingV3/issues/173)
+**Date de relecture initiale :** 22 juin 2026  
+**Mise à jour :** 30 juin 2026  
+**Issue parent :** [#173 — Roadmap globale TradingV3](https://github.com/pivox/tradingV3/issues/173)  
+**PR de structuration des vagues :** [#244 — docs: add TradingV3 roadmap waves](https://github.com/pivox/tradingV3/pull/244)
+
+Ce document est l’index parent de la roadmap V2.
+
+Il ne doit pas devenir une checklist exhaustive. Les critères détaillés, plans de migration, prompts de PR et décisions longues doivent vivre dans les documents de vagues, les issues filles et les PR atomiques.
+
+---
 
 ## 1. Décision
 
-L’issue #173 contient trop de sujets pour rester une checklist technique détaillée.
-
-Elle doit devenir une **issue parent de pilotage**, courte et stable, qui contient uniquement :
+L’issue #173 doit rester une **issue parent de pilotage**, courte et stable, contenant uniquement :
 
 - la vision du projet ;
 - les invariants à ne jamais casser ;
 - l’état synthétique des grands chantiers ;
 - l’ordre de priorité ;
 - les liens vers les issues filles ;
-- les critères permettant de clôturer la roadmap.
+- les liens vers les documents de roadmap ;
+- les critères permettant de clôturer ou de réorienter la roadmap.
 
-Les critères d’acceptation détaillés, plans de migration, historiques de PR et décisions d’architecture doivent vivre dans :
+Les détails doivent être répartis dans :
 
-1. des documents Markdown versionnés dans `docs/` ;
-2. des issues techniques atomiques ;
+1. les documents Markdown versionnés dans `docs/roadmap/` ;
+2. les issues techniques atomiques ;
 3. les PR qui implémentent chaque issue.
 
 ---
 
 ## 2. Cap produit à conserver
 
-TradingV3 ne doit plus être piloté par l’objectif « plus de trades ».
+TradingV3 ne doit plus être piloté par l’objectif **« plus de trades »**.
 
 La priorité est :
 
@@ -34,7 +41,7 @@ La priorité est :
 2. fiabiliser la donnée d’analyse ;
 3. obtenir une expectancy nette positive ;
 4. intégrer les frais, le spread, le slippage et le funding ;
-5. seulement ensuite ajuster la fréquence ou ouvrir de nouveaux exchanges.
+5. seulement ensuite ajuster la fréquence, ouvrir de nouveaux exchanges ou envisager une phase live contrôlée.
 
 La comparaison entre `regular`, `scalper` et `scalper_micro` doit reposer sur :
 
@@ -46,7 +53,7 @@ La comparaison entre `regular`, `scalper` et `scalper_micro` doit reposer sur :
 - le MFE et le MAE ;
 - la durée moyenne ;
 - les coûts d’exécution ;
-- un forward test suffisamment long.
+- un forward test ou shadow test suffisamment long.
 
 ---
 
@@ -55,11 +62,14 @@ La comparaison entre `regular`, `scalper` et `scalper_micro` doit reposer sur :
 - Aucune position sans stop-loss automatique immédiatement attaché.
 - Le levier est dérivé du risque, du stop et des limites de l’exchange ; il n’est jamais choisi arbitrairement.
 - Aucune bascule live sans runtime-check validé.
-- Aucune EntryZone desserrée sans preuve PnL.
+- Aucune EntryZone desserrée sans preuve PnL nette.
 - Toute PR doit rester atomique, testée et traçable.
 - Les analyses doivent partir de `position_trade_analysis`, après vérification de sa fiabilité.
-- Les résultats doivent inclure les frais, le spread et le slippage.
-- OKX et Hyperliquid restent en dry-run tant que leur branchement runtime complet n’est pas validé.
+- Les résultats doivent inclure les frais, le spread, le slippage et le funding si applicable.
+- OKX et Hyperliquid ne sont pas prêts au trading réel.
+- OKX/Hyperliquid doivent suivre la séquence : dry-run local → demo/testnet mutatif contrôlé → shadow/readiness → décision go/no-go.
+- Toute écriture mainnet reste interdite tant qu’une readiness dédiée et une décision humaine explicite ne sont pas validées.
+- Aucun secret mainnet ne doit être demandé, stocké, loggé ou documenté dans les vagues demo/testnet.
 - Bitmart ne doit pas être supprimé tant qu’une solution de remplacement n’est pas réellement opérationnelle.
 
 ---
@@ -74,86 +84,88 @@ La comparaison entre `regular`, `scalper` et `scalper_micro` doit reposer sur :
 | `position_trade_analysis` | Vue centrale pour l’analyse | Vérifier le rapprochement entrée/sortie et la définition exacte du PnL net |
 | TradingCore | Fondations présentes | Le branchement runtime complet reste à terminer |
 | Effective Config | Resolver en couches présent | Le connecter progressivement au runtime et rendre la config effective observable |
-| Front Ops | Symfony/Twig et React existent | Décider quelle surface devient canonique avant d’étendre les écrans |
+| Front Ops | Symfony/Twig et React existent | Décider la surface canonique avant d’étendre les écrans |
 | Bitmart | Provider runtime historique | Le conserver temporairement et inventorier ses dépendances |
 | Fake/Paper | Filet de sécurité | Le rendre représentatif avant les migrations exchange |
-| OKX | Adapter/dry-run | Ne pas le considérer prêt au live |
-| Hyperliquid | Adapter/dry-run | Ne pas le considérer prêt au live |
+| OKX | Intégration demo-testnet en cours | Dry-run local puis OKX Demo Trading contrôlé, jamais mainnet |
+| Hyperliquid | Intégration testnet en cours | Dry-run local puis Hyperliquid testnet contrôlé, jamais mainnet |
 | Analytics | Baseline complète non finalisée | Priorité « bad trades first » |
 | Backtesting net | À compléter | Intégrer frais, spread, slippage, funding et qualité des fills |
-
-### État de la série orchestration
-
-Lors de la dernière relecture :
-
-- les lots UI, Temporal, sécurité, audit, tests et nettoyage étaient majoritairement fusionnés ;
-- la PR [#181](https://github.com/pivox/tradingV3/pull/181) reste une référence historique, mais son périmètre incomplet est désormais repris par [#189](https://github.com/pivox/tradingV3/issues/189) et [#190](https://github.com/pivox/tradingV3/issues/190) ;
-- le lineage complet par `set_id`, profil, exchange et trade est suivi dans #189 ;
-- la fiabilité de `position_trade_analysis` et du PnL net est suivie dans #190 ;
-- la recette de bout en bout sur la stack réelle est suivie dans [#188](https://github.com/pivox/tradingV3/issues/188).
-
-L’état d’avancement doit désormais être maintenu dans les issues de suivi plutôt que dupliqué dans #173.
+| Backstaging MTF | Nouveau chantier de validation configs | Optimiser les configs par mode sans look-ahead puis valider hors période |
+| Shadow production | Nouveau chantier post-config | Tester l’edge sans capital réel avant toute décision live |
 
 ---
 
-## 5. Ce qui doit rester dans l’issue #173
+## 5. Roadmap par vagues
 
-L’issue parent doit rester limitée aux blocs suivants :
+Les 4 fichiers suivants sont les documents opérationnels de la roadmap.
 
-### Vision
+### Vague 1 — OKX / Hyperliquid demo-testnet
 
-Construire un moteur de trading modulaire, observable et testable, en séparant :
+Document : [`01-okx-hyperliquid-demo-testnet.md`](./01-okx-hyperliquid-demo-testnet.md)
 
-- stratégie ;
-- orchestration ;
-- runtime applicatif ;
-- providers exchange ;
-- analytics ;
-- backtesting ;
-- Front Ops.
+Objectif : fiabiliser OKX demo et Hyperliquid testnet sans aucune écriture mainnet.
 
-### État global
+Décision produit :
 
-Utiliser uniquement quatre statuts :
+- `dry_run=true` reste la première étape ;
+- `dry_run=false` peut être autorisé uniquement sur `environment=demo|testnet`, avec gates explicites ;
+- le mainnet reste interdit ;
+- aucun secret mainnet n’est attendu.
 
-- `À faire` ;
-- `En cours` ;
-- `Bloqué` ;
-- `Terminé`.
+### Vague 2 — Data, YAML, Cockpit & Profitability Foundation
 
-### Priorités
+Document : [`02-data-yaml-cockpit-profitability-foundation.md`](./02-data-yaml-cockpit-profitability-foundation.md)
 
-Afficher seulement les priorités P0 à P4 décrites plus bas.
+Objectif : construire la base data/config/ops nécessaire pour décider par données.
 
-### Liens
+Axes principaux :
 
-Chaque chantier doit pointer vers une issue fille et, si nécessaire, vers un document dans `docs/`.
+- fiabiliser `position_trade_analysis` ;
+- intégrer frais, spread, slippage et funding ;
+- brancher le YAML layered resolver ;
+- rendre l’effective config observable ;
+- industrialiser le cockpit opérateur ;
+- tracer le lineage run/set/mode/exchange/symbol jusqu’au trade.
+
+### Vague 3 — MTF Backstaging Config Mining
+
+Document : [`03-mtf-backstaging-config-mining.md`](./03-mtf-backstaging-config-mining.md)
+
+Objectif : optimiser les configs par mode via backstaging chronologique, puis valider hors période.
+
+Axes principaux :
+
+- backstaging sans look-ahead ;
+- stockage des no-trades et des échecs ;
+- optimisation séparée de `regular`, `scalper`, `scalper_micro` ;
+- scoring net avec MFE, MAE, `pnl_R`, frais, spread et slippage ;
+- market regime classifier ;
+- walk-forward / out-of-sample validation ;
+- export YAML candidate/validated/rejected.
+
+### Vague 4 — Shadow, Capital Protection & Live-readiness
+
+Document : [`04-shadow-capital-protection-live-readiness.md`](./04-shadow-capital-protection-live-readiness.md)
+
+Objectif : vérifier que l’edge survit aux conditions de marché réelles sans capital réel, puis préparer la gouvernance de risque.
+
+Axes principaux :
+
+- shadow production ;
+- fills réalistes ;
+- spread/slippage réels ou pessimistes ;
+- capital protection layer ;
+- mainnet-readiness sans activation mainnet ;
+- go/no-go pilot contrôlé éventuel ;
+- production risk governance ;
+- scaling contrôlé uniquement si l’edge est prouvé.
 
 ---
 
-## 6. Ce qui doit sortir de l’issue #173
+## 6. Issues de suivi créées ou réutilisées
 
-Les éléments suivants rendent l’issue illisible et doivent être déplacés :
-
-- l’historique complet des PR ;
-- les détails fichier par fichier ;
-- les payloads JSON complets ;
-- les scénarios détaillés de tests ;
-- les plans de migration exchange ;
-- les spécifications complètes des écrans ;
-- les détails des couches YAML ;
-- les règles complètes de backtesting ;
-- les longues checklists runtime ;
-- les décisions React contre Symfony/Twig ;
-- les investigations sur les trades perdants.
-
----
-
-## 7. Issues de suivi créées ou réutilisées
-
-Les lots ci-dessous possèdent désormais une issue GitHub dédiée. Les issues existantes #132 et #133 sont réutilisées afin d’éviter les doublons.
-
-| Domaine | Issue | Statut de création |
+| Domaine | Issue | Statut |
 |---|---|---|
 | Recette runtime orchestrateur | [#188 — TV3-ORCH-001](https://github.com/pivox/tradingV3/issues/188) | Créée |
 | Lineage run → set → trade | [#189 — TV3-DATA-001](https://github.com/pivox/tradingV3/issues/189) | Créée |
@@ -166,203 +178,18 @@ Les lots ci-dessous possèdent désormais une issue GitHub dédiée. Les issues 
 | Roadmap Front Ops investigation | [#194 — TV3-FRONT-002](https://github.com/pivox/tradingV3/issues/194) | Créée |
 | Inventaire Bitmart | [#195 — TV3-EXCHANGE-001](https://github.com/pivox/tradingV3/issues/195) | Créée |
 | Readiness Fake/Paper | [#196 — TV3-EXCHANGE-002](https://github.com/pivox/tradingV3/issues/196) | Créée |
-| Readiness OKX dry-run | [#197 — TV3-EXCHANGE-003](https://github.com/pivox/tradingV3/issues/197) | Créée |
-| Readiness Hyperliquid dry-run | [#198 — TV3-EXCHANGE-004](https://github.com/pivox/tradingV3/issues/198) | Créée |
+| Readiness OKX dry-run/demo | [#197 — TV3-EXCHANGE-003](https://github.com/pivox/tradingV3/issues/197) | Créée |
+| Readiness Hyperliquid dry-run/testnet | [#198 — TV3-EXCHANGE-004](https://github.com/pivox/tradingV3/issues/198) | Créée |
 
-### Orchestration et observabilité
+Les nouvelles vagues issues de #244 peuvent ensuite donner lieu à des issues filles supplémentaires, notamment pour :
 
-#### [#188 — TV3-ORCH-001 : Recette runtime de l’orchestrateur Python](https://github.com/pivox/tradingV3/issues/188)
-
-Objectif : valider l’orchestrateur sur la stack réelle.
-
-Critères principaux :
-
-- migrations appliquées ;
-- dashboards et sets réels ;
-- appels dry-run vers Symfony ;
-- parallélisme borné ;
-- reprise après crash ;
-- redémarrage de container ;
-- replay ;
-- audit ;
-- métriques ;
-- rollback testé ;
-- vérification dans Temporal UI.
-
-#### [#189 — TV3-DATA-001 : Lineage complet run, set et trade](https://github.com/pivox/tradingV3/issues/189)
-
-Propager et persister :
-
-- `run_id` ;
-- `dashboard_id` ;
-- `set_id` ;
-- `mtf_profile` ;
-- `exchange` ;
-- `market_type` ;
-- `symbol` ;
-- identifiant du trade ou de la position.
-
-#### [#190 — TV3-DATA-002 : Fiabiliser `position_trade_analysis`](https://github.com/pivox/tradingV3/issues/190)
-
-Vérifier notamment :
-
-- le rapprochement entrée/clôture par `trade_id` ou `position_id` ;
-- l’absence de doublons ;
-- la cohérence des événements partiels ;
-- la définition contractuelle de `pnl_usdt` ;
-- la présence des frais, du spread, du slippage et du funding.
-
-### Analytics et stratégie
-
-#### [#132 — Baseline « bad trades first »](https://github.com/pivox/tradingV3/issues/132)
-
-Produire une baseline séparée pour :
-
-- `regular` ;
-- `scalper` ;
-- `scalper_micro`.
-
-Mesurer au minimum :
-
-- winrate ;
-- expectancy nette ;
-- profit factor ;
-- max drawdown ;
-- `pnl_R` ;
-- MFE/MAE ;
-- durée ;
-- coûts ;
-- causes récurrentes de pertes.
-
-#### [#191 — TV3-BACKTEST-001 : Backtesting net réaliste](https://github.com/pivox/tradingV3/issues/191)
-
-Inclure :
-
-- frais maker/taker ;
-- spread ;
-- slippage ;
-- funding ;
-- partial fills ;
-- rejet d’ordre ;
-- fallback maker/taker ;
-- time-stop ;
-- TP/SL ;
-- liquidation guard.
-
-Aucun résultat de backtest ne doit être inventé ou extrapolé sans données.
-
-### Effective Config
-
-#### [#133 — Effective Config en couches et branchement runtime](https://github.com/pivox/tradingV3/issues/133)
-
-Architecture cible :
-
-```text
-base
-+ mode
-+ exchange
-+ mode_exchange
-+ env
-= effective config
-```
-
-Le branchement doit être progressif, avec possibilité de comparer ancien et nouveau comportement.
-
-#### [#192 — TV3-CONFIG-002 : Effective Config Viewer](https://github.com/pivox/tradingV3/issues/192)
-
-Afficher :
-
-- les couches chargées ;
-- les valeurs surchargées ;
-- la provenance de chaque valeur ;
-- la config finale utilisée ;
-- les écarts avec la config attendue ;
-- le lien avec le run et le trade.
-
-### Front Ops
-
-#### [#193 — TV3-FRONT-001 : Décider la surface Front Ops canonique](https://github.com/pivox/tradingV3/issues/193)
-
-Décider explicitement entre :
-
-- Symfony/Twig comme front principal ;
-- React comme front principal ;
-- migration progressive ;
-- répartition fonctionnelle clairement définie.
-
-Aucun gros chantier d’écran ne doit démarrer avant cette décision.
-
-#### [#194 — TV3-FRONT-002 : Roadmap Front Ops orientée investigation](https://github.com/pivox/tradingV3/issues/194)
-
-Prioriser les parcours permettant de comprendre :
-
-- pourquoi un run a échoué ;
-- pourquoi un symbole a été ignoré ;
-- pourquoi un trade a été ouvert ;
-- pourquoi il a perdu ;
-- quelle config effective a été utilisée ;
-- quels coûts ont dégradé le résultat.
-
-### Exchanges
-
-#### [#195 — TV3-EXCHANGE-001 : Inventaire Bitmart](https://github.com/pivox/tradingV3/issues/195)
-
-Inventorier :
-
-- services ;
-- providers ;
-- commandes ;
-- workflows ;
-- paramètres ;
-- credentials ;
-- tests ;
-- comportements spécifiques ;
-- dépendances cachées.
-
-#### [#196 — TV3-EXCHANGE-002 : Readiness Fake/Paper](https://github.com/pivox/tradingV3/issues/196)
-
-Vérifier que Fake/Paper représente suffisamment :
-
-- les statuts d’ordre ;
-- les partial fills ;
-- les erreurs ;
-- les timeouts ;
-- les frais ;
-- le slippage ;
-- les positions ;
-- les SL/TP.
-
-#### [#197 — TV3-EXCHANGE-003 : Readiness OKX dry-run](https://github.com/pivox/tradingV3/issues/197)
-
-Le lot doit couvrir :
-
-- provider bundle ;
-- signature ;
-- permissions ;
-- précision ;
-- rate limits ;
-- runtime-check ;
-- dry-run de bout en bout ;
-- tests d’intégration ;
-- rollback.
-
-#### [#198 — TV3-EXCHANGE-004 : Readiness Hyperliquid dry-run](https://github.com/pivox/tradingV3/issues/198)
-
-Le lot doit couvrir :
-
-- wallet et signature ;
-- environnement d’exécution ;
-- précision ;
-- limites ;
-- risk guards ;
-- runtime-check ;
-- dry-run de bout en bout ;
-- tests d’intégration ;
-- rollback.
+- Vague 2 : `position_trade_analysis`, YAML layered resolver, cockpit opérateur ;
+- Vague 3 : MTF Backstaging Config Mining et optimisation par mode ;
+- Vague 4 : Shadow Production, Capital Protection et Live-readiness.
 
 ---
 
-## 8. Ordre de priorité recommandé
+## 7. Ordre de priorité recommandé
 
 ### P0 — Fiabiliser l’exécution et la donnée
 
@@ -379,31 +206,41 @@ Le lot doit couvrir :
 3. Vérifier l’impact réel des frais et du slippage à partir des données certifiées de #190.
 4. Proposer des corrections atomiques, sans tuning de fréquence prématuré.
 
-### P2 — Backtesting net
+### P2 — Backtesting net et fondations profitabilité
 
 1. Construire le moteur et le modèle de coûts dans [#191](https://github.com/pivox/tradingV3/issues/191).
 2. Rejouer chaque profil séparément.
 3. Comparer expectancy, drawdown et profit factor.
-4. Préparer un forward test d’au moins 500 trades lorsque les données le permettent.
+4. Préparer un forward test ou shadow test lorsque les données le permettent.
+5. Exécuter la vague 2 pour fiabiliser les métriques, YAML et cockpit.
 
-### P3 — Config effective et Front Ops
+### P3 — Config effective, Front Ops et backstaging
 
 1. Brancher l’Effective Config progressivement via [#133](https://github.com/pivox/tradingV3/issues/133).
 2. Ajouter le viewer via [#192](https://github.com/pivox/tradingV3/issues/192).
 3. Décider la surface canonique via [#193](https://github.com/pivox/tradingV3/issues/193).
 4. Construire la roadmap d’investigation via [#194](https://github.com/pivox/tradingV3/issues/194).
+5. Exécuter la vague 3 MTF Backstaging Config Mining.
 
-### P4 — Nouveaux exchanges
+### P4 — Exchanges demo/testnet puis shadow/readiness
 
 1. Inventorier Bitmart via [#195](https://github.com/pivox/tradingV3/issues/195).
 2. Stabiliser Fake/Paper via [#196](https://github.com/pivox/tradingV3/issues/196).
-3. Valider OKX en dry-run via [#197](https://github.com/pivox/tradingV3/issues/197).
-4. Valider Hyperliquid en dry-run via [#198](https://github.com/pivox/tradingV3/issues/198).
-5. N’envisager le live qu’après runtime-check, recette et rollback validés.
+3. Valider OKX en dry-run puis demo trading contrôlé via [#197](https://github.com/pivox/tradingV3/issues/197) et la vague 1.
+4. Valider Hyperliquid en dry-run puis testnet contrôlé via [#198](https://github.com/pivox/tradingV3/issues/198) et la vague 1.
+5. N’envisager le mainnet qu’après runtime-check, recette, rollback, shadow et go/no-go explicite.
+
+### P5 — Shadow, capital protection et décision business
+
+1. Exécuter la vague 4 Shadow Production.
+2. Ajouter le capital protection layer.
+3. Préparer la mainnet-readiness sans activation.
+4. Produire un go/no-go pilot contrôlé.
+5. Décider : source rentable, pause, refonte, ou projet R&D/portfolio.
 
 ---
 
-## 9. Corps court proposé pour l’issue #173
+## 8. Corps court proposé pour l’issue #173
 
 Le contenu suivant peut remplacer le corps trop détaillé de l’issue parent.
 
@@ -420,9 +257,10 @@ Construire un moteur de trading modulaire, observable et testable, piloté par l
 - Le levier est dérivé du risque et du stop.
 - Aucune activation live sans runtime-check.
 - Aucune EntryZone desserrée sans preuve PnL.
-- Les résultats incluent frais, spread et slippage.
+- Les résultats incluent frais, spread, slippage et funding si applicable.
 - Bitmart reste en place tant qu’un remplacement opérationnel n’est pas validé.
-- OKX et Hyperliquid restent en dry-run avant readiness complète.
+- OKX et Hyperliquid suivent : dry-run local → demo/testnet mutatif contrôlé → shadow/readiness → go/no-go.
+- Aucune écriture mainnet sans décision humaine explicite.
 
 ## État global
 
@@ -433,16 +271,21 @@ Construire un moteur de trading modulaire, observable et testable, piloté par l
 - Front Ops : **surface canonique à décider**.
 - Analytics « bad trades first » : **priorité produit**.
 - Backtesting net : **à compléter**.
-- OKX / Hyperliquid : **dry-run uniquement**.
+- OKX / Hyperliquid : **demo/testnet uniquement, jamais mainnet**.
+- Backstaging MTF : **nouveau chantier config mining**.
+- Shadow / Capital Protection : **nouveau chantier pre-live**.
 - Bitmart : **legacy encore nécessaire**.
 
 ## Priorités
 
 1. Fiabilité orchestration et données.
 2. Baseline des pertes par profil.
-3. Backtesting net.
+3. Backtesting net et coûts réels.
 4. Effective Config et Front Ops.
-5. Readiness des nouveaux exchanges.
+5. OKX/Hyperliquid demo-testnet.
+6. MTF Backstaging Config Mining.
+7. Shadow Production et Capital Protection.
+8. Décision go/no-go business.
 
 ## Suivi
 
@@ -458,7 +301,11 @@ Les critères détaillés sont suivis dans :
 
 La roadmap détaillée est maintenue dans :
 
-`docs/roadmap/tradingv3-roadmap-v2.md`
+- `docs/roadmap/tradingv3-roadmap-v2.md` ;
+- `docs/roadmap/01-okx-hyperliquid-demo-testnet.md` ;
+- `docs/roadmap/02-data-yaml-cockpit-profitability-foundation.md` ;
+- `docs/roadmap/03-mtf-backstaging-config-mining.md` ;
+- `docs/roadmap/04-shadow-capital-protection-live-readiness.md`.
 
 ## Critère de clôture
 
@@ -470,17 +317,27 @@ Cette issue sera clôturée lorsque :
 - le backtesting net sera opérationnel ;
 - la config effective sera observable ;
 - la stratégie Front Ops sera tranchée ;
-- au moins un chemin exchange cible sera validé hors live puis en live contrôlé.
+- OKX/Hyperliquid seront validés hors mainnet ;
+- au moins une config par mode aura un verdict : validated, candidate, rejected ou disabled ;
+- une décision go/no-go sera possible sur shadow/pilot contrôlé.
 ```
 
 ---
 
-## 10. Sources projet et suivi
+## 9. Sources projet et suivi
 
 ### Pilotage
 
 - [Issue #173](https://github.com/pivox/tradingV3/issues/173)
 - [PR #187 — Documentation roadmap V2](https://github.com/pivox/tradingV3/pull/187)
+- [PR #244 — Roadmap waves](https://github.com/pivox/tradingV3/pull/244)
+
+### Documents de vagues
+
+- [`01-okx-hyperliquid-demo-testnet.md`](./01-okx-hyperliquid-demo-testnet.md)
+- [`02-data-yaml-cockpit-profitability-foundation.md`](./02-data-yaml-cockpit-profitability-foundation.md)
+- [`03-mtf-backstaging-config-mining.md`](./03-mtf-backstaging-config-mining.md)
+- [`04-shadow-capital-protection-live-readiness.md`](./04-shadow-capital-protection-live-readiness.md)
 
 ### Issues de suivi
 
@@ -495,12 +352,11 @@ Cette issue sera clôturée lorsque :
 - [#194 — Roadmap Front Ops investigation](https://github.com/pivox/tradingV3/issues/194)
 - [#195 — Inventaire Bitmart](https://github.com/pivox/tradingV3/issues/195)
 - [#196 — Readiness Fake/Paper](https://github.com/pivox/tradingV3/issues/196)
-- [#197 — Readiness OKX dry-run](https://github.com/pivox/tradingV3/issues/197)
-- [#198 — Readiness Hyperliquid dry-run](https://github.com/pivox/tradingV3/issues/198)
+- [#197 — Readiness OKX dry-run/demo](https://github.com/pivox/tradingV3/issues/197)
+- [#198 — Readiness Hyperliquid dry-run/testnet](https://github.com/pivox/tradingV3/issues/198)
 
 ### PR et documents historiques
 
-- [Issue #173](https://github.com/pivox/tradingV3/issues/173)
 - [PR #141 — Architecture TradingCore](https://github.com/pivox/tradingV3/pull/141)
 - [PR #142 — Effective Config Resolver](https://github.com/pivox/tradingV3/pull/142)
 - [PR #155 — Orchestrateur Python / Temporal](https://github.com/pivox/tradingV3/pull/155)
@@ -509,9 +365,11 @@ Cette issue sera clôturée lorsque :
 - [PR #172 — Lecture du payload effectif](https://github.com/pivox/tradingV3/pull/172)
 - [PR #181 — Corrélation outcome/PnL](https://github.com/pivox/tradingV3/pull/181)
 
-## Conclusion
+---
 
-L’issue #173 doit devenir un **index de pilotage**, pas une documentation exhaustive.
+## 10. Conclusion
+
+L’issue #173 doit rester un **index de pilotage**, pas une documentation exhaustive.
 
 La structure cible est :
 
@@ -519,12 +377,23 @@ La structure cible est :
 Issue parent #173
     -> vision, invariants, état global et priorités
 
-Documents dans docs/
-    -> décisions et descriptions durables
+Documents dans docs/roadmap/
+    -> décisions durables, vagues et plans de PR
 
 Issues de suivi #132, #133 et #188 à #198
-    -> critères d’acceptation détaillés et découpage PR atomique
+    -> critères d’acceptation détaillés et découpage atomique
 
 PR
-    -> implémentation et tests
+    -> implémentation, tests, documentation et rollback
+```
+
+Le cap final reste :
+
+```text
+moins de mauvais trades
++ expectancy nette positive
++ sécurité d’exécution
++ preuve par position_trade_analysis
++ validation config par mode
++ shadow avant capital réel
 ```


### PR DESCRIPTION
## Résumé

Cette PR aligne `docs/roadmap/tradingv3-roadmap-v2.md` avec les 4 vagues ajoutées par #244.

## Changements

- Transforme `tradingv3-roadmap-v2.md` en index parent de pilotage.
- Ajoute les liens vers :
  - `01-okx-hyperliquid-demo-testnet.md`
  - `02-data-yaml-cockpit-profitability-foundation.md`
  - `03-mtf-backstaging-config-mining.md`
  - `04-shadow-capital-protection-live-readiness.md`
- Corrige la formulation OKX/Hyperliquid :
  - dry-run local d’abord ;
  - demo/testnet mutatif contrôlé ensuite ;
  - mainnet toujours interdit ;
  - aucun secret mainnet.
- Ajoute les nouvelles priorités : backstaging MTF, shadow production, capital protection et décision go/no-go.
- Garde #173 comme issue parent/index, pas comme checklist exhaustive.

## Tests

- Non lancés : documentation uniquement.

Refs: #173, #244