### PR TITLE
Harden Fake Paper persistent recovery contract

### DIFF
--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -142,6 +142,26 @@ reste legacy.
   prouvent seulement que les branches locales de protection sont visibles avant
   toute tentative mutative.
 
+## Reprise persistante du Fake Exchange
+
+Le fake exchange de niveau adapter (`App\Exchange\Fake\*`), distinct du
+`FakeExecutionPort` TradingCore en memoire, conserve son etat HTTP local dans
+`var/fake_exchange_state.dat`. Son format v1 persiste ensemble les ordres,
+positions, balances, protections, evenements, index d idempotence et prochaine
+sequence d evenement.
+
+Le fichier porte une version de format, une version moteur, un hash de
+configuration de scenario et un checksum. Une ecriture passe par un fichier
+temporaire puis un remplacement atomique. Au restart, un etat present mais
+corrompu ou incompatible echoue explicitement avec
+`FakeExchangeStateCorruptedException`; il n est jamais transforme silencieusement
+en etat vide. L ancien payload non versionne reste lisible et est migre lors de
+la prochaine ecriture.
+
+Cette reprise prouve uniquement la continuite locale Fake/Paper. Elle ne remplace
+ni une reconciliation REST/WS exchange, ni le ledger PostgreSQL, et n active
+aucune permission demo, testnet ou live.
+
 ## Rollback
 
 Le rollback de COMMON-005 consiste a retirer le mode scenario et revenir au

--- a/trading-app/src/Exchange/Fake/FakeExchangeStateCorruptedException.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeStateCorruptedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+final class FakeExchangeStateCorruptedException extends \RuntimeException
+{
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
@@ -395,7 +395,14 @@ final class FakeExchangeStateStore
             throw new FakeExchangeStateCorruptedException('fake_exchange_state_unreadable');
         }
 
-        $state = @unserialize($raw, ['allowed_classes' => self::allowedSerializedClasses()]);
+        try {
+            $state = @unserialize($raw, ['allowed_classes' => self::allowedSerializedClasses()]);
+        } catch (\Throwable $exception) {
+            throw new FakeExchangeStateCorruptedException(
+                'fake_exchange_state_deserialization_failed',
+                previous: $exception,
+            );
+        }
         if (!\is_array($state)) {
             throw new FakeExchangeStateCorruptedException('fake_exchange_state_invalid_payload');
         }

--- a/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
@@ -9,15 +9,28 @@ use App\Common\Enum\MarketType;
 use App\Exchange\Dto\ExchangeBalanceDto;
 use App\Exchange\Dto\ExchangeOrderDto;
 use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Enum\ExchangeOrderSide;
 use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
 use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class FakeExchangeStateStore
 {
+    private const STATE_FORMAT_VERSION = 1;
+    private const ENGINE_VERSION = 'fake-paper-state-v1';
+    private const SCENARIO_CONFIG_ID = 'fake-paper-default-v1';
+
     private ?string $stateFile;
 
     private int $nextOrderSequence = 1;
+
+    private int $nextEventSequence = 1;
+
+    private bool $restored = false;
+
+    private bool $restoredLegacyState = false;
 
     /** @var array<string, ExchangeOrderDto> */
     private array $orders = [];
@@ -42,8 +55,7 @@ final class FakeExchangeStateStore
     public function __construct(
         #[Autowire('%kernel.project_dir%/var/fake_exchange_state.dat')]
         ?string $stateFile = null,
-    )
-    {
+    ) {
         $this->stateFile = $stateFile;
         if (!$this->restore()) {
             $this->reset();
@@ -53,6 +65,9 @@ final class FakeExchangeStateStore
     public function reset(): void
     {
         $this->nextOrderSequence = 1;
+        $this->nextEventSequence = 1;
+        $this->restored = false;
+        $this->restoredLegacyState = false;
         $this->orders = [];
         $this->clientOrderIndex = [];
         $this->positions = [];
@@ -200,7 +215,14 @@ final class FakeExchangeStateStore
     {
         $payload = $event->payload;
         if (!\array_key_exists('event_sequence', $event->payload)) {
-            $payload = ['event_sequence' => $this->nextEventSequence()] + $payload;
+            $payload = ['event_sequence' => $this->nextEventSequence++] + $payload;
+        } else {
+            $explicitSequence = $event->payload['event_sequence'];
+            if (\is_int($explicitSequence) && $explicitSequence > 0) {
+                $this->nextEventSequence = max($this->nextEventSequence, $explicitSequence + 1);
+            } elseif (\is_string($explicitSequence) && ctype_digit($explicitSequence)) {
+                $this->nextEventSequence = max($this->nextEventSequence, (int) $explicitSequence + 1);
+        }
         }
 
         $orderId = $payload['order_id'] ?? null;
@@ -275,19 +297,19 @@ final class FakeExchangeStateStore
         return \count($this->getOpenPositions($symbol));
     }
 
-    private function nextEventSequence(): int
+    /**
+     * @return array{format_version:int,engine_version:string,scenario_config_hash:string,restored:bool,legacy:bool,next_event_sequence:int}
+     */
+    public function recoveryMetadata(): array
     {
-        $maximum = 0;
-        foreach ($this->events as $event) {
-            $sequence = $event->payload['event_sequence'] ?? null;
-            if (\is_int($sequence)) {
-                $maximum = max($maximum, $sequence);
-            } elseif (\is_string($sequence) && ctype_digit($sequence)) {
-                $maximum = max($maximum, (int)$sequence);
-            }
-        }
-
-        return $maximum + 1;
+        return [
+            'format_version' => self::STATE_FORMAT_VERSION,
+            'engine_version' => self::ENGINE_VERSION,
+            'scenario_config_hash' => self::scenarioConfigHash(),
+            'restored' => $this->restored,
+            'legacy' => $this->restoredLegacyState,
+            'next_event_sequence' => $this->nextEventSequence,
+        ];
     }
 
     private function clientOrderKey(string $symbol, string $clientOrderId): string
@@ -370,24 +392,22 @@ final class FakeExchangeStateStore
 
         $raw = file_get_contents($this->stateFile);
         if ($raw === false || $raw === '') {
-            return false;
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_unreadable');
         }
 
-        $state = @unserialize($raw, ['allowed_classes' => true]);
+        $state = @unserialize($raw, ['allowed_classes' => self::allowedSerializedClasses()]);
         if (!\is_array($state)) {
-            return false;
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_invalid_payload');
         }
 
-        $this->nextOrderSequence = \is_int($state['nextOrderSequence'] ?? null) ? $state['nextOrderSequence'] : 1;
-        $this->orders = \is_array($state['orders'] ?? null) ? $state['orders'] : [];
-        $this->clientOrderIndex = \is_array($state['clientOrderIndex'] ?? null) ? $state['clientOrderIndex'] : [];
-        $this->positions = \is_array($state['positions'] ?? null) ? $state['positions'] : [];
-        $this->balances = \is_array($state['balances'] ?? null) ? $state['balances'] : [];
-        $this->orderBooks = \is_array($state['orderBooks'] ?? null) ? $state['orderBooks'] : [];
-        $this->events = \is_array($state['events'] ?? null) ? $state['events'] : [];
-        $this->rejectNextProtectionOrder = \is_bool($state['rejectNextProtectionOrder'] ?? null)
-            ? $state['rejectNextProtectionOrder']
-            : false;
+        $legacy = !\array_key_exists('format_version', $state);
+        if (!$legacy) {
+            $state = $this->validatedEnvelopePayload($state);
+        }
+
+        $this->hydrate($state);
+        $this->restored = true;
+        $this->restoredLegacyState = $legacy;
 
         return true;
     }
@@ -399,12 +419,13 @@ final class FakeExchangeStateStore
         }
 
         $directory = \dirname($this->stateFile);
-        if (!is_dir($directory)) {
-            mkdir($directory, 0775, true);
+        if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+            throw new \RuntimeException('fake_exchange_state_directory_unavailable');
         }
 
-        file_put_contents($this->stateFile, serialize([
+        $payload = [
             'nextOrderSequence' => $this->nextOrderSequence,
+            'nextEventSequence' => $this->nextEventSequence,
             'orders' => $this->orders,
             'clientOrderIndex' => $this->clientOrderIndex,
             'positions' => $this->positions,
@@ -412,6 +433,207 @@ final class FakeExchangeStateStore
             'orderBooks' => $this->orderBooks,
             'events' => $this->events,
             'rejectNextProtectionOrder' => $this->rejectNextProtectionOrder,
-        ]), \LOCK_EX);
+        ];
+        $serialized = serialize([
+            'format_version' => self::STATE_FORMAT_VERSION,
+            'engine_version' => self::ENGINE_VERSION,
+            'scenario_config_hash' => self::scenarioConfigHash(),
+            'payload_checksum' => hash('sha256', serialize($payload)),
+            'payload' => $payload,
+        ]);
+        $temporaryFile = tempnam($directory, basename($this->stateFile) . '.tmp.');
+        if ($temporaryFile === false) {
+            throw new \RuntimeException('fake_exchange_state_temporary_file_unavailable');
+        }
+
+        try {
+            $written = file_put_contents($temporaryFile, $serialized, \LOCK_EX);
+            if ($written !== strlen($serialized)) {
+                throw new \RuntimeException('fake_exchange_state_write_failed');
+            }
+            if (!rename($temporaryFile, $this->stateFile)) {
+                throw new \RuntimeException('fake_exchange_state_replace_failed');
+            }
+        } finally {
+            if (is_file($temporaryFile)) {
+                @unlink($temporaryFile);
+            }
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $envelope
+     * @return array<string,mixed>
+     */
+    private function validatedEnvelopePayload(array $envelope): array
+    {
+        if (($envelope['format_version'] ?? null) !== self::STATE_FORMAT_VERSION) {
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_format_unsupported');
+        }
+        if (($envelope['engine_version'] ?? null) !== self::ENGINE_VERSION) {
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_engine_version_mismatch');
+        }
+        if (($envelope['scenario_config_hash'] ?? null) !== self::scenarioConfigHash()) {
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_config_mismatch');
+        }
+
+        $payload = $envelope['payload'] ?? null;
+        $checksum = $envelope['payload_checksum'] ?? null;
+        if (!\is_array($payload) || !\is_string($checksum)) {
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_envelope_invalid');
+        }
+        if (!hash_equals(hash('sha256', serialize($payload)), $checksum)) {
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_checksum_mismatch');
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string,mixed> $state
+     */
+    private function hydrate(array $state): void
+    {
+        $nextOrderSequence = $state['nextOrderSequence'] ?? null;
+        $orders = $state['orders'] ?? null;
+        $clientOrderIndex = $state['clientOrderIndex'] ?? null;
+        $positions = $state['positions'] ?? null;
+        $balances = $state['balances'] ?? null;
+        $orderBooks = $state['orderBooks'] ?? null;
+        $events = $state['events'] ?? null;
+        $rejectNextProtectionOrder = $state['rejectNextProtectionOrder'] ?? null;
+        if (
+            !\is_int($nextOrderSequence) || $nextOrderSequence < 1
+            || !$this->isTypedMap($orders, ExchangeOrderDto::class)
+            || !$this->isStringMap($clientOrderIndex)
+            || !$this->isTypedMap($positions, ExchangePositionDto::class)
+            || !$this->isTypedMap($balances, ExchangeBalanceDto::class)
+            || !$this->isOrderBookMap($orderBooks)
+            || !$this->isTypedArray($events, FakeExchangeEvent::class)
+            || !\is_bool($rejectNextProtectionOrder)
+        ) {
+            throw new FakeExchangeStateCorruptedException('fake_exchange_state_shape_invalid');
+        }
+
+        $this->nextOrderSequence = $nextOrderSequence;
+        $this->orders = $orders;
+        $this->clientOrderIndex = $clientOrderIndex;
+        $this->positions = $positions;
+        $this->balances = $balances;
+        $this->orderBooks = $orderBooks;
+        $this->events = array_values($events);
+        $this->rejectNextProtectionOrder = $rejectNextProtectionOrder;
+
+        $nextEventSequence = $state['nextEventSequence'] ?? null;
+        $this->nextEventSequence = \is_int($nextEventSequence) && $nextEventSequence > 0
+            ? $nextEventSequence
+            : $this->inferNextEventSequence();
+    }
+
+    private function inferNextEventSequence(): int
+    {
+        $maximum = 0;
+        foreach ($this->events as $event) {
+            $sequence = $event->payload['event_sequence'] ?? null;
+            if (\is_int($sequence)) {
+                $maximum = max($maximum, $sequence);
+            } elseif (\is_string($sequence) && ctype_digit($sequence)) {
+                $maximum = max($maximum, (int) $sequence);
+            }
+        }
+
+        return $maximum + 1;
+    }
+
+    private static function scenarioConfigHash(): string
+    {
+        return hash('sha256', self::SCENARIO_CONFIG_ID);
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private static function allowedSerializedClasses(): array
+    {
+        return [
+            ExchangeBalanceDto::class,
+            ExchangeOrderDto::class,
+            ExchangePositionDto::class,
+            FakeExchangeEvent::class,
+            Exchange::class,
+            MarketType::class,
+            ExchangeOrderSide::class,
+            ExchangeOrderStatus::class,
+            ExchangeOrderType::class,
+            ExchangePositionSide::class,
+            ExchangeTimeInForce::class,
+            \DateTimeImmutable::class,
+            \DateTimeZone::class,
+        ];
+    }
+
+    private function isTypedArray(mixed $value, string $class): bool
+    {
+        if (!\is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $item) {
+            if (!$item instanceof $class) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isTypedMap(mixed $value, string $class): bool
+    {
+        if (!\is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $key => $item) {
+            if (!\is_string($key) || !$item instanceof $class) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isStringMap(mixed $value): bool
+    {
+        if (!\is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $key => $item) {
+            if (!\is_string($key) || !\is_string($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isOrderBookMap(mixed $value): bool
+    {
+        if (!\is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $symbol => $book) {
+            if (
+                !\is_string($symbol)
+                || !\is_array($book)
+                || !\is_float($book['bid'] ?? null)
+                || !\is_float($book['ask'] ?? null)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -43,3 +43,11 @@ orders, fills and positions from the Fake REST snapshots through
 the next contiguous sequence is consumed normally. The one-shot disconnect is not
 reinjected. This fixture remains local, performs no network request and never
 sends an exchange order.
+
+## Persistent recovery contract
+
+The file-backed store writes a versioned `fake-paper-state-v1` envelope containing the engine version, a deterministic scenario configuration hash, a payload checksum, and the next event sequence. Writes use a temporary file followed by an atomic replacement.
+
+On restart, orders, the `client_order_id` index, positions, balances, order books, protection orders, events, and the pending protection-failure fixture are restored together. A legacy unversioned state file is accepted and upgraded on the next write. A present but unreadable, unsupported, or checksum-invalid file raises `FakeExchangeStateCorruptedException`; it is never silently replaced with an empty state.
+
+`FakeExchangeStateStore::recoveryMetadata()` exposes the effective format, engine/config identity, whether the instance restored persisted state, whether that state used the legacy format, and the next event sequence. This is local Paper evidence only and does not certify exchange reconciliation or enable any demo/live write path.

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
@@ -18,6 +18,7 @@ use App\Exchange\Enum\ExchangeTimeInForce;
 use App\Exchange\Fake\FakeExchangeMatchingEngine;
 use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeScenarioService;
+use App\Exchange\Fake\FakeExchangeStateCorruptedException;
 use App\Exchange\Fake\FakeExchangeStateStore;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -695,6 +696,115 @@ final class FakeExchangeAdapterTest extends TestCase
 
             self::assertCount(1, $restoredAdapter->getOpenOrders('BTCUSDT'));
             self::assertSame('cid-1', $restoredAdapter->getOpenOrders('BTCUSDT')[0]->clientOrderId);
+        } finally {
+            @unlink($stateFile);
+        }
+    }
+
+    public function testStateStoreRestoresProtectedPositionAndContinuesEventSequence(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_state_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            $state = new FakeExchangeStateStore($stateFile);
+            $adapter = $this->adapterForState($state);
+            $adapter->placeOrder($this->request(
+                orderType: ExchangeOrderType::MARKET,
+                price: null,
+                postOnly: false,
+                attachedStopLossPrice: 24800.0,
+            ));
+
+            $restoredState = new FakeExchangeStateStore($stateFile);
+            $restoredAdapter = $this->adapterForState($restoredState);
+            $book = new FakeExchangeOrderBook($restoredState);
+            $engine = new FakeExchangeMatchingEngine($restoredState, $book, $this->fixedClock());
+            $scenario = new FakeExchangeScenarioService($restoredState, $book, $engine);
+
+            self::assertTrue($restoredState->recoveryMetadata()['restored']);
+            self::assertFalse($restoredState->recoveryMetadata()['legacy']);
+            self::assertCount(1, $restoredAdapter->getOpenPositions('BTCUSDT'));
+            self::assertCount(1, $restoredAdapter->getOpenOrders('BTCUSDT'));
+
+            $replayed = $restoredAdapter->placeOrder($this->request(
+                orderType: ExchangeOrderType::MARKET,
+                price: null,
+                postOnly: false,
+                attachedStopLossPrice: 24800.0,
+            ));
+            self::assertTrue($replayed->metadata['idempotent_replay'] ?? false);
+            self::assertCount(1, $restoredAdapter->getOpenPositions('BTCUSDT'));
+
+            $scenario->movePrice('BTCUSDT', 24790.0, 0.0);
+            self::assertCount(0, $restoredAdapter->getOpenPositions('BTCUSDT'));
+
+            $sequences = array_map(
+                static fn ($event): int => (int) ($event->payload['event_sequence'] ?? 0),
+                $scenario->events(),
+            );
+            self::assertSame($sequences, array_values(array_unique($sequences)));
+            $sortedSequences = $sequences;
+            sort($sortedSequences);
+            self::assertSame($sortedSequences, $sequences);
+        } finally {
+            @unlink($stateFile);
+        }
+    }
+
+    public function testStateStoreRejectsChecksumMismatchWithoutSilentReset(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_state_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            $state = new FakeExchangeStateStore($stateFile);
+            $this->adapterForState($state)->placeOrder($this->request(price: 24950.0, postOnly: true));
+
+            $raw = file_get_contents($stateFile);
+            self::assertIsString($raw);
+            $envelope = unserialize($raw, ['allowed_classes' => true]);
+            self::assertIsArray($envelope);
+            $envelope['payload_checksum'] = str_repeat('0', 64);
+            file_put_contents($stateFile, serialize($envelope));
+
+            $this->expectException(FakeExchangeStateCorruptedException::class);
+            $this->expectExceptionMessage('fake_exchange_state_checksum_mismatch');
+            new FakeExchangeStateStore($stateFile);
+        } finally {
+            @unlink($stateFile);
+        }
+    }
+
+    public function testStateStoreRestoresLegacyPayloadAndUpgradesOnNextWrite(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_state_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            $state = new FakeExchangeStateStore($stateFile);
+            $this->adapterForState($state)->placeOrder($this->request(price: 24950.0, postOnly: true));
+
+            $raw = file_get_contents($stateFile);
+            self::assertIsString($raw);
+            $envelope = unserialize($raw, ['allowed_classes' => true]);
+            self::assertIsArray($envelope);
+            self::assertIsArray($envelope['payload'] ?? null);
+            file_put_contents($stateFile, serialize($envelope['payload']));
+
+            $legacyState = new FakeExchangeStateStore($stateFile);
+            self::assertTrue($legacyState->recoveryMetadata()['restored']);
+            self::assertTrue($legacyState->recoveryMetadata()['legacy']);
+            self::assertCount(1, $legacyState->getOpenOrders('BTCUSDT'));
+
+            $legacyState->setOrderBookTop('BTCUSDT', 24998.0, 25002.0);
+            $upgraded = unserialize((string) file_get_contents($stateFile), ['allowed_classes' => true]);
+            self::assertIsArray($upgraded);
+            self::assertSame(1, $upgraded['format_version'] ?? null);
+            self::assertIsString($upgraded['payload_checksum'] ?? null);
         } finally {
             @unlink($stateFile);
         }

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
@@ -778,6 +778,28 @@ final class FakeExchangeAdapterTest extends TestCase
         }
     }
 
+    public function testStateStoreWrapsTypedPropertyDeserializationFailure(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_state_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            new FakeExchangeStateStore($stateFile);
+            $raw = file_get_contents($stateFile);
+            self::assertIsString($raw);
+            $corrupted = str_replace('d:100000;', 's:6:"broken";', $raw, $replacements);
+            self::assertGreaterThan(0, $replacements);
+            file_put_contents($stateFile, $corrupted);
+
+            $this->expectException(FakeExchangeStateCorruptedException::class);
+            $this->expectExceptionMessage('fake_exchange_state_deserialization_failed');
+            new FakeExchangeStateStore($stateFile);
+        } finally {
+            @unlink($stateFile);
+        }
+    }
+
     public function testStateStoreRestoresLegacyPayloadAndUpgradesOnNextWrite(): void
     {
         $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_state_');


### PR DESCRIPTION
## Summary

- introduce a versioned `fake-paper-state-v1` envelope for the file-backed Fake/Paper store
- persist engine identity, deterministic scenario config hash, payload checksum and next event sequence
- restore orders, idempotency index, positions, balances, protections, order books and events together
- accept the legacy unversioned payload and upgrade it on the next write
- reject present but unreadable, incompatible or checksum-invalid state instead of silently resetting
- replace state files atomically through a same-directory temporary file

## Safety

- local Fake/Paper only
- no exchange network request
- no demo/testnet/mainnet order
- no strategy, EntryZone, risk, leverage, SL/TP policy or live guard change
- no secret or raw sensitive payload
- no database migration

## Tests

- `php vendor/bin/phpunit tests/Exchange` (845 tests, 3243 assertions, 30 skipped)
- PHPStan on all touched PHP files with `--memory-limit=512M`
- `php bin/console lint:container --no-debug`
- `php bin/console lint:yaml config`
- `python3 -m mkdocs build --strict --site-dir /tmp/tradingv3-mkdocs-196-p1`
- `git diff --check`

Part of #196.
Related to #197.
Related to #198.
Related to #226.
Related to #274.