### PR TITLE
HL-011 Hyperliquid orchestrator dry-run recipe

### DIFF
--- a/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
+++ b/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
@@ -62,6 +62,7 @@ Fixtures versionnees :
 - `python-orchestrator/fixtures/runtime-recipe/r1_r16_nominal_fake_dashboard.json`
 - `python-orchestrator/fixtures/runtime-recipe/r1_r16_degraded_fake_dashboard.json`
 - `python-orchestrator/fixtures/runtime-recipe/r1_r16_okx_dry_run_dashboard.json`
+- `python-orchestrator/fixtures/runtime-recipe/r1_r16_hyperliquid_dry_run_dashboard.json`
 
 Les fixtures Fake/Paper utilisent uniquement :
 
@@ -89,6 +90,25 @@ Si la sortie ne contient pas `Schedule ready: yes`, les scenarios OKX sont
 exportes en `BLOCKED` et aucun appel `/orchestrator/run` n'est envoye pour
 R1/R2/R14. Les autres scenarios restent sur les fixtures Fake/Paper et peuvent
 continuer a produire leur preuve baseline.
+
+La fixture Hyperliquid est limitee a la recette dry-run :
+
+- `exchange=hyperliquid` ;
+- `market_type=perpetual` ;
+- `environment=testnet` ;
+- `dry_run=true` ;
+- `workers=1` ;
+- symboles internes allow-listes `BTCUSDT` ;
+- profils `regular` et `scalper_micro`.
+
+Elle ne cree aucun set Bitmart et ne doit jamais servir a `dry_run=false`.
+Avant d'executer R1/R2/R14 avec `--target-exchange hyperliquid`, le runner
+lance `docker compose exec -T trading-app-php php bin/console app:exchange:runtime-check hyperliquid perpetual`.
+Si la sortie ne contient pas `Schedule ready: yes`, les scenarios Hyperliquid
+sont exportes en `BLOCKED` et aucun appel `/orchestrator/run` n'est envoye pour
+R1/R2/R14. Le probe R14 cree uniquement un set desactive `dry_run=false` pour
+verifier le refus de persistance avant dispatch ; aucun broadcast exchange n'est
+possible dans ce runner.
 
 Application idempotente attendue :
 
@@ -228,6 +248,30 @@ Preuves attendues dans `runtime-recipe-report.json` :
 - `metadata.runtime_check.status=PASS` et `schedule_ready=yes` ;
 - dashboard `recipe-r1-r16-okx-dry-run` applique ;
 - sets `recipe_okx_regular` et `recipe_okx_scalper_micro` dispatches en R2 ;
+- aucun set ou payload `exchange=bitmart` ;
+- R14 refuse le probe `dry_run=false` avant dispatch.
+
+Pour exercer Hyperliquid en dry-run uniquement sur R1, R2 et R14 :
+
+```bash
+cd python-orchestrator
+python scripts/runtime_recipe_runner.py \
+  --orchestrator-url http://localhost:8099 \
+  --confirm DRY_RUN_ONLY \
+  --target-exchange hyperliquid \
+  --scenario R1 \
+  --scenario R2 \
+  --scenario R14 \
+  --export-dir var/runtime-recipe/hyperliquid-dry-run \
+  --keep-fixtures
+```
+
+Preuves attendues dans `runtime-recipe-report.json` :
+
+- `metadata.target_exchange=hyperliquid` ;
+- `metadata.runtime_check.status=PASS` et `schedule_ready=yes` ;
+- dashboard `recipe-r1-r16-hyperliquid-dry-run` applique ;
+- sets `recipe_hyperliquid_regular` et `recipe_hyperliquid_scalper_micro` dispatches en R2 ;
 - aucun set ou payload `exchange=bitmart` ;
 - R14 refuse le probe `dry_run=false` avant dispatch.
 

--- a/docs/handbook/technical/hyperliquid-dry-run.md
+++ b/docs/handbook/technical/hyperliquid-dry-run.md
@@ -132,12 +132,48 @@ Rollback HL-010 : remettre `HYPERLIQUID_TESTNET_TRADING_ENABLED=0` et/ou revert 
 runtime-check Hyperliquid. Le port dry-run local reste no-broadcast et les schedules Hyperliquid
 restent `dry_run=true`.
 
-## Hors-scope PR12
+## Recette orchestrateur Hyperliquid dry-run
+
+HL-011 ajoute une fixture orchestrateur reproductible :
+
+```text
+python-orchestrator/fixtures/runtime-recipe/r1_r16_hyperliquid_dry_run_dashboard.json
+```
+
+Elle cible uniquement `exchange=hyperliquid`, `market_type=perpetual`,
+`environment=testnet`, `dry_run=true`, `workers=1` et les scenarios `R1`, `R2`,
+`R14`. Le runner `python-orchestrator/scripts/runtime_recipe_runner.py` execute
+d'abord `app:exchange:runtime-check hyperliquid perpetual` via Docker Compose. Si
+la sortie ne contient pas `Schedule ready: yes`, les scenarios Hyperliquid sont
+exportes en `BLOCKED` et aucun appel `/orchestrator/run` n'est envoye pour ces
+scenarios.
+
+Commande de recette :
+
+```bash
+cd python-orchestrator
+python3 scripts/runtime_recipe_runner.py \
+  --orchestrator-url http://localhost:8099 \
+  --confirm DRY_RUN_ONLY \
+  --target-exchange hyperliquid \
+  --scenario R1 \
+  --scenario R2 \
+  --scenario R14 \
+  --export-dir var/runtime-recipe/hyperliquid-dry-run \
+  --keep-fixtures
+```
+
+Preuves attendues : dashboard `recipe-r1-r16-hyperliquid-dry-run`, sets
+`recipe_hyperliquid_regular` et `recipe_hyperliquid_scalper_micro`, aucun set ou
+payload Bitmart, et refus R14 du probe `dry_run=false` avant dispatch. Cette
+recette ne change pas les strategies et ne diffuse aucun ordre.
+
+## Hors-scope activation live
 
 - aucune activation live Hyperliquid, aucun mainnet trading (PR de readiness live dédiée requise) ;
 - aucun signing réel, aucun appel HTTP, aucun broadcast `/exchange` ;
-- **aucun bundle provider Hyperliquid runtime MTF activé** : `mtf:run`, `POST /api/mtf/run` et le
-  Temporal scheduler ne sont pas branchés sur Hyperliquid par cette PR ;
+- aucune activation Temporal live Hyperliquid ; la recette orchestrateur HL-011 reste
+  `dry_run=true` et fail-closed avant tout dispatch si le runtime-check n'est pas schedule-ready ;
 - aucun branchement `TradeEntry` runtime ;
 - aucun changement de stratégie (`regular` / `scalper` / `scalper_micro`), EntryZone,
   Risk / Leverage / SL-TP ni YAML ;

--- a/docs/roadmap/01-okx-hyperliquid-demo-testnet.md
+++ b/docs/roadmap/01-okx-hyperliquid-demo-testnet.md
@@ -37,7 +37,7 @@ Cette vague remplace la logique “dry-run uniquement” par une cible plus pré
 - [x] OKX-005 — Metadata / precision / fees / funding OKX — #231 / `5d7f399`.
 - [x] OKX-006 — Normalizers lifecycle OKX — #232 / `bf8c1fb`.
 - [x] OKX-007 — Local dry-run write serialization OKX — #233 / `18ef164`.
-- [x] OKX-008 — Runtime-check demo/testnet candidate OKX — #234 / `4e5919c`.
+- [x] OKX-008 — Runtime-check demo/testnet candidate OKX — #234 / `8444f7b`.
 - [x] OKX-009 — Orchestrator dry-run recipe OKX — #235 / `c103c1b`.
 - [x] HL-001 — Capability matrix + ADR Hyperliquid testnet — #236 / `5724aab`.
 - [x] HL-002 — Provider bundle skeleton Hyperliquid — #237 / `ac8e1d2`.
@@ -46,12 +46,12 @@ Cette vague remplace la logique “dry-run uniquement” par une cible plus pré
 - [x] HL-005 — Nonce manager Hyperliquid persistant — #240 / `932d686`.
 - [x] HL-006 — Account read-only Hyperliquid — #241 / `7bfad8f`.
 - [x] HL-007 — Metadata / precision / fees / funding Hyperliquid — #242 / `b0ce547`.
+- [x] HL-008 — Order/fill/position normalizers Hyperliquid — #243 / `8d75cf5`.
+- [x] HL-009 — Local dry-run no broadcast Hyperliquid — #245 / `d595d4d`.
+- [x] HL-010 — Runtime-check `demo_testnet_candidate` Hyperliquid — #248 / `8e1650f`.
 
 ## Restant vague 1
 
-- [ ] HL-008 — Order/fill/position normalizers Hyperliquid.
-- [ ] HL-009 — Local dry-run no broadcast Hyperliquid.
-- [ ] HL-010 — Runtime-check `demo_testnet_candidate` Hyperliquid.
 - [ ] HL-011 — Orchestrator dry-run recipe Hyperliquid.
 - [ ] DEMO-001 — Fixtures demo OKX + Hyperliquid.
 - [ ] DEMO-002 — Recette R1-R16 double exchange en dry-run.
@@ -65,9 +65,6 @@ Cette vague remplace la logique “dry-run uniquement” par une cible plus pré
 ## Ordre strict recommandé
 
 ```text
-HL-008
-HL-009
-HL-010
 HL-011
 
 DEMO-001

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -350,6 +350,14 @@ Par defaut, il cible les scenarios critiques `R1`, `R2`, `R5`, `R6`, `R8`,
 schedule reel : les scenarios qui exigent une panne/crash/Temporal reel sont
 marques `BLOCKED` si la condition n'est pas observable depuis le runner.
 
+Pour cibler les recettes exchange dry-run sur `R1`, `R2` et `R14`, utiliser
+`--target-exchange okx` ou `--target-exchange hyperliquid`. Le runner execute
+d'abord `app:exchange:runtime-check <exchange> perpetual` dans le conteneur
+Symfony ; si `Schedule ready: yes` n'est pas observe, les scenarios cibles sont
+exportes en `BLOCKED` et aucun appel `/orchestrator/run` n'est envoye pour ces
+scenarios. Les fixtures exchange restent `dry_run=true`, n'envoient aucun champ
+`payload` et ne creent aucun set Bitmart.
+
 Commandes de verification locale :
 
 ```bash

--- a/python-orchestrator/fixtures/runtime-recipe/r1_r16_hyperliquid_dry_run_dashboard.json
+++ b/python-orchestrator/fixtures/runtime-recipe/r1_r16_hyperliquid_dry_run_dashboard.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://pivox.local/schemas/orchestrator-runtime-recipe-fixture-v1.json",
+  "fixture_id": "runtime-recipe-r1-r16-hyperliquid-dry-run-v1",
+  "version": 1,
+  "dry_run_only": true,
+  "purpose": "Dashboard Hyperliquid dry-run pour exercer R1, R2 et R14 via l'orchestrateur sans broadcast exchange.",
+  "dashboard": {
+    "name": "recipe-r1-r16-hyperliquid-dry-run",
+    "enabled": true,
+    "description": "Recette runtime Hyperliquid local dry-run - lecture/provider Hyperliquid et serialization locale, sans broadcast exchange."
+  },
+  "sets": [
+    {
+      "set_id": "recipe_hyperliquid_regular",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "hyperliquid",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "testnet",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 30,
+      "recipe_role": "r1_single_set_hyperliquid"
+    },
+    {
+      "set_id": "recipe_hyperliquid_scalper_micro",
+      "enabled": true,
+      "action": "mtf_run",
+      "exchange": "hyperliquid",
+      "market_type": "perpetual",
+      "mtf_profile": "scalper_micro",
+      "environment": "testnet",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 10,
+      "recipe_role": "r2_multi_set_hyperliquid_scalper_micro"
+    },
+    {
+      "set_id": "recipe_hyperliquid_disabled",
+      "enabled": false,
+      "action": "mtf_run",
+      "exchange": "hyperliquid",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "testnet",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 99,
+      "recipe_role": "r3_disabled_set_hyperliquid"
+    }
+  ],
+  "scenario_mapping": {
+    "R1": ["recipe_hyperliquid_regular"],
+    "R2": ["recipe_hyperliquid_regular", "recipe_hyperliquid_scalper_micro"],
+    "R3": ["recipe_hyperliquid_disabled"],
+    "R14": ["recipe_hyperliquid_regular"]
+  },
+  "expected_invariants": {
+    "dry_run": true,
+    "mainnet": false,
+    "workers_per_set": 1,
+    "fixture_application": "upsert_by_dashboard_name_and_set_id",
+    "no_bitmart_fallback": true,
+    "no_broadcast": true
+  }
+}

--- a/python-orchestrator/scripts/runtime_recipe_runner.py
+++ b/python-orchestrator/scripts/runtime_recipe_runner.py
@@ -55,7 +55,7 @@ SECRET_KEY_RE = re.compile(
     re.IGNORECASE,
 )
 
-OKX_RUNTIME_CHECK_COMMAND = (
+RUNTIME_CHECK_COMMAND_PREFIX = (
     "docker",
     "compose",
     "exec",
@@ -64,9 +64,12 @@ OKX_RUNTIME_CHECK_COMMAND = (
     "php",
     "bin/console",
     "app:exchange:runtime-check",
-    "okx",
-    "perpetual",
 )
+
+TARGET_FIXTURE_FILES = {
+    "okx": "r1_r16_okx_dry_run_dashboard.json",
+    "hyperliquid": "r1_r16_hyperliquid_dry_run_dashboard.json",
+}
 
 
 class RecipeHttpClient(Protocol):
@@ -140,7 +143,7 @@ class RecipeRunner:
 
         if service_ok:
             dashboards = self._apply_all_fixtures(
-                include_target=self.config.target_exchange.strip().lower() != "okx"
+                include_target=not self._target_requires_preflight()
                 or preflight["status"] == "PASS"
             )
             for scenario in selected:
@@ -196,12 +199,12 @@ class RecipeRunner:
         target = self.config.target_exchange.strip().lower()
         if target == "fake":
             return {"status": "PASS", "notes": "runtime-check not required for Fake/Paper dry-run"}
-        if target != "okx":
+        if target not in TARGET_FIXTURE_FILES:
             return {
                 "status": "BLOCKED",
                 "notes": f"unsupported runtime recipe target_exchange: {self.config.target_exchange}",
             }
-        command = OKX_RUNTIME_CHECK_COMMAND
+        command = (*RUNTIME_CHECK_COMMAND_PREFIX, target, "perpetual")
         try:
             completed = subprocess.run(
                 command,
@@ -214,7 +217,7 @@ class RecipeRunner:
         except (OSError, subprocess.TimeoutExpired) as exc:
             return {
                 "status": "BLOCKED",
-                "notes": "OKX runtime-check did not complete",
+                "notes": f"{target} runtime-check did not complete",
                 "command": list(command),
                 "error_type": exc.__class__.__name__,
                 "error": str(exc),
@@ -224,14 +227,14 @@ class RecipeRunner:
         if completed.returncode == 0 and schedule_ready == "yes":
             return {
                 "status": "PASS",
-                "notes": "OKX runtime-check schedule ready",
+                "notes": f"{target} runtime-check schedule ready",
                 "command": list(command),
                 "readiness_level": parsed.get("readiness_level"),
                 "schedule_ready": schedule_ready,
             }
         return {
             "status": "BLOCKED",
-            "notes": "OKX runtime-check is not schedule ready",
+            "notes": f"{target} runtime-check is not schedule ready",
             "command": list(command),
             "returncode": completed.returncode,
             "readiness_level": parsed.get("readiness_level"),
@@ -254,29 +257,37 @@ class RecipeRunner:
         nominal = self._read_fixture("r1_r16_nominal_fake_dashboard.json")
         degraded = self._read_fixture("r1_r16_degraded_fake_dashboard.json")
         fixtures = {"nominal": nominal, "degraded": degraded}
-        if self.config.target_exchange.strip().lower() != "okx":
+        target = self.config.target_exchange.strip().lower()
+        if target == "fake":
             return fixtures
-        okx_path = self.config.fixtures_dir / "r1_r16_okx_dry_run_dashboard.json"
-        if not okx_path.exists():
-            raise FileNotFoundError(f"missing OKX runtime recipe fixture: {okx_path}")
-        fixtures["okx"] = json.loads(okx_path.read_text(encoding="utf-8"))
+        fixture_file = TARGET_FIXTURE_FILES.get(target)
+        if fixture_file is None:
+            return fixtures
+        target_path = self.config.fixtures_dir / fixture_file
+        if not target_path.exists():
+            raise FileNotFoundError(f"missing {target} runtime recipe fixture: {target_path}")
+        fixtures[target] = json.loads(target_path.read_text(encoding="utf-8"))
         return fixtures
 
     def _read_fixture(self, filename: str) -> dict[str, Any]:
         return json.loads((self.config.fixtures_dir / filename).read_text(encoding="utf-8"))
 
     def _apply_all_fixtures(self, *, include_target: bool = True) -> dict[str, dict[str, Any]]:
+        target = self.config.target_exchange.strip().lower()
         return {
             name: self._apply_fixture(fixture)
             for name, fixture in self.fixtures.items()
-            if include_target or name != "okx"
+            if include_target or name != target
         }
 
     def _scenario_requires_target_preflight(self, scenario: str) -> bool:
         return (
-            self.config.target_exchange.strip().lower() == "okx"
+            self._target_requires_preflight()
             and scenario in TARGET_EXCHANGE_SCENARIOS
         )
+
+    def _target_requires_preflight(self) -> bool:
+        return self.config.target_exchange.strip().lower() in TARGET_FIXTURE_FILES
 
     def _apply_fixture(self, fixture: dict[str, Any]) -> dict[str, Any]:
         dashboard_id = self._upsert_dashboard(fixture["dashboard"])
@@ -532,18 +543,19 @@ class RecipeRunner:
         )
 
     def _scenario_r14(self, dashboards: dict[str, dict[str, Any]]) -> dict[str, Any]:
-        dashboard_id = dashboards[self._target_recipe()["dashboard"]]["id"]
+        target = self._target_recipe()
+        dashboard_id = dashboards[target["dashboard"]]["id"]
         status, body = self.http.request(
             "POST",
             f"/dashboards/{dashboard_id}/sets",
             json_body={
-                "set_id": "recipe_okx_live_forbidden_probe",
+                "set_id": target["live_probe_set"],
                 "enabled": False,
                 "action": "mtf_run",
-                "exchange": "okx",
+                "exchange": target["live_probe_exchange"],
                 "market_type": "perpetual",
                 "mtf_profile": "regular",
-                "environment": "demo",
+                "environment": target["live_probe_environment"],
                 "dry_run": False,
                 "workers": 1,
                 "sync_tables": False,
@@ -555,7 +567,7 @@ class RecipeRunner:
         )
         ok = self._is_expected_live_guard_refusal(status, body)
         if not ok:
-            self._delete_set_if_present(dashboard_id, "recipe_okx_live_forbidden_probe")
+            self._delete_set_if_present(dashboard_id, target["live_probe_set"])
         return self._result(
             "R14",
             "PASS" if ok else "FAIL",
@@ -571,6 +583,9 @@ class RecipeRunner:
                 "r1_set": "recipe_fake_regular",
                 "r2_sets": ("recipe_fake_regular", "recipe_fake_scalper", "recipe_fake_scalper_micro"),
                 "disabled_set": "recipe_fake_disabled",
+                "live_probe_set": "recipe_okx_live_forbidden_probe",
+                "live_probe_exchange": "okx",
+                "live_probe_environment": "demo",
             }
         if target == "okx":
             return {
@@ -578,6 +593,19 @@ class RecipeRunner:
                 "r1_set": "recipe_okx_regular",
                 "r2_sets": ("recipe_okx_regular", "recipe_okx_scalper_micro"),
                 "disabled_set": "recipe_okx_disabled",
+                "live_probe_set": "recipe_okx_live_forbidden_probe",
+                "live_probe_exchange": "okx",
+                "live_probe_environment": "demo",
+            }
+        if target == "hyperliquid":
+            return {
+                "dashboard": "hyperliquid",
+                "r1_set": "recipe_hyperliquid_regular",
+                "r2_sets": ("recipe_hyperliquid_regular", "recipe_hyperliquid_scalper_micro"),
+                "disabled_set": "recipe_hyperliquid_disabled",
+                "live_probe_set": "recipe_hyperliquid_live_forbidden_probe",
+                "live_probe_exchange": "hyperliquid",
+                "live_probe_environment": "testnet",
             }
         raise ValueError(f"unsupported runtime recipe target_exchange: {self.config.target_exchange}")
 
@@ -863,7 +891,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--scenario", action="append", choices=ALL_SCENARIOS)
     parser.add_argument(
         "--target-exchange",
-        choices=("fake", "okx"),
+        choices=("fake", "okx", "hyperliquid"),
         default="fake",
         help="Recipe target for R1/R2/R14; fake remains the default R1-R16 baseline.",
     )

--- a/python-orchestrator/tests/test_runtime_recipe_fixtures.py
+++ b/python-orchestrator/tests/test_runtime_recipe_fixtures.py
@@ -146,6 +146,30 @@ def test_runtime_recipe_okx_dry_run_fixture_is_exchange_scoped():
             assert symbol.endswith("USDT")
 
 
+def test_runtime_recipe_hyperliquid_dry_run_fixture_is_exchange_scoped():
+    fixture = _load(FIXTURE_DIR / "r1_r16_hyperliquid_dry_run_dashboard.json")
+
+    assert fixture["fixture_id"] == "runtime-recipe-r1-r16-hyperliquid-dry-run-v1"
+    assert fixture["dry_run_only"] is True
+    assert fixture["dashboard"]["name"] == "recipe-r1-r16-hyperliquid-dry-run"
+    assert {item["set_id"] for item in fixture["sets"]} == {
+        "recipe_hyperliquid_regular",
+        "recipe_hyperliquid_scalper_micro",
+        "recipe_hyperliquid_disabled",
+    }
+    for item in fixture["sets"]:
+        assert item["exchange"] == "hyperliquid"
+        assert item["market_type"] == "perpetual"
+        assert item["environment"] == "testnet"
+        assert item["dry_run"] is True
+        assert item["workers"] == 1
+        assert item["sync_tables"] is False
+        assert item["symbols"]
+        for symbol in item["symbols"]:
+            assert symbol == symbol.strip().upper()
+            assert symbol.endswith("USDT")
+
+
 def test_runtime_recipe_fixtures_do_not_contain_secret_material():
     for path in _fixture_paths():
         fixture = _load(path)

--- a/python-orchestrator/tests/test_runtime_recipe_runner.py
+++ b/python-orchestrator/tests/test_runtime_recipe_runner.py
@@ -419,6 +419,80 @@ def test_runner_can_target_okx_dry_run_recipe_without_bitmart_fallback(tmp_path:
     )
 
 
+def test_runner_can_target_hyperliquid_dry_run_recipe_without_bitmart_fallback(
+    tmp_path: Path,
+    monkeypatch,
+):
+    api = FakeRecipeApi()
+    runtime_check_calls: list[tuple[Any, ...]] = []
+
+    def runtime_check(*args, **kwargs):
+        runtime_check_calls.append(args)
+
+        class Completed:
+            returncode = 0
+            stdout = "Readiness level: local_dry_run_ready\nSchedule ready: yes\n"
+            stderr = ""
+
+        return Completed()
+
+    monkeypatch.setattr(runner_module.subprocess, "run", runtime_check)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            target_exchange="hyperliquid",
+        ),
+        http_client=api,
+    ).run(scenarios=("R1", "R2", "R14"), keep_fixtures=True)
+
+    statuses = {item["scenario"]: item["status"] for item in report["results"]}
+    assert statuses == {"R1": "PASS", "R2": "PASS", "R14": "PASS"}
+    assert report["dashboards"]["hyperliquid"]["name"] == "recipe-r1-r16-hyperliquid-dry-run"
+    assert report["metadata"]["runtime_check"]["status"] == "PASS"
+    assert report["metadata"]["runtime_check"]["schedule_ready"] == "yes"
+    assert runtime_check_calls
+    assert list(runtime_check_calls[0][0][-3:]) == [
+        "app:exchange:runtime-check",
+        "hyperliquid",
+        "perpetual",
+    ]
+
+    dashboard_id = report["dashboards"]["hyperliquid"]["id"]
+    sets = api.sets[dashboard_id]
+    assert {item["set_id"] for item in sets} == {
+        "recipe_hyperliquid_regular",
+        "recipe_hyperliquid_scalper_micro",
+        "recipe_hyperliquid_disabled",
+    }
+    assert {item["exchange"] for item in sets} == {"hyperliquid"}
+    assert all(item["dry_run"] is True for item in sets)
+    assert all(item["environment"] == "testnet" for item in sets)
+
+    run_requests = [request for request in api.requests if request["path"] == "/orchestrator/run"]
+    assert [request["json"]["idempotency_key"].split("-")[1] for request in run_requests] == [
+        "r1",
+        "r2",
+    ]
+    assert not any(
+        request["json"] and request["json"].get("exchange") == "bitmart"
+        for request in api.requests
+        if isinstance(request["json"], dict)
+    )
+    probe_requests = [
+        request
+        for request in api.requests
+        if request["method"] == "POST"
+        and request["path"].endswith("/sets")
+        and request["json"]["set_id"] == "recipe_hyperliquid_live_forbidden_probe"
+    ]
+    assert probe_requests
+    assert probe_requests[0]["json"]["exchange"] == "hyperliquid"
+    assert probe_requests[0]["json"]["environment"] == "testnet"
+    assert probe_requests[0]["json"]["dry_run"] is False
+
+
 def test_runner_blocks_okx_recipe_when_runtime_check_is_not_schedule_ready(
     tmp_path: Path,
     monkeypatch,
@@ -446,6 +520,42 @@ def test_runner_blocks_okx_recipe_when_runtime_check_is_not_schedule_ready(
 
     assert report["metadata"]["runtime_check"]["status"] == "BLOCKED"
     assert report["summary"]["scenario_counts"] == {"BLOCKED": 3}
+    assert not any(request["path"] == "/orchestrator/run" for request in api.requests)
+
+
+def test_runner_blocks_hyperliquid_recipe_when_runtime_check_is_not_schedule_ready(
+    tmp_path: Path,
+    monkeypatch,
+):
+    api = FakeRecipeApi()
+
+    def runtime_check(*args, **kwargs):
+        class Completed:
+            returncode = 0
+            stdout = "Readiness level: public_read_only\nSchedule ready: no\n"
+            stderr = ""
+
+        return Completed()
+
+    monkeypatch.setattr(runner_module.subprocess, "run", runtime_check)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            target_exchange="hyperliquid",
+        ),
+        http_client=api,
+    ).run(scenarios=("R1", "R2", "R14"), keep_fixtures=True)
+
+    assert report["metadata"]["runtime_check"]["status"] == "BLOCKED"
+    assert report["metadata"]["runtime_check"]["schedule_ready"] == "no"
+    assert report["summary"]["scenario_counts"] == {"BLOCKED": 3}
+    assert "hyperliquid" not in report["dashboards"]
+    assert not any(
+        dashboard["name"] == "recipe-r1-r16-hyperliquid-dry-run"
+        for dashboard in api.dashboards
+    )
     assert not any(request["path"] == "/orchestrator/run" for request in api.requests)
 
 
@@ -569,6 +679,22 @@ def test_temporal_command_parser_accepts_flagged_arguments():
         "--schedule-id",
         "recipe-orchestrator-r1-r16",
     ]
+
+
+def test_parser_accepts_hyperliquid_runtime_recipe_target():
+    args = runner_module._parse_args(
+        [
+            "--confirm",
+            "DRY_RUN_ONLY",
+            "--target-exchange",
+            "hyperliquid",
+            "--scenario",
+            "R1",
+        ]
+    )
+
+    assert args.target_exchange == "hyperliquid"
+    assert args.scenario == ["R1"]
 
 
 def test_r11_uses_distinct_anchors_for_schedule_overlap(tmp_path: Path):


### PR DESCRIPTION
Part of HL-011
Related to #188
Related to #173
Related to #248

## Summary
- add a Hyperliquid R1/R2/R14 dry-run fixture for the orchestrator runtime recipe
- extend `runtime_recipe_runner.py` with `--target-exchange hyperliquid`, Hyperliquid runtime-check preflight, and Hyperliquid R14 live-guard probe
- document the Hyperliquid recipe path in the #188 runbook, Hyperliquid dry-run docs, Python orchestrator README, and roadmap

## Safety
- fixture and runner force `dry_run=true`, `workers=1`, and `sync_tables=false` for persisted sets
- no Bitmart fallback, no payload injection, no broadcast exchange
- R1/R2/R14 block before `/orchestrator/run` unless `app:exchange:runtime-check hyperliquid perpetual` reports `Schedule ready: yes`

## Tests
- `cd python-orchestrator && python3 -m pytest tests/test_runtime_recipe_runner.py tests/test_runtime_recipe_fixtures.py -q`
- `/tmp/tradingv3-docs-venv/bin/python -m mkdocs build --strict`
- `git diff --check`
- sensitive-term scan on new fixture/docs: no secret values, only guardrail wording

## Rollback
- revert this PR to remove the Hyperliquid fixture and runner target
- existing Fake/Paper and OKX recipe targets remain independent
