### PR TITLE
fix(okx): accept readable empty demo account

### DIFF
--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -17,6 +17,7 @@ use App\Exchange\Readiness\ExchangeReadinessLevel;
 use App\Exchange\Readiness\ExchangeReadinessReport;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Hyperliquid\HyperliquidMutationReadinessProbeInterface;
+use App\Provider\Okx\OkxAccountGateway;
 use App\Provider\Okx\OkxRuntimeCheck;
 use App\Provider\Registry\ExchangeProviderBundle;
 use App\TradingCore\Execution\Hyperliquid\HyperliquidMutationReadinessGate;
@@ -381,7 +382,10 @@ final class ExchangeRuntimeCheckCommand extends Command
         }
 
         try {
-            if ($providerBundle->account()->getAccountInfo() !== null) {
+            $accountProvider = $providerBundle->account();
+            if ($accountProvider instanceof OkxAccountGateway
+                ? $accountProvider->healthCheck()
+                : $accountProvider->getAccountInfo() !== null) {
                 return [true, []];
             }
         } catch (\Throwable) {

--- a/trading-app/src/Provider/Okx/OkxAccountGateway.php
+++ b/trading-app/src/Provider/Okx/OkxAccountGateway.php
@@ -162,7 +162,10 @@ final class OkxAccountGateway implements AccountProviderInterface
     public function healthCheck(): bool
     {
         try {
-            return $this->getAccountInfo() instanceof AccountDto;
+            return $this->dataRows(
+                $this->privateGet('/api/v5/account/balance', [], __METHOD__),
+                __METHOD__,
+            ) !== [];
         } catch (\Throwable) {
             return false;
         }

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -20,10 +20,12 @@ use App\Exchange\Dto\ExchangeCapabilities;
 use App\Exchange\Hyperliquid\HttpHyperliquidSignedActionClient;
 use App\Exchange\Hyperliquid\HyperliquidConfig;
 use App\Exchange\Okx\OkxConfig;
+use App\Exchange\Okx\OkxRestClientInterface;
 use App\Exchange\Readiness\ExchangeReadinessLevel;
 use App\Exchange\Readiness\ExchangeReadinessReport;
 use App\Provider\Context\ExchangeContext;
 use App\Provider\Hyperliquid\HyperliquidMutationReadinessProbeInterface;
+use App\Provider\Okx\OkxAccountGateway;
 use App\Provider\Registry\ExchangeProviderBundle;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -302,6 +304,43 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('Readiness level: public_read_only', $output);
         self::assertStringContainsString('Readiness warnings: okx_private_read_probe_failed, private_read_not_ready', $output);
         self::assertStringContainsString('Schedule ready: no', $output);
+    }
+
+    public function testOkxRuntimeCheckAcceptsReadableDemoAccountWithoutBalances(): void
+    {
+        $command = new ExchangeRuntimeCheckCommand(
+            $this->adapterRegistry($this->adapter(
+                Exchange::OKX,
+                MarketType::PERPETUAL,
+                supportsPrivateWs: true,
+                supportsTriggerOrders: true,
+            )),
+            $this->providerRegistry($this->providerBundle(
+                Exchange::OKX,
+                MarketType::PERPETUAL,
+                accountProvider: new OkxAccountGateway(new ReadableEmptyOkxAccountClient()),
+            )),
+            new OkxConfig(
+                environment: 'demo',
+                apiKey: 'key',
+                apiSecret: 'secret',
+                apiPassphrase: 'pass',
+                simulatedTrading: true,
+                demoTradingEnabled: true,
+                liveEnabled: false,
+            ),
+            new HyperliquidConfig(),
+        );
+
+        $tester = new CommandTester($command);
+        self::assertSame(Command::SUCCESS, $tester->execute([
+            'exchange' => 'okx',
+            'market_type' => 'perpetual',
+        ]));
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('Readiness level: demo_testnet_candidate', $output);
+        self::assertStringNotContainsString('okx_private_read_probe_failed', $output);
     }
 
     public function testReportsUnreadyHyperliquidRuntimeWithoutProviderOrCredentials(): void
@@ -817,19 +856,22 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         MarketType $marketType,
         bool $contractsLoaded = true,
         bool $accountReadable = true,
+        ?AccountProviderInterface $accountProvider = null,
     ): ExchangeProviderBundle
     {
         $contractProvider = $this->createMock(ContractProviderInterface::class);
         $contractProvider->method('getContracts')->willReturn($contractsLoaded ? [['symbol' => 'BTCUSDT']] : []);
-        $accountProvider = $this->createMock(AccountProviderInterface::class);
-        $accountProvider->method('getAccountInfo')->willReturn($accountReadable ? AccountDto::fromArray([
-            'currency' => 'USDT',
-            'available_balance' => '100',
-            'frozen_balance' => '0',
-            'unrealized' => '0',
-            'equity' => '100',
-            'position_deposit' => '0',
-        ]) : null);
+        if (!$accountProvider instanceof AccountProviderInterface) {
+            $accountProvider = $this->createMock(AccountProviderInterface::class);
+            $accountProvider->method('getAccountInfo')->willReturn($accountReadable ? AccountDto::fromArray([
+                'currency' => 'USDT',
+                'available_balance' => '100',
+                'frozen_balance' => '0',
+                'unrealized' => '0',
+                'equity' => '100',
+                'position_deposit' => '0',
+            ]) : null);
+        }
 
         return new ExchangeProviderBundle(
             new ExchangeContext($exchange, $marketType),
@@ -889,5 +931,23 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
                 );
             }
         };
+    }
+}
+
+final class ReadableEmptyOkxAccountClient implements OkxRestClientInterface
+{
+    public function publicGet(string $path, array $query = []): array
+    {
+        throw new \LogicException('Public reads are not used by this fixture.');
+    }
+
+    public function privateGet(string $path, array $query = []): array
+    {
+        return ['code' => '0', 'data' => [['details' => []]]];
+    }
+
+    public function privatePost(string $path, array $body = []): array
+    {
+        throw new \LogicException('Writes are not used by this fixture.');
     }
 }

--- a/trading-app/tests/Provider/Okx/OkxPrivateReadProviderTest.php
+++ b/trading-app/tests/Provider/Okx/OkxPrivateReadProviderTest.php
@@ -48,6 +48,16 @@ final class OkxPrivateReadProviderTest extends TestCase
         self::assertSame(99.5, $gateway->getAccountBalance('USDT'));
     }
 
+    public function testHealthCheckAcceptsReadableDemoAccountWithoutBalances(): void
+    {
+        $client = $this->client();
+        $client->emptyBalanceDetails = true;
+        $gateway = new OkxAccountGateway($client);
+
+        self::assertTrue($gateway->healthCheck());
+        self::assertNull($gateway->getAccountInfo());
+    }
+
     public function testReadsOpenPositions(): void
     {
         $gateway = new OkxPositionGateway($this->client());
@@ -366,6 +376,7 @@ final class FakeOkxPrivateReadClient implements OkxRestClientInterface
 {
     public bool $rateLimited = false;
     public bool $emptyAvailableEquity = false;
+    public bool $emptyBalanceDetails = false;
     public bool $hidePendingOrders = false;
     public bool $hideOrderDetail = false;
     public bool $orderDetailReturnsNotFoundCode = false;
@@ -426,7 +437,7 @@ final class FakeOkxPrivateReadClient implements OkxRestClientInterface
     {
         return ['code' => '0', 'data' => [[
             'totalEq' => '120.75',
-            'details' => [[
+            'details' => $this->emptyBalanceDetails ? [] : [[
                 'ccy' => 'USDT',
                 'availEq' => $this->emptyAvailableEquity ? '' : '100.5',
                 'availBal' => '99.5',


### PR DESCRIPTION
## Summary

- decouple OKX private-read readiness from the presence of a USDT balance
- treat a successful, structured `/api/v5/account/balance` response as readable even when `details` is empty
- keep currency-specific balance reads unchanged and add runtime/provider regressions

## Runtime evidence

Before:

```text
Readiness level: public_read_only
Readiness warnings: okx_private_read_probe_failed, private_read_not_ready
Schedule ready: no
```

After, with write flags still disabled and kill switch active:

```text
Readiness level: local_dry_run_ready
Readiness warnings: private_observability_absent_for_dry_run, demo_testnet_write_not_enabled
Demo trading enabled: no
Kill switch: enabled
Schedule ready: yes
```

No exchange order was sent. No secret is included.

## Verification

- `php bin/phpunit tests/Command/ExchangeRuntimeCheckCommandTest.php tests/Provider/Okx`: 72 tests, 476 assertions
- PHPStan on all touched PHP files: no errors
- `php bin/console lint:container --no-debug`
- `php bin/console lint:yaml config`
- `git diff --check`

Related to #197
Prerequisite work for OKX-010
