### PR TITLE
test(fake): consolidate #196 golden scenarios v1

### DIFF
--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -226,6 +226,62 @@ donc temporairement son chemin Fake local existant. Sa bascule vers cette gate s
 faite apres la golden suite et les metadata, afin de ne pas annoncer une readiness
 que le modele actuel ne couvre pas.
 
+## Golden suite Fake/Paper v1
+
+Le catalogue versionne des 20 scenarios obligatoires de #196 est disponible dans :
+
+```text
+trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
+```
+
+Il utilise trois statuts stricts :
+
+- `executable` : le scenario possede un runner deterministe et est execute deux fois
+  depuis des etats frais ; les deux resultats normalises doivent etre identiques ;
+- `partial` : une partie du comportement existe, mais le critere golden complet reste
+  bloque par au moins un `gap_code` stable ;
+- `unsupported` : la capability necessaire n existe pas encore et aucun runner ne
+  peut etre declare.
+
+Une ligne presente dans le catalogue n est pas un PASS. Seul le statut `executable`
+avec un test vert constitue une preuve. Les lignes `partial` et `unsupported` ne
+peuvent ni rendre le runtime-check ready, ni autoriser une mutation demo/testnet.
+
+Les neuf scenarios executes dans cette version sont : maker limit rempli, limit IOC
+expire sans fill, partial fill puis cancel, replay du `client_order_id`, timeout
+apres acceptation, attachement SL reussi, gap au SL au prochain prix disponible,
+deconnexion/reprise private WS, et restart avec position protegee ouverte.
+
+Les ecarts encore explicites sont :
+
+| Scenario | Statut | Gap stable |
+| --- | --- | --- |
+| fallback taker | `unsupported` | `fallback_taker_not_implemented` |
+| market avec slippage | `partial` | `slippage_model_zero` |
+| insufficient balance | `unsupported` | `balance_margin_validation_not_implemented` |
+| precision reject | `unsupported` | `instrument_precision_validation_not_implemented` |
+| leverage cap reject | `unsupported` | `leverage_cap_validation_not_implemented` |
+| echec attachement SL | `partial` | `stop_attach_failure_compensation_not_integrated` |
+| TP1 puis trailing | `partial` | `trailing_stop_not_implemented` |
+| duplicate/out-of-order event | `partial` | `out_of_order_event_injection_not_implemented` |
+| funding | `unsupported` | `funding_model_not_implemented` |
+| One-Way conflict | `unsupported` | `one_way_conflict_guard_not_implemented` |
+| dry-run multi-profils meme symbole | `partial` | `multi_profile_fake_recipe_not_consolidated` |
+
+Commande consolidee :
+
+```bash
+cd trading-app
+php vendor/bin/phpunit \
+  tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php \
+  tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php \
+  tests/TradingCore/Execution/FakeExecutionScenarioFixtureParityTest.php
+```
+
+La suite appelle uniquement les moteurs Fake locaux, avec horloge controlee et etat
+ephemere. Elle ne lit aucun secret, ne contacte aucun endpoint prive exchange et
+n envoie aucun ordre reel, demo ou testnet.
+
 ## Rollback
 
 Le rollback de COMMON-005 consiste a retirer le mode scenario et revenir au

--- a/docs/superpowers/plans/2026-07-15-fake-paper-golden-suite-v1.md
+++ b/docs/superpowers/plans/2026-07-15-fake-paper-golden-suite-v1.md
@@ -1,0 +1,187 @@
+# Fake/Paper Golden Suite v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate the 20 mandatory #196 Fake/Paper scenarios in one versioned, deterministic and fail-closed golden contract without claiming unsupported capabilities as passing.
+
+**Architecture:** A JSON catalog is the source of truth for scenario order, support status, stable gap codes and runner keys. PHPUnit validates the catalog and COMMON-005 fixture parity, while a test-only runner executes only `executable` scenarios twice from fresh state and compares normalized results. `partial` and `unsupported` entries are asserted as explicit gaps and cannot carry a runner key or expected PASS payload.
+
+**Tech Stack:** PHP 8.4, PHPUnit 11, existing `App\Exchange\Fake` and `App\TradingCore\Execution\Fake` engines, JSON fixtures, MkDocs.
+
+---
+
+### Task 1: Versioned catalog contract
+
+**Files:**
+- Create: `trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json`
+- Create: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php`
+
+- [x] **Step 1: Write the failing catalog test**
+
+Create a test that loads `tests/fixtures/fake-paper/golden-scenarios-v1.json` and asserts:
+
+```php
+self::assertSame('fake-paper-golden-v1', $catalog['schema_version']);
+self::assertSame(range(1, 20), array_column($catalog['scenarios'], 'id'));
+self::assertSame($expectedNames, array_column($catalog['scenarios'], 'name'));
+```
+
+For every row, require exactly one of these contracts:
+
+```php
+if ($scenario['status'] === 'executable') {
+    self::assertNotSame('', $scenario['runner']);
+    self::assertSame([], $scenario['gap_codes']);
+} else {
+    self::assertContains($scenario['status'], ['partial', 'unsupported']);
+    self::assertNull($scenario['runner']);
+    self::assertNotEmpty($scenario['gap_codes']);
+}
+```
+
+- [x] **Step 2: Verify RED**
+
+Run `cd trading-app && php vendor/bin/phpunit tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php`.
+
+Expected: failure because `golden-scenarios-v1.json` does not exist.
+
+- [x] **Step 3: Add the minimal catalog**
+
+Create exactly 20 ordered rows with these statuses:
+
+| ID | Name | Status | Stable gap when not executable |
+| --- | --- | --- | --- |
+| 1 | `limit_maker_full_fill` | executable | none |
+| 2 | `limit_unfilled_then_expired` | executable | none |
+| 3 | `partial_fill_then_cancel` | executable | none |
+| 4 | `fallback_taker` | unsupported | `fallback_taker_not_implemented` |
+| 5 | `market_with_slippage` | partial | `slippage_model_zero` |
+| 6 | `insufficient_balance` | unsupported | `balance_margin_validation_not_implemented` |
+| 7 | `precision_reject` | unsupported | `instrument_precision_validation_not_implemented` |
+| 8 | `leverage_cap_reject` | unsupported | `leverage_cap_validation_not_implemented` |
+| 9 | `duplicate_client_order_id` | executable | none |
+| 10 | `timeout_after_acceptance` | executable | none |
+| 11 | `stop_loss_attach_success` | executable | none |
+| 12 | `stop_loss_attach_failure` | partial | `stop_attach_failure_compensation_not_integrated` |
+| 13 | `tp1_then_trailing` | partial | `trailing_stop_not_implemented` |
+| 14 | `gap_at_stop_loss` | executable | none |
+| 15 | `websocket_disconnect_resync` | executable | none |
+| 16 | `duplicate_out_of_order_event` | partial | `out_of_order_event_injection_not_implemented` |
+| 17 | `restart_with_open_position` | executable | none |
+| 18 | `funding` | unsupported | `funding_model_not_implemented` |
+| 19 | `one_way_conflict` | unsupported | `one_way_conflict_guard_not_implemented` |
+| 20 | `dry_run_multi_profiles_same_symbol` | partial | `multi_profile_fake_recipe_not_consolidated` |
+
+Every row also contains `requirement`, `evidence` as a non-empty list of current test references, `runner` as a stable string or `null`, and `gap_codes` as a list.
+
+- [x] **Step 4: Verify GREEN**
+
+Run the catalog test and expect it to pass.
+
+### Task 2: COMMON-005 fixture parity
+
+**Files:**
+- Modify: `trading-app/tests/fixtures/fake-paper/demo-recipe-scenarios.json`
+- Create: `trading-app/tests/TradingCore/Execution/FakeExecutionScenarioFixtureParityTest.php`
+
+- [x] **Step 1: Write the failing parity test**
+
+Map each JSON row to a public fixture factory declared by a new `php_fixture` field, invoke the factory, normalize it to the JSON keys, and assert strict equality:
+
+```php
+$scenario = FakeExecutionScenarioFixtures::{$row['php_fixture']}();
+self::assertSame([
+    'name' => $scenario->name,
+    'order_outcome' => $scenario->orderOutcome,
+    'fill_ratio' => $scenario->fillRatio,
+    'protection_outcome' => $scenario->protectionOutcome,
+    'reject_reason' => $scenario->rejectReason,
+    'quality_flags' => $scenario->qualityFlags,
+    'fail_safe_action' => $scenario->failSafeAction,
+], $normalizedJsonRow);
+```
+
+Also assert that factory names are unique and callable.
+
+- [x] **Step 2: Verify RED**
+
+Run the parity test and expect failure because existing JSON rows have no `php_fixture` field.
+
+- [x] **Step 3: Add explicit factory names**
+
+Add `orderAccepted`, `orderRejected`, `fullFillStopAttachSuccess`, `fullFillStopAttachFailure`, `partialFillStopRejected`, and `cancelAcceptedOrder` without changing scenario semantics.
+
+- [x] **Step 4: Verify GREEN**
+
+Run both fixture tests and expect them to pass.
+
+### Task 3: Deterministic executable golden runner
+
+**Files:**
+- Create: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php`
+- Create: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php`
+
+- [x] **Step 1: Write the failing execution test**
+
+The data provider reads only catalog rows with `status=executable`. The test executes each runner twice using two fresh runner instances and compares the complete normalized result:
+
+```php
+$first = (new FakePaperGoldenScenarioRunner())->run($scenario['runner']);
+$second = (new FakePaperGoldenScenarioRunner())->run($scenario['runner']);
+
+self::assertSame($first, $second);
+self::assertSame($scenario['name'], $first['scenario']);
+self::assertSame('pass', $first['outcome']);
+self::assertSame('2026-01-01T00:00:00+00:00', $first['clock']);
+```
+
+Add a separate test proving the executable runner key set equals the catalog runner key set, so no supported row can silently skip execution.
+
+- [x] **Step 2: Verify RED**
+
+Run the execution test and expect failure because `FakePaperGoldenScenarioRunner` does not exist.
+
+- [x] **Step 3: Implement the runner with current real engines**
+
+Use a fixed PSR clock, fresh `FakeExchangeStateStore`, `FakeExchangeOrderBook`, `FakeExchangeMatchingEngine`, `FakeExchangeAdapter`, `FakeExchangeScenarioService`, and where appropriate `FakeExecutionPort` or `FakeExchangeWsClient`. Implement one method per executable key:
+
+```text
+limit_maker_full_fill
+limit_unfilled_then_expired
+partial_fill_then_cancel
+duplicate_client_order_id
+timeout_after_acceptance
+stop_loss_attach_success
+gap_at_stop_loss
+websocket_disconnect_resync
+restart_with_open_position
+```
+
+Each method must assert the semantic invariant in its returned normalized fields, omit generated temporary paths, and expose only stable IDs, statuses, quantities, sequences and redacted error codes.
+
+- [x] **Step 4: Verify GREEN and determinism**
+
+Run:
+
+```bash
+cd trading-app
+php vendor/bin/phpunit \
+  tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php \
+  tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php \
+  tests/TradingCore/Execution/FakeExecutionScenarioFixtureParityTest.php
+```
+
+Expected: all executable rows run twice and all tests pass.
+
+### Task 4: Documentation and validation
+
+**Files:**
+- Modify: `docs/handbook/technical/fake-paper-gateway.md`
+
+- [x] **Step 1: Document the contract**
+
+Add the command to run the consolidated suite, the three statuses, the exact executable scenario list, and the stable gaps. State explicitly that a catalog row is not a PASS, `partial`/`unsupported` cannot enable demo/testnet mutation, and no private exchange endpoint is contacted.
+
+- [x] **Step 2: Run focused and broad validation**
+
+Run the focused PHPUnit suite, PHPStan on all touched PHP, `php bin/console lint:container --no-debug`, `php bin/console lint:yaml config`, `python3 -m mkdocs build --strict`, and `git diff --check`. All commands must exit 0. Then inspect `git diff`, run independent spec and quality reviews, and fix every finding before opening the PR.

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Fake;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class FakePaperGoldenScenarioCatalogTest extends TestCase
+{
+    private const EXPECTED_CLASSIFICATIONS = [
+        'limit_maker_full_fill' => ['executable', []],
+        'limit_unfilled_then_expired' => ['executable', []],
+        'partial_fill_then_cancel' => ['executable', []],
+        'fallback_taker' => ['unsupported', ['fallback_taker_not_implemented']],
+        'market_with_slippage' => ['partial', ['slippage_model_zero']],
+        'insufficient_balance' => ['unsupported', ['balance_margin_validation_not_implemented']],
+        'precision_reject' => ['unsupported', ['instrument_precision_validation_not_implemented']],
+        'leverage_cap_reject' => ['unsupported', ['leverage_cap_validation_not_implemented']],
+        'duplicate_client_order_id' => ['executable', []],
+        'timeout_after_acceptance' => ['executable', []],
+        'stop_loss_attach_success' => ['executable', []],
+        'stop_loss_attach_failure' => ['partial', ['stop_attach_failure_compensation_not_integrated']],
+        'tp1_then_trailing' => ['partial', ['trailing_stop_not_implemented']],
+        'gap_at_stop_loss' => ['executable', []],
+        'websocket_disconnect_resync' => ['executable', []],
+        'duplicate_out_of_order_event' => ['partial', ['out_of_order_event_injection_not_implemented']],
+        'restart_with_open_position' => ['executable', []],
+        'funding' => ['unsupported', ['funding_model_not_implemented']],
+        'one_way_conflict' => ['unsupported', ['one_way_conflict_guard_not_implemented']],
+        'dry_run_multi_profiles_same_symbol' => ['partial', ['multi_profile_fake_recipe_not_consolidated']],
+    ];
+
+    private const EXPECTED_NAMES = [
+        'limit_maker_full_fill',
+        'limit_unfilled_then_expired',
+        'partial_fill_then_cancel',
+        'fallback_taker',
+        'market_with_slippage',
+        'insufficient_balance',
+        'precision_reject',
+        'leverage_cap_reject',
+        'duplicate_client_order_id',
+        'timeout_after_acceptance',
+        'stop_loss_attach_success',
+        'stop_loss_attach_failure',
+        'tp1_then_trailing',
+        'gap_at_stop_loss',
+        'websocket_disconnect_resync',
+        'duplicate_out_of_order_event',
+        'restart_with_open_position',
+        'funding',
+        'one_way_conflict',
+        'dry_run_multi_profiles_same_symbol',
+    ];
+
+    public function testCatalogContainsTheTwentyMandatoryScenariosInCanonicalOrder(): void
+    {
+        $catalog = self::catalog();
+
+        self::assertSame('fake-paper-golden-v1', $catalog['schema_version']);
+        self::assertSame(range(1, 20), array_column($catalog['scenarios'], 'id'));
+        self::assertSame(self::EXPECTED_NAMES, array_column($catalog['scenarios'], 'name'));
+    }
+
+    public function testEveryScenarioIsEitherExecutableOrAnExplicitGap(): void
+    {
+        foreach (self::catalog()['scenarios'] as $scenario) {
+            $fields = array_keys($scenario);
+            sort($fields);
+            self::assertSame(
+                ['evidence', 'gap_codes', 'id', 'name', 'requirement', 'runner', 'status'],
+                $fields,
+                sprintf('Scenario %s must use the canonical schema.', $scenario['name']),
+            );
+            self::assertNotSame('', $scenario['requirement']);
+            self::assertNotEmpty($scenario['evidence']);
+            self::assertSame(
+                self::EXPECTED_CLASSIFICATIONS[$scenario['name']],
+                [$scenario['status'], $scenario['gap_codes']],
+                sprintf('Scenario %s classification and gap codes are stable.', $scenario['name']),
+            );
+
+            if ($scenario['status'] === 'executable') {
+                self::assertIsString($scenario['runner']);
+                self::assertNotSame('', $scenario['runner']);
+                self::assertSame([], $scenario['gap_codes']);
+
+                continue;
+            }
+
+            self::assertContains($scenario['status'], ['partial', 'unsupported']);
+            self::assertNull($scenario['runner']);
+            self::assertNotEmpty($scenario['gap_codes']);
+        }
+    }
+
+    public function testEveryEvidenceReferenceResolvesToAnExistingFileAndMethod(): void
+    {
+        $repositoryRoot = dirname(__DIR__, 4);
+
+        foreach (self::catalog()['scenarios'] as $scenario) {
+            foreach ($scenario['evidence'] as $reference) {
+                self::assertIsString($reference);
+                self::assertNotSame('', $reference);
+
+                [$pathAndAnchor, $method] = array_pad(explode('::', $reference, 2), 2, null);
+                [$path] = explode('#', $pathAndAnchor, 2);
+                $absolutePath = str_starts_with($path, 'docs/')
+                    ? $repositoryRoot . '/' . $path
+                    : $repositoryRoot . '/trading-app/' . $path;
+
+                self::assertFileExists($absolutePath, sprintf('Missing evidence %s.', $reference));
+                if ($method !== null) {
+                    $contents = file_get_contents($absolutePath);
+                    self::assertIsString($contents);
+                    self::assertStringContainsString('function ' . $method . '(', $contents);
+                }
+            }
+        }
+    }
+
+    /** @return array{schema_version:string,scenarios:list<array<string,mixed>>} */
+    private static function catalog(): array
+    {
+        $path = dirname(__DIR__, 2) . '/fixtures/fake-paper/golden-scenarios-v1.json';
+        $raw = file_get_contents($path);
+        self::assertIsString($raw, 'The Fake/Paper golden catalog must be readable.');
+
+        /** @var array{schema_version:string,scenarios:list<array<string,mixed>>} $catalog */
+        $catalog = json_decode($raw, true, 64, JSON_THROW_ON_ERROR);
+
+        return $catalog;
+    }
+}

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Fake;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class FakePaperGoldenScenarioExecutionTest extends TestCase
+{
+    private const EXPECTED_FACTS = [
+        'limit_maker_full_fill' => [
+            'filled_quantity' => 1.0,
+            'initial_order_status' => 'open',
+            'matched_order_count' => 1,
+            'open_protection_count' => 1,
+            'order_status' => 'filled',
+            'position_size' => 1.0,
+        ],
+        'limit_unfilled_then_expired' => [
+            'open_order_count' => 0,
+            'order_status' => 'expired',
+            'reason' => 'immediate_execution_not_available',
+        ],
+        'partial_fill_then_cancel' => [
+            'filled_quantity' => 0.4,
+            'open_protection_count' => 1,
+            'order_status' => 'cancelled',
+            'position_size' => 0.4,
+            'protection_quantity' => 0.4,
+            'remaining_quantity' => 0.6,
+        ],
+        'duplicate_client_order_id' => [
+            'active_order_count' => 1,
+            'idempotent_replay' => true,
+            'same_exchange_order_id' => true,
+        ],
+        'timeout_after_acceptance' => [
+            'error_code' => 'network_timeout',
+            'event_count_unchanged' => true,
+            'idempotent_replay' => true,
+            'order_count_unchanged' => true,
+            'outcome_unknown' => true,
+            'open_protection_count' => 1,
+            'protection_status' => 'accepted',
+            'same_exchange_order_id' => true,
+        ],
+        'stop_loss_attach_success' => [
+            'entry_status' => 'filled',
+            'open_protection_count' => 1,
+            'protection_reduce_only' => true,
+            'protection_status' => 'accepted',
+        ],
+        'gap_at_stop_loss' => [
+            'fill_price' => 24790.0,
+            'open_position_count' => 0,
+            'order_status' => 'filled',
+            'stop_price' => 24800.0,
+        ],
+        'websocket_disconnect_resync' => [
+            'disconnect_code' => 'fake_private_ws_disconnected',
+            'events_before_disconnect' => 2,
+            'open_protection_count' => 2,
+            'resumed_without_duplicate_or_loss' => true,
+            'resync_required_before_reconnect' => true,
+        ],
+        'restart_with_open_position' => [
+            'event_sequence_continued' => true,
+            'historical_events_preserved' => true,
+            'position_size' => 1.0,
+            'protection_order_count' => 1,
+        ],
+    ];
+
+    public function testGoldenRunnerContractExists(): void
+    {
+        self::assertTrue(class_exists(FakePaperGoldenScenarioRunner::class));
+    }
+
+    public function testRunnerKeysExactlyMatchExecutableCatalogRows(): void
+    {
+        self::assertTrue(method_exists(FakePaperGoldenScenarioRunner::class, 'keys'));
+
+        $catalogKeys = array_values(array_map(
+            static fn (array $scenario): string => $scenario['runner'],
+            array_filter(
+                self::catalog()['scenarios'],
+                static fn (array $scenario): bool => $scenario['status'] === 'executable',
+            ),
+        ));
+
+        self::assertCount(9, $catalogKeys);
+        self::assertSame($catalogKeys, FakePaperGoldenScenarioRunner::keys());
+    }
+
+    /** @param array<string,mixed> $scenario */
+    #[DataProvider('executableScenarioProvider')]
+    public function testExecutableScenarioIsDeterministicAndMatchesGoldenFacts(array $scenario): void
+    {
+        self::assertTrue(method_exists(FakePaperGoldenScenarioRunner::class, 'run'));
+
+        $first = (new FakePaperGoldenScenarioRunner())->run($scenario['runner']);
+        $second = (new FakePaperGoldenScenarioRunner())->run($scenario['runner']);
+
+        self::assertSame($first, $second);
+        self::assertSame($scenario['name'], $first['scenario']);
+        self::assertSame('pass', $first['outcome']);
+        self::assertSame('2026-01-01T00:00:00+00:00', $first['clock']);
+        self::assertSame(self::EXPECTED_FACTS[$scenario['name']], $first['facts']);
+    }
+
+    /** @return iterable<string,array{0:array<string,mixed>}> */
+    public static function executableScenarioProvider(): iterable
+    {
+        foreach (self::catalog()['scenarios'] as $scenario) {
+            if ($scenario['status'] === 'executable') {
+                yield $scenario['name'] => [$scenario];
+            }
+        }
+    }
+
+    /** @return array{schema_version:string,scenarios:list<array<string,mixed>>} */
+    private static function catalog(): array
+    {
+        $path = dirname(__DIR__, 2) . '/fixtures/fake-paper/golden-scenarios-v1.json';
+        $raw = file_get_contents($path);
+        self::assertIsString($raw, 'The Fake/Paper golden catalog must be readable.');
+
+        /** @var array{schema_version:string,scenarios:list<array<string,mixed>>} $catalog */
+        $catalog = json_decode($raw, true, 64, JSON_THROW_ON_ERROR);
+
+        return $catalog;
+    }
+}

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
@@ -1,0 +1,459 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Fake;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Fake\FakeExchangeEvent;
+use App\Exchange\Fake\FakeExchangeFault;
+use App\Exchange\Fake\FakeExchangeFaultKind;
+use App\Exchange\Fake\FakeExchangeFaultOutcome;
+use App\Exchange\Fake\FakeExchangeInjectedException;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOperation;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeScenarioService;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Fake\FakeExchangeWsClient;
+use App\Exchange\Fake\FakePrivateWsException;
+use Psr\Clock\ClockInterface;
+
+final class FakePaperGoldenScenarioRunner
+{
+    private const KEYS = [
+        'limit_maker_full_fill',
+        'limit_unfilled_then_expired',
+        'partial_fill_then_cancel',
+        'duplicate_client_order_id',
+        'timeout_after_acceptance',
+        'stop_loss_attach_success',
+        'gap_at_stop_loss',
+        'websocket_disconnect_resync',
+        'restart_with_open_position',
+    ];
+
+    /** @return list<string> */
+    public static function keys(): array
+    {
+        return self::KEYS;
+    }
+
+    /**
+     * @return array{scenario:string,outcome:string,clock:string,facts:array<string,mixed>}
+     */
+    public function run(string $key): array
+    {
+        if (!\in_array($key, self::KEYS, true)) {
+            throw new \InvalidArgumentException(sprintf('Unknown Fake/Paper golden scenario "%s".', $key));
+        }
+
+        $facts = match ($key) {
+            'limit_maker_full_fill' => $this->limitMakerFullFill(),
+            'limit_unfilled_then_expired' => $this->limitUnfilledThenExpired(),
+            'partial_fill_then_cancel' => $this->partialFillThenCancel(),
+            'duplicate_client_order_id' => $this->duplicateClientOrderId(),
+            'timeout_after_acceptance' => $this->timeoutAfterAcceptance(),
+            'stop_loss_attach_success' => $this->stopLossAttachSuccess(),
+            'gap_at_stop_loss' => $this->gapAtStopLoss(),
+            'websocket_disconnect_resync' => $this->websocketDisconnectResync(),
+            'restart_with_open_position' => $this->restartWithOpenPosition(),
+        };
+
+        return [
+            'scenario' => $key,
+            'outcome' => 'pass',
+            'clock' => $this->clock()->now()->format(\DateTimeInterface::ATOM),
+            'facts' => $facts,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function limitMakerFullFill(): array
+    {
+        [, $adapter, $scenario] = $this->exchange();
+        $placed = $adapter->placeOrder($this->request(
+            price: 25000.0,
+            attachedStopLossPrice: 24800.0,
+        ));
+
+        $move = $scenario->movePrice('BTCUSDT', 24990.0, 0.0);
+        $filled = $adapter->getOrder('BTCUSDT', (string) $placed->exchangeOrderId);
+        $protectionOrders = $adapter->getOpenOrders('BTCUSDT');
+        $position = $adapter->getOpenPositions('BTCUSDT')[0] ?? null;
+
+        return [
+            'filled_quantity' => $filled?->filledQuantity,
+            'initial_order_status' => $placed->status->value,
+            'matched_order_count' => \count($move['matched_orders']),
+            'open_protection_count' => \count($protectionOrders),
+            'order_status' => $filled?->status->value,
+            'position_size' => $position?->size,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function limitUnfilledThenExpired(): array
+    {
+        [, $adapter] = $this->exchange();
+        $result = $adapter->placeOrder($this->request(
+            price: 24950.0,
+            timeInForce: ExchangeTimeInForce::IOC,
+        ));
+
+        return [
+            'open_order_count' => \count($adapter->getOpenOrders('BTCUSDT')),
+            'order_status' => $result->status->value,
+            'reason' => $result->order?->metadata['reason'] ?? null,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function partialFillThenCancel(): array
+    {
+        [, $adapter, $scenario] = $this->exchange();
+        $placed = $adapter->placeOrder($this->request(
+            price: 24950.0,
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+        ));
+        $scenario->fillOrder((string) $placed->exchangeOrderId, 0.4, 24950.0);
+        $adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: $placed->exchangeOrderId,
+            clientOrderId: $placed->clientOrderId,
+        ));
+
+        $cancelled = $adapter->getOrder('BTCUSDT', (string) $placed->exchangeOrderId);
+        $position = $adapter->getOpenPositions('BTCUSDT')[0] ?? null;
+        if ($cancelled !== null && $cancelled->filledQuantity > 0.0) {
+            $adapter->placeOrder($this->protectionRequest(
+                quantity: $cancelled->filledQuantity,
+                stopPrice: 24800.0,
+            ));
+        }
+        $protectionOrders = $adapter->getOpenOrders('BTCUSDT');
+        $protection = $protectionOrders[0] ?? null;
+
+        return [
+            'filled_quantity' => $cancelled?->filledQuantity,
+            'open_protection_count' => \count($protectionOrders),
+            'order_status' => $cancelled?->status->value,
+            'position_size' => $position?->size,
+            'protection_quantity' => $protection?->quantity,
+            'remaining_quantity' => $cancelled?->remainingQuantity,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function duplicateClientOrderId(): array
+    {
+        [, $adapter] = $this->exchange();
+        $request = $this->request(price: 24950.0, postOnly: true);
+        $first = $adapter->placeOrder($request);
+        $replay = $adapter->placeOrder($request);
+
+        return [
+            'active_order_count' => \count($adapter->getOpenOrders('BTCUSDT')),
+            'idempotent_replay' => $replay->metadata['idempotent_replay'] ?? false,
+            'same_exchange_order_id' => $first->exchangeOrderId === $replay->exchangeOrderId,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function timeoutAfterAcceptance(): array
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $request = $this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'timeout-after-acceptance',
+            attachedStopLossPrice: 24000.0,
+        );
+        $scenario->failNext(new FakeExchangeFault(
+            FakeExchangeOperation::PlaceOrder,
+            FakeExchangeFaultKind::NetworkTimeout,
+            FakeExchangeFaultOutcome::AppliedResponseLost,
+        ));
+
+        try {
+            $adapter->placeOrder($request);
+            throw new \LogicException('The timeout-after-acceptance fixture did not lose its response.');
+        } catch (FakeExchangeInjectedException $exception) {
+            $injected = $exception;
+        }
+
+        $accepted = $state->getOrderByClientOrderId('BTCUSDT', 'timeout-after-acceptance');
+        $orderCountBeforeReplay = \count($state->getOrders());
+        $eventCountBeforeReplay = \count($state->events());
+        $replay = $adapter->placeOrder($request);
+
+        return [
+            'error_code' => $injected->fault->kind->value,
+            'event_count_unchanged' => $eventCountBeforeReplay === \count($state->events()),
+            'idempotent_replay' => $replay->metadata['idempotent_replay'] ?? false,
+            'order_count_unchanged' => $orderCountBeforeReplay === \count($state->getOrders()),
+            'outcome_unknown' => $injected->outcomeUnknown(),
+            'open_protection_count' => \count($adapter->getOpenOrders('BTCUSDT')),
+            'protection_status' => $replay->order?->metadata['protection_status'] ?? null,
+            'same_exchange_order_id' => $accepted?->exchangeOrderId === $replay->exchangeOrderId,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function stopLossAttachSuccess(): array
+    {
+        [, $adapter] = $this->exchange();
+        $entry = $adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            attachedStopLossPrice: 24800.0,
+        ));
+        $protectionOrders = $adapter->getOpenOrders('BTCUSDT');
+        $protection = $protectionOrders[0] ?? null;
+
+        return [
+            'entry_status' => $entry->status->value,
+            'open_protection_count' => \count($protectionOrders),
+            'protection_reduce_only' => $protection?->reduceOnly,
+            'protection_status' => $entry->order?->metadata['protection_status'] ?? null,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function gapAtStopLoss(): array
+    {
+        [, $adapter, $scenario] = $this->exchange();
+        $adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            attachedStopLossPrice: 24800.0,
+        ));
+        $move = $scenario->movePrice('BTCUSDT', 24790.0, 0.0);
+        $stop = $move['matched_orders'][0] ?? null;
+
+        return [
+            'fill_price' => $stop?->averagePrice !== null ? round($stop->averagePrice, 6) : null,
+            'open_position_count' => \count($adapter->getOpenPositions('BTCUSDT')),
+            'order_status' => $stop?->status->value,
+            'stop_price' => $stop?->stopPrice,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function websocketDisconnectResync(): array
+    {
+        [$state, $adapter] = $this->exchange();
+        $adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'golden-ws-btc',
+            attachedStopLossPrice: 24000.0,
+        ));
+        $adapter->placeOrder($this->request(
+            symbol: 'ETHUSDT',
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'golden-ws-eth',
+            attachedStopLossPrice: 24000.0,
+        ));
+
+        $expectedSignatures = [];
+        $this->drainSignatures(new FakeExchangeWsClient($state), $expectedSignatures);
+
+        $client = new FakeExchangeWsClient($state, disconnectAfterAcknowledgedEvents: 2);
+        $actualSignatures = [];
+        try {
+            $this->drainSignatures($client, $actualSignatures);
+            throw new \LogicException('The Fake private WS fixture did not disconnect.');
+        } catch (FakePrivateWsException $exception) {
+            $disconnectCode = $exception->errorCode;
+        }
+
+        $eventsBeforeDisconnect = \count($actualSignatures);
+        $resyncRequired = $client->requiresResync();
+        $client->reconnect();
+        $this->drainSignatures($client, $actualSignatures);
+        $afterCompleteDrain = [];
+        $this->drainSignatures($client, $afterCompleteDrain);
+
+        return [
+            'disconnect_code' => $disconnectCode,
+            'events_before_disconnect' => $eventsBeforeDisconnect,
+            'open_protection_count' => \count($adapter->getOpenOrders()),
+            'resumed_without_duplicate_or_loss' => $actualSignatures === $expectedSignatures
+                && \count($actualSignatures) === \count(array_unique($actualSignatures))
+                && $afterCompleteDrain === [],
+            'resync_required_before_reconnect' => $resyncRequired,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function restartWithOpenPosition(): array
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_paper_golden_restart_');
+        if ($stateFile === false) {
+            throw new \RuntimeException('Unable to allocate the Fake/Paper restart state file.');
+        }
+        @unlink($stateFile);
+
+        try {
+            [$state, $adapter] = $this->exchange($stateFile);
+            $adapter->placeOrder($this->request(
+                orderType: ExchangeOrderType::MARKET,
+                price: null,
+                attachedStopLossPrice: 24800.0,
+            ));
+            $sequenceBeforeRestart = $this->eventSequences($state->events());
+
+            $restoredState = new FakeExchangeStateStore($stateFile);
+            [, $restoredAdapter, $restoredScenario] = $this->exchangeForState($restoredState);
+            $recovery = $restoredState->recoveryMetadata();
+            $position = $restoredAdapter->getOpenPositions('BTCUSDT')[0] ?? null;
+            $protectionOrderCount = \count($restoredAdapter->getOpenOrders('BTCUSDT'));
+
+            $restoredScenario->movePrice('BTCUSDT', 24790.0, 0.0);
+            $sequenceAfterRestart = $this->eventSequences($restoredState->events());
+            $sortedSequences = $sequenceAfterRestart;
+            sort($sortedSequences);
+            $lastBeforeRestart = max($sequenceBeforeRestart);
+
+            return [
+                'event_sequence_continued' => $recovery['next_event_sequence'] === $lastBeforeRestart + 1
+                    && max($sequenceAfterRestart) > $lastBeforeRestart
+                    && $sequenceAfterRestart === array_values(array_unique($sequenceAfterRestart))
+                    && $sequenceAfterRestart === $sortedSequences,
+                'historical_events_preserved' => $sequenceBeforeRestart === array_slice(
+                    $sequenceAfterRestart,
+                    0,
+                    \count($sequenceBeforeRestart),
+                ),
+                'position_size' => $position?->size,
+                'protection_order_count' => $protectionOrderCount,
+            ];
+        } finally {
+            @unlink($stateFile);
+            foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+                @unlink($temporaryFile);
+            }
+        }
+    }
+
+    /**
+     * @return array{FakeExchangeStateStore,FakeExchangeAdapter,FakeExchangeScenarioService}
+     */
+    private function exchange(?string $stateFile = null): array
+    {
+        return $this->exchangeForState(new FakeExchangeStateStore($stateFile));
+    }
+
+    /**
+     * @return array{FakeExchangeStateStore,FakeExchangeAdapter,FakeExchangeScenarioService}
+     */
+    private function exchangeForState(FakeExchangeStateStore $state): array
+    {
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->clock());
+
+        return [
+            $state,
+            new FakeExchangeAdapter($state, $book, $engine, $this->clock()),
+            new FakeExchangeScenarioService($state, $book, $engine),
+        ];
+    }
+
+    private function request(
+        string $symbol = 'BTCUSDT',
+        ExchangeOrderType $orderType = ExchangeOrderType::LIMIT,
+        ?float $price = 24950.0,
+        string $clientOrderId = 'golden-client-order',
+        bool $postOnly = false,
+        ExchangeTimeInForce $timeInForce = ExchangeTimeInForce::GTC,
+        ?float $attachedStopLossPrice = null,
+    ): PlaceOrderRequest {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: $orderType,
+            timeInForce: $timeInForce,
+            quantity: 1.0,
+            price: $price,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: $postOnly,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+            attachedStopLossPrice: $attachedStopLossPrice,
+        );
+    }
+
+    private function protectionRequest(float $quantity, float $stopPrice): PlaceOrderRequest
+    {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::SELL,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::STOP_LOSS,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: $quantity,
+            price: null,
+            stopPrice: $stopPrice,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'golden-partial-protection',
+        );
+    }
+
+    /** @param list<string> $signatures */
+    private function drainSignatures(FakeExchangeWsClient $client, array &$signatures): void
+    {
+        foreach ($client->drainPrivateEvents() as $event) {
+            $signatures[] = $this->eventSignature($event);
+        }
+    }
+
+    private function eventSignature(FakeExchangeEvent $event): string
+    {
+        return hash('sha256', serialize($event->toArray()));
+    }
+
+    /**
+     * @param FakeExchangeEvent[] $events
+     * @return list<int>
+     */
+    private function eventSequences(array $events): array
+    {
+        return array_map(
+            static fn (FakeExchangeEvent $event): int => (int) ($event->payload['event_sequence'] ?? 0),
+            $events,
+        );
+    }
+
+    private function clock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}

--- a/trading-app/tests/TradingCore/Execution/FakeExecutionScenarioFixtureParityTest.php
+++ b/trading-app/tests/TradingCore/Execution/FakeExecutionScenarioFixtureParityTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\TradingCore\Execution;
+
+use App\TradingCore\Execution\Fake\FakeExecutionScenario;
+use App\TradingCore\Execution\Fake\FakeExecutionScenarioFixtures;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FakeExecutionScenario::class)]
+#[CoversClass(FakeExecutionScenarioFixtures::class)]
+final class FakeExecutionScenarioFixtureParityTest extends TestCase
+{
+    public function testJsonRecipeScenariosMatchTheirPhpFactoriesExactly(): void
+    {
+        $factories = [];
+
+        foreach (self::fixture()['scenarios'] as $row) {
+            self::assertArrayHasKey('php_fixture', $row);
+            self::assertIsString($row['php_fixture']);
+            self::assertTrue(
+                is_callable([FakeExecutionScenarioFixtures::class, $row['php_fixture']]),
+                sprintf('Unknown Fake execution fixture factory "%s".', $row['php_fixture']),
+            );
+            self::assertNotContains($row['php_fixture'], $factories, 'Fixture factories must be unique.');
+            $factories[] = $row['php_fixture'];
+
+            /** @var FakeExecutionScenario $scenario */
+            $scenario = FakeExecutionScenarioFixtures::{$row['php_fixture']}();
+            unset($row['php_fixture']);
+
+            self::assertSame([
+                'name' => $scenario->name,
+                'order_outcome' => $scenario->orderOutcome,
+                'fill_ratio' => $scenario->fillRatio,
+                'protection_outcome' => $scenario->protectionOutcome,
+                'reject_reason' => $scenario->rejectReason,
+                'quality_flags' => $scenario->qualityFlags,
+                'fail_safe_action' => $scenario->failSafeAction,
+            ], $row);
+        }
+    }
+
+    /** @return array{schema_version:int,scope:string,scenarios:list<array<string,mixed>>} */
+    private static function fixture(): array
+    {
+        $path = dirname(__DIR__, 2) . '/fixtures/fake-paper/demo-recipe-scenarios.json';
+        $raw = file_get_contents($path);
+        self::assertIsString($raw, 'The COMMON-005 JSON fixture must be readable.');
+
+        /** @var array{schema_version:int,scope:string,scenarios:list<array<string,mixed>>} $fixture */
+        $fixture = json_decode($raw, true, 64, JSON_THROW_ON_ERROR);
+
+        return $fixture;
+    }
+}

--- a/trading-app/tests/fixtures/fake-paper/demo-recipe-scenarios.json
+++ b/trading-app/tests/fixtures/fake-paper/demo-recipe-scenarios.json
@@ -4,48 +4,63 @@
   "scenarios": [
     {
       "name": "order_accepted",
+      "php_fixture": "orderAccepted",
       "order_outcome": "accepted",
-      "fill_ratio": 0,
+      "fill_ratio": 0.0,
       "protection_outcome": "not_requested",
-      "quality_flags": []
+      "reject_reason": null,
+      "quality_flags": [],
+      "fail_safe_action": null
     },
     {
       "name": "order_rejected",
+      "php_fixture": "orderRejected",
       "order_outcome": "rejected",
-      "fill_ratio": 0,
+      "fill_ratio": 0.0,
       "protection_outcome": "not_requested",
       "reject_reason": "fake_exchange_rejected_order",
-      "quality_flags": []
+      "quality_flags": [],
+      "fail_safe_action": null
     },
     {
       "name": "full_fill_stop_attach_success",
+      "php_fixture": "fullFillStopAttachSuccess",
       "order_outcome": "accepted",
-      "fill_ratio": 1,
+      "fill_ratio": 1.0,
       "protection_outcome": "attached",
-      "quality_flags": []
+      "reject_reason": null,
+      "quality_flags": [],
+      "fail_safe_action": null
     },
     {
       "name": "full_fill_stop_attach_failure",
+      "php_fixture": "fullFillStopAttachFailure",
       "order_outcome": "accepted",
-      "fill_ratio": 1,
+      "fill_ratio": 1.0,
       "protection_outcome": "failed",
-      "fail_safe_action": "cancel_or_reduce_only_close_required",
-      "quality_flags": ["protection_attach_failed"]
+      "reject_reason": null,
+      "quality_flags": ["protection_attach_failed"],
+      "fail_safe_action": "cancel_or_reduce_only_close_required"
     },
     {
       "name": "partial_fill_stop_rejected",
+      "php_fixture": "partialFillStopRejected",
       "order_outcome": "accepted",
       "fill_ratio": 0.5,
       "protection_outcome": "rejected",
-      "fail_safe_action": "cancel_or_reduce_only_close_required",
-      "quality_flags": ["partial_fill", "partial_stop_rejected"]
+      "reject_reason": null,
+      "quality_flags": ["partial_fill", "partial_stop_rejected"],
+      "fail_safe_action": "cancel_or_reduce_only_close_required"
     },
     {
       "name": "cancel_accepted_order",
+      "php_fixture": "cancelAcceptedOrder",
       "order_outcome": "cancelled",
-      "fill_ratio": 0,
+      "fill_ratio": 0.0,
       "protection_outcome": "not_requested",
-      "quality_flags": []
+      "reject_reason": null,
+      "quality_flags": [],
+      "fail_safe_action": null
     }
   ]
 }

--- a/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
+++ b/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
@@ -1,0 +1,185 @@
+{
+  "schema_version": "fake-paper-golden-v1",
+  "scenarios": [
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testMovePriceFillsLimitOrderAndCreatesPosition"],
+      "gap_codes": [],
+      "id": 1,
+      "name": "limit_maker_full_fill",
+      "requirement": "A resting maker limit order fills completely after the simulated book crosses it.",
+      "runner": "limit_maker_full_fill",
+      "status": "executable"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testNonCrossingIocLimitExpiresWithoutResting"],
+      "gap_codes": [],
+      "id": 2,
+      "name": "limit_unfilled_then_expired",
+      "requirement": "A non-crossing immediate limit order remains unfilled and expires deterministically.",
+      "runner": "limit_unfilled_then_expired",
+      "status": "executable"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testCancelledPartialClientOrderIdReplayPreservesFilledSemantics"],
+      "gap_codes": [],
+      "id": 3,
+      "name": "partial_fill_then_cancel",
+      "requirement": "A maker order can partially fill before its remaining quantity is cancelled.",
+      "runner": "partial_fill_then_cancel",
+      "status": "executable"
+    },
+    {
+      "evidence": ["docs/handbook/technical/fake-paper-gateway.md#limites-restantes"],
+      "gap_codes": ["fallback_taker_not_implemented"],
+      "id": 4,
+      "name": "fallback_taker",
+      "requirement": "An expired maker attempt can be replaced by a bounded taker fallback.",
+      "runner": null,
+      "status": "unsupported"
+    },
+    {
+      "evidence": ["tests/Exchange/Readiness/FakeRuntimeCheckTest.php::testInMemoryFakeReportsMissingPaperModelsWithoutClaimingReadiness"],
+      "gap_codes": ["slippage_model_zero"],
+      "id": 5,
+      "name": "market_with_slippage",
+      "requirement": "A market fill applies and reports a deterministic non-zero slippage model.",
+      "runner": null,
+      "status": "partial"
+    },
+    {
+      "evidence": ["docs/handbook/technical/fake-paper-gateway.md#runtime-check-fakepaper"],
+      "gap_codes": ["balance_margin_validation_not_implemented"],
+      "id": 6,
+      "name": "insufficient_balance",
+      "requirement": "An order whose initial margin exceeds available balance is rejected.",
+      "runner": null,
+      "status": "unsupported"
+    },
+    {
+      "evidence": ["tests/Exchange/Readiness/FakeRuntimeCheckTest.php::testInMemoryFakeReportsMissingPaperModelsWithoutClaimingReadiness"],
+      "gap_codes": ["instrument_precision_validation_not_implemented"],
+      "id": 7,
+      "name": "precision_reject",
+      "requirement": "An order violating price or quantity precision is rejected before acceptance.",
+      "runner": null,
+      "status": "unsupported"
+    },
+    {
+      "evidence": ["tests/Exchange/Readiness/FakeRuntimeCheckTest.php::testInMemoryFakeReportsMissingPaperModelsWithoutClaimingReadiness"],
+      "gap_codes": ["leverage_cap_validation_not_implemented"],
+      "id": 8,
+      "name": "leverage_cap_reject",
+      "requirement": "An order above the instrument leverage cap is rejected.",
+      "runner": null,
+      "status": "unsupported"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testClientOrderIdReplayDoesNotCreateSecondActiveOrder"],
+      "gap_codes": [],
+      "id": 9,
+      "name": "duplicate_client_order_id",
+      "requirement": "Replaying a client order identifier does not create a second order or fill.",
+      "runner": "duplicate_client_order_id",
+      "status": "executable"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeFaultInjectionTest.php::testTimeoutAfterAcceptedOrderIsAmbiguousAndReplayIsIdempotent"],
+      "gap_codes": [],
+      "id": 10,
+      "name": "timeout_after_acceptance",
+      "requirement": "A lost response after acceptance is ambiguous and an identical retry is idempotent.",
+      "runner": "timeout_after_acceptance",
+      "status": "executable"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testAcceptedAttachedProtectionCreatesReduceOnlyStopOrder"],
+      "gap_codes": [],
+      "id": 11,
+      "name": "stop_loss_attach_success",
+      "requirement": "A filled entry immediately creates a full-size reduce-only simulated stop loss.",
+      "runner": "stop_loss_attach_success",
+      "status": "executable"
+    },
+    {
+      "evidence": ["tests/TradingCore/Execution/FakeExecutionPortTest.php::testFullFillWithStopAttachFailureRequiresFailSafe"],
+      "gap_codes": ["stop_attach_failure_compensation_not_integrated"],
+      "id": 12,
+      "name": "stop_loss_attach_failure",
+      "requirement": "A stop attachment failure is explicit and requires the documented compensation action.",
+      "runner": null,
+      "status": "partial"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testMovePriceTriggersAttachedTakeProfitAndClosesPosition"],
+      "gap_codes": ["trailing_stop_not_implemented"],
+      "id": 13,
+      "name": "tp1_then_trailing",
+      "requirement": "A partial TP1 fill arms a trailing stop for the remaining position.",
+      "runner": null,
+      "status": "partial"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testMovePriceTriggersAttachedStopLossAndClosesPosition"],
+      "gap_codes": [],
+      "id": 14,
+      "name": "gap_at_stop_loss",
+      "requirement": "A price gap through the stop fills at the next available simulated book price.",
+      "runner": "gap_at_stop_loss",
+      "status": "executable"
+    },
+    {
+      "evidence": ["tests/Exchange/Event/ExchangeWsIngestionServiceTest.php::testReconnectResumesAfterDeterministicDisconnectWithoutLossOrDuplicate"],
+      "gap_codes": [],
+      "id": 15,
+      "name": "websocket_disconnect_resync",
+      "requirement": "A deterministic private WebSocket disconnect resumes without event loss or duplication.",
+      "runner": "websocket_disconnect_resync",
+      "status": "executable"
+    },
+    {
+      "evidence": ["tests/Exchange/Event/ExchangeWsIngestionServiceTest.php::testSequenceGapRequiresResync"],
+      "gap_codes": ["out_of_order_event_injection_not_implemented"],
+      "id": 16,
+      "name": "duplicate_out_of_order_event",
+      "requirement": "Duplicate and out-of-order private events are injected, deduplicated and reconciled.",
+      "runner": null,
+      "status": "partial"
+    },
+    {
+      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testStateStoreRestoresProtectedPositionAndContinuesEventSequence"],
+      "gap_codes": [],
+      "id": 17,
+      "name": "restart_with_open_position",
+      "requirement": "A protected open position and event sequence survive a Paper state restart.",
+      "runner": "restart_with_open_position",
+      "status": "executable"
+    },
+    {
+      "evidence": ["docs/handbook/technical/fake-paper-gateway.md#limites-restantes"],
+      "gap_codes": ["funding_model_not_implemented"],
+      "id": 18,
+      "name": "funding",
+      "requirement": "Positive and negative funding are accrued and reported separately from fees.",
+      "runner": null,
+      "status": "unsupported"
+    },
+    {
+      "evidence": ["docs/handbook/technical/fake-paper-gateway.md#limites-restantes"],
+      "gap_codes": ["one_way_conflict_guard_not_implemented"],
+      "id": 19,
+      "name": "one_way_conflict",
+      "requirement": "A conflicting One-Way position intent is rejected without changing exposure.",
+      "runner": null,
+      "status": "unsupported"
+    },
+    {
+      "evidence": ["tests/Repository/ExchangeScopedStorageTest.php::testOrderIntentReservationBlocksDifferentProfileOnSameExchangeMarketSymbol"],
+      "gap_codes": ["multi_profile_fake_recipe_not_consolidated"],
+      "id": 20,
+      "name": "dry_run_multi_profiles_same_symbol",
+      "requirement": "Two dry-run profiles targeting the same symbol preserve profile isolation and the global exposure lock.",
+      "runner": null,
+      "status": "partial"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a versioned catalog for all 20 mandatory Fake/Paper golden scenarios
- execute 9 currently supported scenarios twice from fresh deterministic state and keep 11 partial/unsupported gaps explicit
- enforce strict COMMON-005 JSON/PHP fixture parity and document the operator command and fail-closed semantics

## Safety
- no network or private exchange endpoint
- no credential, permission, demo/testnet or live activation
- `stop_loss_attach_failure` remains partial until adapter rejection is integrated with an executed compensation path
- every executable scenario that opens a position proves simulated SL coverage

## Verification
- `php vendor/bin/phpunit tests/Exchange tests/TradingCore/Execution` (1262 tests, 4823 assertions, 30 expected skips)
- PHPStan on every touched PHP file
- `php bin/console lint:container --no-debug`
- `php bin/console lint:yaml config`
- `python3 -m mkdocs build --strict`
- `git diff --check`

Part of #196
Related to #195
Related to #197
Related to #198
Related to #219
Related to #220

Builds on #226, #274, #275, #276 and #277.