### PR TITLE
Add deterministic Fake/Paper transport fault injection

### DIFF
--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -162,6 +162,38 @@ Cette reprise prouve uniquement la continuite locale Fake/Paper. Elle ne remplac
 ni une reconciliation REST/WS exchange, ni le ledger PostgreSQL, et n active
 aucune permission demo, testnet ou live.
 
+## Injection deterministe des erreurs adapter
+
+Le Fake Exchange de niveau adapter expose une file de fautes typees via
+`FakeExchangeScenarioService::failNext()`. Les fixtures supportees sont :
+
+| Kind | Statut HTTP normalise | Contexte |
+| --- | --- | --- |
+| `network_timeout` | absent | timeout immediat sans attente reelle |
+| `transport_error` | absent | echec transport generique |
+| `http_429` | `429` | `retry_after_seconds` positif obligatoire |
+| `http_500` | `500` | erreur serveur deterministe |
+
+Le resultat `not_applied` consomme la faute avant toute mutation. Pour
+`place_order` et `cancel_order`, `applied_response_lost` applique d abord la
+mutation puis leve `FakeExchangeInjectedException` avec `outcome_unknown=true`.
+Ce second mode reproduit une reponse perdue : le caller doit rejouer avec les memes
+identifiants, et le Fake restitue alors l ordre ou l annulation deja appliquee sans
+dupliquer les evenements.
+
+La file est FIFO, isolee par operation et persistee dans l enveloppe
+`fake-paper-state-v1`. Une faute armee survit donc au restart. Pour un resultat
+`applied_response_lost`, la mutation et le retrait de la faute sont commits dans
+le meme remplacement atomique du fichier d etat. Un no-op ou une exception restaure
+l etat et conserve la faute. Le contexte d erreur ne contient que le kind,
+l operation, le resultat, le statut HTTP normalise et le retry-after. Aucun payload
+brut, credential, URL ou header sensible n est conserve.
+
+Ce contrat couvre les erreurs adapter REST simulees. Il ne modelise pas encore un
+quota glissant, la latence/jitter avec seed, les erreurs de precision/marge, ni les
+divergences Bitmart. La deconnexion et le resync private WS sont couverts par la
+fixture separee `FakeExchangeWsClient`.
+
 ## Rollback
 
 Le rollback de COMMON-005 consiste a retirer le mode scenario et revenir au

--- a/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
@@ -19,7 +19,10 @@ use App\Exchange\Dto\ExchangeReconciliationResult;
 use App\Exchange\Dto\PlaceOrderRequest;
 use App\Exchange\Dto\PlaceOrderResult;
 use App\Exchange\Fake\FakeExchangeEvent;
+use App\Exchange\Fake\FakeExchangeFaultOutcome;
+use App\Exchange\Fake\FakeExchangeInjectedException;
 use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOperation;
 use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeStateStore;
 use App\Exchange\Reconciliation\ExchangeRestSnapshotProviderInterface;
@@ -73,6 +76,8 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
      */
     public function getBalances(): array
     {
+        $this->throwInjectedFault(FakeExchangeOperation::GetBalances, FakeExchangeFaultOutcome::NotApplied);
+
         return $this->stateStore->getBalances();
     }
 
@@ -81,6 +86,8 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
      */
     public function getOpenPositions(?string $symbol = null): array
     {
+        $this->throwInjectedFault(FakeExchangeOperation::GetOpenPositions, FakeExchangeFaultOutcome::NotApplied);
+
         return $this->stateStore->getOpenPositions($symbol);
     }
 
@@ -89,6 +96,8 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
      */
     public function getOpenOrders(?string $symbol = null): array
     {
+        $this->throwInjectedFault(FakeExchangeOperation::GetOpenOrders, FakeExchangeFaultOutcome::NotApplied);
+
         return $this->stateStore->getOpenOrders($symbol);
     }
 
@@ -97,6 +106,8 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
      */
     public function getOrdersSnapshot(?string $symbol = null): array
     {
+        $this->throwInjectedFault(FakeExchangeOperation::GetOrdersSnapshot, FakeExchangeFaultOutcome::NotApplied);
+
         return $this->stateStore->getOrders($symbol);
     }
 
@@ -105,6 +116,8 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
      */
     public function getFillsSnapshot(?string $symbol = null): array
     {
+        $this->throwInjectedFault(FakeExchangeOperation::GetFillsSnapshot, FakeExchangeFaultOutcome::NotApplied);
+
         $normalizedSymbol = $symbol !== null ? strtoupper($symbol) : null;
         $fills = [];
         foreach ($this->stateStore->events() as $index => $event) {
@@ -131,16 +144,36 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
 
     public function placeOrder(PlaceOrderRequest $request): PlaceOrderResult
     {
-        return $this->matchingEngine->submit($request);
+        $this->throwInjectedFault(FakeExchangeOperation::PlaceOrder, FakeExchangeFaultOutcome::NotApplied);
+        $execution = $this->stateStore->runWithAppliedResponseLoss(
+            FakeExchangeOperation::PlaceOrder,
+            fn (): PlaceOrderResult => $this->matchingEngine->submit($request),
+        );
+        if ($execution['fault'] !== null) {
+            throw new FakeExchangeInjectedException($execution['fault']);
+        }
+
+        return $execution['result'];
     }
 
     public function cancelOrder(CancelOrderRequest $request): CancelOrderResult
     {
-        return $this->matchingEngine->cancel($request);
+        $this->throwInjectedFault(FakeExchangeOperation::CancelOrder, FakeExchangeFaultOutcome::NotApplied);
+        $execution = $this->stateStore->runWithAppliedResponseLoss(
+            FakeExchangeOperation::CancelOrder,
+            fn (): CancelOrderResult => $this->matchingEngine->cancel($request),
+        );
+        if ($execution['fault'] !== null) {
+            throw new FakeExchangeInjectedException($execution['fault']);
+        }
+
+        return $execution['result'];
     }
 
     public function getOrder(string $symbol, string $exchangeOrderId): ?ExchangeOrderDto
     {
+        $this->throwInjectedFault(FakeExchangeOperation::GetOrder, FakeExchangeFaultOutcome::NotApplied);
+
         $order = $this->stateStore->getOrder($exchangeOrderId);
         if (!$order instanceof ExchangeOrderDto || $order->symbol !== strtoupper($symbol)) {
             return null;
@@ -151,11 +184,15 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
 
     public function getOrderBookTop(string $symbol): SymbolBidAskDto
     {
+        $this->throwInjectedFault(FakeExchangeOperation::GetOrderBookTop, FakeExchangeFaultOutcome::NotApplied);
+
         return $this->orderBook->top($symbol);
     }
 
     public function setLeverage(string $symbol, int $leverage, string $marginMode): bool
     {
+        $this->throwInjectedFault(FakeExchangeOperation::SetLeverage, FakeExchangeFaultOutcome::NotApplied);
+
         if (trim($symbol) === '' || $leverage <= 0 || trim($marginMode) === '') {
             return false;
         }
@@ -165,6 +202,8 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
 
     public function reconcile(?string $symbol = null): ExchangeReconciliationResult
     {
+        $this->throwInjectedFault(FakeExchangeOperation::Reconcile, FakeExchangeFaultOutcome::NotApplied);
+
         $startedAt = $this->clock->now();
 
         return new ExchangeReconciliationResult(
@@ -236,5 +275,15 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
     private function fillFee(float $quantity, float $price): float
     {
         return round($quantity * $price * self::FEE_RATE, 12);
+    }
+
+    private function throwInjectedFault(
+        FakeExchangeOperation $operation,
+        FakeExchangeFaultOutcome $outcome,
+    ): void {
+        $fault = $this->stateStore->consumeFault($operation, $outcome);
+        if ($fault !== null) {
+            throw new FakeExchangeInjectedException($fault);
+        }
     }
 }

--- a/trading-app/src/Exchange/Fake/FakeExchangeFault.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeFault.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+final readonly class FakeExchangeFault
+{
+    public function __construct(
+        public FakeExchangeOperation $operation,
+        public FakeExchangeFaultKind $kind,
+        public FakeExchangeFaultOutcome $outcome = FakeExchangeFaultOutcome::NotApplied,
+        public ?int $retryAfterSeconds = null,
+    ) {
+        if ($kind === FakeExchangeFaultKind::Http429 && ($retryAfterSeconds === null || $retryAfterSeconds < 1)) {
+            throw new \InvalidArgumentException('fake_exchange_fault_retry_after_invalid');
+        }
+        if ($kind !== FakeExchangeFaultKind::Http429 && $retryAfterSeconds !== null) {
+            throw new \InvalidArgumentException('fake_exchange_fault_retry_after_unexpected');
+        }
+        if ($outcome === FakeExchangeFaultOutcome::AppliedResponseLost && !$operation->isMutation()) {
+            throw new \InvalidArgumentException('fake_exchange_fault_applied_outcome_requires_mutation');
+        }
+        if (
+            $outcome === FakeExchangeFaultOutcome::AppliedResponseLost
+            && !\in_array($kind, [FakeExchangeFaultKind::NetworkTimeout, FakeExchangeFaultKind::TransportError], true)
+        ) {
+            throw new \InvalidArgumentException('fake_exchange_fault_applied_outcome_requires_transport_failure');
+        }
+    }
+
+    /**
+     * @return array{operation:string,kind:string,outcome:string,retry_after_seconds:?int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'operation' => $this->operation->value,
+            'kind' => $this->kind->value,
+            'outcome' => $this->outcome->value,
+            'retry_after_seconds' => $this->retryAfterSeconds,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $operation = $payload['operation'] ?? null;
+        $kind = $payload['kind'] ?? null;
+        $outcome = $payload['outcome'] ?? null;
+        $retryAfterSeconds = $payload['retry_after_seconds'] ?? null;
+        if (
+            !\is_string($operation)
+            || !\is_string($kind)
+            || !\is_string($outcome)
+            || ($retryAfterSeconds !== null && !\is_int($retryAfterSeconds))
+        ) {
+            throw new \InvalidArgumentException('fake_exchange_fault_payload_invalid');
+        }
+
+        try {
+            return new self(
+                FakeExchangeOperation::from($operation),
+                FakeExchangeFaultKind::from($kind),
+                FakeExchangeFaultOutcome::from($outcome),
+                $retryAfterSeconds,
+            );
+        } catch (\ValueError $exception) {
+            throw new \InvalidArgumentException('fake_exchange_fault_payload_invalid', previous: $exception);
+        }
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeFaultKind.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeFaultKind.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+enum FakeExchangeFaultKind: string
+{
+    case NetworkTimeout = 'network_timeout';
+    case TransportError = 'transport_error';
+    case Http429 = 'http_429';
+    case Http500 = 'http_500';
+
+    public function httpStatus(): ?int
+    {
+        return match ($this) {
+            self::Http429 => 429,
+            self::Http500 => 500,
+            default => null,
+        };
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeFaultOutcome.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeFaultOutcome.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+enum FakeExchangeFaultOutcome: string
+{
+    case NotApplied = 'not_applied';
+    case AppliedResponseLost = 'applied_response_lost';
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeInjectedException.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeInjectedException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+final class FakeExchangeInjectedException extends \RuntimeException
+{
+    public function __construct(public readonly FakeExchangeFault $fault)
+    {
+        parent::__construct($fault->kind->value);
+    }
+
+    public function outcomeUnknown(): bool
+    {
+        return $this->fault->outcome === FakeExchangeFaultOutcome::AppliedResponseLost;
+    }
+
+    /**
+     * @return array{injected_error:string,operation:string,outcome:string,outcome_unknown:bool,http_status:?int,retry_after_seconds:?int}
+     */
+    public function context(): array
+    {
+        return [
+            'injected_error' => $this->fault->kind->value,
+            'operation' => $this->fault->operation->value,
+            'outcome' => $this->fault->outcome->value,
+            'outcome_unknown' => $this->outcomeUnknown(),
+            'http_status' => $this->fault->kind->httpStatus(),
+            'retry_after_seconds' => $this->fault->retryAfterSeconds,
+        ];
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -130,6 +130,17 @@ final readonly class FakeExchangeMatchingEngine
             $order = $this->stateStore->getOrderByClientOrderId($request->symbol, $request->clientOrderId);
         }
 
+        if ($order instanceof ExchangeOrderDto && $order->status === ExchangeOrderStatus::CANCELLED) {
+            return new CancelOrderResult(
+                cancelled: true,
+                symbol: $order->symbol,
+                exchangeOrderId: $order->exchangeOrderId,
+                clientOrderId: $order->clientOrderId,
+                status: ExchangeOrderStatus::CANCELLED,
+                metadata: ['idempotent_replay' => true],
+            );
+        }
+
         if (!$order instanceof ExchangeOrderDto || !$this->isActiveStatus($order->status)) {
             return $this->cancelNotActive($request);
         }

--- a/trading-app/src/Exchange/Fake/FakeExchangeOperation.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeOperation.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+enum FakeExchangeOperation: string
+{
+    case PlaceOrder = 'place_order';
+    case CancelOrder = 'cancel_order';
+    case GetBalances = 'get_balances';
+    case GetOpenPositions = 'get_open_positions';
+    case GetOpenOrders = 'get_open_orders';
+    case GetOrdersSnapshot = 'get_orders_snapshot';
+    case GetFillsSnapshot = 'get_fills_snapshot';
+    case GetOrder = 'get_order';
+    case GetOrderBookTop = 'get_order_book_top';
+    case SetLeverage = 'set_leverage';
+    case Reconcile = 'reconcile';
+
+    public function isMutation(): bool
+    {
+        return $this === self::PlaceOrder || $this === self::CancelOrder;
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeExchangeScenarioService.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeScenarioService.php
@@ -44,6 +44,19 @@ final readonly class FakeExchangeScenarioService
         $this->stateStore->rejectNextProtectionOrder();
     }
 
+    public function failNext(FakeExchangeFault $fault): void
+    {
+        $this->stateStore->queueFault($fault);
+    }
+
+    /**
+     * @return FakeExchangeFault[]
+     */
+    public function pendingFaults(): array
+    {
+        return $this->stateStore->pendingFaults();
+    }
+
     /**
      * @return FakeExchangeEvent[]
      */

--- a/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
@@ -52,6 +52,11 @@ final class FakeExchangeStateStore
 
     private bool $rejectNextProtectionOrder = false;
 
+    /** @var list<array{operation:string,kind:string,outcome:string,retry_after_seconds:?int}> */
+    private array $pendingFaults = [];
+
+    private bool $deferPersistence = false;
+
     public function __construct(
         #[Autowire('%kernel.project_dir%/var/fake_exchange_state.dat')]
         ?string $stateFile = null,
@@ -74,6 +79,7 @@ final class FakeExchangeStateStore
         $this->orderBooks = [];
         $this->events = [];
         $this->rejectNextProtectionOrder = false;
+        $this->pendingFaults = [];
         $this->balances = [
             'USDT' => new ExchangeBalanceDto(
                 exchange: Exchange::FAKE,
@@ -287,6 +293,96 @@ final class FakeExchangeStateStore
         return true;
     }
 
+    public function queueFault(FakeExchangeFault $fault): void
+    {
+        $this->pendingFaults[] = $fault->toArray();
+        $this->persist();
+    }
+
+    /**
+     * @return FakeExchangeFault[]
+     */
+    public function pendingFaults(): array
+    {
+        return array_map(
+            static fn (array $fault): FakeExchangeFault => FakeExchangeFault::fromArray($fault),
+            $this->pendingFaults,
+        );
+    }
+
+    public function consumeFault(
+        FakeExchangeOperation $operation,
+        FakeExchangeFaultOutcome $outcome,
+    ): ?FakeExchangeFault {
+        $index = $this->firstFaultIndex($operation);
+        if ($index === null) {
+            return null;
+        }
+
+        $fault = FakeExchangeFault::fromArray($this->pendingFaults[$index]);
+        if ($fault->outcome !== $outcome) {
+            return null;
+        }
+
+        $this->removeFaultAt($index);
+        $this->persist();
+
+        return $fault;
+    }
+
+    /**
+     * @template TResult
+     * @param callable(): TResult $operationCallback
+     * @return array{result:TResult,fault:?FakeExchangeFault}
+     */
+    public function runWithAppliedResponseLoss(
+        FakeExchangeOperation $operation,
+        callable $operationCallback,
+    ): array {
+        $index = $this->firstFaultIndex($operation);
+        if ($index === null) {
+            return ['result' => $operationCallback(), 'fault' => null];
+        }
+
+        $fault = FakeExchangeFault::fromArray($this->pendingFaults[$index]);
+        if ($fault->outcome !== FakeExchangeFaultOutcome::AppliedResponseLost) {
+            return ['result' => $operationCallback(), 'fault' => null];
+        }
+
+        return $this->transactional(function () use ($index, $fault, $operationCallback): array {
+            $eventsBefore = \count($this->events);
+            $this->removeFaultAt($index);
+            $this->persist();
+            $result = $operationCallback();
+
+            if (\count($this->events) === $eventsBefore) {
+                array_splice($this->pendingFaults, $index, 0, [$fault->toArray()]);
+                $this->persist();
+
+                return ['result' => $result, 'fault' => null];
+            }
+
+            return ['result' => $result, 'fault' => $fault];
+        });
+    }
+
+    private function firstFaultIndex(FakeExchangeOperation $operation): ?int
+    {
+        foreach ($this->pendingFaults as $index => $payload) {
+            if (FakeExchangeFault::fromArray($payload)->operation === $operation) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    private function removeFaultAt(int $index): void
+    {
+        unset($this->pendingFaults[$index]);
+        $this->pendingFaults = array_values($this->pendingFaults);
+    }
+
     public function openOrderCount(?string $symbol = null): int
     {
         return \count($this->getOpenOrders($symbol));
@@ -298,7 +394,7 @@ final class FakeExchangeStateStore
     }
 
     /**
-     * @return array{format_version:int,engine_version:string,scenario_config_hash:string,restored:bool,legacy:bool,next_event_sequence:int}
+     * @return array{format_version:int,engine_version:string,scenario_config_hash:string,restored:bool,legacy:bool,next_event_sequence:int,pending_fault_count:int}
      */
     public function recoveryMetadata(): array
     {
@@ -309,6 +405,7 @@ final class FakeExchangeStateStore
             'restored' => $this->restored,
             'legacy' => $this->restoredLegacyState,
             'next_event_sequence' => $this->nextEventSequence,
+            'pending_fault_count' => \count($this->pendingFaults),
         ];
     }
 
@@ -421,6 +518,10 @@ final class FakeExchangeStateStore
 
     private function persist(): void
     {
+        if ($this->deferPersistence) {
+            return;
+        }
+
         if ($this->stateFile === null) {
             return;
         }
@@ -440,6 +541,7 @@ final class FakeExchangeStateStore
             'orderBooks' => $this->orderBooks,
             'events' => $this->events,
             'rejectNextProtectionOrder' => $this->rejectNextProtectionOrder,
+            'pendingFaults' => $this->pendingFaults,
         ];
         $serialized = serialize([
             'format_version' => self::STATE_FORMAT_VERSION,
@@ -509,6 +611,7 @@ final class FakeExchangeStateStore
         $orderBooks = $state['orderBooks'] ?? null;
         $events = $state['events'] ?? null;
         $rejectNextProtectionOrder = $state['rejectNextProtectionOrder'] ?? null;
+        $pendingFaults = $state['pendingFaults'] ?? [];
         if (
             !\is_int($nextOrderSequence) || $nextOrderSequence < 1
             || !$this->isTypedMap($orders, ExchangeOrderDto::class)
@@ -518,6 +621,7 @@ final class FakeExchangeStateStore
             || !$this->isOrderBookMap($orderBooks)
             || !$this->isTypedArray($events, FakeExchangeEvent::class)
             || !\is_bool($rejectNextProtectionOrder)
+            || !$this->isFaultQueue($pendingFaults)
         ) {
             throw new FakeExchangeStateCorruptedException('fake_exchange_state_shape_invalid');
         }
@@ -530,6 +634,7 @@ final class FakeExchangeStateStore
         $this->orderBooks = $orderBooks;
         $this->events = array_values($events);
         $this->rejectNextProtectionOrder = $rejectNextProtectionOrder;
+        $this->pendingFaults = array_values($pendingFaults);
 
         $nextEventSequence = $state['nextEventSequence'] ?? null;
         $this->nextEventSequence = \is_int($nextEventSequence) && $nextEventSequence > 0
@@ -642,5 +747,94 @@ final class FakeExchangeStateStore
         }
 
         return true;
+    }
+
+    private function isFaultQueue(mixed $value): bool
+    {
+        if (!\is_array($value) || !array_is_list($value)) {
+            return false;
+        }
+
+        foreach ($value as $fault) {
+            if (!\is_array($fault)) {
+                return false;
+            }
+
+            try {
+                FakeExchangeFault::fromArray($fault);
+            } catch (\InvalidArgumentException) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @template TResult
+     * @param callable(): TResult $callback
+     * @return TResult
+     */
+    private function transactional(callable $callback): mixed
+    {
+        if ($this->deferPersistence) {
+            throw new \LogicException('fake_exchange_state_nested_transaction_not_supported');
+        }
+
+        $snapshot = $this->runtimeState();
+        $this->deferPersistence = true;
+
+        try {
+            $result = $callback();
+            $this->deferPersistence = false;
+            $this->persist();
+
+            return $result;
+        } catch (\Throwable $exception) {
+            $this->deferPersistence = false;
+            $this->restoreRuntimeState($snapshot);
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function runtimeState(): array
+    {
+        return [
+            'nextOrderSequence' => $this->nextOrderSequence,
+            'nextEventSequence' => $this->nextEventSequence,
+            'restored' => $this->restored,
+            'restoredLegacyState' => $this->restoredLegacyState,
+            'orders' => $this->orders,
+            'clientOrderIndex' => $this->clientOrderIndex,
+            'positions' => $this->positions,
+            'balances' => $this->balances,
+            'orderBooks' => $this->orderBooks,
+            'events' => $this->events,
+            'rejectNextProtectionOrder' => $this->rejectNextProtectionOrder,
+            'pendingFaults' => $this->pendingFaults,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $snapshot
+     */
+    private function restoreRuntimeState(array $snapshot): void
+    {
+        $this->nextOrderSequence = $snapshot['nextOrderSequence'];
+        $this->nextEventSequence = $snapshot['nextEventSequence'];
+        $this->restored = $snapshot['restored'];
+        $this->restoredLegacyState = $snapshot['restoredLegacyState'];
+        $this->orders = $snapshot['orders'];
+        $this->clientOrderIndex = $snapshot['clientOrderIndex'];
+        $this->positions = $snapshot['positions'];
+        $this->balances = $snapshot['balances'];
+        $this->orderBooks = $snapshot['orderBooks'];
+        $this->events = $snapshot['events'];
+        $this->rejectNextProtectionOrder = $snapshot['rejectNextProtectionOrder'];
+        $this->pendingFaults = $snapshot['pendingFaults'];
     }
 }

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -51,3 +51,33 @@ The file-backed store writes a versioned `fake-paper-state-v1` envelope containi
 On restart, orders, the `client_order_id` index, positions, balances, order books, protection orders, events, and the pending protection-failure fixture are restored together. A legacy unversioned state file is accepted and upgraded on the next write. A present but unreadable, unsupported, or checksum-invalid file raises `FakeExchangeStateCorruptedException`; it is never silently replaced with an empty state.
 
 `FakeExchangeStateStore::recoveryMetadata()` exposes the effective format, engine/config identity, whether the instance restored persisted state, whether that state used the legacy format, and the next event sequence. This is local Paper evidence only and does not certify exchange reconciliation or enable any demo/live write path.
+
+## Deterministic adapter faults
+
+`FakeExchangeScenarioService::failNext()` queues a typed one-shot fault for one
+adapter operation. The supported kinds are `network_timeout`, `transport_error`,
+`http_429`, and `http_500`. A 429 fixture must provide a positive normalized
+`retry_after_seconds`; no raw transport response or request payload is retained.
+
+Faults default to `not_applied` and are consumed before the matching engine or
+read store is called. `place_order` and `cancel_order` also support
+`applied_response_lost` for timeout/transport failures: the mutation is committed,
+then `FakeExchangeInjectedException` reports an ambiguous outcome. Retrying the
+same client order or cancel request returns the existing result without a second
+order, fill, protection, or cancellation event.
+
+```php
+$scenario->failNext(new FakeExchangeFault(
+    FakeExchangeOperation::PlaceOrder,
+    FakeExchangeFaultKind::NetworkTimeout,
+    FakeExchangeFaultOutcome::AppliedResponseLost,
+));
+```
+
+The queue is FIFO per operation and survives a Paper restart. For an
+`applied_response_lost` fixture, the matching mutation and fault removal are
+committed in the same atomic state-file replacement. If the operation is a no-op
+or fails, the transaction restores the state and keeps the fault queued. No delay
+or `sleep` is used: timeout behavior is deterministic and does not contact a
+network. Faults run at the adapter boundary, so a `not_applied` fixture may reject
+a request before the matching engine performs its normal request validation.

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeFaultInjectionTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeFaultInjectionTest.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Adapter;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Fake\FakeExchangeFault;
+use App\Exchange\Fake\FakeExchangeFaultKind;
+use App\Exchange\Fake\FakeExchangeFaultOutcome;
+use App\Exchange\Fake\FakeExchangeInjectedException;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOperation;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeScenarioService;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(FakeExchangeAdapter::class)]
+#[CoversClass(FakeExchangeFault::class)]
+#[CoversClass(FakeExchangeInjectedException::class)]
+#[CoversClass(FakeExchangeScenarioService::class)]
+#[CoversClass(FakeExchangeStateStore::class)]
+final class FakeExchangeFaultInjectionTest extends TestCase
+{
+    private FakeExchangeStateStore $state;
+    private FakeExchangeAdapter $adapter;
+    private FakeExchangeScenarioService $scenario;
+
+    protected function setUp(): void
+    {
+        $this->state = new FakeExchangeStateStore();
+        [$this->adapter, $this->scenario] = $this->services($this->state);
+    }
+
+    public function testRateLimitFaultRequiresPositiveRetryAfter(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('fake_exchange_fault_retry_after_invalid');
+
+        new FakeExchangeFault(
+            operation: FakeExchangeOperation::PlaceOrder,
+            kind: FakeExchangeFaultKind::Http429,
+            outcome: FakeExchangeFaultOutcome::NotApplied,
+            retryAfterSeconds: 0,
+        );
+    }
+
+    public function testTimeoutBeforeSubmitIsOneShotAndDoesNotMutateState(): void
+    {
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::PlaceOrder,
+            FakeExchangeFaultKind::NetworkTimeout,
+        ));
+
+        try {
+            $this->adapter->placeOrder($this->request());
+            self::fail('The injected timeout must fail the first submit.');
+        } catch (FakeExchangeInjectedException $exception) {
+            self::assertSame('network_timeout', $exception->getMessage());
+            self::assertSame(FakeExchangeOperation::PlaceOrder, $exception->fault->operation);
+            self::assertFalse($exception->outcomeUnknown());
+        }
+
+        self::assertCount(0, $this->state->getOrders());
+        self::assertCount(0, $this->state->events());
+
+        $retry = $this->adapter->placeOrder($this->request());
+
+        self::assertTrue($retry->accepted);
+        self::assertCount(1, $this->state->getOrders());
+    }
+
+    public function testTimeoutAfterAcceptedOrderIsAmbiguousAndReplayIsIdempotent(): void
+    {
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::PlaceOrder,
+            FakeExchangeFaultKind::NetworkTimeout,
+            FakeExchangeFaultOutcome::AppliedResponseLost,
+        ));
+
+        try {
+            $this->adapter->placeOrder($this->request(
+                orderType: ExchangeOrderType::MARKET,
+                price: null,
+                postOnly: false,
+                attachedStopLossPrice: 24000.0,
+            ));
+            self::fail('The accepted response must be lost.');
+        } catch (FakeExchangeInjectedException $exception) {
+            self::assertTrue($exception->outcomeUnknown());
+            self::assertSame('applied_response_lost', $exception->context()['outcome']);
+        }
+
+        $ordersBeforeReplay = $this->state->getOrders();
+        $eventsBeforeReplay = $this->state->events();
+        $entryOrder = array_values(array_filter(
+            $ordersBeforeReplay,
+            static fn ($order): bool => $order->clientOrderId === 'fault-cid',
+        ))[0];
+
+        $retry = $this->adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            postOnly: false,
+            attachedStopLossPrice: 24000.0,
+        ));
+
+        self::assertSame($entryOrder->exchangeOrderId, $retry->exchangeOrderId);
+        self::assertTrue($retry->metadata['idempotent_replay'] ?? false);
+        self::assertCount(\count($ordersBeforeReplay), $this->state->getOrders());
+        self::assertCount(\count($eventsBeforeReplay), $this->state->events());
+    }
+
+    public function testRateLimitExposesNormalizedRetryAfterWithoutRawPayload(): void
+    {
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::GetOpenOrders,
+            FakeExchangeFaultKind::Http429,
+            retryAfterSeconds: 7,
+        ));
+
+        try {
+            $this->adapter->getOpenOrders();
+            self::fail('The read must be rate limited once.');
+        } catch (FakeExchangeInjectedException $exception) {
+            self::assertSame([
+                'injected_error' => 'http_429',
+                'operation' => 'get_open_orders',
+                'outcome' => 'not_applied',
+                'outcome_unknown' => false,
+                'http_status' => 429,
+                'retry_after_seconds' => 7,
+            ], $exception->context());
+        }
+
+        self::assertSame([], $this->adapter->getOpenOrders());
+    }
+
+    public function testLostCancelResponseCanBeRetriedWithoutDuplicateEvent(): void
+    {
+        $placed = $this->adapter->placeOrder($this->request());
+        $request = new CancelOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: $placed->exchangeOrderId,
+            clientOrderId: $placed->clientOrderId,
+        );
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::CancelOrder,
+            FakeExchangeFaultKind::TransportError,
+            FakeExchangeFaultOutcome::AppliedResponseLost,
+        ));
+
+        try {
+            $this->adapter->cancelOrder($request);
+            self::fail('The cancel response must be lost after application.');
+        } catch (FakeExchangeInjectedException $exception) {
+            self::assertTrue($exception->outcomeUnknown());
+        }
+        self::assertCount(1, $this->state->events('order.cancelled'));
+
+        $retry = $this->adapter->cancelOrder($request);
+
+        self::assertTrue($retry->cancelled);
+        self::assertTrue($retry->metadata['idempotent_replay'] ?? false);
+        self::assertCount(1, $this->state->events('order.cancelled'));
+    }
+
+    public function testFaultQueueIsIsolatedByOperationAndPreservesFifo(): void
+    {
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::GetBalances,
+            FakeExchangeFaultKind::Http500,
+        ));
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::PlaceOrder,
+            FakeExchangeFaultKind::TransportError,
+        ));
+
+        try {
+            $this->adapter->placeOrder($this->request());
+            self::fail('The operation-specific transport fault must be consumed.');
+        } catch (FakeExchangeInjectedException $exception) {
+            self::assertSame(FakeExchangeFaultKind::TransportError, $exception->fault->kind);
+        }
+
+        self::assertCount(1, $this->scenario->pendingFaults());
+        self::assertSame(FakeExchangeOperation::GetBalances, $this->scenario->pendingFaults()[0]->operation);
+
+        $this->expectException(FakeExchangeInjectedException::class);
+        $this->expectExceptionMessage('http_500');
+        $this->adapter->getBalances();
+    }
+
+    public function testFaultQueuePreservesFifoAcrossOutcomesForSameOperation(): void
+    {
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::PlaceOrder,
+            FakeExchangeFaultKind::NetworkTimeout,
+            FakeExchangeFaultOutcome::AppliedResponseLost,
+        ));
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::PlaceOrder,
+            FakeExchangeFaultKind::Http500,
+        ));
+
+        try {
+            $this->adapter->placeOrder($this->request());
+            self::fail('The oldest fault for the operation must be applied first.');
+        } catch (FakeExchangeInjectedException $exception) {
+            self::assertSame(FakeExchangeFaultOutcome::AppliedResponseLost, $exception->fault->outcome);
+        }
+        self::assertCount(1, $this->state->getOrders());
+
+        try {
+            $this->adapter->placeOrder($this->request());
+            self::fail('The second fault must remain queued until the next call.');
+        } catch (FakeExchangeInjectedException $exception) {
+            self::assertSame(FakeExchangeFaultKind::Http500, $exception->fault->kind);
+        }
+    }
+
+    public function testAppliedResponseLostRemainsQueuedWhenCancelDoesNotMutate(): void
+    {
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::CancelOrder,
+            FakeExchangeFaultKind::NetworkTimeout,
+            FakeExchangeFaultOutcome::AppliedResponseLost,
+        ));
+
+        $result = $this->adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: 'unknown-order',
+        ));
+
+        self::assertFalse($result->cancelled);
+        self::assertCount(1, $this->scenario->pendingFaults());
+        self::assertSame(FakeExchangeFaultOutcome::AppliedResponseLost, $this->scenario->pendingFaults()[0]->outcome);
+    }
+
+    public function testAppliedResponseLostRollsBackAndRemainsQueuedWhenOperationFails(): void
+    {
+        $this->scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::PlaceOrder,
+            FakeExchangeFaultKind::NetworkTimeout,
+            FakeExchangeFaultOutcome::AppliedResponseLost,
+        ));
+
+        try {
+            $this->adapter->placeOrder($this->request(symbol: ''));
+            self::fail('The invalid operation must fail before any mutation.');
+        } catch (\InvalidArgumentException) {
+            self::assertCount(0, $this->state->getOrders());
+        }
+
+        self::assertCount(1, $this->scenario->pendingFaults());
+    }
+
+    public function testPendingFaultSurvivesRestartAndConsumptionIsPersisted(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_fault_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            $state = new FakeExchangeStateStore($stateFile);
+            [, $scenario] = $this->services($state);
+            $scenario->failNext(new FakeExchangeFault(
+                FakeExchangeOperation::GetBalances,
+                FakeExchangeFaultKind::NetworkTimeout,
+            ));
+
+            $restored = new FakeExchangeStateStore($stateFile);
+            self::assertSame(1, $restored->recoveryMetadata()['pending_fault_count']);
+            [$adapter] = $this->services($restored);
+            try {
+                $adapter->getBalances();
+                self::fail('The persisted fault must be restored.');
+            } catch (FakeExchangeInjectedException) {
+                self::assertCount(0, $restored->pendingFaults());
+            }
+
+            $afterConsumption = new FakeExchangeStateStore($stateFile);
+            [$adapterAfterConsumption] = $this->services($afterConsumption);
+            self::assertCount(1, $adapterAfterConsumption->getBalances());
+        } finally {
+            @unlink($stateFile);
+        }
+    }
+
+    public function testPreviousVersionedEnvelopeWithoutFaultQueueRemainsReadable(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_fault_legacy_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            new FakeExchangeStateStore($stateFile);
+            $envelope = unserialize((string) file_get_contents($stateFile), ['allowed_classes' => true]);
+            self::assertIsArray($envelope);
+            self::assertIsArray($envelope['payload'] ?? null);
+            unset($envelope['payload']['pendingFaults']);
+            $envelope['payload_checksum'] = hash('sha256', serialize($envelope['payload']));
+            file_put_contents($stateFile, serialize($envelope));
+
+            $restored = new FakeExchangeStateStore($stateFile);
+
+            self::assertSame([], $restored->pendingFaults());
+        } finally {
+            @unlink($stateFile);
+        }
+    }
+
+    public function testAppliedResponseLostIsRejectedForReadOperations(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('fake_exchange_fault_applied_outcome_requires_mutation');
+
+        new FakeExchangeFault(
+            FakeExchangeOperation::GetOrder,
+            FakeExchangeFaultKind::NetworkTimeout,
+            FakeExchangeFaultOutcome::AppliedResponseLost,
+        );
+    }
+
+    /**
+     * @return array{FakeExchangeAdapter,FakeExchangeScenarioService}
+     */
+    private function services(FakeExchangeStateStore $state): array
+    {
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->clock());
+
+        return [
+            new FakeExchangeAdapter($state, $book, $engine, $this->clock()),
+            new FakeExchangeScenarioService($state, $book, $engine),
+        ];
+    }
+
+    private function request(
+        string $symbol = 'BTCUSDT',
+        ExchangeOrderType $orderType = ExchangeOrderType::LIMIT,
+        ?float $price = 24950.0,
+        bool $postOnly = true,
+        ?float $attachedStopLossPrice = null,
+    ): PlaceOrderRequest {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: $orderType,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: $price,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: $postOnly,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'fault-cid',
+            attachedStopLossPrice: $attachedStopLossPrice,
+        );
+    }
+
+    private function clock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01 00:00:00 UTC');
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- add typed one-shot Fake/Paper faults for `network_timeout`, `transport_error`, `http_429`, and `http_500`
- keep a FIFO queue per adapter operation and persist it in the versioned Paper state
- support `not_applied` and atomic `applied_response_lost` outcomes for submit/cancel
- preserve idempotent order and cancellation retries without duplicate events
- expose normalized, redacted failure context including HTTP status and retry-after
- keep prior v1 state envelopes readable when no fault queue is present

## Safety

- local Fake/Paper only
- no exchange network request
- no demo/testnet/mainnet order
- no strategy, EntryZone, risk, leverage, SL/TP policy or live guard change
- no secret or raw request/response payload
- no database migration

## Tests

- `php vendor/bin/phpunit tests/Exchange` (858 tests, 3293 assertions, 30 skipped)
- PHPStan on all touched PHP files with `--memory-limit=512M`
- `php bin/console lint:container --no-debug`
- `php bin/console lint:yaml config`
- `python3 -m mkdocs build --strict --site-dir /tmp/tradingv3-mkdocs-196-faults-final`
- `git diff --check`

Part of #196.
Related to #197.
Related to #198.
Related to #226.
Related to #274.
Related to #275.