### PR TITLE
fix(okx): align private observability with EEA

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ OKX_DEMO_API_SECRET=
 OKX_DEMO_API_PASSPHRASE=
 OKX_API_BASE_URI=https://eea.okx.com
 OKX_WS_PUBLIC_URI=wss://wseeapap.okx.com:8443/ws/v5/public
-OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999
+OKX_WS_PRIVATE_URI=wss://wseeapap.okx.com:8443/ws/v5/private
 OKX_WS_BUSINESS_URI=wss://wseeapap.okx.com:8443/ws/v5/business
 OKX_SIMULATED_TRADING=1
 OKX_DEMO_TRADING_ENABLED=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -453,7 +453,7 @@ services:
       OKX_DEMO_API_PASSPHRASE: "${OKX_DEMO_API_PASSPHRASE:-}"
       OKX_API_BASE_URI: "${OKX_API_BASE_URI:-https://eea.okx.com}"
       OKX_WS_PUBLIC_URI: "${OKX_WS_PUBLIC_URI:-wss://wseeapap.okx.com:8443/ws/v5/public}"
-      OKX_WS_PRIVATE_URI: "${OKX_WS_PRIVATE_URI:-wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999}"
+      OKX_WS_PRIVATE_URI: "${OKX_WS_PRIVATE_URI:-wss://wseeapap.okx.com:8443/ws/v5/private}"
       OKX_WS_BUSINESS_URI: "${OKX_WS_BUSINESS_URI:-wss://wseeapap.okx.com:8443/ws/v5/business}"
       OKX_SIMULATED_TRADING: '1'
       DEMO_TRADING_ENABLED: '0'

--- a/docs/handbook/runbooks/okx-private-ws-observability.md
+++ b/docs/handbook/runbooks/okx-private-ws-observability.md
@@ -53,7 +53,7 @@ export OKX_ENV_FILE="${OKX_ENV_FILE:-trading-app/.env.local}"
 
 Les valeurs non sensibles attendues sont `OKX_ENV=demo`,
 `OKX_SIMULATED_TRADING=1`,
-`OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999`,
+`OKX_WS_PRIVATE_URI=wss://wseeapap.okx.com:8443/ws/v5/private`,
 `OKX_WS_BUSINESS_URI=wss://wseeapap.okx.com:8443/ws/v5/business`,
 `DEMO_TRADING_ENABLED=0`, `OKX_DEMO_TRADING_ENABLED=0` et
 `OKX_LIVE_ENABLED=0`. Le service Compose force ces trois gates consommees.
@@ -80,7 +80,7 @@ Les logs applicatifs dedies sont dans
 des transitions, phases et codes bornes, jamais de message WS brut.
 
 Le worker ouvre deux connexions authentifiees : `/ws/v5/private` pour
-`orders`, `positions`, `balance_and_position` et `fills`, puis
+`orders`, `positions` et `balance_and_position`, puis
 `/ws/v5/business` pour `orders-algo`. Le login de la paire est borne a 5
 secondes. Une fois authentifie, l'ensemble
 souscriptions + snapshot REST + reconciliation doit devenir pret en moins de
@@ -175,13 +175,14 @@ contradictoire, projection Doctrine impossible ou budget global de 10 secondes
 depasse entrainent une reconnexion. Ne pas marquer manuellement le snapshot
 comme charge et ne pas ignorer une projection partielle.
 
-### Fills VIP
+### Fills EEA
 
-Le rejet du canal VIP `fills` est attendu pour certains comptes. Le statut doit
-alors exposer `fills_source=orders_plus_rest` et
-`okx_fills_channel_vip_unavailable`. Le stream `orders` et le snapshot REST des
-fills doivent tous deux etre operationnels; sinon la couverture fills reste non
-prete.
+L'API EEA ne documente pas le canal prive `fills` et le refuse avec `60028` sur
+`/private`. Le worker EEA ne souscrit donc pas a ce canal. Le statut expose
+`fills_source=orders_plus_rest` seulement apres chargement complet du snapshot
+REST. Le stream `orders` et le snapshot REST des fills doivent tous deux etre
+operationnels; sinon la couverture fills reste non prete. Ne pas inferer le
+canal concerne depuis une erreur `60028` sans `arg`.
 
 ### Redis
 

--- a/docs/handbook/technical/okx-demo-readiness.md
+++ b/docs/handbook/technical/okx-demo-readiness.md
@@ -150,10 +150,15 @@ le fallback volontaire est le polling REST public.
 | Bills / ledger account | Endpoint account bills si retenu | Frais/funding non presents dans les fills. |
 
 L'observabilite temps reel utilise deux connexions authentifiees indissociables :
-`/ws/v5/private` pour les ordres standards, fills et positions, et
+`/ws/v5/private` pour les ordres standards et positions, et
 `/ws/v5/business` pour `orders-algo`. La couverture ordres n'est prete qu'apres
 ACK des deux canaux `orders` et `orders-algo`; une panne de l'un des sockets
 invalide et reconnecte toute la paire.
+
+Sur l'API EEA, `/ws/v5/private` couvre les ordres et positions mais pas le canal
+`fills`, absent de la documentation EEA et refuse avec `60028`. La couverture
+fills repose explicitement sur `orders` et le snapshot REST recent, avec
+`fills_source=orders_plus_rest`.
 
 Configuration demo private OKX-004 :
 
@@ -163,7 +168,7 @@ OKX_DEMO_API_KEY=...
 OKX_DEMO_API_SECRET=...
 OKX_DEMO_API_PASSPHRASE=...
 OKX_API_BASE_URI=https://eea.okx.com
-OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999
+OKX_WS_PRIVATE_URI=wss://wseeapap.okx.com:8443/ws/v5/private
 OKX_WS_BUSINESS_URI=wss://wseeapap.okx.com:8443/ws/v5/business
 OKX_SIMULATED_TRADING=1
 OKX_DEMO_TRADING_ENABLED=0

--- a/docs/superpowers/plans/2026-07-13-okx-private-ws-observability.md
+++ b/docs/superpowers/plans/2026-07-13-okx-private-ws-observability.md
@@ -56,8 +56,7 @@
 - [x] **Étape 1 : Écrire les tests en échec**
 
 ```php
-#[TestWith(['wss://wspap.okx.com:8443/ws/v5/private'])]
-#[TestWith(['wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999'])]
+#[TestWith(['wss://wseeapap.okx.com:8443/ws/v5/private'])]
 public function testAcceptsOnlyCanonicalDemoPrivateUri(string $uri): void
 {
     self::assertSame('okx_demo_private_v1', (new OkxPrivateWebSocketEndpointGuard())->assertAllowed($uri));
@@ -68,7 +67,7 @@ public function testAcceptsOnlyCanonicalDemoPrivateUri(string $uri): void
 #[TestWith(['wss://wspap.okx.com.evil.test:8443/ws/v5/private'])]
 #[TestWith(['wss://wspap.okx.com/ws/v5/private'])]
 #[TestWith(['wss://wspap.okx.com:8443/ws/v5/public'])]
-#[TestWith(['wss://wspap.okx.com:8443/ws/v5/private?x=1'])]
+#[TestWith(['wss://wseeapap.okx.com:8443/ws/v5/private?x=1'])]
 public function testRejectsEveryNonAllowlistedUri(string $uri): void
 {
     $this->expectExceptionMessage('okx_demo_private_ws_endpoint_not_allowed');
@@ -106,8 +105,7 @@ final class OkxPrivateWebSocketEndpointGuard
     private const ENDPOINT_ID = 'okx_demo_private_v1';
 
     private const ALLOWED_URIS = [
-        'wss://wspap.okx.com:8443/ws/v5/private',
-        'wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999',
+        'wss://wseeapap.okx.com:8443/ws/v5/private',
     ];
 
     public function assertAllowed(string $uri): string

--- a/docs/superpowers/specs/2026-07-13-okx-private-ws-observability-design.md
+++ b/docs/superpowers/specs/2026-07-13-okx-private-ws-observability-design.md
@@ -71,8 +71,8 @@ Le worker démarre uniquement si toutes les conditions suivantes sont vraies :
 - `OKX_LIVE_ENABLED=0` ;
 - `OKX_DEMO_API_KEY`, `OKX_DEMO_API_SECRET` et
   `OKX_DEMO_API_PASSPHRASE` sont non vides ;
-- l'URI privée utilise `wspap.okx.com:8443/ws/v5/private`, avec une query vide
-  ou exactement égale à `brokerId=9999` ;
+- l'URI privée utilise exactement
+  `wss://wseeapap.okx.com:8443/ws/v5/private`, sans query ;
 - l'URI business utilise exactement
   `wss://wseeapap.okx.com:8443/ws/v5/business`, sans query.
 
@@ -98,6 +98,10 @@ Après un acknowledgement de login réussi, le worker souscrit à :
 - `positions` avec `instType=SWAP` ;
 - `balance_and_position` ;
 - `fills` lorsque le compte accepte cette souscription.
+
+Pour le domaine EEA `wseeapap`, le canal `fills` n'est pas expose et renvoie
+`60028` sans `arg`. Le worker EEA ne l'envoie donc pas et active le fallback
+`orders_plus_rest` uniquement apres un snapshot REST complet.
 
 Les endpoints `/ws/v5/private` et `/ws/v5/business` utilisent deux transports
 et deux heartbeats indépendants. Le statut agrégé n'est connecté/authentifié que

--- a/trading-app/docs/API_FIRST_RUNBOOK.md
+++ b/trading-app/docs/API_FIRST_RUNBOOK.md
@@ -143,7 +143,7 @@ OKX_DEMO_API_SECRET=
 OKX_DEMO_API_PASSPHRASE=
 OKX_API_BASE_URI=https://eea.okx.com
 OKX_WS_PUBLIC_URI=wss://wseeapap.okx.com:8443/ws/v5/public
-OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999
+OKX_WS_PRIVATE_URI=wss://wseeapap.okx.com:8443/ws/v5/private
 OKX_SIMULATED_TRADING=1
 OKX_DEMO_TRADING_ENABLED=0
 OKX_LIVE_ENABLED=0

--- a/trading-app/src/Exchange/Okx/OkxConfig.php
+++ b/trading-app/src/Exchange/Okx/OkxConfig.php
@@ -66,7 +66,7 @@ final readonly class OkxConfig
         }
 
         return $this->isDemo()
-            ? 'wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999'
+            ? 'wss://wseeapap.okx.com:8443/ws/v5/private'
             : 'wss://ws.okx.com:8443/ws/v5/private';
     }
 

--- a/trading-app/src/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketEndpointGuard.php
+++ b/trading-app/src/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketEndpointGuard.php
@@ -7,8 +7,7 @@ namespace App\Exchange\Okx\PrivateWebSocket;
 final class OkxPrivateWebSocketEndpointGuard
 {
     private const ALLOWED_URIS = [
-        'wss://wspap.okx.com:8443/ws/v5/private' => 'okx_demo_private_v1',
-        'wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999' => 'okx_demo_private_v1',
+        'wss://wseeapap.okx.com:8443/ws/v5/private' => 'okx_demo_private_v1',
         'wss://wseeapap.okx.com:8443/ws/v5/business' => 'okx_demo_business_v1',
     ];
 

--- a/trading-app/src/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketSession.php
+++ b/trading-app/src/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketSession.php
@@ -34,6 +34,7 @@ final class OkxPrivateWebSocketSession
     public function __construct(
         OkxExchangeEventNormalizer $normalizer,
         DateTimeImmutable $now,
+        private readonly bool $fillsChannelEnabled = true,
     ) {
         $this->normalizer = $normalizer;
         $this->status = OkxPrivateWebSocketObservabilityStatus::connecting(self::utc($now));
@@ -112,6 +113,8 @@ final class OkxPrivateWebSocketSession
             $this->replaceStatus(
                 now: $now,
                 updateHeartbeat: false,
+                fillsStreamReady: $this->fillsChannelEnabled ? null : true,
+                fillsSource: $this->fillsChannelEnabled ? null : 'orders_plus_rest',
                 initialSnapshotLoaded: true,
                 reconciliationFresh: true,
                 blockingErrors: self::withoutCode(
@@ -227,15 +230,19 @@ final class OkxPrivateWebSocketSession
             ),
         );
 
+        $subscriptionArgs = [
+            ['channel' => 'orders', 'instType' => 'SWAP'],
+            ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+            ['channel' => 'positions', 'instType' => 'SWAP'],
+            ['channel' => 'balance_and_position'],
+        ];
+        if ($this->fillsChannelEnabled) {
+            $subscriptionArgs[] = ['channel' => 'fills'];
+        }
+
         return new OkxPrivateWebSocketSessionResult(outgoingCommands: [[
             'op' => 'subscribe',
-            'args' => [
-                ['channel' => 'orders', 'instType' => 'SWAP'],
-                ['channel' => 'orders-algo', 'instType' => 'SWAP'],
-                ['channel' => 'positions', 'instType' => 'SWAP'],
-                ['channel' => 'balance_and_position'],
-                ['channel' => 'fills'],
-            ],
+            'args' => $subscriptionArgs,
         ]]);
     }
 
@@ -339,6 +346,7 @@ final class OkxPrivateWebSocketSession
         if (!in_array($channel, self::REQUIRED_CHANNELS, true)) {
             return new OkxPrivateWebSocketSessionResult();
         }
+        $this->assertChannelEnabled($channel, $now);
 
         $data = $message['data'];
         if (!is_array($data)
@@ -449,6 +457,7 @@ final class OkxPrivateWebSocketSession
         if (!is_string($channel) || !in_array($channel, self::REQUIRED_CHANNELS, true)) {
             $this->rejectInvalidMessage($now);
         }
+        $this->assertChannelEnabled($channel, $now);
 
         $actual = $arg;
         $expected = self::expectedSubscriptionArg($channel);
@@ -459,6 +468,13 @@ final class OkxPrivateWebSocketSession
         }
 
         return $channel;
+    }
+
+    private function assertChannelEnabled(string $channel, DateTimeImmutable $now): void
+    {
+        if ('fills' === $channel && !$this->fillsChannelEnabled) {
+            $this->rejectInvalidMessage($now);
+        }
     }
 
     /** @return array<string, string> */

--- a/trading-app/src/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketWorker.php
+++ b/trading-app/src/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketWorker.php
@@ -72,7 +72,11 @@ final class OkxPrivateWebSocketWorker
         ?LoopInterface $loop = null,
     ) {
         $this->loop = $loop ?? Loop::get();
-        $this->session = new OkxPrivateWebSocketSession($normalizer, $clock->now());
+        $this->session = new OkxPrivateWebSocketSession(
+            $normalizer,
+            $clock->now(),
+            fillsChannelEnabled: false,
+        );
     }
 
     public function run(?int $maxCycles = null): void

--- a/trading-app/src/Exchange/Okx/README.md
+++ b/trading-app/src/Exchange/Okx/README.md
@@ -36,15 +36,14 @@ the Pawl transport. `OkxPrivateWebSocketSession` owns login, channel
 subscriptions, normalized events and readiness state. It never builds, submits,
 cancels or amends an order.
 
-The login deadline is 5 seconds. After a successful login, the worker first
-sends the subscription command for `orders`, `fills`, `positions` and
+The login deadline is 5 seconds. After a successful login, the EEA worker first
+sends the subscription command for `orders`, `positions` and
 `balance_and_position`, then immediately executes and projects the private REST
 snapshot for account, positions, open orders, algo orders and recent fills. It
 does not wait for subscription acknowledgements before starting the snapshot.
-The VIP-only `fills` channel may be rejected by OKX; in that case the explicit
-supported fallback is the `orders` stream plus the recent-fills REST snapshot.
-The status then reports `fills_source=orders_plus_rest` and the allow-listed
-warning `okx_fills_channel_vip_unavailable`.
+The EEA API does not expose the private `fills` channel, so fill observability
+uses the `orders` stream plus the recent-fills REST snapshot. The status reports
+`fills_source=orders_plus_rest` only after that snapshot is complete.
 
 Each private REST read has a 2-second timeout and 2-second maximum duration. The
 whole readiness phase is bounded to 10 seconds. Readiness is published only
@@ -167,7 +166,7 @@ OKX_DEMO_API_SECRET=
 OKX_DEMO_API_PASSPHRASE=
 OKX_API_BASE_URI=https://eea.okx.com
 OKX_WS_PUBLIC_URI=wss://wseeapap.okx.com:8443/ws/v5/public
-OKX_WS_PRIVATE_URI=wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999
+OKX_WS_PRIVATE_URI=wss://wseeapap.okx.com:8443/ws/v5/private
 OKX_WS_BUSINESS_URI=wss://wseeapap.okx.com:8443/ws/v5/business
 OKX_SIMULATED_TRADING=1
 OKX_DEMO_TRADING_ENABLED=0
@@ -175,7 +174,7 @@ OKX_LIVE_ENABLED=0
 ```
 
 Le worker prive ouvre deux transports distincts. Le socket `/private` couvre
-`orders`, `fills` et `positions`; le socket `/business` couvre
+`orders` et `positions`; le socket `/business` couvre
 `orders-algo`. `orders_stream_ready` reste faux tant que les deux abonnements ne
 sont pas acquittes, et la perte d'un socket recycle la paire.
 

--- a/trading-app/tests/Command/OkxPrivateWebSocketCommandTest.php
+++ b/trading-app/tests/Command/OkxPrivateWebSocketCommandTest.php
@@ -80,7 +80,7 @@ final class OkxPrivateWebSocketCommandTest extends TestCase
             'apiKey' => 'demo-key',
             'apiSecret' => 'demo-secret',
             'apiPassphrase' => 'demo-passphrase',
-            'wsPrivateUri' => 'wss://wspap.okx.com:8443/ws/v5/private',
+            'wsPrivateUri' => 'wss://wseeapap.okx.com:8443/ws/v5/private',
             'wsBusinessUri' => 'wss://wseeapap.okx.com:8443/ws/v5/business',
             'simulatedTrading' => true,
             'liveEnabled' => false,

--- a/trading-app/tests/Exchange/Okx/OkxConfigTest.php
+++ b/trading-app/tests/Exchange/Okx/OkxConfigTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Okx;
+
+use App\Exchange\Okx\OkxConfig;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OkxConfig::class)]
+final class OkxConfigTest extends TestCase
+{
+    public function testDemoPrivateWebSocketDefaultsToEeaEndpoint(): void
+    {
+        self::assertSame(
+            'wss://wseeapap.okx.com:8443/ws/v5/private',
+            (new OkxConfig(environment: 'demo'))->wsPrivateUri(),
+        );
+    }
+}

--- a/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketEndpointGuardTest.php
+++ b/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketEndpointGuardTest.php
@@ -12,8 +12,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(OkxPrivateWebSocketEndpointGuard::class)]
 final class OkxPrivateWebSocketEndpointGuardTest extends TestCase
 {
-    #[TestWith(['wss://wspap.okx.com:8443/ws/v5/private'])]
-    #[TestWith(['wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999'])]
+    #[TestWith(['wss://wseeapap.okx.com:8443/ws/v5/private'])]
     public function testAcceptsOnlyCanonicalDemoPrivateUri(string $uri): void
     {
         self::assertSame(
@@ -32,6 +31,8 @@ final class OkxPrivateWebSocketEndpointGuardTest extends TestCase
     }
 
     #[TestWith(['https://wspap.okx.com:8443/ws/v5/private'])]
+    #[TestWith(['wss://wspap.okx.com:8443/ws/v5/private'])]
+    #[TestWith(['wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999'])]
     #[TestWith(['wss://ws.okx.com:8443/ws/v5/private'])]
     #[TestWith(['wss://wspap.okx.com.evil.test:8443/ws/v5/private'])]
     #[TestWith(['wss://user@wspap.okx.com:8443/ws/v5/private'])]

--- a/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketSessionTest.php
+++ b/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketSessionTest.php
@@ -38,11 +38,12 @@ final class OkxPrivateWebSocketSessionTest extends TestCase
         $this->session = $this->newSession();
     }
 
-    private function newSession(): OkxPrivateWebSocketSession
+    private function newSession(bool $fillsChannelEnabled = true): OkxPrivateWebSocketSession
     {
         return new OkxPrivateWebSocketSession(
             new OkxExchangeEventNormalizer(new OkxInstrumentResolver(), $this->fixedClock()),
             self::at(0),
+            fillsChannelEnabled: $fillsChannelEnabled,
         );
     }
 
@@ -93,6 +94,64 @@ final class OkxPrivateWebSocketSessionTest extends TestCase
         ]], $result->outgoingCommands);
         self::assertSame([], $result->normalizedEvents);
         self::assertTrue($this->session->status()->authenticated);
+    }
+
+    public function testEeaModeUsesOrdersPlusRestInsteadOfUnsupportedFillsChannel(): void
+    {
+        $session = $this->newSession(fillsChannelEnabled: false);
+        $session->onConnected([['sign' => self::SECRET]], self::at(1));
+
+        $result = $session->onMessage(['event' => 'login', 'code' => '0'], self::at(2));
+
+        self::assertSame([[
+            'op' => 'subscribe',
+            'args' => [
+                ['channel' => 'orders', 'instType' => 'SWAP'],
+                ['channel' => 'orders-algo', 'instType' => 'SWAP'],
+                ['channel' => 'positions', 'instType' => 'SWAP'],
+                ['channel' => 'balance_and_position'],
+            ],
+        ]], $result->outgoingCommands);
+
+        $session->applySnapshot(self::snapshot(true), self::at(3));
+
+        self::assertTrue($session->status()->fillsStreamReady);
+        self::assertSame('orders_plus_rest', $session->status()->fillsSource);
+        self::assertSame([], $session->status()->warnings);
+    }
+
+    /** @param array<string, mixed> $message */
+    #[DataProvider('unsolicitedEeaFillsMessages')]
+    public function testEeaModeRejectsUnsolicitedFillsMessages(array $message): void
+    {
+        $session = $this->newSession(fillsChannelEnabled: false);
+        $session->onConnected([['sign' => self::SECRET]], self::at(1));
+        $session->onMessage(['event' => 'login', 'code' => '0'], self::at(2));
+        $session->applySnapshot(self::snapshot(true), self::at(3));
+
+        try {
+            $session->onMessage($message, self::at(4));
+            self::fail('Expected unsolicited EEA fills message to fail closed.');
+        } catch (InvalidArgumentException $exception) {
+            self::assertSame('okx_private_ws_message_invalid', $exception->getMessage());
+        }
+
+        self::assertContains('okx_private_ws_message_invalid', $session->status()->blockingErrors);
+        self::assertSame('orders_plus_rest', $session->status()->fillsSource);
+        self::assertSame([], $session->status()->warnings);
+    }
+
+    /** @return iterable<string, array{array<string, mixed>}> */
+    public static function unsolicitedEeaFillsMessages(): iterable
+    {
+        yield 'acknowledgement' => [[
+            'event' => 'subscribe',
+            'arg' => ['channel' => 'fills'],
+        ]];
+        yield 'data' => [[
+            'arg' => ['channel' => 'fills', 'instType' => 'SWAP'],
+            'data' => [],
+        ]];
     }
 
     public function testAllRequiredAcknowledgementsAreNeededForStreamReadiness(): void
@@ -617,6 +676,7 @@ final class OkxPrivateWebSocketSessionTest extends TestCase
                 'balanceAndPositionAcknowledged',
                 'loginExpected',
                 'failedSubscriptions',
+                'fillsChannelEnabled',
             ],
             array_map(static fn (\ReflectionProperty $property): string => $property->getName(), $reflection->getProperties()),
         );

--- a/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketWorkerTest.php
+++ b/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketWorkerTest.php
@@ -63,7 +63,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
 
         $opened = false;
         $transport->connect(
-            'wss://wspap.okx.com:8443/ws/v5/private',
+            'wss://wseeapap.okx.com:8443/ws/v5/private',
             static function () use (&$opened): void {
                 $opened = true;
             },
@@ -88,7 +88,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             connector: static fn (string $uri): PromiseInterface => resolve($connection),
         );
         $transport->connect(
-            'wss://wspap.okx.com:8443/ws/v5/private',
+            'wss://wseeapap.okx.com:8443/ws/v5/private',
             static function (): void {},
             static function (): void {},
             static function (): void {},
@@ -109,7 +109,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             connector: static fn (string $uri): PromiseInterface => $deferred->promise(),
         );
         $transport->connect(
-            'wss://wspap.okx.com:8443/ws/v5/private',
+            'wss://wseeapap.okx.com:8443/ws/v5/private',
             static function () use (&$opened): void { $opened = true; },
             static function (): void {},
             static function (): void {},
@@ -135,14 +135,14 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
         );
         $oldCallbacks = ['message' => 0, 'close' => 0, 'error' => 0];
         $transport->connect(
-            'wss://wspap.okx.com:8443/ws/v5/private',
+            'wss://wseeapap.okx.com:8443/ws/v5/private',
             static function (): void {},
             static function () use (&$oldCallbacks): void { ++$oldCallbacks['message']; },
             static function () use (&$oldCallbacks): void { ++$oldCallbacks['close']; },
             static function () use (&$oldCallbacks): void { ++$oldCallbacks['error']; },
         );
         $transport->connect(
-            'wss://wspap.okx.com:8443/ws/v5/private',
+            'wss://wseeapap.okx.com:8443/ws/v5/private',
             static function (): void {},
             static function (): void {},
             static function (): void {},
@@ -165,7 +165,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
         $received = [];
         foreach (['old', 'current'] as $label) {
             $transport->connect(
-                'wss://wspap.okx.com:8443/ws/v5/private',
+                'wss://wseeapap.okx.com:8443/ws/v5/private',
                 static function (): void {},
                 static function (string $message) use (&$received, $label): void {
                     $received[] = $label . ':' . $message;
@@ -190,7 +190,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
         $worker->start();
 
         self::assertSame(
-            ['wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999'],
+            ['wss://wseeapap.okx.com:8443/ws/v5/private'],
             $transport->connections,
         );
         self::assertFalse($store->saved[0]->connected);
@@ -217,7 +217,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
         $worker->start();
 
         self::assertSame(
-            ['wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999'],
+            ['wss://wseeapap.okx.com:8443/ws/v5/private'],
             $privateTransport->connections,
         );
         self::assertSame(
@@ -253,7 +253,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
                 ['channel' => 'orders', 'instType' => 'SWAP'],
                 ['channel' => 'positions', 'instType' => 'SWAP'],
                 ['channel' => 'balance_and_position'],
-                ['channel' => 'fills'],
             ],
         ], $privateTransport->sent[1]);
         self::assertSame([
@@ -265,7 +264,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $privateTransport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -434,7 +432,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
                 ['channel' => 'orders', 'instType' => 'SWAP'],
                 ['channel' => 'positions', 'instType' => 'SWAP'],
                 ['channel' => 'balance_and_position'],
-                ['channel' => 'fills'],
             ],
         ], $transport->sent[1]);
 
@@ -442,7 +439,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -454,6 +450,8 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
         self::assertTrue($status->authenticated);
         self::assertTrue($status->ordersStreamReady);
         self::assertTrue($status->fillsStreamReady);
+        self::assertSame('orders_plus_rest', $status->fillsSource);
+        self::assertSame([], $status->warnings);
         self::assertTrue($status->positionsStreamReady);
         self::assertTrue($status->initialSnapshotLoaded);
         self::assertTrue($status->reconciliationFresh);
@@ -482,7 +480,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -540,7 +537,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -595,7 +591,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
         self::assertFalse($store->load()?->connected);
     }
 
-    public function testFillsVipFailureKeepsOrdersPlusRestSessionAndDoesNotReconnect(): void
+    public function testUnsolicitedFillsErrorFailsClosedAndReconnects(): void
     {
         $transport = new FakeOkxPrivateWebSocketTransport();
         $loop = new DeterministicLoop();
@@ -621,11 +617,12 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
         $clock->sleep(3);
         $loop->firePeriodicInterval(1.0);
 
-        self::assertSame(0, $transport->closeCount);
+        self::assertSame(1, $transport->closeCount);
+        self::assertContains(1.0, $loop->timerIntervals());
         $status = $store->load();
         self::assertNotNull($status);
-        self::assertSame('orders_plus_rest', $status->fillsSource);
-        self::assertSame([], $status->blockingErrors);
+        self::assertFalse($status->connected);
+        self::assertContains('okx_private_ws_connection_failed', $status->blockingErrors);
     }
 
     #[DataProvider('failedSnapshotSources')]
@@ -744,7 +741,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -835,7 +831,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -874,7 +869,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -968,7 +962,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -1180,7 +1173,6 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             ['channel' => 'orders', 'instType' => 'SWAP'],
             ['channel' => 'positions', 'instType' => 'SWAP'],
             ['channel' => 'balance_and_position'],
-            ['channel' => 'fills'],
         ] as $arg) {
             $transport->message(['event' => 'subscribe', 'arg' => $arg]);
         }
@@ -1427,7 +1419,7 @@ final class OkxPrivateWebSocketWorkerTest extends TestCase
             apiKey: 'demo-key',
             apiSecret: 'demo-secret',
             apiPassphrase: 'demo-passphrase',
-            wsPrivateUri: 'wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999',
+            wsPrivateUri: 'wss://wseeapap.okx.com:8443/ws/v5/private',
             simulatedTrading: true,
             liveEnabled: false,
         );


### PR DESCRIPTION
## Summary

- use the canonical OKX EEA demo private WebSocket endpoint and reject global demo endpoints
- omit the unsupported EEA `fills` subscription and expose the deterministic `orders_plus_rest` source only after a complete REST snapshot
- reject unsolicited fill acknowledgements, errors, and payloads fail-closed
- align examples, runbooks, and regression coverage

## Runtime evidence

A real read-only demo session reached:

```text
Private WS observability: ready
connected/authenticated: true
orders/fills/positions streams: ready
fills_source: orders_plus_rest
initial snapshot/reconciliation: ready
blocking errors: none
```

Persistent write gates remained disabled, the kill switch remained enabled, and no exchange order was sent.

## Verification

- PHPUnit: 235 tests, 1093 assertions
- PHPStan: no errors on all touched PHP files
- Symfony container lint
- YAML lint: 55 files
- Docker Compose config validation
- real OKX EEA read-only runtime check
- git diff --check
- independent local review: no major issue remaining

Related to #197
Related to #188
Follow-up to #261