### PR TITLE
test: isolate destructive PostgreSQL integration suites

### DIFF
--- a/docs/superpowers/plans/2026-07-15-postgres-integration-test-isolation.md
+++ b/docs/superpowers/plans/2026-07-15-postgres-integration-test-isolation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent destructive PostgreSQL integration tests from ever targeting the development database and restore the locally removed schema objects.
 
-**Architecture:** A test-only guard parses the PostgreSQL DSN and requires a database name ending in `_test` before destructive suites connect. Local ignored configuration points to a dedicated migrated test database; missing development schema objects are restored additively from a temporary freshly migrated database.
+**Architecture:** A test-only guard parses the PostgreSQL DSN and requires a database named `test` or ending in `_test` before destructive suites connect. Local ignored configuration points to a dedicated migrated test database; missing development schema objects are restored additively from a temporary freshly migrated database.
 
 **Tech Stack:** PHP 8.2, PHPUnit, Doctrine DBAL/Migrations, PostgreSQL 15, Docker Compose.
 

--- a/docs/superpowers/plans/2026-07-15-postgres-integration-test-isolation.md
+++ b/docs/superpowers/plans/2026-07-15-postgres-integration-test-isolation.md
@@ -1,0 +1,124 @@
+# PostgreSQL Integration Test Isolation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent destructive PostgreSQL integration tests from ever targeting the development database and restore the locally removed schema objects.
+
+**Architecture:** A test-only guard parses the PostgreSQL DSN and requires a database name ending in `_test` before destructive suites connect. Local ignored configuration points to a dedicated migrated test database; missing development schema objects are restored additively from a temporary freshly migrated database.
+
+**Tech Stack:** PHP 8.2, PHPUnit, Doctrine DBAL/Migrations, PostgreSQL 15, Docker Compose.
+
+---
+
+### Task 1: Test-only database guard
+
+**Files:**
+- Create: `trading-app/tests/Support/PostgresIntegrationDatabaseGuard.php`
+- Create: `trading-app/tests/Support/PostgresIntegrationDatabaseGuardTest.php`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Cover acceptance of `trading_app_test`, rejection of `trading_app`, rejection of a
+missing database path, and absence of password/DSN text in the exception.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+php vendor/bin/phpunit tests/Support/PostgresIntegrationDatabaseGuardTest.php
+```
+
+Expected: failure because `PostgresIntegrationDatabaseGuard` does not exist.
+
+- [ ] **Step 3: Implement the minimal guard**
+
+Expose one static method:
+
+```php
+PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(string $dsn): void
+```
+
+Parse only the database path, accept `test` or a name ending `_test`, and throw a
+redacted `LogicException` otherwise.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run the same PHPUnit command. Expected: all guard tests pass.
+
+### Task 2: Protect destructive integration suites
+
+**Files:**
+- Modify: `trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php`
+- Modify: `trading-app/tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php`
+
+- [ ] **Step 1: Add the guard calls before DBAL connection creation**
+
+After the existing PostgreSQL scheme check and before `DriverManager::getConnection()`,
+call `PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase($dsn)`.
+
+- [ ] **Step 2: Run both suites against `trading_app_test`**
+
+```bash
+php vendor/bin/phpunit \
+  tests/Trading/View/PositionTradeAnalysisViewTest.php \
+  tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php
+```
+
+Expected: PASS and no schema changes in `trading_app`.
+
+### Task 3: Isolate local configuration and restore schema
+
+**Files:**
+- Local ignored file only: `trading-app/.env.test`
+
+- [ ] **Step 1: Create and migrate `trading_app_test`**
+
+Create the database if absent, change only the database path in `.env.test`, and run
+all Doctrine migrations against it without printing credentials.
+
+- [ ] **Step 2: Build a temporary migrated repair database**
+
+Create `trading_app_schema_repair` and apply all Doctrine migrations.
+
+- [ ] **Step 3: Restore only absent development objects**
+
+Pipe a schema-only `pg_dump` for `indicator_snapshots`, `trade_lifecycle_event`,
+`position_trade_analysis`, and `position_trade_analysis_v2` from the repair database
+into `trading_app`. Do not drop or overwrite any existing object.
+
+- [ ] **Step 4: Verify schema and data preservation**
+
+Confirm the four objects exist, Doctrine remains at the latest migration, and all
+previously audited trading table counts remain zero.
+
+### Task 4: Verification and delivery
+
+**Files:**
+- Modify if needed: documentation files above
+
+- [ ] **Step 1: Run focused PHPUnit and PHPStan**
+
+```bash
+php vendor/bin/phpunit tests/Support/PostgresIntegrationDatabaseGuardTest.php \
+  tests/Trading/View/PositionTradeAnalysisViewTest.php \
+  tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php
+php vendor/bin/phpstan analyse \
+  tests/Support/PostgresIntegrationDatabaseGuard.php \
+  tests/Support/PostgresIntegrationDatabaseGuardTest.php \
+  tests/Trading/View/PositionTradeAnalysisViewTest.php \
+  tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php
+```
+
+- [ ] **Step 2: Run project checks**
+
+```bash
+php bin/console lint:container --no-debug
+git diff --check
+```
+
+- [ ] **Step 3: Review, commit, push and open a focused PR**
+
+Stage only the guard, its tests, the two protected suites, design, and plan. Never
+stage `.env.test`. Monitor CI and automatic Codex review; merge only when green and
+approved, then fast-forward local `main`.

--- a/docs/superpowers/specs/2026-07-15-postgres-integration-test-isolation-design.md
+++ b/docs/superpowers/specs/2026-07-15-postgres-integration-test-isolation-design.md
@@ -1,0 +1,47 @@
+# PostgreSQL integration test isolation
+
+## Contexte
+
+Deux suites d'integration construisent puis suppriment des tables et vues PostgreSQL
+reelles. La configuration locale `trading-app/.env.test` pointait vers la base de
+developpement `trading_app`. Leur `tearDown()` a donc supprime
+`trade_lifecycle_event`, `indicator_snapshots`, `position_trade_analysis` et
+`position_trade_analysis_v2`, alors que les migrations restaient marquees executees.
+
+## Decision
+
+Ajouter une garde partagee dans l'espace de tests. Avant toute connexion destructive,
+elle extrait le nom de base du DSN PostgreSQL et refuse toute base dont le nom n'est
+pas `test` ou ne se termine pas par `_test`. Le message d'erreur ne contient jamais le
+DSN ni les credentials.
+
+Les deux suites destructives appellent cette garde avant `DriverManager::getConnection()`.
+Les DSN non PostgreSQL continuent d'etre ignores selon le comportement existant.
+
+## Configuration locale
+
+Creer une base locale `trading_app_test`, migrer son schema, puis faire pointer le
+fichier ignore `trading-app/.env.test` vers cette base. Aucun credential n'est ajoute
+au depot.
+
+## Restauration
+
+La base de developpement ne contient actuellement aucune ligne dans les tables de
+trading auditees. Son schema manquant est restaure sans suppression : une base
+temporaire est creee, toutes les migrations y sont appliquees, puis seuls les objets
+absents sont exportes en schema-only et appliques a `trading_app`.
+
+## Verification
+
+- tests unitaires de la garde : base `_test` acceptee, base de developpement refusee,
+  message redacted ;
+- deux suites PostgreSQL destructives executees contre `trading_app_test` ;
+- presence des tables et vues restaurees dans `trading_app` ;
+- migrations Doctrine au dernier niveau dans les deux bases ;
+- PHPStan cible, lint container et `git diff --check`.
+
+## Non-objectifs
+
+- aucune modification fonctionnelle du trading ;
+- aucun ordre demo, testnet ou mainnet ;
+- aucune modification de strategie, risque, SL/TP ou runtime exchange.

--- a/trading-app/tests/Support/PostgresIntegrationDatabaseGuard.php
+++ b/trading-app/tests/Support/PostgresIntegrationDatabaseGuard.php
@@ -4,28 +4,29 @@ declare(strict_types=1);
 
 namespace App\Tests\Support;
 
+use Doctrine\DBAL\Tools\DsnParser;
 use LogicException;
-use ValueError;
+use SensitiveParameter;
+use Throwable;
 
 final class PostgresIntegrationDatabaseGuard
 {
     private const ERROR_MESSAGE = 'An isolated PostgreSQL database ending in "_test" is required.';
 
-    public static function assertIsolatedTestDatabase(string $dsn): void
-    {
+    public static function assertIsolatedTestDatabase(
+        #[SensitiveParameter]
+        string $dsn,
+    ): void {
         try {
-            $path = parse_url($dsn, PHP_URL_PATH);
-        } catch (ValueError) {
+            $params = (new DsnParser())->parse($dsn);
+        } catch (Throwable) {
             throw new LogicException(self::ERROR_MESSAGE);
         }
 
-        if (!is_string($path) || !str_starts_with($path, '/')) {
-            throw new LogicException(self::ERROR_MESSAGE);
-        }
+        $databaseName = $params['dbname'] ?? null;
 
-        $databaseName = rawurldecode(substr($path, 1));
-
-        if ($databaseName !== 'test' && !str_ends_with($databaseName, '_test')) {
+        if (!is_string($databaseName)
+            || ($databaseName !== 'test' && !str_ends_with($databaseName, '_test'))) {
             throw new LogicException(self::ERROR_MESSAGE);
         }
     }

--- a/trading-app/tests/Support/PostgresIntegrationDatabaseGuard.php
+++ b/trading-app/tests/Support/PostgresIntegrationDatabaseGuard.php
@@ -11,7 +11,7 @@ use Throwable;
 
 final class PostgresIntegrationDatabaseGuard
 {
-    private const ERROR_MESSAGE = 'An isolated PostgreSQL database ending in "_test" is required.';
+    private const ERROR_MESSAGE = 'An isolated PostgreSQL database named "test" or ending in "_test" is required.';
 
     public static function assertIsolatedTestDatabase(
         #[SensitiveParameter]

--- a/trading-app/tests/Support/PostgresIntegrationDatabaseGuard.php
+++ b/trading-app/tests/Support/PostgresIntegrationDatabaseGuard.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support;
+
+use LogicException;
+use ValueError;
+
+final class PostgresIntegrationDatabaseGuard
+{
+    private const ERROR_MESSAGE = 'An isolated PostgreSQL database ending in "_test" is required.';
+
+    public static function assertIsolatedTestDatabase(string $dsn): void
+    {
+        try {
+            $path = parse_url($dsn, PHP_URL_PATH);
+        } catch (ValueError) {
+            throw new LogicException(self::ERROR_MESSAGE);
+        }
+
+        if (!is_string($path) || !str_starts_with($path, '/')) {
+            throw new LogicException(self::ERROR_MESSAGE);
+        }
+
+        $databaseName = rawurldecode(substr($path, 1));
+
+        if ($databaseName !== 'test' && !str_ends_with($databaseName, '_test')) {
+            throw new LogicException(self::ERROR_MESSAGE);
+        }
+    }
+}

--- a/trading-app/tests/Support/PostgresIntegrationDatabaseGuardTest.php
+++ b/trading-app/tests/Support/PostgresIntegrationDatabaseGuardTest.php
@@ -6,7 +6,9 @@ namespace App\Tests\Support;
 
 use LogicException;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use SensitiveParameterValue;
 
 #[CoversClass(PostgresIntegrationDatabaseGuard::class)]
 final class PostgresIntegrationDatabaseGuardTest extends TestCase
@@ -57,5 +59,75 @@ final class PostgresIntegrationDatabaseGuardTest extends TestCase
         PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
             'postgresql://user:password@localhost:5432',
         );
+    }
+
+    #[DataProvider('unsafeDbnameOverrides')]
+    public function testRejectsUnsafeDbnameQueryOverride(string $query): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('An isolated PostgreSQL database ending in "_test" is required.');
+
+        PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
+            'postgresql://user:password@localhost:5432/safe_test?' . $query,
+        );
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function unsafeDbnameOverrides(): iterable
+    {
+        yield 'production database' => ['dbname=production'];
+        yield 'empty database' => ['dbname='];
+        yield 'array database value' => ['dbname[]=production'];
+    }
+
+    public function testConvertsParsingErrorsWithoutRetainingPreviousException(): void
+    {
+        try {
+            PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
+                'postgresql://user:parse-secret@localhost:invalid/safe_test',
+            );
+            self::fail('Expected a malformed DSN to be rejected.');
+        } catch (LogicException $exception) {
+            self::assertSame(
+                'An isolated PostgreSQL database ending in "_test" is required.',
+                $exception->getMessage(),
+            );
+            self::assertNull($exception->getPrevious());
+        }
+    }
+
+    public function testRedactsDsnFromExceptionTrace(): void
+    {
+        $dsn = 'postgresql://trace_user:trace-secret@trace.internal:5439/production';
+        $previousSetting = ini_get('zend.exception_ignore_args');
+        self::assertIsString($previousSetting);
+
+        try {
+            self::assertNotFalse(ini_set('zend.exception_ignore_args', '0'));
+
+            try {
+                PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase($dsn);
+                self::fail('Expected an unsafe database name to be rejected.');
+            } catch (LogicException $exception) {
+                $guardFrame = null;
+
+                foreach ($exception->getTrace() as $frame) {
+                    if (($frame['class'] ?? null) === PostgresIntegrationDatabaseGuard::class
+                        && $frame['function'] === 'assertIsolatedTestDatabase') {
+                        $guardFrame = $frame;
+                        break;
+                    }
+                }
+
+                self::assertNotNull($guardFrame);
+                self::assertInstanceOf(SensitiveParameterValue::class, $guardFrame['args'][0] ?? null);
+
+                $traceDump = print_r($exception->getTrace(), true);
+                self::assertStringNotContainsString($dsn, $traceDump);
+                self::assertStringNotContainsString('trace-secret', $traceDump);
+            }
+        } finally {
+            ini_set('zend.exception_ignore_args', $previousSetting);
+        }
     }
 }

--- a/trading-app/tests/Support/PostgresIntegrationDatabaseGuardTest.php
+++ b/trading-app/tests/Support/PostgresIntegrationDatabaseGuardTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Support;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PostgresIntegrationDatabaseGuard::class)]
+final class PostgresIntegrationDatabaseGuardTest extends TestCase
+{
+    public function testAcceptsDatabaseNameEndingInTest(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
+            'postgresql://user:password@localhost:5432/trading_app_test',
+        );
+    }
+
+    public function testAcceptsDatabaseNamedTest(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
+            'postgresql://user:password@localhost:5432/test',
+        );
+    }
+
+    public function testRejectsDatabaseWithoutTestSuffixWithoutLeakingConnectionDetails(): void
+    {
+        $dsn = 'postgresql://integration_user:ultra-secret@db.internal:5433/trading_app';
+
+        try {
+            PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase($dsn);
+            self::fail('Expected an unsafe database name to be rejected.');
+        } catch (LogicException $exception) {
+            self::assertSame(
+                'An isolated PostgreSQL database ending in "_test" is required.',
+                $exception->getMessage(),
+            );
+            self::assertStringNotContainsString($dsn, $exception->getMessage());
+            self::assertStringNotContainsString('integration_user', $exception->getMessage());
+            self::assertStringNotContainsString('ultra-secret', $exception->getMessage());
+            self::assertStringNotContainsString('db.internal', $exception->getMessage());
+            self::assertStringNotContainsString('5433', $exception->getMessage());
+        }
+    }
+
+    public function testRejectsDsnWithoutDatabasePath(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('An isolated PostgreSQL database ending in "_test" is required.');
+
+        PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
+            'postgresql://user:password@localhost:5432',
+        );
+    }
+}

--- a/trading-app/tests/Support/PostgresIntegrationDatabaseGuardTest.php
+++ b/trading-app/tests/Support/PostgresIntegrationDatabaseGuardTest.php
@@ -40,7 +40,7 @@ final class PostgresIntegrationDatabaseGuardTest extends TestCase
             self::fail('Expected an unsafe database name to be rejected.');
         } catch (LogicException $exception) {
             self::assertSame(
-                'An isolated PostgreSQL database ending in "_test" is required.',
+                'An isolated PostgreSQL database named "test" or ending in "_test" is required.',
                 $exception->getMessage(),
             );
             self::assertStringNotContainsString($dsn, $exception->getMessage());
@@ -54,7 +54,7 @@ final class PostgresIntegrationDatabaseGuardTest extends TestCase
     public function testRejectsDsnWithoutDatabasePath(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('An isolated PostgreSQL database ending in "_test" is required.');
+        $this->expectExceptionMessage('An isolated PostgreSQL database named "test" or ending in "_test" is required.');
 
         PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
             'postgresql://user:password@localhost:5432',
@@ -65,7 +65,7 @@ final class PostgresIntegrationDatabaseGuardTest extends TestCase
     public function testRejectsUnsafeDbnameQueryOverride(string $query): void
     {
         $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('An isolated PostgreSQL database ending in "_test" is required.');
+        $this->expectExceptionMessage('An isolated PostgreSQL database named "test" or ending in "_test" is required.');
 
         PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase(
             'postgresql://user:password@localhost:5432/safe_test?' . $query,
@@ -89,7 +89,7 @@ final class PostgresIntegrationDatabaseGuardTest extends TestCase
             self::fail('Expected a malformed DSN to be rejected.');
         } catch (LogicException $exception) {
             self::assertSame(
-                'An isolated PostgreSQL database ending in "_test" is required.',
+                'An isolated PostgreSQL database named "test" or ending in "_test" is required.',
                 $exception->getMessage(),
             );
             self::assertNull($exception->getPrevious());

--- a/trading-app/tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php
+++ b/trading-app/tests/Trading/Backfill/PositionTradeAnalysisBackfillDivergenceReaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Trading\Backfill;
 
+use App\Tests\Support\PostgresIntegrationDatabaseGuard;
 use App\Trading\Backfill\BackfillDivergenceCriteria;
 use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReader;
 use App\Trading\Backfill\PositionTradeAnalysisBackfillDivergenceReportService;
@@ -32,6 +33,8 @@ final class PositionTradeAnalysisBackfillDivergenceReaderTest extends TestCase
         if (!is_string($dsn) || !preg_match('/^(postgres|postgresql|pdo-pgsql)/', $dsn)) {
             self::markTestSkipped('PostgreSQL DATABASE_URL required for the backfill divergence reader integration test.');
         }
+
+        PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase($dsn);
 
         try {
             $conn = DriverManager::getConnection(['url' => $dsn]);

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -63,6 +63,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
     {
         if (isset($this->conn)) {
             $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis_v2');
+            $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
             $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
             $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
             $this->conn->close();
@@ -949,6 +950,7 @@ final class PositionTradeAnalysisViewTest extends TestCase
     private function createMinimalSchema(): void
     {
         $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis_v2');
+        $this->conn->executeStatement('DROP VIEW IF EXISTS position_trade_analysis');
         $this->conn->executeStatement('DROP TABLE IF EXISTS trade_lifecycle_event');
         $this->conn->executeStatement('DROP TABLE IF EXISTS indicator_snapshots');
 

--- a/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
+++ b/trading-app/tests/Trading/View/PositionTradeAnalysisViewTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Trading\View;
 
+use App\Tests\Support\PostgresIntegrationDatabaseGuard;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Schema;
@@ -43,6 +44,8 @@ final class PositionTradeAnalysisViewTest extends TestCase
         if (!is_string($dsn) || !preg_match('/^(postgres|postgresql|pdo-pgsql)/', $dsn)) {
             self::markTestSkipped('PostgreSQL DATABASE_URL required for the view integration test.');
         }
+
+        PostgresIntegrationDatabaseGuard::assertIsolatedTestDatabase($dsn);
 
         try {
             $this->conn = DriverManager::getConnection(['url' => $dsn]);


### PR DESCRIPTION
## Summary

- require destructive PostgreSQL integration suites to target a database named `test` or suffixed `_test` before opening a DBAL connection
- resolve the effective Doctrine `dbname`, including query overrides, and redact connection arguments from exception traces
- clean both analysis views before fixture tables so the suites run against a freshly migrated test database
- document the incident, recovery design, and verification plan

## Local recovery

- created and migrated a dedicated local `trading_app_test` database
- restored the missing `indicator_snapshots`, `trade_lifecycle_event`, `position_trade_analysis`, and `position_trade_analysis_v2` objects additively in `trading_app`
- kept local `.env.test` ignored and pointed at `trading_app_test`; no credentials are committed

## Verification

- PHPUnit: 28 tests, 205 assertions
- PHPStan: no errors on all touched PHP files
- `php bin/console lint:container --no-debug`
- `git diff --check`
- independent spec, quality, and final reviews approved

Part of #188
Related to #132
Related to #197

No exchange order was sent.