### PR TITLE
Fix MTF execution timeframe fallback for regular profile

### DIFF
--- a/trading-app/src/MtfValidator/Service/MtfTimeframeResolver.php
+++ b/trading-app/src/MtfValidator/Service/MtfTimeframeResolver.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\MtfValidator\Service;
+
+final class MtfTimeframeResolver
+{
+    /**
+     * @param array<string, mixed> $mtfConfig
+     * @return list<string>
+     */
+    public function resolveContext(array $mtfConfig): array
+    {
+        $context = $this->normalize($mtfConfig['context_timeframes'] ?? null);
+        if ($context !== []) {
+            return $context;
+        }
+
+        $validationTimeframes = $this->validationTimeframes($mtfConfig);
+
+        return $validationTimeframes !== [] ? $validationTimeframes : ['4h', '1h'];
+    }
+
+    /**
+     * @param array<string, mixed> $mtfConfig
+     * @param list<string>|null    $contextTimeframes
+     * @return list<string>
+     */
+    public function resolveExecution(array $mtfConfig, ?array $contextTimeframes = null): array
+    {
+        $execution = $this->normalize($mtfConfig['execution_timeframes'] ?? null);
+        if ($execution !== []) {
+            return $execution;
+        }
+
+        $execution = array_values(array_diff(
+            $this->validationTimeframes($mtfConfig),
+            $contextTimeframes ?? $this->resolveContext($mtfConfig),
+        ));
+
+        return $execution !== [] ? $execution : ['15m', '5m', '1m'];
+    }
+
+    /**
+     * @param array<string, mixed> $mtfConfig
+     * @return list<string>
+     */
+    public function resolveAll(array $mtfConfig): array
+    {
+        $context = $this->resolveContext($mtfConfig);
+
+        return array_values(array_unique(array_merge(
+            $context,
+            $this->resolveExecution($mtfConfig, $context),
+        )));
+    }
+
+    /**
+     * @param array<string, mixed> $mtfConfig
+     * @return list<string>
+     */
+    private function validationTimeframes(array $mtfConfig): array
+    {
+        return $this->normalize(array_keys($mtfConfig['validation']['timeframe'] ?? []));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalize(mixed $timeframes): array
+    {
+        if (is_string($timeframes)) {
+            $timeframes = [$timeframes];
+        }
+
+        if (!is_array($timeframes)) {
+            return [];
+        }
+
+        return array_values(array_unique(array_filter(
+            $timeframes,
+            static fn (mixed $timeframe): bool => is_string($timeframe) && $timeframe !== '',
+        )));
+    }
+}

--- a/trading-app/src/MtfValidator/Service/MtfValidatorCoreService.php
+++ b/trading-app/src/MtfValidator/Service/MtfValidatorCoreService.php
@@ -26,6 +26,7 @@ class MtfValidatorCoreService
         private readonly AuditLoggerInterface $auditLogger,
         private readonly ClockInterface $clock,
         private readonly LoggerInterface $mtfLogger,
+        private readonly MtfTimeframeResolver $timeframeResolver,
     ) {
     }
 
@@ -41,8 +42,8 @@ class MtfValidatorCoreService
         $mode = $input->mode ?? ($mtfConfig['mode'] ?? null);
 
         // 2. Timeframes
-        $contextTimeframes   = $this->resolveContextTimeframes($mtfConfig);
-        $executionTimeframes = $this->resolveExecutionTimeframes($mtfConfig, $contextTimeframes);
+        $contextTimeframes   = $this->timeframeResolver->resolveContext($mtfConfig);
+        $executionTimeframes = $this->timeframeResolver->resolveExecution($mtfConfig, $contextTimeframes);
 
         $allTimeframes = \array_values(\array_unique(\array_merge(
             $contextTimeframes,
@@ -150,62 +151,6 @@ class MtfValidatorCoreService
         $this->auditResult($input, $result, 'MTF_EXECUTION_RESULT');
 
         return $result;
-    }
-
-    /**
-     * @param array<string,mixed> $mtfConfig
-     * @return string[]
-     */
-    private function resolveContextTimeframes(array $mtfConfig): array
-    {
-        $context = $mtfConfig['context_timeframes'] ?? null;
-
-        if (\is_string($context)) {
-            $context = [$context];
-        }
-
-        if (\is_array($context) && !empty($context)) {
-            /** @var string[] $context */
-            return $context;
-        }
-
-        $validationTimeframes = \array_keys($mtfConfig['validation']['timeframe'] ?? []);
-        if (!empty($validationTimeframes)) {
-            /** @var string[] $validationTimeframes */
-            return $validationTimeframes;
-        }
-
-        return ['4h', '1h'];
-    }
-
-    /**
-     * @param array<string,mixed> $mtfConfig
-     * @param string[]            $contextTimeframes
-     * @return string[]
-     */
-    private function resolveExecutionTimeframes(array $mtfConfig, array $contextTimeframes): array
-    {
-        $execution = $mtfConfig['execution_timeframes'] ?? null;
-
-        if (\is_string($execution)) {
-            $execution = [$execution];
-        }
-
-        if (\is_array($execution) && !empty($execution)) {
-            /** @var string[] $execution */
-            return $execution;
-        }
-
-        $validationTimeframes = \array_keys($mtfConfig['validation']['timeframe'] ?? []);
-        if (!empty($validationTimeframes)) {
-            $executionDerived = \array_values(\array_diff($validationTimeframes, $contextTimeframes));
-            if (!empty($executionDerived)) {
-                /** @var string[] $executionDerived */
-                return $executionDerived;
-            }
-        }
-
-        return ['15m', '5m', '1m'];
     }
 
     private function buildEmptyResult(

--- a/trading-app/src/MtfValidator/Service/MtfValidatorService.php
+++ b/trading-app/src/MtfValidator/Service/MtfValidatorService.php
@@ -21,6 +21,7 @@ class MtfValidatorService implements MtfValidatorInterface
         private readonly MtfValidationConfigProvider $mtfValidationConfigProvider,
         #[Autowire('%app.trade_entry_default_mode%')]
         private readonly string $defaultProfile,
+        private readonly MtfTimeframeResolver $timeframeResolver,
     ) {
     }
 
@@ -128,9 +129,11 @@ class MtfValidatorService implements MtfValidatorInterface
         return 'mtf_validator';
     }
 
+    /** @return list<string> */
     public function getListTimeframe(string $profile = 'scalper'): array
     {
         $config = $this->mtfValidationConfigProvider->getConfigForMode($profile)->getConfig();
-        return array_merge($config['context_timeframes'], $config['execution_timeframes']);
+
+        return $this->timeframeResolver->resolveAll($config);
     }
 }

--- a/trading-app/tests/MtfValidator/Service/MtfTimeframeResolverTest.php
+++ b/trading-app/tests/MtfValidator/Service/MtfTimeframeResolverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfValidator\Service;
+
+use App\MtfValidator\Service\MtfTimeframeResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MtfTimeframeResolver::class)]
+final class MtfTimeframeResolverTest extends TestCase
+{
+    private MtfTimeframeResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new MtfTimeframeResolver();
+    }
+
+    public function testExplicitContextAndExecutionTimeframesKeepFirstOccurrenceOrder(): void
+    {
+        $config = [
+            'context_timeframes' => ['4h', '1h', '4h'],
+            'execution_timeframes' => ['15m', '5m', '15m'],
+        ];
+
+        self::assertSame(['4h', '1h'], $this->resolver->resolveContext($config));
+        self::assertSame(['15m', '5m'], $this->resolver->resolveExecution($config));
+        self::assertSame(['4h', '1h', '15m', '5m'], $this->resolver->resolveAll($config));
+    }
+
+    public function testMissingExecutionTimeframesAreDerivedFromValidationAfterContext(): void
+    {
+        $config = [
+            'context_timeframes' => ['4h', '1h'],
+            'validation' => [
+                'timeframe' => [
+                    '4h' => [],
+                    '1h' => [],
+                    '15m' => [],
+                    '5m' => [],
+                    '1m' => [],
+                ],
+            ],
+        ];
+
+        self::assertSame(
+            ['15m', '5m', '1m'],
+            $this->resolver->resolveExecution($config, ['4h', '1h']),
+        );
+    }
+
+    public function testMissingConfigurationUsesDocumentedFinalFallbacks(): void
+    {
+        self::assertSame(['4h', '1h'], $this->resolver->resolveContext([]));
+        self::assertSame(['15m', '5m', '1m'], $this->resolver->resolveExecution([]));
+        self::assertSame(
+            ['4h', '1h', '15m', '5m', '1m'],
+            $this->resolver->resolveAll([]),
+        );
+    }
+
+    public function testStringValuesAreNormalizedAndDuplicatesAreRemovedAcrossPhases(): void
+    {
+        $config = [
+            'context_timeframes' => '1h',
+            'execution_timeframes' => ['1h', '5m', '5m'],
+        ];
+
+        self::assertSame(['1h', '5m'], $this->resolver->resolveAll($config));
+    }
+}

--- a/trading-app/tests/MtfValidator/Service/MtfValidatorServiceTimeframeTest.php
+++ b/trading-app/tests/MtfValidator/Service/MtfValidatorServiceTimeframeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\MtfValidator\Service;
+
+use App\Config\MtfValidationConfigProvider;
+use App\MtfValidator\Service\MtfValidatorCoreService;
+use App\MtfValidator\Service\MtfValidatorService;
+use App\MtfValidator\Service\MtfTimeframeResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+#[CoversClass(MtfValidatorService::class)]
+final class MtfValidatorServiceTimeframeTest extends TestCase
+{
+    public function testRegularProfileDerivesMissingExecutionTimeframesWithoutDuplicates(): void
+    {
+        $projectDir = \dirname(__DIR__, 3);
+        $configProvider = new MtfValidationConfigProvider(new ParameterBag([
+            'kernel.project_dir' => $projectDir,
+            'mode' => [],
+        ]));
+
+        $service = new MtfValidatorService(
+            $this->createMock(MtfValidatorCoreService::class),
+            $this->createMock(ClockInterface::class),
+            $configProvider,
+            'regular',
+            new MtfTimeframeResolver(),
+        );
+
+        self::assertSame(
+            ['4h', '1h', '15m', '5m', '1m'],
+            $service->getListTimeframe('regular'),
+        );
+    }
+}


### PR DESCRIPTION
## Résumé

- centralise la résolution des timeframes MTF dans `MtfTimeframeResolver`
- réutilise le même contrat dans le core et la façade
- dérive les timeframes d'exécution depuis `validation.timeframe` lorsqu'ils sont absents
- conserve les fallbacks historiques et un ordre dédupliqué déterministe
- ne modifie aucun YAML de stratégie

## Tests

- PHPUnit ciblé : `5 tests, 9 assertions`
- PHPStan sur tous les fichiers touchés : OK
- `php bin/console lint:container --no-debug` : OK
- `php bin/console lint:yaml config src/MtfValidator/config` : OK
- `git diff --check` : OK

## Validation après merge

Rejouer R1/R2/R8 sur la stack représentative avant de fermer #255 et de réévaluer #188/DEMO-005.

Part of #255
Related to #188
Related to #173