### PR TITLE
DEMO-004 guarded demo testnet schedule

### DIFF
--- a/cron_symfony_mtf_workers/README.md
+++ b/cron_symfony_mtf_workers/README.md
@@ -175,6 +175,41 @@ python scripts/manage_orchestrator_schedule.py delete
 
 > `ok=false` n'est pas un succès Temporal. Le workflow propage le `RunResponse` complet sur `ok=true` et lève une `ApplicationError` non-retryable sur `ok=false` (implémenté par **TM-002**), après avoir journalisé `run_id` + `summary`.
 
+### 4.0.1 Schedule demo/testnet gardé (DEMO-004)
+
+- **Objectif** : créer le schedule Temporal dédié OKX demo + Hyperliquid testnet.
+- **Fichier CLI** : `scripts/manage_demo_testnet_schedule.py`.
+- **Défaut sûr** : le schedule est créé `paused=true` et force le `RunRequest` à `dry_run=true`.
+- **Activation** : `resume` et `create --resume-on-create` exécutent les runtime-checks OKX + Hyperliquid et refusent l'activation si `Schedule ready: yes` n'est pas présent pour les deux.
+- **Mainnet** : aucune option mainnet n'est supportée ; `--environment` doit rester `demo-testnet`.
+
+Paramètres via env (surchargés par CLI) :
+
+| Variable | Défaut |
+| --- | --- |
+| `DEMO_TESTNET_ORCHESTRATOR_RUN_URL` | `ORCHESTRATOR_RUN_URL` ou `http://python-orchestrator:8099/orchestrator/run` |
+| `DEMO_TESTNET_ORCHESTRATOR_DASHBOARD_ID` | _(aucun)_ |
+| `DEMO_TESTNET_ORCHESTRATOR_SCHEDULE_ID` | `cron-orchestrator-demo-testnet-1m` |
+| `DEMO_TESTNET_ORCHESTRATOR_WORKFLOW_ID` | `cron-orchestrator-demo-testnet-runner` |
+| `DEMO_TESTNET_ORCHESTRATOR_CRON` | `*/1 * * * *` |
+
+Commandes :
+
+```bash
+# Preview sans connexion Temporal.
+python scripts/manage_demo_testnet_schedule.py create --dry-run --dashboard-id 7
+
+# Création paused par défaut.
+python scripts/manage_demo_testnet_schedule.py create --dashboard-id 7
+
+# Activation après runtime-check OKX + Hyperliquid.
+python scripts/manage_demo_testnet_schedule.py resume --dashboard-id 7
+
+# Rollback opérateur.
+python scripts/manage_demo_testnet_schedule.py pause
+python scripts/manage_demo_testnet_schedule.py delete
+```
+
 ### 4.1 Runtime Matrix Exchange/Profile (legacy, DEPRECATED CLEAN-001)
 
 - **Statut** : **DEPRECATED (CLEAN-001)** — legacy multi-jobs. Conservé pour les déploiements existants ; ne plus créer de nouveaux schedules. Migrer vers le schedule orchestrateur unique (§4.0). Lancer ce script émet un `DeprecationWarning`.

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -323,7 +323,7 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
     if warning is not None:
         print(f"WARNING: {warning}")
 
-    if config.resume_on_create or not config.paused:
+    if not config.dry_run_schedule and (config.resume_on_create or not config.paused):
         ensure_runtime_checks_pass(config.skip_runtime_check)
 
     workflow_config = build_workflow_config(

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -215,8 +215,11 @@ def existing_schedule_is_paused(description: Any) -> bool:
 async def ensure_existing_schedule_pause_state(handle: Any, config: ScheduleConfig) -> None:
     description = await handle.describe()
     await validate_schedule_definition(description, config)
-    if config.paused and not existing_schedule_is_paused(description):
+    is_paused = existing_schedule_is_paused(description)
+    if config.paused and not is_paused:
         await handle.pause(note="demo/testnet create re-applied paused-by-default")
+    elif not config.paused and is_paused:
+        await handle.unpause(note="demo/testnet runtime checks passed")
 
 
 def parse_runtime_check_output(output: str) -> Dict[str, str]:

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -387,6 +387,8 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
 
 
 async def pause_schedule(handle: Any, config: ScheduleConfig) -> None:
+    assert_demo_environment(config.environment)
+    await verify_existing_schedule(handle, config)
     await handle.pause(note="manual demo/testnet pause")
     print(f"schedule '{config.schedule_id}' paused")
 
@@ -400,6 +402,8 @@ async def resume_schedule(handle: Any, config: ScheduleConfig) -> None:
 
 
 async def delete_schedule(handle: Any, config: ScheduleConfig) -> None:
+    assert_demo_environment(config.environment)
+    await verify_existing_schedule(handle, config)
     await handle.delete()
     print(f"schedule '{config.schedule_id}' deleted")
 

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -171,6 +171,19 @@ async def verify_existing_schedule(handle: Any, config: ScheduleConfig) -> None:
     await validate_schedule_definition(description, config)
 
 
+def existing_schedule_is_paused(description: Any) -> bool:
+    schedule = getattr(description, "schedule", None)
+    state = getattr(schedule, "state", None)
+    return bool(getattr(state, "paused", False))
+
+
+async def ensure_existing_schedule_pause_state(handle: Any, config: ScheduleConfig) -> None:
+    description = await handle.describe()
+    await validate_schedule_definition(description, config)
+    if config.paused and not existing_schedule_is_paused(description):
+        await handle.pause(note="demo/testnet create re-applied paused-by-default")
+
+
 def parse_runtime_check_output(output: str) -> Dict[str, str]:
     parsed: Dict[str, str] = {}
     for line in output.splitlines():
@@ -321,10 +334,10 @@ async def create_schedule(client: Any, config: ScheduleConfig) -> None:
 
         if isinstance(exc, ScheduleAlreadyRunningError):
             handle = client.get_schedule_handle(config.schedule_id)
-            await verify_existing_schedule(handle, config)
+            await ensure_existing_schedule_pause_state(handle, config)
             print(
                 f"schedule '{config.schedule_id}' already exists."
-                " Validated existing definition before reusing it."
+                " Validated existing definition and pause state before reusing it."
             )
             return
         raise

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -139,6 +139,17 @@ def _normalize_overlap_policy(value: Any) -> str:
     return name.lower().replace("schedule_overlap_policy_", "")
 
 
+def _normalize_workflow_args_for_comparison(args: list[Any], config: ScheduleConfig) -> list[Any]:
+    if config.dashboard_id is not None:
+        return args
+    normalized: list[Any] = []
+    for arg in args:
+        if isinstance(arg, dict):
+            arg = {key: value for key, value in arg.items() if key != "dashboard_id"}
+        normalized.append(arg)
+    return normalized
+
+
 async def validate_schedule_definition(description: Any, config: ScheduleConfig) -> None:
     schedule = getattr(description, "schedule", None)
     action = getattr(schedule, "action", None)
@@ -154,6 +165,7 @@ async def validate_schedule_definition(description: Any, config: ScheduleConfig)
         )
     ]
     actual_args = await decoded_schedule_args(description, action)
+    actual_args = _normalize_workflow_args_for_comparison(actual_args, config)
     if actual_args != expected_args:
         raise RuntimeError(
             "unexpected workflow args for demo/testnet schedule: "

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -140,7 +140,7 @@ def _normalize_overlap_policy(value: Any) -> str:
 
 
 def _normalize_workflow_args_for_comparison(args: list[Any], config: ScheduleConfig) -> list[Any]:
-    if config.dashboard_id is not None:
+    if config.dashboard_id is not None or config.command not in {"pause", "delete"}:
         return args
     normalized: list[Any] = []
     for arg in args:
@@ -407,6 +407,7 @@ async def pause_schedule(handle: Any, config: ScheduleConfig) -> None:
 
 async def resume_schedule(handle: Any, config: ScheduleConfig) -> None:
     assert_demo_environment(config.environment)
+    assert_dashboard_configured(config)
     ensure_runtime_checks_pass(config.skip_runtime_check)
     await verify_existing_schedule(handle, config)
     await handle.unpause(note="demo/testnet runtime checks passed")

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -130,6 +130,15 @@ async def decoded_schedule_args(description: Any, action: Any) -> list[Any]:
     return list(decoded)
 
 
+def _normalize_overlap_policy(value: Any) -> str:
+    if value == 2:
+        return "buffer_one"
+    name = getattr(value, "name", None)
+    if name is None:
+        name = str(value)
+    return name.lower().replace("schedule_overlap_policy_", "")
+
+
 async def validate_schedule_definition(description: Any, config: ScheduleConfig) -> None:
     schedule = getattr(description, "schedule", None)
     action = getattr(schedule, "action", None)
@@ -163,6 +172,32 @@ async def validate_schedule_definition(description: Any, config: ScheduleConfig)
         raise RuntimeError(
             "unexpected task queue for demo/testnet schedule: "
             f"expected {TASK_QUEUE!r}, got {task_queue!r}"
+        )
+
+    spec = getattr(schedule, "spec", None)
+    cron_expressions = list(getattr(spec, "cron_expressions", []) or [])
+    if cron_expressions != [config.cron]:
+        raise RuntimeError(
+            "unexpected cron for demo/testnet schedule: "
+            f"expected {[config.cron]!r}, got {cron_expressions!r}"
+        )
+
+    time_zone_name = getattr(spec, "time_zone_name", None)
+    if time_zone_name != TIME_ZONE:
+        raise RuntimeError(
+            "unexpected time zone for demo/testnet schedule: "
+            f"expected {TIME_ZONE!r}, got {time_zone_name!r}"
+        )
+
+    policy = getattr(schedule, "policy", None)
+    overlap = getattr(policy, "overlap", None)
+    expected_overlap = temporal_schedule_classes()[-1]
+    if overlap != expected_overlap and _normalize_overlap_policy(overlap) != _normalize_overlap_policy(
+        expected_overlap
+    ):
+        raise RuntimeError(
+            "unexpected overlap policy for demo/testnet schedule: "
+            f"expected {expected_overlap!r}, got {overlap!r}"
         )
 
 

--- a/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py
@@ -1,0 +1,452 @@
+"""Guarded Temporal schedule for OKX demo + Hyperliquid testnet orchestration.
+
+This is the dedicated DEMO-004 entrypoint. It targets the orchestrator workflow,
+forces the run request to dry-run, creates the schedule paused by default, and
+requires OKX + Hyperliquid runtime checks before any activation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import inspect
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+TEMPORAL_ADDRESS = os.getenv("TEMPORAL_ADDRESS", "temporal:7233")
+TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default")
+TASK_QUEUE = os.getenv("TASK_QUEUE_NAME", "cron_symfony_mtf_workers")
+TIME_ZONE = os.getenv("TZ", "UTC")
+
+WORKFLOW_TYPE = "OrchestratorCronWorkflow"
+SUPPORTED_ENVIRONMENT = "demo-testnet"
+RUNTIME_CHECK_EXCHANGES = ("okx", "hyperliquid")
+
+DEFAULT_URL = os.getenv(
+    "DEMO_TESTNET_ORCHESTRATOR_RUN_URL",
+    os.getenv("ORCHESTRATOR_RUN_URL", "http://python-orchestrator:8099/orchestrator/run"),
+)
+DEFAULT_CRON = os.getenv("DEMO_TESTNET_ORCHESTRATOR_CRON", "*/1 * * * *")
+DEFAULT_DASHBOARD_ID = os.getenv("DEMO_TESTNET_ORCHESTRATOR_DASHBOARD_ID")
+DEFAULT_SCHEDULE_ID = os.getenv(
+    "DEMO_TESTNET_ORCHESTRATOR_SCHEDULE_ID",
+    "cron-orchestrator-demo-testnet-1m",
+)
+DEFAULT_WORKFLOW_ID = os.getenv(
+    "DEMO_TESTNET_ORCHESTRATOR_WORKFLOW_ID",
+    "cron-orchestrator-demo-testnet-runner",
+)
+
+
+@dataclass(frozen=True)
+class ScheduleConfig:
+    command: str
+    url: str
+    dashboard_id: Optional[str]
+    cron: str
+    schedule_id: str
+    workflow_id: str
+    dry_run_schedule: bool
+    paused: bool
+    resume_on_create: bool
+    skip_runtime_check: bool
+    environment: str
+
+
+def assert_demo_environment(environment: str) -> None:
+    if environment != SUPPORTED_ENVIRONMENT:
+        raise RuntimeError(
+            f"mainnet schedules are forbidden for this entrypoint: expected "
+            f"{SUPPORTED_ENVIRONMENT!r}, got {environment!r}"
+        )
+
+
+def dashboard_is_valid(dashboard_id: Optional[str]) -> bool:
+    if dashboard_id is None:
+        return False
+    stripped = str(dashboard_id).strip()
+    if not stripped:
+        return False
+    try:
+        int(stripped)
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def assert_dashboard_configured(config: ScheduleConfig) -> Optional[str]:
+    if dashboard_is_valid(config.dashboard_id):
+        return None
+
+    message = (
+        f"no valid demo/testnet dashboard configured (got {config.dashboard_id!r}): "
+        "pass a numeric --dashboard-id or set DEMO_TESTNET_ORCHESTRATOR_DASHBOARD_ID."
+    )
+    if not config.dry_run_schedule:
+        raise SystemExit(f"refusing to create demo/testnet schedule: {message}")
+    return message
+
+
+def build_workflow_config(
+    *,
+    url: str,
+    dashboard_id: Optional[str],
+    schedule_id: str,
+) -> Dict[str, Any]:
+    config: Dict[str, Any] = {
+        "url": url,
+        "schedule_id": schedule_id,
+        "dry_run": True,
+    }
+    if dashboard_id is not None:
+        config["dashboard_id"] = dashboard_id
+    return config
+
+
+def _looks_like_temporal_payload(value: Any) -> bool:
+    return hasattr(value, "metadata") and hasattr(value, "data")
+
+
+async def decoded_schedule_args(description: Any, action: Any) -> list[Any]:
+    raw_args = list(getattr(action, "args", []) or [])
+    if not raw_args or not any(_looks_like_temporal_payload(arg) for arg in raw_args):
+        return raw_args
+
+    data_converter = getattr(description, "data_converter", None)
+    if data_converter is None or not hasattr(data_converter, "decode"):
+        raise RuntimeError("could not decode Temporal schedule args: missing data converter")
+
+    try:
+        decoded = data_converter.decode(raw_args)
+        if inspect.isawaitable(decoded):
+            decoded = await decoded
+    except Exception as exc:  # noqa: BLE001 - expose decode failure as guardrail failure
+        raise RuntimeError(f"could not decode Temporal schedule args: {exc}") from exc
+
+    return list(decoded)
+
+
+async def validate_schedule_definition(description: Any, config: ScheduleConfig) -> None:
+    schedule = getattr(description, "schedule", None)
+    action = getattr(schedule, "action", None)
+    workflow = getattr(action, "workflow", None)
+    if workflow != WORKFLOW_TYPE:
+        raise RuntimeError(f"unexpected workflow for demo/testnet schedule: {workflow!r}")
+
+    expected_args = [
+        build_workflow_config(
+            url=config.url,
+            dashboard_id=config.dashboard_id,
+            schedule_id=config.schedule_id,
+        )
+    ]
+    actual_args = await decoded_schedule_args(description, action)
+    if actual_args != expected_args:
+        raise RuntimeError(
+            "unexpected workflow args for demo/testnet schedule: "
+            f"expected {expected_args!r}, got {actual_args!r}"
+        )
+
+    workflow_id = getattr(action, "id", None)
+    if workflow_id != config.workflow_id:
+        raise RuntimeError(
+            "unexpected workflow id for demo/testnet schedule: "
+            f"expected {config.workflow_id!r}, got {workflow_id!r}"
+        )
+
+    task_queue = getattr(action, "task_queue", None)
+    if task_queue != TASK_QUEUE:
+        raise RuntimeError(
+            "unexpected task queue for demo/testnet schedule: "
+            f"expected {TASK_QUEUE!r}, got {task_queue!r}"
+        )
+
+
+async def verify_existing_schedule(handle: Any, config: ScheduleConfig) -> None:
+    description = await handle.describe()
+    await validate_schedule_definition(description, config)
+
+
+def parse_runtime_check_output(output: str) -> Dict[str, str]:
+    parsed: Dict[str, str] = {}
+    for line in output.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        parsed[key.strip().lower().replace(" ", "_")] = value.strip().lower()
+    return parsed
+
+
+def build_runtime_check_command(exchange: str) -> list[str]:
+    return [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "trading-app-php",
+        "php",
+        "bin/console",
+        "app:exchange:runtime-check",
+        exchange,
+        "perpetual",
+    ]
+
+
+def run_runtime_check(exchange: str) -> Dict[str, str]:
+    repo_root = Path(__file__).resolve().parents[2]
+    result = subprocess.run(
+        build_runtime_check_command(exchange),
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{exchange} runtime-check failed with exit code {result.returncode}: "
+            f"{(result.stderr or result.stdout).strip()}"
+        )
+    return parse_runtime_check_output(result.stdout)
+
+
+def validate_runtime_checks(checks: Dict[str, Dict[str, str]]) -> None:
+    for exchange in RUNTIME_CHECK_EXCHANGES:
+        parsed = checks.get(exchange, {})
+        if parsed.get("schedule_ready") != "yes":
+            raise RuntimeError(f"{exchange} runtime-check schedule_ready must be yes")
+        if parsed.get("exchange") not in {None, exchange}:
+            raise RuntimeError(f"{exchange} runtime-check returned exchange={parsed.get('exchange')!r}")
+        readiness_level = parsed.get("readiness_level")
+        if readiness_level in {"mainnet_ready", "live_ready"}:
+            raise RuntimeError(f"{exchange} runtime-check returned forbidden readiness_level={readiness_level}")
+
+
+def ensure_runtime_checks_pass(skip_runtime_check: bool = False) -> None:
+    if skip_runtime_check:
+        raise RuntimeError("demo/testnet activation cannot skip runtime-check")
+    checks = {exchange: run_runtime_check(exchange) for exchange in RUNTIME_CHECK_EXCHANGES}
+    validate_runtime_checks(checks)
+
+
+async def get_client():  # pragma: no cover - thin Temporal SDK wrapper
+    from temporalio.client import Client
+
+    return await Client.connect(TEMPORAL_ADDRESS, namespace=TEMPORAL_NAMESPACE)
+
+
+def temporal_schedule_classes():  # pragma: no cover - thin Temporal SDK wrapper
+    from temporalio.api.enums.v1 import ScheduleOverlapPolicy
+
+    try:
+        from temporalio.client import (
+            Schedule,
+            ScheduleActionStartWorkflow,
+            SchedulePolicy,
+            ScheduleSpec,
+            ScheduleState,
+        )
+    except ImportError:  # pragma: no cover - compatibility with older Temporal SDKs
+        from temporalio.client.schedule import (  # type: ignore[attr-defined]
+            Schedule,
+            ScheduleActionStartWorkflow,
+            SchedulePolicy,
+            ScheduleSpec,
+            ScheduleState,
+        )
+
+    try:
+        overlap = ScheduleOverlapPolicy.BUFFER_ONE
+    except AttributeError:  # pragma: no cover - compatibility with older Temporal SDKs
+        overlap = ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE
+
+    return Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, ScheduleState, overlap
+
+
+async def create_schedule(client: Any, config: ScheduleConfig) -> None:
+    assert_demo_environment(config.environment)
+    warning = assert_dashboard_configured(config)
+    if warning is not None:
+        print(f"WARNING: {warning}")
+
+    if config.resume_on_create or not config.paused:
+        ensure_runtime_checks_pass(config.skip_runtime_check)
+
+    workflow_config = build_workflow_config(
+        url=config.url,
+        dashboard_id=config.dashboard_id,
+        schedule_id=config.schedule_id,
+    )
+
+    if config.dry_run_schedule:
+        print(
+            "[DRY-RUN] would create demo/testnet schedule "
+            f"{config.schedule_id} (workflow_id='{config.workflow_id}', cron='{config.cron}', "
+            f"tz='{TIME_ZONE}', paused={config.paused}, config={workflow_config})"
+        )
+        return
+
+    Schedule, ScheduleActionStartWorkflow, SchedulePolicy, ScheduleSpec, ScheduleState, overlap = (
+        temporal_schedule_classes()
+    )
+    schedule = Schedule(
+        action=ScheduleActionStartWorkflow(
+            WORKFLOW_TYPE,
+            args=[workflow_config],
+            id=config.workflow_id,
+            task_queue=TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(
+            cron_expressions=[config.cron],
+            time_zone_name=TIME_ZONE,
+        ),
+        policy=SchedulePolicy(overlap=overlap),
+        state=ScheduleState(
+            paused=config.paused,
+            note=(
+                "demo/testnet schedule paused by default"
+                if config.paused
+                else "demo/testnet runtime checks passed"
+            ),
+        ),
+    )
+
+    try:
+        await client.create_schedule(config.schedule_id, schedule)
+    except Exception as exc:
+        from temporalio.client import ScheduleAlreadyRunningError
+
+        if isinstance(exc, ScheduleAlreadyRunningError):
+            handle = client.get_schedule_handle(config.schedule_id)
+            await verify_existing_schedule(handle, config)
+            print(
+                f"schedule '{config.schedule_id}' already exists."
+                " Validated existing definition before reusing it."
+            )
+            return
+        raise
+
+    print(
+        f"created demo/testnet schedule '{config.schedule_id}' -> cron='{config.cron}' "
+        f"-> paused={config.paused} -> config={workflow_config}"
+    )
+
+
+async def pause_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.pause(note="manual demo/testnet pause")
+    print(f"schedule '{config.schedule_id}' paused")
+
+
+async def resume_schedule(handle: Any, config: ScheduleConfig) -> None:
+    assert_demo_environment(config.environment)
+    ensure_runtime_checks_pass(config.skip_runtime_check)
+    await verify_existing_schedule(handle, config)
+    await handle.unpause(note="demo/testnet runtime checks passed")
+    print(f"schedule '{config.schedule_id}' resumed")
+
+
+async def delete_schedule(handle: Any, config: ScheduleConfig) -> None:
+    await handle.delete()
+    print(f"schedule '{config.schedule_id}' deleted")
+
+
+async def describe_schedule(handle: Any) -> None:
+    description = await handle.describe()
+    print("schedule status:")
+    print(description)
+
+
+def resolve_schedule_config(args: argparse.Namespace) -> ScheduleConfig:
+    resume_on_create = bool(getattr(args, "resume_on_create", False))
+    paused = not resume_on_create
+    return ScheduleConfig(
+        command=args.command,
+        url=getattr(args, "url", None) or DEFAULT_URL,
+        dashboard_id=getattr(args, "dashboard_id", None) or DEFAULT_DASHBOARD_ID,
+        cron=getattr(args, "cron", None) or DEFAULT_CRON,
+        schedule_id=getattr(args, "schedule_id", None) or DEFAULT_SCHEDULE_ID,
+        workflow_id=getattr(args, "workflow_id", None) or DEFAULT_WORKFLOW_ID,
+        dry_run_schedule=getattr(args, "dry_run_schedule", False),
+        paused=paused,
+        resume_on_create=resume_on_create,
+        skip_runtime_check=getattr(args, "skip_runtime_check", False),
+        environment=getattr(args, "environment", SUPPORTED_ENVIRONMENT),
+    )
+
+
+async def async_main(args: argparse.Namespace) -> None:
+    config = resolve_schedule_config(args)
+
+    if config.command == "create":
+        assert_demo_environment(config.environment)
+        assert_dashboard_configured(config)
+        client = None if config.dry_run_schedule else await get_client()
+        await create_schedule(client, config)
+        return
+
+    client = await get_client()
+    handle = client.get_schedule_handle(config.schedule_id)
+    if config.command == "pause":
+        await pause_schedule(handle, config)
+    elif config.command == "resume":
+        await resume_schedule(handle, config)
+    elif config.command == "delete":
+        await delete_schedule(handle, config)
+    elif config.command == "status":
+        await describe_schedule(handle)
+
+
+def add_common_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--url", help="Orchestrator run URL")
+    parser.add_argument("--dashboard-id", help="Numeric demo-exchanges dashboard id")
+    parser.add_argument("--cron", help="Cron expression")
+    parser.add_argument("--schedule-id", help="Schedule id")
+    parser.add_argument("--workflow-id", help="Workflow id")
+    parser.add_argument("--environment", default=SUPPORTED_ENVIRONMENT)
+    parser.add_argument(
+        "--skip-runtime-check",
+        action="store_true",
+        help="Accepted for parser compatibility, but rejected before activation",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Manage the guarded OKX demo + Hyperliquid testnet orchestrator schedule"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create_cmd = sub.add_parser("create", help="Create the paused demo/testnet schedule")
+    add_common_options(create_cmd)
+    create_cmd.add_argument(
+        "--dry-run",
+        "--dry-run-schedule",
+        dest="dry_run_schedule",
+        action="store_true",
+        help="Preview without creating the Temporal schedule",
+    )
+    create_cmd.add_argument(
+        "--resume-on-create",
+        action="store_true",
+        help="Create active only after OKX and Hyperliquid runtime checks pass",
+    )
+
+    for command in ("status", "pause", "resume", "delete"):
+        cmd = sub.add_parser(command, help=f"{command.capitalize()} the schedule")
+        add_common_options(cmd)
+        cmd.set_defaults(dry_run_schedule=False, resume_on_create=False)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    asyncio.run(async_main(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -70,6 +70,7 @@ def _description(
     workflow_id=DEFAULT_WORKFLOW_ID,
     task_queue=None,
     data_converter=None,
+    paused=True,
 ):
     if args is None:
         args = [
@@ -87,7 +88,8 @@ def _description(
                 args=args,
                 id=workflow_id,
                 task_queue=task_queue or schedule_manager.TASK_QUEUE,
-            )
+            ),
+            state=types.SimpleNamespace(paused=paused),
         ),
         data_converter=data_converter,
     )
@@ -651,7 +653,44 @@ def test_create_schedule_handles_already_running(monkeypatch, capsys):
 
     output = capsys.readouterr().out
     assert "already exists" in output
-    assert "Validated existing definition" in output
+    assert "Validated existing definition and pause state" in output
+
+
+def test_create_schedule_reapplies_paused_state_for_existing_active_schedule(monkeypatch):
+    _patch_schedule_classes(monkeypatch, {})
+
+    class FakeAlreadyRunning(Exception):
+        pass
+
+    temporalio_module = types.ModuleType("temporalio")
+    temporalio_client_module = types.ModuleType("temporalio.client")
+    temporalio_client_module.ScheduleAlreadyRunningError = FakeAlreadyRunning
+    monkeypatch.setitem(sys.modules, "temporalio", temporalio_module)
+    monkeypatch.setitem(sys.modules, "temporalio.client", temporalio_client_module)
+
+    calls = []
+
+    class Handle:
+        async def describe(self):
+            calls.append(("describe",))
+            return _description(paused=False)
+
+        async def pause(self, *, note=None):
+            calls.append(("pause", note))
+
+    class AlreadyRunningClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise FakeAlreadyRunning("exists")
+
+        def get_schedule_handle(self, schedule_id):
+            return Handle()
+
+    asyncio.run(create_schedule(AlreadyRunningClient(), _config()))
+
+    assert calls == [
+        ("describe",),
+        ("pause", "demo/testnet create re-applied paused-by-default"),
+    ]
 
 
 def test_create_schedule_rejects_existing_unsafe_schedule(monkeypatch):

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -1,0 +1,739 @@
+"""Tests for the guarded demo/testnet orchestrator Temporal schedule."""
+
+import asyncio
+import argparse
+import sys
+import types
+
+import pytest
+
+import scripts.manage_demo_testnet_schedule as schedule_manager
+from scripts.manage_demo_testnet_schedule import (
+    DEFAULT_SCHEDULE_ID,
+    DEFAULT_WORKFLOW_ID,
+    SUPPORTED_ENVIRONMENT,
+    ScheduleConfig,
+    assert_dashboard_configured,
+    assert_demo_environment,
+    async_main,
+    build_parser,
+    build_runtime_check_command,
+    build_workflow_config,
+    create_schedule,
+    delete_schedule,
+    describe_schedule,
+    ensure_runtime_checks_pass,
+    dashboard_is_valid,
+    parse_runtime_check_output,
+    pause_schedule,
+    resolve_schedule_config,
+    resume_schedule,
+    run_runtime_check,
+    validate_schedule_definition,
+    validate_runtime_checks,
+)
+
+
+class _DummyTemporalClass:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _EncodedPayload:
+    metadata = {}
+    data = b"encoded"
+
+
+class _FakeDataConverter:
+    def __init__(self, decoded=None, exc=None):
+        self.decoded = decoded
+        self.exc = exc
+        self.calls = []
+
+    def decode(self, payloads, type_hints=None):
+        self.calls.append((payloads, type_hints))
+        if self.exc is not None:
+            raise self.exc
+        return self.decoded
+
+
+class _AsyncFakeDataConverter(_FakeDataConverter):
+    async def decode(self, payloads, type_hints=None):
+        return super().decode(payloads, type_hints)
+
+
+def _description(
+    *,
+    workflow="OrchestratorCronWorkflow",
+    args=None,
+    workflow_id=DEFAULT_WORKFLOW_ID,
+    task_queue=None,
+    data_converter=None,
+):
+    if args is None:
+        args = [
+            {
+                "url": "http://python-orchestrator:8099/orchestrator/run",
+                "dashboard_id": "7",
+                "schedule_id": DEFAULT_SCHEDULE_ID,
+                "dry_run": True,
+            }
+        ]
+    return types.SimpleNamespace(
+        schedule=types.SimpleNamespace(
+            action=types.SimpleNamespace(
+                workflow=workflow,
+                args=args,
+                id=workflow_id,
+                task_queue=task_queue or schedule_manager.TASK_QUEUE,
+            )
+        ),
+        data_converter=data_converter,
+    )
+
+
+def _patch_schedule_classes(monkeypatch, captured):
+    def action(workflow_type, *, args, id, task_queue):
+        captured["workflow_type"] = workflow_type
+        captured["workflow_args"] = args
+        captured["workflow_id"] = id
+        captured["task_queue"] = task_queue
+        return _DummyTemporalClass()
+
+    monkeypatch.setattr(
+        schedule_manager,
+        "temporal_schedule_classes",
+        lambda: (
+            _DummyTemporalClass,
+            action,
+            _DummyTemporalClass,
+            _DummyTemporalClass,
+            _DummyTemporalClass,
+            "buffer_one",
+        ),
+    )
+
+
+def _config(command="create", **overrides):
+    base = dict(
+        command=command,
+        url="http://python-orchestrator:8099/orchestrator/run",
+        dashboard_id="7",
+        cron="*/1 * * * *",
+        schedule_id=DEFAULT_SCHEDULE_ID,
+        workflow_id=DEFAULT_WORKFLOW_ID,
+        dry_run_schedule=False,
+        paused=True,
+        resume_on_create=False,
+        skip_runtime_check=False,
+        environment=SUPPORTED_ENVIRONMENT,
+    )
+    base.update(overrides)
+    return ScheduleConfig(**base)
+
+
+def test_workflow_config_forces_demo_schedule_dry_run():
+    config = build_workflow_config(
+        url="http://python-orchestrator:8099/orchestrator/run",
+        dashboard_id="7",
+        schedule_id=DEFAULT_SCHEDULE_ID,
+    )
+
+    assert config == {
+        "url": "http://python-orchestrator:8099/orchestrator/run",
+        "dashboard_id": "7",
+        "schedule_id": DEFAULT_SCHEDULE_ID,
+        "dry_run": True,
+    }
+
+
+def test_workflow_config_omits_absent_dashboard():
+    config = build_workflow_config(
+        url="http://python-orchestrator:8099/orchestrator/run",
+        dashboard_id=None,
+        schedule_id=DEFAULT_SCHEDULE_ID,
+    )
+
+    assert config == {
+        "url": "http://python-orchestrator:8099/orchestrator/run",
+        "schedule_id": DEFAULT_SCHEDULE_ID,
+        "dry_run": True,
+    }
+
+
+def test_parser_defaults_to_dedicated_paused_demo_schedule():
+    parser = build_parser()
+    args = parser.parse_args(["create", "--dashboard-id", "7"])
+    config = resolve_schedule_config(args)
+
+    assert config.schedule_id == DEFAULT_SCHEDULE_ID
+    assert config.workflow_id == DEFAULT_WORKFLOW_ID
+    assert config.paused is True
+    assert config.resume_on_create is False
+    assert config.environment == SUPPORTED_ENVIRONMENT
+
+
+def test_parser_resume_on_create_creates_active_config():
+    parser = build_parser()
+    args = parser.parse_args(["create", "--dashboard-id", "7", "--resume-on-create"])
+    config = resolve_schedule_config(args)
+
+    assert config.resume_on_create is True
+    assert config.paused is False
+
+
+def test_mainnet_environment_is_rejected():
+    with pytest.raises(RuntimeError, match="mainnet schedules are forbidden"):
+        assert_demo_environment("mainnet")
+
+
+def test_dashboard_validation_rejects_missing_blank_and_non_numeric():
+    assert dashboard_is_valid("7") is True
+    assert dashboard_is_valid(" 7 ") is True
+    assert dashboard_is_valid(None) is False
+    assert dashboard_is_valid("") is False
+    assert dashboard_is_valid("   ") is False
+    assert dashboard_is_valid("abc") is False
+
+
+def test_create_without_dashboard_fails_unless_preview():
+    with pytest.raises(SystemExit, match="no valid demo/testnet dashboard configured"):
+        assert_dashboard_configured(_config(dashboard_id=None, dry_run_schedule=False))
+
+    warning = assert_dashboard_configured(_config(dashboard_id=None, dry_run_schedule=True))
+    assert "no valid demo/testnet dashboard configured" in warning
+
+
+def test_create_schedule_is_paused_by_default(monkeypatch):
+    captured = {}
+    _patch_schedule_classes(monkeypatch, captured)
+
+    class CapturingClient:
+        def __init__(self):
+            self.created = []
+
+        async def create_schedule(self, schedule_id, schedule):
+            self.created.append((schedule_id, schedule))
+
+    client = CapturingClient()
+    asyncio.run(create_schedule(client, _config()))
+
+    assert client.created[0][0] == DEFAULT_SCHEDULE_ID
+    schedule = client.created[0][1]
+    assert schedule.kwargs["state"].kwargs["paused"] is True
+    assert "paused by default" in schedule.kwargs["state"].kwargs["note"]
+    assert captured["workflow_type"] == "OrchestratorCronWorkflow"
+    assert captured["workflow_args"] == [
+        {
+            "url": "http://python-orchestrator:8099/orchestrator/run",
+            "dashboard_id": "7",
+            "schedule_id": DEFAULT_SCHEDULE_ID,
+            "dry_run": True,
+        }
+    ]
+
+
+def test_create_schedule_preview_with_missing_dashboard_warns(capsys):
+    asyncio.run(create_schedule(object(), _config(dashboard_id=None, dry_run_schedule=True)))
+
+    output = capsys.readouterr().out
+    assert "WARNING: no valid demo/testnet dashboard configured" in output
+    assert "[DRY-RUN] would create demo/testnet schedule" in output
+
+
+def test_create_schedule_can_be_active_after_runtime_checks(monkeypatch):
+    calls = []
+    captured = {}
+    _patch_schedule_classes(monkeypatch, captured)
+
+    def pass_runtime_checks(skip):
+        calls.append(("runtime_checks", skip))
+
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", pass_runtime_checks)
+
+    class CapturingClient:
+        def __init__(self):
+            self.created = []
+
+        async def create_schedule(self, schedule_id, schedule):
+            self.created.append((schedule_id, schedule))
+
+    client = CapturingClient()
+    asyncio.run(create_schedule(client, _config(paused=False, resume_on_create=True)))
+
+    assert calls == [("runtime_checks", False)]
+    schedule = client.created[0][1]
+    assert schedule.kwargs["state"].kwargs["paused"] is False
+    assert schedule.kwargs["state"].kwargs["note"] == "demo/testnet runtime checks passed"
+
+
+def test_create_resume_on_create_requires_runtime_checks(monkeypatch):
+    def fail_runtime_checks(skip):
+        raise RuntimeError("okx runtime-check failed")
+
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", fail_runtime_checks)
+
+    class FailingClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise AssertionError("schedule must not be created when readiness fails")
+
+    with pytest.raises(RuntimeError, match="okx runtime-check failed"):
+        asyncio.run(create_schedule(FailingClient(), _config(resume_on_create=True, paused=False)))
+
+
+def test_resume_requires_runtime_checks_before_unpause(monkeypatch):
+    def fail_runtime_checks(skip):
+        raise RuntimeError("hyperliquid runtime-check failed")
+
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", fail_runtime_checks)
+
+    class Handle:
+        def __init__(self):
+            self.unpaused = False
+
+        async def unpause(self, *, note=None):
+            self.unpaused = True
+
+    handle = Handle()
+    with pytest.raises(RuntimeError, match="hyperliquid runtime-check failed"):
+        asyncio.run(resume_schedule(handle, _config("resume")))
+
+    assert handle.unpaused is False
+
+
+def test_resume_unpauses_when_runtime_checks_pass(monkeypatch):
+    calls = []
+
+    def pass_runtime_checks(skip):
+        calls.append(("runtime_checks", skip))
+
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", pass_runtime_checks)
+
+    class Handle:
+        async def describe(self):
+            calls.append(("describe",))
+            return _description()
+
+        async def unpause(self, *, note=None):
+            calls.append(("unpause", note))
+
+    asyncio.run(resume_schedule(Handle(), _config("resume")))
+
+    assert calls == [
+        ("runtime_checks", False),
+        ("describe",),
+        ("unpause", "demo/testnet runtime checks passed"),
+    ]
+
+
+def test_resume_rejects_unsafe_existing_schedule_before_unpause(monkeypatch):
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", lambda skip: None)
+
+    class Handle:
+        def __init__(self):
+            self.unpaused = False
+
+        async def describe(self):
+            return _description(
+                workflow="CronSymfonyMtfWorkersWorkflow",
+                args=[[{"dry_run": False, "exchange": "bitmart"}]],
+            )
+
+        async def unpause(self, *, note=None):
+            self.unpaused = True
+
+    handle = Handle()
+    with pytest.raises(RuntimeError, match="unexpected workflow"):
+        asyncio.run(resume_schedule(handle, _config("resume")))
+
+    assert handle.unpaused is False
+
+
+def test_validate_schedule_definition_rejects_missing_dry_run():
+    unsafe_description = _description(args=[{"dashboard_id": "7", "schedule_id": DEFAULT_SCHEDULE_ID}])
+
+    with pytest.raises(RuntimeError, match="unexpected workflow args"):
+        asyncio.run(validate_schedule_definition(unsafe_description, _config("resume")))
+
+
+def test_validate_schedule_definition_decodes_temporal_payload_args():
+    decoded_args = [
+        {
+            "url": "http://python-orchestrator:8099/orchestrator/run",
+            "dashboard_id": "7",
+            "schedule_id": DEFAULT_SCHEDULE_ID,
+            "dry_run": True,
+        }
+    ]
+    converter = _AsyncFakeDataConverter(decoded=decoded_args)
+    payload = _EncodedPayload()
+
+    asyncio.run(
+        validate_schedule_definition(
+            _description(args=[payload], data_converter=converter),
+            _config("resume"),
+        )
+    )
+
+    assert converter.calls == [([payload], None)]
+
+
+def test_validate_schedule_definition_supports_sync_converter_and_requires_converter():
+    decoded_args = [
+        {
+            "url": "http://python-orchestrator:8099/orchestrator/run",
+            "dashboard_id": "7",
+            "schedule_id": DEFAULT_SCHEDULE_ID,
+            "dry_run": True,
+        }
+    ]
+    asyncio.run(
+        validate_schedule_definition(
+            _description(args=[_EncodedPayload()], data_converter=_FakeDataConverter(decoded=decoded_args)),
+            _config("resume"),
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="missing data converter"):
+        asyncio.run(
+            validate_schedule_definition(
+                _description(args=[_EncodedPayload()], data_converter=None),
+                _config("resume"),
+            )
+        )
+
+
+def test_validate_schedule_definition_reports_payload_decode_failure():
+    converter = _FakeDataConverter(exc=ValueError("bad payload"))
+
+    with pytest.raises(RuntimeError, match="could not decode Temporal schedule args"):
+        asyncio.run(
+            validate_schedule_definition(
+                _description(args=[_EncodedPayload()], data_converter=converter),
+                _config("resume"),
+            )
+        )
+
+
+def test_validate_schedule_definition_rejects_wrong_workflow_id_and_task_queue():
+    with pytest.raises(RuntimeError, match="unexpected workflow id"):
+        asyncio.run(
+            validate_schedule_definition(_description(workflow_id="other-workflow"), _config("resume"))
+        )
+
+    with pytest.raises(RuntimeError, match="unexpected task queue"):
+        asyncio.run(
+            validate_schedule_definition(_description(task_queue="other-task-queue"), _config("resume"))
+        )
+
+
+def test_pause_and_delete_delegate_to_handle():
+    calls = []
+
+    class Handle:
+        async def pause(self, *, note=None):
+            calls.append(("pause", note))
+
+        async def delete(self):
+            calls.append(("delete",))
+
+    asyncio.run(pause_schedule(Handle(), _config("pause")))
+    asyncio.run(delete_schedule(Handle(), _config("delete")))
+
+    assert calls == [("pause", "manual demo/testnet pause"), ("delete",)]
+
+
+def test_describe_schedule_prints_description(capsys):
+    class Handle:
+        async def describe(self):
+            return "DEMO-SCHEDULE-DESCRIPTION"
+
+    asyncio.run(describe_schedule(Handle()))
+
+    output = capsys.readouterr().out
+    assert "schedule status" in output
+    assert "DEMO-SCHEDULE-DESCRIPTION" in output
+
+
+def test_runtime_check_commands_cover_okx_and_hyperliquid():
+    assert build_runtime_check_command("okx") == [
+        "docker",
+        "compose",
+        "exec",
+        "-T",
+        "trading-app-php",
+        "php",
+        "bin/console",
+        "app:exchange:runtime-check",
+        "okx",
+        "perpetual",
+    ]
+    assert build_runtime_check_command("hyperliquid")[-2:] == ["hyperliquid", "perpetual"]
+
+
+def test_runtime_check_output_parser_skips_non_key_value_lines():
+    parsed = parse_runtime_check_output(
+        "not-a-pair\nExchange: okx\nSchedule ready: yes\nReadiness level: demo_testnet_candidate"
+    )
+
+    assert parsed == {
+        "exchange": "okx",
+        "schedule_ready": "yes",
+        "readiness_level": "demo_testnet_candidate",
+    }
+
+
+def test_validate_runtime_checks_requires_schedule_ready_yes():
+    okx = parse_runtime_check_output("Exchange: okx\nSchedule ready: yes\n")
+    hyperliquid = parse_runtime_check_output(
+        "Exchange: hyperliquid\nSchedule ready: no\n"
+    )
+
+    with pytest.raises(RuntimeError, match="hyperliquid runtime-check schedule_ready must be yes"):
+        validate_runtime_checks({"okx": okx, "hyperliquid": hyperliquid})
+
+
+def test_validate_runtime_checks_rejects_wrong_exchange_and_mainnet_readiness():
+    with pytest.raises(RuntimeError, match="okx runtime-check returned exchange='bitmart'"):
+        validate_runtime_checks(
+            {
+                "okx": {"exchange": "bitmart", "schedule_ready": "yes"},
+                "hyperliquid": {"schedule_ready": "yes"},
+            }
+        )
+
+    with pytest.raises(RuntimeError, match="forbidden readiness_level=mainnet_ready"):
+        validate_runtime_checks(
+            {
+                "okx": {"exchange": "okx", "schedule_ready": "yes", "readiness_level": "mainnet_ready"},
+                "hyperliquid": {"schedule_ready": "yes"},
+            }
+        )
+
+
+def test_ensure_runtime_checks_rejects_skip_and_runs_both_checks(monkeypatch):
+    with pytest.raises(RuntimeError, match="cannot skip runtime-check"):
+        ensure_runtime_checks_pass(skip_runtime_check=True)
+
+    calls = []
+
+    def fake_run_runtime_check(exchange):
+        calls.append(exchange)
+        return {"exchange": exchange, "schedule_ready": "yes"}
+
+    monkeypatch.setattr(schedule_manager, "run_runtime_check", fake_run_runtime_check)
+
+    ensure_runtime_checks_pass()
+
+    assert calls == ["okx", "hyperliquid"]
+
+
+def test_run_runtime_check_parses_success_and_reports_failure(monkeypatch):
+    class Result:
+        def __init__(self, returncode, stdout="", stderr=""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    calls = []
+
+    def fake_run(command, cwd, capture_output, check, text):
+        calls.append((command, cwd, capture_output, check, text))
+        return Result(0, stdout="Exchange: okx\nSchedule ready: yes\n")
+
+    monkeypatch.setattr(schedule_manager.subprocess, "run", fake_run)
+
+    assert run_runtime_check("okx") == {"exchange": "okx", "schedule_ready": "yes"}
+    assert calls[0][0] == build_runtime_check_command("okx")
+
+    def fake_fail(command, cwd, capture_output, check, text):
+        return Result(1, stdout="", stderr="boom")
+
+    monkeypatch.setattr(schedule_manager.subprocess, "run", fake_fail)
+
+    with pytest.raises(RuntimeError, match="okx runtime-check failed with exit code 1: boom"):
+        run_runtime_check("okx")
+
+
+def test_async_main_create_preview_skips_temporal(monkeypatch, capsys):
+    async def fail_get_client():
+        raise AssertionError("preview must not connect to Temporal")
+
+    monkeypatch.setattr(schedule_manager, "get_client", fail_get_client)
+
+    parser = build_parser()
+    args = parser.parse_args(["create", "--dashboard-id", "7", "--dry-run"])
+
+    asyncio.run(async_main(args))
+
+    assert "[DRY-RUN] would create demo/testnet schedule" in capsys.readouterr().out
+
+
+def test_async_main_create_connects_and_lifecycle_routes(monkeypatch):
+    _patch_schedule_classes(monkeypatch, {})
+    calls = []
+
+    def pass_runtime_checks(skip):
+        calls.append(("runtime_checks", skip))
+
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", pass_runtime_checks)
+
+    class Handle:
+        async def pause(self, *, note=None):
+            calls.append(("pause", note))
+
+        async def unpause(self, *, note=None):
+            calls.append(("unpause", note))
+
+        async def delete(self):
+            calls.append(("delete",))
+
+        async def describe(self):
+            calls.append(("describe",))
+            return _description()
+
+    class Client:
+        async def create_schedule(self, schedule_id, schedule):
+            calls.append(("create", schedule_id))
+
+        def get_schedule_handle(self, schedule_id):
+            calls.append(("handle", schedule_id))
+            return Handle()
+
+    async def fake_get_client():
+        return Client()
+
+    monkeypatch.setattr(schedule_manager, "get_client", fake_get_client)
+
+    parser = build_parser()
+    for argv in (
+        ["create", "--dashboard-id", "7"],
+        ["pause"],
+        ["resume", "--dashboard-id", "7"],
+        ["delete"],
+        ["status"],
+    ):
+        asyncio.run(async_main(parser.parse_args(argv)))
+
+    assert ("create", DEFAULT_SCHEDULE_ID) in calls
+    assert ("pause", "manual demo/testnet pause") in calls
+    assert ("unpause", "demo/testnet runtime checks passed") in calls
+    assert ("delete",) in calls
+    assert ("describe",) in calls
+
+
+def test_create_schedule_handles_already_running(monkeypatch, capsys):
+    captured = {}
+    _patch_schedule_classes(monkeypatch, captured)
+
+    class FakeAlreadyRunning(Exception):
+        pass
+
+    temporalio_module = types.ModuleType("temporalio")
+    temporalio_client_module = types.ModuleType("temporalio.client")
+    temporalio_client_module.ScheduleAlreadyRunningError = FakeAlreadyRunning
+    monkeypatch.setitem(sys.modules, "temporalio", temporalio_module)
+    monkeypatch.setitem(sys.modules, "temporalio.client", temporalio_client_module)
+
+    class Handle:
+        async def describe(self):
+            return _description()
+
+    class AlreadyRunningClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise FakeAlreadyRunning("exists")
+
+        def get_schedule_handle(self, schedule_id):
+            return Handle()
+
+    asyncio.run(create_schedule(AlreadyRunningClient(), _config()))
+
+    output = capsys.readouterr().out
+    assert "already exists" in output
+    assert "Validated existing definition" in output
+
+
+def test_create_schedule_rejects_existing_unsafe_schedule(monkeypatch):
+    _patch_schedule_classes(monkeypatch, {})
+
+    class FakeAlreadyRunning(Exception):
+        pass
+
+    temporalio_module = types.ModuleType("temporalio")
+    temporalio_client_module = types.ModuleType("temporalio.client")
+    temporalio_client_module.ScheduleAlreadyRunningError = FakeAlreadyRunning
+    monkeypatch.setitem(sys.modules, "temporalio", temporalio_module)
+    monkeypatch.setitem(sys.modules, "temporalio.client", temporalio_client_module)
+
+    class Handle:
+        async def describe(self):
+            return _description(args=[{"dashboard_id": "7", "schedule_id": DEFAULT_SCHEDULE_ID}])
+
+    class AlreadyRunningClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise FakeAlreadyRunning("exists")
+
+        def get_schedule_handle(self, schedule_id):
+            return Handle()
+
+    with pytest.raises(RuntimeError, match="unexpected workflow args"):
+        asyncio.run(create_schedule(AlreadyRunningClient(), _config()))
+
+
+def test_create_schedule_reraises_unexpected_create_error(monkeypatch):
+    _patch_schedule_classes(monkeypatch, {})
+
+    class BoomClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(create_schedule(BoomClient(), _config()))
+
+
+def test_async_main_unknown_command_resolves_handle_but_noops(monkeypatch):
+    calls = []
+
+    class Handle:
+        async def pause(self, *, note=None):
+            calls.append("pause")
+
+        async def unpause(self, *, note=None):
+            calls.append("unpause")
+
+        async def delete(self):
+            calls.append("delete")
+
+        async def describe(self):
+            calls.append("describe")
+
+    class Client:
+        def get_schedule_handle(self, schedule_id):
+            calls.append(("handle", schedule_id))
+            return Handle()
+
+    async def fake_get_client():
+        return Client()
+
+    monkeypatch.setattr(schedule_manager, "get_client", fake_get_client)
+
+    args = argparse.Namespace(command="bogus", schedule_id=DEFAULT_SCHEDULE_ID)
+    asyncio.run(async_main(args))
+
+    assert calls == [("handle", DEFAULT_SCHEDULE_ID)]
+
+
+def test_main_parses_args_and_runs(monkeypatch):
+    ran = {}
+
+    async def fake_async_main(args):
+        ran["command"] = args.command
+        ran["schedule_id"] = args.schedule_id
+
+    monkeypatch.setattr(schedule_manager, "async_main", fake_async_main)
+    monkeypatch.setattr(sys, "argv", ["prog", "status", "--schedule-id", "demo-schedule"])
+
+    schedule_manager.main()
+
+    assert ran == {"command": "status", "schedule_id": "demo-schedule"}

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -71,6 +71,9 @@ def _description(
     task_queue=None,
     data_converter=None,
     paused=True,
+    cron=None,
+    time_zone=None,
+    overlap="buffer_one",
 ):
     if args is None:
         args = [
@@ -89,6 +92,11 @@ def _description(
                 id=workflow_id,
                 task_queue=task_queue or schedule_manager.TASK_QUEUE,
             ),
+            spec=types.SimpleNamespace(
+                cron_expressions=[cron or "*/1 * * * *"],
+                time_zone_name=time_zone or schedule_manager.TIME_ZONE,
+            ),
+            policy=types.SimpleNamespace(overlap=overlap),
             state=types.SimpleNamespace(paused=paused),
         ),
         data_converter=data_converter,
@@ -427,6 +435,25 @@ def test_validate_schedule_definition_rejects_wrong_workflow_id_and_task_queue()
     with pytest.raises(RuntimeError, match="unexpected task queue"):
         asyncio.run(
             validate_schedule_definition(_description(task_queue="other-task-queue"), _config("resume"))
+        )
+
+
+def test_validate_schedule_definition_rejects_wrong_spec_and_policy(monkeypatch):
+    _patch_schedule_classes(monkeypatch, {})
+
+    with pytest.raises(RuntimeError, match="unexpected cron"):
+        asyncio.run(
+            validate_schedule_definition(_description(cron="*/5 * * * *"), _config("resume"))
+        )
+
+    with pytest.raises(RuntimeError, match="unexpected time zone"):
+        asyncio.run(
+            validate_schedule_definition(_description(time_zone="Europe/Paris"), _config("resume"))
+        )
+
+    with pytest.raises(RuntimeError, match="unexpected overlap policy"):
+        asyncio.run(
+            validate_schedule_definition(_description(overlap="allow_all"), _config("resume"))
         )
 
 

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -330,6 +330,27 @@ def test_resume_requires_runtime_checks_before_unpause(monkeypatch):
     assert handle.unpaused is False
 
 
+def test_resume_requires_dashboard_before_unpause(monkeypatch):
+    monkeypatch.setattr(
+        schedule_manager,
+        "ensure_runtime_checks_pass",
+        lambda skip: (_ for _ in ()).throw(AssertionError("dashboard guard must run first")),
+    )
+
+    class Handle:
+        def __init__(self):
+            self.unpaused = False
+
+        async def unpause(self, *, note=None):
+            self.unpaused = True
+
+    handle = Handle()
+    with pytest.raises(SystemExit, match="no valid demo/testnet dashboard configured"):
+        asyncio.run(resume_schedule(handle, _config("resume", dashboard_id=None)))
+
+    assert handle.unpaused is False
+
+
 def test_resume_unpauses_when_runtime_checks_pass(monkeypatch):
     calls = []
 

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -252,6 +252,24 @@ def test_create_schedule_preview_with_missing_dashboard_warns(capsys):
     assert "[DRY-RUN] would create demo/testnet schedule" in output
 
 
+def test_create_schedule_resume_on_create_preview_skips_runtime_checks(monkeypatch, capsys):
+    def fail_runtime_checks(skip):
+        raise AssertionError("dry-run preview must not run activation checks")
+
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", fail_runtime_checks)
+
+    asyncio.run(
+        create_schedule(
+            object(),
+            _config(dry_run_schedule=True, paused=False, resume_on_create=True),
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "[DRY-RUN] would create demo/testnet schedule" in output
+    assert "paused=False" in output
+
+
 def test_create_schedule_can_be_active_after_runtime_checks(monkeypatch):
     calls = []
     captured = {}

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -479,6 +479,10 @@ def test_pause_and_delete_delegate_to_handle():
     calls = []
 
     class Handle:
+        async def describe(self):
+            calls.append(("describe",))
+            return _description()
+
         async def pause(self, *, note=None):
             calls.append(("pause", note))
 
@@ -488,7 +492,37 @@ def test_pause_and_delete_delegate_to_handle():
     asyncio.run(pause_schedule(Handle(), _config("pause")))
     asyncio.run(delete_schedule(Handle(), _config("delete")))
 
-    assert calls == [("pause", "manual demo/testnet pause"), ("delete",)]
+    assert calls == [
+        ("describe",),
+        ("pause", "manual demo/testnet pause"),
+        ("describe",),
+        ("delete",),
+    ]
+
+
+def test_pause_and_delete_reject_unsafe_schedule_before_mutation():
+    class Handle:
+        def __init__(self):
+            self.mutated = False
+
+        async def describe(self):
+            return _description(workflow="CronSymfonyMtfWorkersWorkflow")
+
+        async def pause(self, *, note=None):
+            self.mutated = True
+
+        async def delete(self):
+            self.mutated = True
+
+    pause_handle = Handle()
+    with pytest.raises(RuntimeError, match="unexpected workflow"):
+        asyncio.run(pause_schedule(pause_handle, _config("pause")))
+    assert pause_handle.mutated is False
+
+    delete_handle = Handle()
+    with pytest.raises(RuntimeError, match="unexpected workflow"):
+        asyncio.run(delete_schedule(delete_handle, _config("delete")))
+    assert delete_handle.mutated is False
 
 
 def test_describe_schedule_prints_description(capsys):
@@ -656,9 +690,9 @@ def test_async_main_create_connects_and_lifecycle_routes(monkeypatch):
     parser = build_parser()
     for argv in (
         ["create", "--dashboard-id", "7"],
-        ["pause"],
+        ["pause", "--dashboard-id", "7"],
         ["resume", "--dashboard-id", "7"],
-        ["delete"],
+        ["delete", "--dashboard-id", "7"],
         ["status"],
     ):
         asyncio.run(async_main(parser.parse_args(argv)))

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -690,9 +690,9 @@ def test_async_main_create_connects_and_lifecycle_routes(monkeypatch):
     parser = build_parser()
     for argv in (
         ["create", "--dashboard-id", "7"],
-        ["pause", "--dashboard-id", "7"],
+        ["pause"],
         ["resume", "--dashboard-id", "7"],
-        ["delete", "--dashboard-id", "7"],
+        ["delete"],
         ["status"],
     ):
         asyncio.run(async_main(parser.parse_args(argv)))

--- a/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
+++ b/cron_symfony_mtf_workers/tests/test_manage_demo_testnet_schedule.py
@@ -720,6 +720,49 @@ def test_create_schedule_reapplies_paused_state_for_existing_active_schedule(mon
     ]
 
 
+def test_create_schedule_resume_on_create_unpauses_existing_paused_schedule(monkeypatch):
+    _patch_schedule_classes(monkeypatch, {})
+    monkeypatch.setattr(schedule_manager, "ensure_runtime_checks_pass", lambda skip: None)
+
+    class FakeAlreadyRunning(Exception):
+        pass
+
+    temporalio_module = types.ModuleType("temporalio")
+    temporalio_client_module = types.ModuleType("temporalio.client")
+    temporalio_client_module.ScheduleAlreadyRunningError = FakeAlreadyRunning
+    monkeypatch.setitem(sys.modules, "temporalio", temporalio_module)
+    monkeypatch.setitem(sys.modules, "temporalio.client", temporalio_client_module)
+
+    calls = []
+
+    class Handle:
+        async def describe(self):
+            calls.append(("describe",))
+            return _description(paused=True)
+
+        async def unpause(self, *, note=None):
+            calls.append(("unpause", note))
+
+    class AlreadyRunningClient:
+        async def create_schedule(self, schedule_id, schedule):
+            raise FakeAlreadyRunning("exists")
+
+        def get_schedule_handle(self, schedule_id):
+            return Handle()
+
+    asyncio.run(
+        create_schedule(
+            AlreadyRunningClient(),
+            _config(paused=False, resume_on_create=True),
+        )
+    )
+
+    assert calls == [
+        ("describe",),
+        ("unpause", "demo/testnet runtime checks passed"),
+    ]
+
+
 def test_create_schedule_rejects_existing_unsafe_schedule(monkeypatch):
     _patch_schedule_classes(monkeypatch, {})
 

--- a/docs/handbook/runbooks/demo-testnet-operations.md
+++ b/docs/handbook/runbooks/demo-testnet-operations.md
@@ -217,6 +217,54 @@ Le resultat doit etre conserve tel quel dans les preuves redacted. Si
 `Schedule ready: yes` n'apparait pas, la section exchange de la recette reste
 `BLOCKED`.
 
+## Schedule demo/testnet
+
+Le schedule DEMO-004 utilise `cron_symfony_mtf_workers/scripts/manage_demo_testnet_schedule.py`.
+Il cible `OrchestratorCronWorkflow`, force le `RunRequest` a `dry_run=true` et
+cree le schedule en pause par defaut. Aucun schedule mainnet n'est fourni par ce
+script.
+
+Recuperer l'id du dashboard `demo-exchanges` :
+
+```bash
+dashboard_id="$(
+  curl -sS http://localhost:8099/dashboards \
+    | python3 -c 'import json, sys; print(next((str(d["id"]) for d in json.load(sys.stdin) if d["name"] == "demo-exchanges"), ""))'
+)"
+test -n "$dashboard_id"
+```
+
+Previsualiser sans connexion Temporal :
+
+```bash
+cd cron_symfony_mtf_workers
+python scripts/manage_demo_testnet_schedule.py create \
+  --dry-run \
+  --dashboard-id "$dashboard_id"
+```
+
+Creer le schedule paused :
+
+```bash
+python scripts/manage_demo_testnet_schedule.py create \
+  --dashboard-id "$dashboard_id"
+python scripts/manage_demo_testnet_schedule.py status
+```
+
+Activer seulement apres runtime-check OKX + Hyperliquid `Schedule ready: yes` :
+
+```bash
+python scripts/manage_demo_testnet_schedule.py resume \
+  --dashboard-id "$dashboard_id"
+```
+
+Rollback schedule :
+
+```bash
+python scripts/manage_demo_testnet_schedule.py pause
+python scripts/manage_demo_testnet_schedule.py delete
+```
+
 ## Recette dry-run
 
 Commande DEMO-002/DEMO-003 :

--- a/docs/roadmap/01-okx-hyperliquid-demo-testnet.md
+++ b/docs/roadmap/01-okx-hyperliquid-demo-testnet.md
@@ -52,11 +52,11 @@ Cette vague remplace la logique “dry-run uniquement” par une cible plus pré
 - [x] HL-011 — Orchestrator dry-run recipe Hyperliquid — #249 / `0b62049`.
 - [x] DEMO-001 — Fixtures demo OKX + Hyperliquid — #250 / `d90b3dd`.
 - [x] DEMO-002 — Recette R1-R16 double exchange en dry-run — #251 / `e524424`.
+- [x] DEMO-003 — Demo ops runbook + rollback — #252 / `79acc0c`.
+- [x] DEMO-004 — Enable demo schedule guarded — #253.
 
 ## Restant vague 1
 
-- [ ] DEMO-003 — Demo ops runbook + rollback.
-- [ ] DEMO-004 — Enable demo schedule guarded.
 - [ ] DEMO-005 — Pre-mutative demo readiness decision.
 - [ ] OKX-010 — Demo trading controlled avec SL.
 - [ ] HL-012 — Testnet trading controlled avec SL.
@@ -65,8 +65,6 @@ Cette vague remplace la logique “dry-run uniquement” par une cible plus pré
 ## Ordre strict recommandé
 
 ```text
-DEMO-003
-DEMO-004
 DEMO-005
 
 OKX-010


### PR DESCRIPTION
Part of DEMO-004
Related to #188
Related to #173
Related to PR #250
Related to PR #251
Related to PR #252

## Summary
- Add a dedicated guarded demo/testnet Temporal schedule manager for OKX demo + Hyperliquid testnet.
- Create schedules paused by default and force orchestrator runs to dry_run=true.
- Require OKX and Hyperliquid runtime-check Schedule ready=yes before resume or active creation; no mainnet environment supported.
- Document create/status/resume/pause/delete commands and update the demo/testnet roadmap.

## Tests
- PYTHONPATH=$PWD python3 -m pytest --cov --cov-report=term-missing -q (cron_symfony_mtf_workers)
- /tmp/tradingv3-docs-venv/bin/python -m mkdocs build --strict
- python3 -m compileall -q scripts tests (cron_symfony_mtf_workers)
- git diff --check

## Notes
- `codex status` was run after commit and failed in this non-interactive environment with `Error: stdin is not a terminal`.
- No PHP or Symfony DI files touched; no PHPStan/container lint applicable for this docs/Python schedule change.