### PR TITLE
DEMO-002 double exchange runtime recipe report

### DIFF
--- a/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
+++ b/docs/handbook/runbooks/orchestrator-runtime-recipe-r1-r16.md
@@ -376,6 +376,41 @@ Preuves attendues dans `runtime-recipe-report.json` :
 - aucun set ou payload `exchange=bitmart` ;
 - R14 refuse le probe `dry_run=false` avant dispatch.
 
+Pour produire le rapport DEMO-002 double exchange :
+
+```bash
+cd python-orchestrator
+python scripts/runtime_recipe_runner.py \
+  --orchestrator-url http://localhost:8099 \
+  --confirm DRY_RUN_ONLY \
+  --target-exchange demo-exchanges \
+  --export-dir var/runtime-recipe/demo-exchanges \
+  --keep-fixtures
+```
+
+Le rapport racine `var/runtime-recipe/demo-exchanges/runtime-recipe-report.json`
+contient :
+
+- `metadata.target_exchange=demo-exchanges` ;
+- `exchange_results.global` pour la baseline R1-R16 Fake/Paper ;
+- `exchange_results.okx` pour OKX demo ;
+- `exchange_results.hyperliquid` pour Hyperliquid testnet ;
+- `exchange_summaries.*.scenario_counts` pour chaque section ;
+- `metadata.runtime_checks.okx` et `metadata.runtime_checks.hyperliquid`
+  avec le resultat des commandes `app:exchange:runtime-check`.
+
+Les sections OKX et Hyperliquid automatisent uniquement les scenarios
+exchange-specifiques `R1`, `R2` et `R14`. Les autres scenarios restent marques
+`BLOCKED` dans ces sections et sont couverts par `exchange_results.global`.
+Cette classification evite de presenter comme valide un scenario non exerce sur
+l'exchange cible.
+
+Le runner exporte aussi les sous-rapports suivants pour faciliter l'audit :
+
+- `var/runtime-recipe/demo-exchanges/global/runtime-recipe-report.json` ;
+- `var/runtime-recipe/demo-exchanges/okx/runtime-recipe-report.json` ;
+- `var/runtime-recipe/demo-exchanges/hyperliquid/runtime-recipe-report.json`.
+
 Pour cibler un sous-ensemble :
 
 ```bash

--- a/python-orchestrator/README.md
+++ b/python-orchestrator/README.md
@@ -358,6 +358,12 @@ exportes en `BLOCKED` et aucun appel `/orchestrator/run` n'est envoye pour ces
 scenarios. Les fixtures exchange restent `dry_run=true`, n'envoient aucun champ
 `payload` et ne creent aucun set Bitmart.
 
+Pour DEMO-002, `--target-exchange demo-exchanges` exporte un rapport agrege avec
+sections `global`, `okx` et `hyperliquid`. La section globale couvre R1-R16 sur
+Fake/Paper ; les sections OKX et Hyperliquid couvrent R1/R2/R14 et marquent les
+autres scenarios `BLOCKED` tant qu'ils ne sont pas automatises sur l'exchange
+cible.
+
 Commandes de verification locale :
 
 ```bash

--- a/python-orchestrator/scripts/runtime_recipe_runner.py
+++ b/python-orchestrator/scripts/runtime_recipe_runner.py
@@ -70,6 +70,12 @@ TARGET_FIXTURE_FILES = {
     "okx": "r1_r16_okx_dry_run_dashboard.json",
     "hyperliquid": "r1_r16_hyperliquid_dry_run_dashboard.json",
 }
+DEMO_EXCHANGES_TARGET = "demo-exchanges"
+DEMO_EXCHANGE_TARGETS = {
+    "global": "fake",
+    "okx": "okx",
+    "hyperliquid": "hyperliquid",
+}
 
 
 class RecipeHttpClient(Protocol):
@@ -132,7 +138,14 @@ class RecipeRunner:
         keep_fixtures: bool = False,
     ) -> dict[str, Any]:
         self._assert_confirmed()
-        selected = tuple(scenarios or DEFAULT_SCENARIOS)
+        target_exchange = self.config.target_exchange.strip().lower()
+        default_scenarios = (
+            ALL_SCENARIOS if target_exchange == DEMO_EXCHANGES_TARGET else DEFAULT_SCENARIOS
+        )
+        selected = tuple(scenarios if scenarios is not None else default_scenarios)
+        if target_exchange == DEMO_EXCHANGES_TARGET:
+            return self._run_demo_exchanges(selected, keep_fixtures=keep_fixtures)
+
         started_at = datetime.now(timezone.utc).isoformat()
         self.invocation_id = uuid4().hex[:12]
 
@@ -181,6 +194,110 @@ class RecipeRunner:
         report = self._redact(report)
         self._export(report)
         return report
+
+    def _run_demo_exchanges(
+        self,
+        selected: tuple[str, ...],
+        *,
+        keep_fixtures: bool,
+    ) -> dict[str, Any]:
+        started_at = datetime.now(timezone.utc).isoformat()
+        self.invocation_id = uuid4().hex[:12]
+
+        exchange_results: dict[str, list[dict[str, Any]]] = {}
+        exchange_summaries: dict[str, dict[str, Any]] = {}
+        dashboards: dict[str, dict[str, Any]] = {}
+        runtime_checks: dict[str, Any] = {}
+        flattened_results: list[dict[str, Any]] = []
+
+        for exchange_scope, target_exchange in DEMO_EXCHANGE_TARGETS.items():
+            target_scenarios = self._demo_exchange_scenarios(exchange_scope, selected)
+            sub_report: dict[str, Any] | None = None
+            observed_by_scenario: dict[str, dict[str, Any]] = {}
+            if target_scenarios:
+                sub_runner = RecipeRunner(
+                    RunnerConfig(
+                        export_dir=self.config.export_dir / exchange_scope,
+                        fixtures_dir=self.config.fixtures_dir,
+                        orchestrator_url=self.config.orchestrator_url,
+                        confirmation_token=self.config.confirmation_token,
+                        target_exchange=target_exchange,
+                        timeout_seconds=self.config.timeout_seconds,
+                        temporal_available=self.config.temporal_available,
+                        temporal_dry_run_command=self.config.temporal_dry_run_command,
+                        cleanup=self.config.cleanup,
+                    ),
+                    http_client=self.http,
+                )
+                sub_report = sub_runner.run(scenarios=target_scenarios, keep_fixtures=keep_fixtures)
+                observed_by_scenario = {
+                    item["scenario"]: {**item, "exchange_scope": exchange_scope}
+                    for item in sub_report["results"]
+                }
+
+            ordered_results: list[dict[str, Any]] = []
+            for scenario in selected:
+                result = observed_by_scenario.get(scenario)
+                if result is None:
+                    result = {
+                        **self._result(
+                            scenario,
+                            "BLOCKED",
+                            (
+                                f"{scenario} is covered by the global Fake/Paper baseline; "
+                                f"no {exchange_scope} exchange-specific automation exists in this dry-run runner"
+                            ),
+                        ),
+                        "exchange_scope": exchange_scope,
+                    }
+                ordered_results.append(result)
+
+            exchange_results[exchange_scope] = ordered_results
+            exchange_summaries[exchange_scope] = {
+                "target_exchange": target_exchange,
+                "scenario_counts": dict(Counter(item["status"] for item in ordered_results)),
+            }
+            dashboards[exchange_scope] = sub_report.get("dashboards", {}) if sub_report else {}
+            runtime_checks[exchange_scope] = (
+                sub_report.get("metadata", {}).get("runtime_check") if sub_report else None
+            )
+            flattened_results.extend(ordered_results)
+
+        report = {
+            "metadata": {
+                "started_at": started_at,
+                "finished_at": datetime.now(timezone.utc).isoformat(),
+                "dry_run_forced": True,
+                "confirmation_token": "REDACTED",
+                "invocation_id": self.invocation_id,
+                "orchestrator_url": self.config.orchestrator_url,
+                "fixtures_dir": str(self.config.fixtures_dir),
+                "target_exchange": DEMO_EXCHANGES_TARGET,
+                "exchange_targets": DEMO_EXCHANGE_TARGETS,
+                "runtime_checks": runtime_checks,
+                "cleanup_requested": self.config.cleanup,
+            },
+            "dashboards": dashboards,
+            "exchange_results": exchange_results,
+            "exchange_summaries": exchange_summaries,
+            "results": flattened_results,
+            "summary": {
+                "scenario_counts": dict(Counter(item["status"] for item in flattened_results)),
+                "ready_for_final_report": False,
+            },
+        }
+        report = self._redact(report)
+        self._export(report)
+        return report
+
+    def _demo_exchange_scenarios(
+        self,
+        exchange_scope: str,
+        selected: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        if exchange_scope == "global":
+            return selected
+        return tuple(scenario for scenario in selected if scenario in TARGET_EXCHANGE_SCENARIOS)
 
     def _assert_confirmed(self) -> None:
         if self.config.confirmation_token != CONFIRMATION_TOKEN:
@@ -891,9 +1008,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--scenario", action="append", choices=ALL_SCENARIOS)
     parser.add_argument(
         "--target-exchange",
-        choices=("fake", "okx", "hyperliquid"),
+        choices=("fake", "okx", "hyperliquid", DEMO_EXCHANGES_TARGET),
         default="fake",
-        help="Recipe target for R1/R2/R14; fake remains the default R1-R16 baseline.",
+        help=(
+            "Recipe target for R1/R2/R14; fake remains the default R1-R16 baseline. "
+            "Use demo-exchanges to export global, OKX, and Hyperliquid sections."
+        ),
     )
     parser.add_argument("--timeout-seconds", type=float, default=30.0)
     parser.add_argument("--confirm", required=True, help=f"Must be {CONFIRMATION_TOKEN}")

--- a/python-orchestrator/tests/test_runtime_recipe_runner.py
+++ b/python-orchestrator/tests/test_runtime_recipe_runner.py
@@ -493,6 +493,103 @@ def test_runner_can_target_hyperliquid_dry_run_recipe_without_bitmart_fallback(
     assert probe_requests[0]["json"]["dry_run"] is False
 
 
+def test_runner_exports_demo_exchange_report_by_exchange(tmp_path: Path, monkeypatch):
+    api = FakeRecipeApi()
+    runtime_check_targets: list[str] = []
+
+    def runtime_check(*args, **kwargs):
+        runtime_check_targets.append(args[0][-2])
+
+        class Completed:
+            returncode = 0
+            stdout = "Readiness level: local_dry_run_ready\nSchedule ready: yes\n"
+            stderr = ""
+
+        return Completed()
+
+    monkeypatch.setattr(runner_module.subprocess, "run", runtime_check)
+
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            target_exchange="demo-exchanges",
+        ),
+        http_client=api,
+    ).run(scenarios=("R1", "R2", "R3", "R14"), keep_fixtures=True)
+
+    assert report["metadata"]["target_exchange"] == "demo-exchanges"
+    assert set(report["exchange_results"]) == {"global", "okx", "hyperliquid"}
+    assert runtime_check_targets == ["okx", "hyperliquid"]
+
+    global_statuses = {
+        item["scenario"]: item["status"] for item in report["exchange_results"]["global"]
+    }
+    okx_statuses = {
+        item["scenario"]: item["status"] for item in report["exchange_results"]["okx"]
+    }
+    hyperliquid_statuses = {
+        item["scenario"]: item["status"]
+        for item in report["exchange_results"]["hyperliquid"]
+    }
+
+    assert global_statuses == {"R1": "PASS", "R2": "PASS", "R3": "BLOCKED", "R14": "PASS"}
+    assert okx_statuses == {"R1": "PASS", "R2": "PASS", "R3": "BLOCKED", "R14": "PASS"}
+    assert hyperliquid_statuses == {
+        "R1": "PASS",
+        "R2": "PASS",
+        "R3": "BLOCKED",
+        "R14": "PASS",
+    }
+    assert report["exchange_summaries"]["okx"]["scenario_counts"] == {
+        "PASS": 3,
+        "BLOCKED": 1,
+    }
+    assert report["exchange_summaries"]["hyperliquid"]["scenario_counts"] == {
+        "PASS": 3,
+        "BLOCKED": 1,
+    }
+
+    exported = json.loads((tmp_path / "runtime-recipe-report.json").read_text(encoding="utf-8"))
+    assert exported == report
+    assert not any(
+        request["json"] and request["json"].get("exchange") == "bitmart"
+        for request in api.requests
+        if isinstance(request["json"], dict)
+    )
+
+
+def test_demo_exchange_runner_materializes_scenario_iterable_once(
+    tmp_path: Path,
+    monkeypatch,
+):
+    api = FakeRecipeApi()
+
+    def runtime_check(*args, **kwargs):
+        class Completed:
+            returncode = 0
+            stdout = "Readiness level: local_dry_run_ready\nSchedule ready: yes\n"
+            stderr = ""
+
+        return Completed()
+
+    monkeypatch.setattr(runner_module.subprocess, "run", runtime_check)
+
+    scenarios = (scenario for scenario in ("R1", "R2"))
+    report = RecipeRunner(
+        RunnerConfig(
+            export_dir=tmp_path,
+            confirmation_token="DRY_RUN_ONLY",
+            target_exchange="demo-exchanges",
+        ),
+        http_client=api,
+    ).run(scenarios=scenarios, keep_fixtures=True)
+
+    assert [item["scenario"] for item in report["exchange_results"]["global"]] == ["R1", "R2"]
+    assert [item["scenario"] for item in report["exchange_results"]["okx"]] == ["R1", "R2"]
+    assert [item["scenario"] for item in report["exchange_results"]["hyperliquid"]] == ["R1", "R2"]
+
+
 def test_runner_blocks_okx_recipe_when_runtime_check_is_not_schedule_ready(
     tmp_path: Path,
     monkeypatch,
@@ -694,6 +791,22 @@ def test_parser_accepts_hyperliquid_runtime_recipe_target():
     )
 
     assert args.target_exchange == "hyperliquid"
+    assert args.scenario == ["R1"]
+
+
+def test_parser_accepts_demo_exchange_runtime_recipe_target():
+    args = runner_module._parse_args(
+        [
+            "--confirm",
+            "DRY_RUN_ONLY",
+            "--target-exchange",
+            "demo-exchanges",
+            "--scenario",
+            "R1",
+        ]
+    )
+
+    assert args.target_exchange == "demo-exchanges"
     assert args.scenario == ["R1"]
 
 


### PR DESCRIPTION
## Summary
- Add `--target-exchange demo-exchanges` to export a double exchange runtime recipe report.
- Aggregate `global`, `okx`, and `hyperliquid` sections with deterministic PASS/FAIL/BLOCKED classification.
- Keep OKX/Hyperliquid scoped to R1/R2/R14, with other scenarios explicitly BLOCKED instead of implied complete.
- Document the DEMO-002 command and report layout.

## Test Plan
- [x] `cd python-orchestrator && python3 -m pytest tests/test_runtime_recipe_runner.py tests/test_runtime_recipe_fixtures.py -q`
- [x] `/tmp/tradingv3-docs-venv/bin/python -m mkdocs build --strict`
- [x] `git diff --check`
- [x] `git diff --cached --check`

Related to #188

Builds on #249 and #250.