### PR TITLE
DEMO-001 demo exchange fixtures

### DIFF
--- a/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
+++ b/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
@@ -63,6 +63,7 @@ Fixtures versionnees :
 - `python-orchestrator/fixtures/runtime-recipe/r1_r16_degraded_fake_dashboard.json`
 - `python-orchestrator/fixtures/runtime-recipe/r1_r16_okx_dry_run_dashboard.json`
 - `python-orchestrator/fixtures/runtime-recipe/r1_r16_hyperliquid_dry_run_dashboard.json`
+- `python-orchestrator/fixtures/runtime-recipe/demo_exchanges_dashboard.json`
 
 Les fixtures Fake/Paper utilisent uniquement :
 
@@ -109,6 +110,26 @@ sont exportes en `BLOCKED` et aucun appel `/orchestrator/run` n'est envoye pour
 R1/R2/R14. Le probe R14 cree uniquement un set desactive `dry_run=false` pour
 verifier le refus de persistance avant dispatch ; aucun broadcast exchange n'est
 possible dans ce runner.
+
+La fixture `demo-exchanges` prepare les dashboards/sets dedies a la recette
+double exchange OKX demo + Hyperliquid testnet :
+
+- dashboard `demo-exchanges` ;
+- sets `okx_scalper_demo`, `okx_regular_demo`, `hyperliquid_scalper_testnet`,
+  `hyperliquid_regular_testnet` ;
+- `dry_run=true`, `workers=1`, `sync_tables=false` ;
+- sets desactives par defaut ;
+- symboles allow-listes `BTCUSDT` uniquement ;
+- `max_notional_usdt=25` dans la politique de securite documentaire ;
+- `require_stop_loss=true`, `kill_switch_enabled=true`,
+  `demo_testnet_write_enabled=false` ;
+- les sets existants du dashboard qui ne figurent pas dans la fixture sont
+  desactives lors de la reapplication ;
+- aucun set `mainnet`, aucun set Bitmart et aucun broadcast exchange.
+
+Cette fixture sert a preparer l'environnement, pas a lancer une recette mutative.
+Rollback : supprimer le dashboard `demo-exchanges` via l'API orchestrateur, ou le
+desactiver si l'on souhaite conserver l'historique des runs associes.
 
 Application idempotente attendue :
 
@@ -157,6 +178,86 @@ curl -sS -X POST "http://localhost:8099/dashboards/${RECIPE_DASHBOARD_ID}/sets" 
 
 Pour une execution reproductible, preferer le runner du prochain lot #188. Cette
 PR livre seulement les donnees et le contrat d'application.
+
+Application de la fixture DEMO-001 :
+
+```bash
+cd python-orchestrator
+python3 - <<'PY'
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+BASE_URL = "http://localhost:8099"
+FIXTURE = Path("fixtures/runtime-recipe/demo_exchanges_dashboard.json")
+SET_FIELDS = {
+    "set_id", "enabled", "action", "exchange", "market_type", "mtf_profile",
+    "environment", "dry_run", "workers", "sync_tables", "symbols",
+    "contracts_limit", "priority",
+}
+
+def request(method, path, payload=None):
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body) if body else None
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"{method} {path} failed: {exc.code} {exc.read().decode('utf-8')}")
+
+fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+dashboard = fixture["dashboard"]
+existing = next(
+    (item for item in request("GET", "/dashboards") if item["name"] == dashboard["name"]),
+    None,
+)
+if existing:
+    request("PATCH", f"/dashboards/{existing['id']}", dashboard)
+    dashboard_id = existing["id"]
+else:
+    dashboard_id = request("POST", "/dashboards", dashboard)["id"]
+
+existing_sets = {
+    item["set_id"]: item
+    for item in request("GET", f"/dashboards/{dashboard_id}/sets")
+}
+expected_set_ids = {item["set_id"] for item in fixture["sets"]}
+if fixture["expected_invariants"].get("disable_stale_sets") is True:
+    for set_id, existing_set in existing_sets.items():
+        if set_id not in expected_set_ids and existing_set.get("enabled") is True:
+            request(
+                "PATCH",
+                f"/dashboards/{dashboard_id}/sets/{set_id}",
+                {"enabled": False, "dry_run": True},
+            )
+
+for item in fixture["sets"]:
+    payload = {key: item[key] for key in SET_FIELDS if key in item}
+    if item["set_id"] in existing_sets:
+        request("PATCH", f"/dashboards/{dashboard_id}/sets/{item['set_id']}", {
+            key: value for key, value in payload.items() if key != "set_id"
+        })
+    else:
+        request("POST", f"/dashboards/{dashboard_id}/sets", payload)
+
+print(f"demo-exchanges dashboard applied with id={dashboard_id}")
+PY
+```
+
+Rollback DEMO-001 :
+
+```bash
+curl -sS http://localhost:8099/dashboards \
+  | python3 -c 'import json, sys; print(next((str(d["id"]) for d in json.load(sys.stdin) if d["name"] == "demo-exchanges"), ""))' \
+  | xargs -r -I{} curl -sS -X DELETE "http://localhost:8099/dashboards/{}"
+```
 
 ## Format des resultats
 

--- a/python-orchestrator/fixtures/runtime-recipe/demo_exchanges_dashboard.json
+++ b/python-orchestrator/fixtures/runtime-recipe/demo_exchanges_dashboard.json
@@ -1,0 +1,131 @@
+{
+  "$schema": "https://pivox.local/schemas/orchestrator-runtime-recipe-fixture-v1.json",
+  "fixture_id": "demo-exchanges-okx-hyperliquid-v1",
+  "version": 1,
+  "dry_run_only": true,
+  "purpose": "Dashboard de preparation demo/testnet pour OKX demo et Hyperliquid testnet, sans ordre exchange.",
+  "dashboard": {
+    "name": "demo-exchanges",
+    "enabled": true,
+    "description": "Preparation demo/testnet OKX + Hyperliquid - sets dry-run desactives par defaut, kill switch actif."
+  },
+  "sets": [
+    {
+      "set_id": "okx_scalper_demo",
+      "enabled": false,
+      "action": "mtf_run",
+      "exchange": "okx",
+      "market_type": "perpetual",
+      "mtf_profile": "scalper_micro",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 10,
+      "demo_role": "okx_demo_scalper_micro",
+      "safety_policy": {
+        "kill_switch_enabled": true,
+        "demo_testnet_write_enabled": false,
+        "require_stop_loss": true,
+        "allowed_symbols": ["BTCUSDT"],
+        "allowed_markets": ["perpetual"],
+        "max_notional_usdt": 25
+      }
+    },
+    {
+      "set_id": "okx_regular_demo",
+      "enabled": false,
+      "action": "mtf_run",
+      "exchange": "okx",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "demo",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 20,
+      "demo_role": "okx_demo_regular",
+      "safety_policy": {
+        "kill_switch_enabled": true,
+        "demo_testnet_write_enabled": false,
+        "require_stop_loss": true,
+        "allowed_symbols": ["BTCUSDT"],
+        "allowed_markets": ["perpetual"],
+        "max_notional_usdt": 25
+      }
+    },
+    {
+      "set_id": "hyperliquid_scalper_testnet",
+      "enabled": false,
+      "action": "mtf_run",
+      "exchange": "hyperliquid",
+      "market_type": "perpetual",
+      "mtf_profile": "scalper_micro",
+      "environment": "testnet",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 30,
+      "demo_role": "hyperliquid_testnet_scalper_micro",
+      "safety_policy": {
+        "kill_switch_enabled": true,
+        "demo_testnet_write_enabled": false,
+        "require_stop_loss": true,
+        "allowed_symbols": ["BTCUSDT"],
+        "allowed_markets": ["perpetual"],
+        "max_notional_usdt": 25
+      }
+    },
+    {
+      "set_id": "hyperliquid_regular_testnet",
+      "enabled": false,
+      "action": "mtf_run",
+      "exchange": "hyperliquid",
+      "market_type": "perpetual",
+      "mtf_profile": "regular",
+      "environment": "testnet",
+      "dry_run": true,
+      "workers": 1,
+      "sync_tables": false,
+      "symbols": ["BTCUSDT"],
+      "contracts_limit": null,
+      "priority": 40,
+      "demo_role": "hyperliquid_testnet_regular",
+      "safety_policy": {
+        "kill_switch_enabled": true,
+        "demo_testnet_write_enabled": false,
+        "require_stop_loss": true,
+        "allowed_symbols": ["BTCUSDT"],
+        "allowed_markets": ["perpetual"],
+        "max_notional_usdt": 25
+      }
+    }
+  ],
+  "scenario_mapping": {
+    "DEMO-001": [
+      "okx_scalper_demo",
+      "okx_regular_demo",
+      "hyperliquid_scalper_testnet",
+      "hyperliquid_regular_testnet"
+    ]
+  },
+  "expected_invariants": {
+    "dry_run": true,
+    "mainnet": false,
+    "workers_per_set": 1,
+    "fixture_application": "upsert_by_dashboard_name_and_set_id",
+    "no_bitmart_fallback": true,
+    "no_broadcast": true,
+    "demo_testnet_write_enabled": false,
+    "disable_stale_sets": true,
+    "kill_switch_enabled": true,
+    "require_stop_loss": true,
+    "max_notional_usdt": 25
+  }
+}

--- a/python-orchestrator/tests/test_runtime_recipe_fixtures.py
+++ b/python-orchestrator/tests/test_runtime_recipe_fixtures.py
@@ -78,6 +78,15 @@ def _apply_fixture(client, fixture: dict[str, Any]) -> int:
         item["set_id"]: item
         for item in client.get(f"/dashboards/{dashboard_id}/sets").json()
     }
+    if fixture.get("expected_invariants", {}).get("disable_stale_sets") is True:
+        expected_ids = {item["set_id"] for item in fixture["sets"]}
+        for set_id, existing_set in existing_sets.items():
+            if set_id not in expected_ids and existing_set.get("enabled") is True:
+                response = client.patch(
+                    f"/dashboards/{dashboard_id}/sets/{set_id}",
+                    json={"enabled": False, "dry_run": True},
+                )
+                assert response.status_code == 200
     for fixture_set in fixture["sets"]:
         payload = {key: fixture_set[key] for key in SET_FIELDS if key in fixture_set}
         if fixture_set["set_id"] in existing_sets:
@@ -170,6 +179,61 @@ def test_runtime_recipe_hyperliquid_dry_run_fixture_is_exchange_scoped():
             assert symbol.endswith("USDT")
 
 
+def test_demo_exchange_fixture_prepares_okx_and_hyperliquid_sets():
+    fixture = _load(FIXTURE_DIR / "demo_exchanges_dashboard.json")
+
+    assert fixture["fixture_id"] == "demo-exchanges-okx-hyperliquid-v1"
+    assert fixture["dry_run_only"] is True
+    assert fixture["dashboard"]["name"] == "demo-exchanges"
+    assert {item["set_id"] for item in fixture["sets"]} == {
+        "okx_scalper_demo",
+        "okx_regular_demo",
+        "hyperliquid_scalper_testnet",
+        "hyperliquid_regular_testnet",
+    }
+
+    expected = {
+        "okx_scalper_demo": ("okx", "demo", "scalper_micro"),
+        "okx_regular_demo": ("okx", "demo", "regular"),
+        "hyperliquid_scalper_testnet": ("hyperliquid", "testnet", "scalper_micro"),
+        "hyperliquid_regular_testnet": ("hyperliquid", "testnet", "regular"),
+    }
+    for item in fixture["sets"]:
+        exchange, environment, profile = expected[item["set_id"]]
+        assert item["exchange"] == exchange
+        assert item["environment"] == environment
+        assert item["mtf_profile"] == profile
+        assert item["market_type"] == "perpetual"
+        assert item["dry_run"] is True
+        assert item["enabled"] is False
+        assert item["workers"] == 1
+        assert item["sync_tables"] is False
+        assert item["symbols"] == ["BTCUSDT"]
+
+
+def test_demo_exchange_fixture_is_guarded_for_preparation_only():
+    fixture = _load(FIXTURE_DIR / "demo_exchanges_dashboard.json")
+    invariants = fixture["expected_invariants"]
+
+    assert invariants["mainnet"] is False
+    assert invariants["no_bitmart_fallback"] is True
+    assert invariants["no_broadcast"] is True
+    assert invariants["demo_testnet_write_enabled"] is False
+    assert invariants["disable_stale_sets"] is True
+    assert invariants["fixture_application"] == "upsert_by_dashboard_name_and_set_id"
+
+    for item in fixture["sets"]:
+        assert item["environment"] != "mainnet"
+        assert item["dry_run"] is True
+        assert item["safety_policy"]["kill_switch_enabled"] is True
+        assert item["safety_policy"]["require_stop_loss"] is True
+        assert item["safety_policy"]["max_notional_usdt"] > 0
+        assert item["safety_policy"]["max_notional_usdt"] <= 50
+        assert item["safety_policy"]["allowed_markets"] == ["perpetual"]
+        assert item["safety_policy"]["allowed_symbols"] == item["symbols"]
+        assert item["safety_policy"]["demo_testnet_write_enabled"] is False
+
+
 def test_runtime_recipe_fixtures_do_not_contain_secret_material():
     for path in _fixture_paths():
         fixture = _load(path)
@@ -197,6 +261,48 @@ def test_runtime_recipe_fixtures_apply_repeatedly_without_duplicates(api_client)
         observed_ids = {item["set_id"] for item in sets}
         assert expected_ids == observed_ids
         assert len(sets) == len(expected_ids)
+
+
+def test_demo_exchange_fixture_disables_stale_live_sets_on_reapply(orchestrator_env):
+    from app.db.models import Dashboard, OrchestrationSet
+
+    api_client, session = orchestrator_env
+    fixture = _load(FIXTURE_DIR / "demo_exchanges_dashboard.json")
+    dashboard = Dashboard(
+        name=fixture["dashboard"]["name"],
+        enabled=True,
+        description="existing demo dashboard",
+    )
+    session.add(dashboard)
+    session.flush()
+    session.add(
+        OrchestrationSet(
+            dashboard_id=dashboard.id,
+            set_id="old_bitmart_live",
+            enabled=True,
+            action="mtf_run",
+            exchange="bitmart",
+            market_type="perpetual",
+            mtf_profile="regular",
+            environment="mainnet",
+            dry_run=False,
+            workers=1,
+            sync_tables=False,
+            symbols=["BTCUSDT"],
+            priority=90,
+        )
+    )
+    session.commit()
+
+    dashboard_id = _apply_fixture(api_client, fixture)
+
+    sets = {
+        item["set_id"]: item
+        for item in api_client.get(f"/dashboards/{dashboard_id}/sets").json()
+    }
+    assert sets["old_bitmart_live"]["enabled"] is False
+    assert sets["old_bitmart_live"]["dry_run"] is True
+    assert {item["set_id"] for item in fixture["sets"]}.issubset(sets)
 
 
 def test_runtime_recipe_fixtures_generate_server_payloads(api_client):


### PR DESCRIPTION
## Summary
- Add the demo-exchanges dashboard fixture for OKX demo and Hyperliquid testnet preparation.
- Keep all sets dry-run, disabled by default, with documented kill-switch, stop-loss requirement, symbol allow-list, and max notional guardrails.
- Document idempotent application and rollback in the orchestrator runtime recipe runbook.

## Test Plan
- [x] `cd python-orchestrator && python3 -m pytest tests/test_runtime_recipe_fixtures.py tests/test_runtime_recipe_runner.py -q`
- [x] `/tmp/tradingv3-docs-venv/bin/python -m mkdocs build --strict`
- [x] `git diff --check`
- [x] `git diff --cached --check`

Related to #188

References prior readiness work: #234, #235, #248, #249.