### PR TITLE
Fake private WS disconnect and resync scenarios

### DIFF
--- a/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
+++ b/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
@@ -156,6 +156,15 @@ final readonly class DoctrineExchangeLocalProjectionStore implements ExchangeLoc
         }
     }
 
+    public function projectAtomically(array $events): void
+    {
+        $this->entityManager->wrapInTransaction(function () use ($events): void {
+            foreach ($events as $event) {
+                $this->project($event);
+            }
+        });
+    }
+
     /**
      * @return array<string,mixed>
      */

--- a/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
+++ b/trading-app/src/Exchange/Event/DoctrineExchangeLocalProjectionStore.php
@@ -158,11 +158,19 @@ final readonly class DoctrineExchangeLocalProjectionStore implements ExchangeLoc
 
     public function projectAtomically(array $events): void
     {
-        $this->entityManager->wrapInTransaction(function () use ($events): void {
-            foreach ($events as $event) {
-                $this->project($event);
+        try {
+            $this->entityManager->getConnection()->transactional(function () use ($events): void {
+                foreach ($events as $event) {
+                    $this->project($event);
+                }
+            });
+        } catch (\Throwable $exception) {
+            if ($this->entityManager->isOpen()) {
+                $this->entityManager->clear();
             }
-        });
+
+            throw $exception;
+        }
     }
 
     /**

--- a/trading-app/src/Exchange/Event/ExchangeEventBus.php
+++ b/trading-app/src/Exchange/Event/ExchangeEventBus.php
@@ -18,6 +18,11 @@ final readonly class ExchangeEventBus
     public function publish(ExchangeEventInterface $event): void
     {
         $this->projectionStore->project($event);
+        $this->logProjected($event);
+    }
+
+    private function logProjected(ExchangeEventInterface $event): void
+    {
         $this->logger->info('exchange_event.projected', [
             'event_type' => $event->eventType(),
             'exchange' => $event->exchange()->value,
@@ -32,12 +37,16 @@ final readonly class ExchangeEventBus
      */
     public function publishMany(iterable $events): int
     {
-        $count = 0;
-        foreach ($events as $event) {
-            $this->publish($event);
-            ++$count;
+        $batch = \is_array($events) ? array_values($events) : iterator_to_array($events, false);
+        if ($batch === []) {
+            return 0;
         }
 
-        return $count;
+        $this->projectionStore->projectAtomically($batch);
+        foreach ($batch as $event) {
+            $this->logProjected($event);
+        }
+
+        return \count($batch);
     }
 }

--- a/trading-app/src/Exchange/Event/ExchangeLocalProjectionStoreInterface.php
+++ b/trading-app/src/Exchange/Event/ExchangeLocalProjectionStoreInterface.php
@@ -21,4 +21,9 @@ interface ExchangeLocalProjectionStoreInterface
     public function openPositions(Exchange $exchange, MarketType $marketType, ?string $symbol = null): array;
 
     public function project(ExchangeEventInterface $event): void;
+
+    /**
+     * @param list<ExchangeEventInterface> $events
+     */
+    public function projectAtomically(array $events): void;
 }

--- a/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
@@ -200,7 +200,7 @@ final class FakeExchangeStateStore
     {
         $payload = $event->payload;
         if (!\array_key_exists('event_sequence', $event->payload)) {
-            $payload = ['event_sequence' => \count($this->events) + 1] + $payload;
+            $payload = ['event_sequence' => $this->nextEventSequence()] + $payload;
         }
 
         $orderId = $payload['order_id'] ?? null;
@@ -273,6 +273,21 @@ final class FakeExchangeStateStore
     public function openPositionCount(?string $symbol = null): int
     {
         return \count($this->getOpenPositions($symbol));
+    }
+
+    private function nextEventSequence(): int
+    {
+        $maximum = 0;
+        foreach ($this->events as $event) {
+            $sequence = $event->payload['event_sequence'] ?? null;
+            if (\is_int($sequence)) {
+                $maximum = max($maximum, $sequence);
+            } elseif (\is_string($sequence) && ctype_digit($sequence)) {
+                $maximum = max($maximum, (int)$sequence);
+            }
+        }
+
+        return $maximum + 1;
     }
 
     private function clientOrderKey(string $symbol, string $clientOrderId): string

--- a/trading-app/src/Exchange/Fake/FakeExchangeWsClient.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeWsClient.php
@@ -12,12 +12,25 @@ use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
 #[AutoconfigureTag('app.exchange_ws_client')]
 final class FakeExchangeWsClient implements ExchangeWsClientInterface
 {
+    private const STATE_CONNECTED = 'connected';
+    private const STATE_RESYNC_REQUIRED = 'resync_required';
+
     /** @var array<string,bool> */
     private array $consumedSequences = [];
+    private bool $resyncRequired = false;
+    private ?string $resyncReason = null;
+    private bool $disconnectInjected = false;
+    private int $acknowledgedEvents = 0;
+    private ?string $lastAcknowledgedSequence = null;
+    private int $lastObservedNumericSequence = 0;
 
     public function __construct(
         private readonly FakeExchangeStateStore $stateStore,
+        private readonly ?int $disconnectAfterAcknowledgedEvents = null,
     ) {
+        if ($this->disconnectAfterAcknowledgedEvents !== null && $this->disconnectAfterAcknowledgedEvents < 0) {
+            throw new \InvalidArgumentException('disconnectAfterAcknowledgedEvents must be greater than or equal to zero');
+        }
     }
 
     public function exchange(): Exchange
@@ -31,14 +44,39 @@ final class FakeExchangeWsClient implements ExchangeWsClientInterface
     }
 
     /**
-     * @return FakeExchangeEvent[]
+     * A sequence is acknowledged only when the caller resumes the generator
+     * after successfully handling the yielded event.
+     *
+     * @return \Generator<int,FakeExchangeEvent>
      */
     public function drainPrivateEvents(?string $symbol = null): iterable
     {
+        if ($this->resyncRequired) {
+            throw $this->resyncReason === 'fake_private_ws_sequence_gap'
+                ? FakePrivateWsException::snapshotResyncRequired($this->lastAcknowledgedSequence)
+                : FakePrivateWsException::disconnected($this->lastAcknowledgedSequence);
+        }
+
         $normalizedSymbol = $symbol !== null ? strtoupper($symbol) : null;
-        $events = [];
         foreach ($this->stateStore->events() as $index => $event) {
             $sequence = $this->sequence($event, $index);
+            $numericSequence = $this->numericSequence($sequence);
+            if ($numericSequence !== null && $numericSequence > $this->lastObservedNumericSequence) {
+                $expectedSequence = $this->lastObservedNumericSequence + 1;
+                if ($numericSequence !== $expectedSequence) {
+                    $this->resyncRequired = true;
+                    $this->resyncReason = 'fake_private_ws_sequence_gap';
+
+                    throw FakePrivateWsException::sequenceGap(
+                        lastAcknowledgedSequence: $this->lastAcknowledgedSequence,
+                        expectedSequence: (string)$expectedSequence,
+                        actualSequence: $sequence,
+                    );
+                }
+
+                $this->lastObservedNumericSequence = $numericSequence;
+            }
+
             if (isset($this->consumedSequences[$sequence])) {
                 continue;
             }
@@ -46,11 +84,60 @@ final class FakeExchangeWsClient implements ExchangeWsClientInterface
                 continue;
             }
 
+            if (
+                !$this->disconnectInjected
+                && $this->disconnectAfterAcknowledgedEvents !== null
+                && $this->acknowledgedEvents >= $this->disconnectAfterAcknowledgedEvents
+            ) {
+                $this->disconnectInjected = true;
+                $this->resyncRequired = true;
+                $this->resyncReason = 'fake_private_ws_disconnected';
+
+                throw FakePrivateWsException::disconnected($this->lastAcknowledgedSequence);
+            }
+
+            yield $event;
+
             $this->consumedSequences[$sequence] = true;
-            $events[] = $event;
+            $this->lastAcknowledgedSequence = $sequence;
+            ++$this->acknowledgedEvents;
+        }
+    }
+
+    public function requiresResync(): bool
+    {
+        return $this->resyncRequired;
+    }
+
+    public function connectionState(): string
+    {
+        return $this->resyncRequired ? self::STATE_RESYNC_REQUIRED : self::STATE_CONNECTED;
+    }
+
+    public function reconnect(): void
+    {
+        if ($this->resyncReason === 'fake_private_ws_sequence_gap') {
+            throw new \LogicException('fake_private_ws_snapshot_resync_required');
         }
 
-        return $events;
+        $this->resyncRequired = false;
+        $this->resyncReason = null;
+    }
+
+    public function completeSnapshotResync(): void
+    {
+        foreach ($this->stateStore->events() as $index => $event) {
+            $sequence = $this->sequence($event, $index);
+            $this->consumedSequences[$sequence] = true;
+            $this->lastAcknowledgedSequence = $sequence;
+            $numericSequence = $this->numericSequence($sequence);
+            if ($numericSequence !== null) {
+                $this->lastObservedNumericSequence = max($this->lastObservedNumericSequence, $numericSequence);
+            }
+        }
+
+        $this->resyncRequired = false;
+        $this->resyncReason = null;
     }
 
     private function sequence(FakeExchangeEvent $event, int $index): string
@@ -58,5 +145,10 @@ final class FakeExchangeWsClient implements ExchangeWsClientInterface
         $sequence = $event->payload['event_sequence'] ?? null;
 
         return \is_scalar($sequence) ? (string)$sequence : 'idx-' . $index;
+    }
+
+    private function numericSequence(string $sequence): ?int
+    {
+        return ctype_digit($sequence) ? (int)$sequence : null;
     }
 }

--- a/trading-app/src/Exchange/Fake/FakePrivateWsException.php
+++ b/trading-app/src/Exchange/Fake/FakePrivateWsException.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+final class FakePrivateWsException extends \RuntimeException
+{
+    private const RESYNC_REQUIRED = 'resync_required';
+
+    private function __construct(
+        public readonly string $errorCode,
+        public readonly string $state,
+        public readonly ?string $lastAcknowledgedSequence,
+        public readonly ?string $expectedSequence = null,
+        public readonly ?string $actualSequence = null,
+    ) {
+        parent::__construct($errorCode);
+    }
+
+    public static function disconnected(?string $lastAcknowledgedSequence): self
+    {
+        return new self(
+            errorCode: 'fake_private_ws_disconnected',
+            state: self::RESYNC_REQUIRED,
+            lastAcknowledgedSequence: $lastAcknowledgedSequence,
+        );
+    }
+
+    public static function sequenceGap(
+        ?string $lastAcknowledgedSequence,
+        string $expectedSequence,
+        string $actualSequence,
+    ): self {
+        return new self(
+            errorCode: 'fake_private_ws_sequence_gap',
+            state: self::RESYNC_REQUIRED,
+            lastAcknowledgedSequence: $lastAcknowledgedSequence,
+            expectedSequence: $expectedSequence,
+            actualSequence: $actualSequence,
+        );
+    }
+
+    public static function snapshotResyncRequired(?string $lastAcknowledgedSequence): self
+    {
+        return new self(
+            errorCode: 'fake_private_ws_snapshot_resync_required',
+            state: self::RESYNC_REQUIRED,
+            lastAcknowledgedSequence: $lastAcknowledgedSequence,
+        );
+    }
+}

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -25,3 +25,21 @@ curl http://localhost:8082/fake-exchange/events
 ```
 
 The HTTP service state is stored in `var/fake_exchange_state.dat` so multi-step curl scenarios survive PHP-FPM request boundaries. Tests can instantiate `FakeExchangeStateStore` without a file path for isolated in-memory state, and should call `reset()` before each scenario when sharing a store.
+
+## Private WS disconnect/resync fixture
+
+`FakeExchangeWsClient` can inject one deterministic disconnect after a configured
+number of acknowledged raw events. The client then reports
+`fake_private_ws_disconnected` with state `resync_required`. A yielded sequence is
+acknowledged only after its normalization and projection complete, so a projection
+failure leaves that raw event available to the next drain. Numeric sequence gaps
+report `fake_private_ws_sequence_gap` and also require resync.
+
+After an injected disconnect, `reconnect()` resumes unacknowledged events. A
+sequence gap fails closed: plain reconnect is rejected until the caller reconciles
+orders, fills and positions from the Fake REST snapshots through
+`ExchangeReconciliationService`, then confirms that snapshot with
+`completeSnapshotResync()`. Events covered by that snapshot are not replayed and
+the next contiguous sequence is consumed normally. The one-shot disconnect is not
+reinjected. This fixture remains local, performs no network request and never
+sends an exchange order.

--- a/trading-app/tests/Exchange/Event/DoctrineExchangeLocalProjectionStoreTest.php
+++ b/trading-app/tests/Exchange/Event/DoctrineExchangeLocalProjectionStoreTest.php
@@ -31,6 +31,7 @@ use App\Repository\TradeLineageRepository;
 use App\Trading\Lineage\TradeLineageManager;
 use App\Trading\Pnl\FillCostLedgerIngestionConflict;
 use App\Trading\Pnl\FillCostLedgerIngestionService;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Persisters\Entity\EntityPersister;
@@ -44,16 +45,29 @@ use Psr\Log\NullLogger;
 #[CoversClass(DoctrineExchangeLocalProjectionStore::class)]
 final class DoctrineExchangeLocalProjectionStoreTest extends TestCase
 {
-    public function testProjectsNormalizedBatchInsideOneEntityManagerTransaction(): void
+    public function testFailedAtomicBatchCanRetryWithSameEntityManager(): void
     {
+        $projectionAttempt = 0;
         $orderSync = $this->createMock(FuturesOrderSyncService::class);
-        $orderSync->expects(self::exactly(2))
+        $orderSync->expects(self::exactly(3))
             ->method('syncOrderFromApi')
-            ->willReturn($this->createStub(FuturesOrder::class));
+            ->willReturnCallback(function () use (&$projectionAttempt): FuturesOrder {
+                ++$projectionAttempt;
+                if ($projectionAttempt === 2) {
+                    throw new \RuntimeException('transient_projection_failure');
+                }
+
+                return $this->createStub(FuturesOrder::class);
+            });
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::exactly(2))
+            ->method('transactional')
+            ->willReturnCallback(static fn (callable $callback): mixed => $callback($connection));
         $entityManager = $this->createMock(EntityManagerInterface::class);
-        $entityManager->expects(self::once())
-            ->method('wrapInTransaction')
-            ->willReturnCallback(static fn (callable $callback): mixed => $callback($entityManager));
+        $entityManager->method('getConnection')->willReturn($connection);
+        $entityManager->method('isOpen')->willReturn(true);
+        $entityManager->expects(self::once())->method('clear');
+        $entityManager->expects(self::never())->method('close');
         $store = $this->storeWithPersistenceDoubles(
             $orderSync,
             $this->createStub(FillCostLedgerEntryRepository::class),
@@ -64,7 +78,15 @@ final class DoctrineExchangeLocalProjectionStoreTest extends TestCase
             new \DateTimeImmutable('2026-01-01 UTC'),
         );
 
-        $store->projectAtomically([$event, $event]);
+        try {
+            $store->projectAtomically([$event, $event]);
+            self::fail('The second projection must fail the first batch.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('transient_projection_failure', $exception->getMessage());
+        }
+
+        $store->projectAtomically([$event]);
+        self::assertSame(3, $projectionAttempt);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('numericSideProvider')]

--- a/trading-app/tests/Exchange/Event/DoctrineExchangeLocalProjectionStoreTest.php
+++ b/trading-app/tests/Exchange/Event/DoctrineExchangeLocalProjectionStoreTest.php
@@ -44,6 +44,29 @@ use Psr\Log\NullLogger;
 #[CoversClass(DoctrineExchangeLocalProjectionStore::class)]
 final class DoctrineExchangeLocalProjectionStoreTest extends TestCase
 {
+    public function testProjectsNormalizedBatchInsideOneEntityManagerTransaction(): void
+    {
+        $orderSync = $this->createMock(FuturesOrderSyncService::class);
+        $orderSync->expects(self::exactly(2))
+            ->method('syncOrderFromApi')
+            ->willReturn($this->createStub(FuturesOrder::class));
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())
+            ->method('wrapInTransaction')
+            ->willReturnCallback(static fn (callable $callback): mixed => $callback($entityManager));
+        $store = $this->storeWithPersistenceDoubles(
+            $orderSync,
+            $this->createStub(FillCostLedgerEntryRepository::class),
+            entityManager: $entityManager,
+        );
+        $event = new ExchangeOrderUpdated(
+            $this->orderDto(ExchangeOrderSide::BUY, ExchangePositionSide::LONG),
+            new \DateTimeImmutable('2026-01-01 UTC'),
+        );
+
+        $store->projectAtomically([$event, $event]);
+    }
+
     #[\PHPUnit\Framework\Attributes\DataProvider('numericSideProvider')]
     public function testOrderPayloadUsesCanonicalNumericSide(
         ExchangeOrderSide $side,

--- a/trading-app/tests/Exchange/Event/ExchangeWsIngestionServiceTest.php
+++ b/trading-app/tests/Exchange/Event/ExchangeWsIngestionServiceTest.php
@@ -150,7 +150,7 @@ final class ExchangeWsIngestionServiceTest extends TestCase
         $expectedStore = new RecordingProjectionStore();
         $this->service($expectedStore)->drain(new FakeExchangeWsClient($state));
 
-        $store = new RecordingProjectionStore(failNextProjection: true);
+        $store = new RecordingProjectionStore(failOnProjectionNumber: 2);
         $service = $this->service($store);
         $client = new FakeExchangeWsClient($state);
 
@@ -215,7 +215,7 @@ final class ExchangeWsIngestionServiceTest extends TestCase
             'order.created',
             'BTCUSDT',
             new \DateTimeImmutable('2026-01-01 00:00:02 UTC'),
-            ['event_sequence' => 4],
+            [],
         ));
 
         /** @var list<FakeExchangeEvent> $resumed */
@@ -280,7 +280,9 @@ final class ExchangeWsIngestionServiceTest extends TestCase
 
 final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInterface
 {
-    public function __construct(private bool $failNextProjection = false)
+    private int $projectionAttempts = 0;
+
+    public function __construct(private ?int $failOnProjectionNumber = null)
     {
     }
 
@@ -304,13 +306,28 @@ final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInte
 
     public function project(ExchangeEventInterface $event): void
     {
-        if ($this->failNextProjection) {
-            $this->failNextProjection = false;
+        ++$this->projectionAttempts;
+        if ($this->failOnProjectionNumber === $this->projectionAttempts) {
+            $this->failOnProjectionNumber = null;
 
             throw new \RuntimeException('test_projection_failed');
         }
 
         $this->events[] = $event;
+    }
+
+    public function projectAtomically(array $events): void
+    {
+        $before = $this->events;
+        try {
+            foreach ($events as $event) {
+                $this->project($event);
+            }
+        } catch (\Throwable $exception) {
+            $this->events = $before;
+
+            throw $exception;
+        }
     }
 
     /**

--- a/trading-app/tests/Exchange/Event/ExchangeWsIngestionServiceTest.php
+++ b/trading-app/tests/Exchange/Event/ExchangeWsIngestionServiceTest.php
@@ -20,11 +20,13 @@ use App\Exchange\Event\ExchangeLocalProjectionStoreInterface;
 use App\Exchange\Event\ExchangeOrderFilled;
 use App\Exchange\Event\ExchangePositionOpened;
 use App\Exchange\Event\ExchangePositionUpdated;
+use App\Exchange\Fake\FakeExchangeEvent;
 use App\Exchange\Fake\FakeExchangeEventNormalizer;
 use App\Exchange\Fake\FakeExchangeMatchingEngine;
 use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeStateStore;
 use App\Exchange\Fake\FakeExchangeWsClient;
+use App\Exchange\Fake\FakePrivateWsException;
 use App\Exchange\Ws\ExchangeWsIngestionResult;
 use App\Exchange\Ws\ExchangeWsIngestionService;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -37,6 +39,7 @@ use Psr\Log\NullLogger;
 #[CoversClass(ExchangeEventNormalizerRegistry::class)]
 #[CoversClass(ExchangeEventBus::class)]
 #[CoversClass(FakeExchangeWsClient::class)]
+#[CoversClass(FakePrivateWsException::class)]
 #[CoversClass(FakeExchangeEventNormalizer::class)]
 #[CoversClass(ExchangeOrderFilled::class)]
 #[CoversClass(ExchangePositionOpened::class)]
@@ -100,6 +103,136 @@ final class ExchangeWsIngestionServiceTest extends TestCase
         self::assertEqualsWithDelta(6.0, $positionUpdates[0]->size(), 0.000001);
     }
 
+    public function testReconnectResumesAfterDeterministicDisconnectWithoutLossOrDuplicate(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $adapter = $this->adapter($state);
+        $adapter->placeOrder($this->marketRequest(symbol: 'BTCUSDT', clientOrderId: 'btc-cid'));
+        $adapter->placeOrder($this->marketRequest(symbol: 'ETHUSDT', clientOrderId: 'eth-cid'));
+
+        $expectedStore = new RecordingProjectionStore();
+        $this->service($expectedStore)->drain(new FakeExchangeWsClient($state));
+
+        $store = new RecordingProjectionStore();
+        $service = $this->service($store);
+        $client = new FakeExchangeWsClient($state, disconnectAfterAcknowledgedEvents: 2);
+
+        try {
+            $service->drain($client);
+            self::fail('The deterministic private WS disconnect must interrupt ingestion.');
+        } catch (FakePrivateWsException $exception) {
+            self::assertSame('fake_private_ws_disconnected', $exception->errorCode);
+            self::assertSame('resync_required', $exception->state);
+            self::assertSame('2', $exception->lastAcknowledgedSequence);
+        }
+
+        self::assertTrue($client->requiresResync());
+        self::assertSame('resync_required', $client->connectionState());
+
+        $client->reconnect();
+        $resumed = $service->drain($client);
+        $empty = $service->drain($client);
+
+        self::assertFalse($client->requiresResync());
+        self::assertGreaterThan(0, $resumed->rawEventsRead);
+        self::assertSame(0, $empty->rawEventsRead);
+        self::assertSame($expectedStore->eventSignatures(), $store->eventSignatures());
+    }
+
+    public function testProjectionFailureDoesNotAcknowledgeRawEvent(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $this->adapter($state)->placeOrder($this->marketRequest(
+            symbol: 'BTCUSDT',
+            clientOrderId: 'projection-retry-cid',
+        ));
+
+        $expectedStore = new RecordingProjectionStore();
+        $this->service($expectedStore)->drain(new FakeExchangeWsClient($state));
+
+        $store = new RecordingProjectionStore(failNextProjection: true);
+        $service = $this->service($store);
+        $client = new FakeExchangeWsClient($state);
+
+        try {
+            $service->drain($client);
+            self::fail('The projection failure must escape ingestion.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('test_projection_failed', $exception->getMessage());
+        }
+
+        $retried = $service->drain($client);
+        $empty = $service->drain($client);
+
+        self::assertGreaterThan(0, $retried->rawEventsRead);
+        self::assertSame(0, $empty->rawEventsRead);
+        self::assertSame($expectedStore->eventSignatures(), $store->eventSignatures());
+    }
+
+    public function testSequenceGapRequiresResync(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $state->appendEvent(new FakeExchangeEvent(
+            'order.created',
+            'BTCUSDT',
+            new \DateTimeImmutable('2026-01-01 00:00:00 UTC'),
+            ['event_sequence' => 1],
+        ));
+        $state->appendEvent(new FakeExchangeEvent(
+            'order.created',
+            'BTCUSDT',
+            new \DateTimeImmutable('2026-01-01 00:00:01 UTC'),
+            ['event_sequence' => 3],
+        ));
+
+        $client = new FakeExchangeWsClient($state);
+
+        try {
+            iterator_to_array($client->drainPrivateEvents());
+            self::fail('A private WS sequence gap must interrupt ingestion.');
+        } catch (FakePrivateWsException $exception) {
+            self::assertSame('fake_private_ws_sequence_gap', $exception->errorCode);
+            self::assertSame('resync_required', $exception->state);
+            self::assertSame('1', $exception->lastAcknowledgedSequence);
+            self::assertSame('2', $exception->expectedSequence);
+            self::assertSame('3', $exception->actualSequence);
+        }
+
+        self::assertTrue($client->requiresResync());
+
+        try {
+            $client->reconnect();
+            self::fail('A sequence gap requires a snapshot resync, not a plain reconnect.');
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_private_ws_snapshot_resync_required', $exception->getMessage());
+        }
+
+        $client->completeSnapshotResync();
+        self::assertFalse($client->requiresResync());
+        self::assertSame([], iterator_to_array($client->drainPrivateEvents()));
+
+        $state->appendEvent(new FakeExchangeEvent(
+            'order.created',
+            'BTCUSDT',
+            new \DateTimeImmutable('2026-01-01 00:00:02 UTC'),
+            ['event_sequence' => 4],
+        ));
+
+        /** @var list<FakeExchangeEvent> $resumed */
+        $resumed = array_values(iterator_to_array($client->drainPrivateEvents()));
+        self::assertCount(1, $resumed);
+        self::assertSame(4, $resumed[0]->payload['event_sequence'] ?? null);
+    }
+
+    private function service(RecordingProjectionStore $store): ExchangeWsIngestionService
+    {
+        return new ExchangeWsIngestionService(
+            new ExchangeEventNormalizerRegistry([new FakeExchangeEventNormalizer()]),
+            new ExchangeEventBus($store, new NullLogger()),
+            new NullLogger(),
+        );
+    }
+
     private function adapter(FakeExchangeStateStore $state): FakeExchangeAdapter
     {
         $book = new FakeExchangeOrderBook($state);
@@ -147,6 +280,10 @@ final class ExchangeWsIngestionServiceTest extends TestCase
 
 final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInterface
 {
+    public function __construct(private bool $failNextProjection = false)
+    {
+    }
+
     public function openOrders(Exchange $exchange, MarketType $marketType): array
     {
         return [];
@@ -167,7 +304,29 @@ final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInte
 
     public function project(ExchangeEventInterface $event): void
     {
+        if ($this->failNextProjection) {
+            $this->failNextProjection = false;
+
+            throw new \RuntimeException('test_projection_failed');
+        }
+
         $this->events[] = $event;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function eventSignatures(): array
+    {
+        return array_map(
+            static fn (ExchangeEventInterface $event): string => implode(':', [
+                $event::class,
+                $event->eventType(),
+                $event->symbol(),
+                $event->occurredAt()->format('U.u'),
+            ]),
+            $this->events,
+        );
     }
 
     /**

--- a/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateRestSnapshotReconcilerTest.php
+++ b/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateRestSnapshotReconcilerTest.php
@@ -641,4 +641,11 @@ final class SnapshotRecordingProjectionStore implements ExchangeLocalProjectionS
     {
         $this->events[] = $event;
     }
+
+    public function projectAtomically(array $events): void
+    {
+        foreach ($events as $event) {
+            $this->project($event);
+        }
+    }
 }

--- a/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketWorkerTest.php
+++ b/trading-app/tests/Exchange/Okx/PrivateWebSocket/OkxPrivateWebSocketWorkerTest.php
@@ -1642,6 +1642,24 @@ final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInte
             $this->timeline->events[] = 'project:' . $event->eventType();
         }
     }
+
+    public function projectAtomically(array $events): void
+    {
+        $projectedBefore = $this->events;
+        $timelineBefore = $this->timeline?->events;
+        try {
+            foreach ($events as $event) {
+                $this->project($event);
+            }
+        } catch (\Throwable $exception) {
+            $this->events = $projectedBefore;
+            if ($this->timeline !== null && $timelineBefore !== null) {
+                $this->timeline->events = $timelineBefore;
+            }
+
+            throw $exception;
+        }
+    }
 }
 
 #[CoversNothing]

--- a/trading-app/tests/Exchange/Reconciliation/ExchangeReconciliationServiceTest.php
+++ b/trading-app/tests/Exchange/Reconciliation/ExchangeReconciliationServiceTest.php
@@ -490,6 +490,13 @@ final class RecordingProjectionStore implements ExchangeLocalProjectionStoreInte
         $this->events[] = $event;
     }
 
+    public function projectAtomically(array $events): void
+    {
+        foreach ($events as $event) {
+            $this->project($event);
+        }
+    }
+
     /**
      * @param class-string $class
      */


### PR DESCRIPTION
## Summary

- add a deterministic one-shot disconnect fixture to the Fake private WebSocket client
- acknowledge raw sequences only after successful atomic projection of every normalized event
- resume unacknowledged events without loss or duplication after reconnect
- detect numeric sequence gaps, require explicit snapshot resynchronization, and continue auto-allocation from the maximum observed sequence
- project normalized batches through a single Doctrine transaction so mid-batch failures roll back before retry

## Safety

- local Fake/Paper only
- no exchange network request
- no demo/testnet/mainnet order
- no strategy, EntryZone, risk, leverage, SL/TP policy or live guard change
- no secret or raw sensitive payload

## Tests

- `php vendor/bin/phpunit tests/Exchange` (842 tests, 3215 assertions, 30 skipped)
- PHPStan on all touched PHP files with `--memory-limit=512M`
- `php bin/console lint:container --no-debug`
- `php bin/console lint:yaml config`
- `git diff --check`

Part of #196.
Related to #197.
Related to #198.
Related to #226.