### PR TITLE
Fake/Paper: add deterministic slippage cost model v1

### DIFF
--- a/docs/handbook/technical/certified-net-pnl-contract.md
+++ b/docs/handbook/technical/certified-net-pnl-contract.md
@@ -48,7 +48,8 @@ Aucun flag provider du type `quantity_coherent=true` ne remplace cette preuve qu
 | Fake/Paper | entry/exit fill price/qty | `FakeExchangeMatchingEngine` events + `getFillsSnapshot()` | brut fill | prix/qty positifs | au fill | fill | complet pour fixtures | non | fill event `fake_paper_fill_ledger_v1` | `FakeExchangeAdapterTest`, `NetPnlCertificationServiceTest` |
 | Fake/Paper | maker/taker | metadata fill/order | classification execution | `maker`/`taker` | au fill | fill | partiel, derive ordre | oui | metadata | test service |
 | Fake/Paper | fee par fill/devise | fee deterministe `notional * 0.0005`, `USDT` | cout explicite | positif | au fill | fill | complet | non | fill fee USDT | `testFakeFillsExpose...` |
-| Fake/Paper | funding/spread/slippage/borrow/liquidation | lifecycle `extra` explicite fixture | couts normalises | funding credit positif/debit negatif | a la cloture | trade | complet si fourni | non pour certification | `position_trade_analysis_v2` fixture | PostgreSQL view test |
+| Fake/Paper | spread/slippage | fill event explicite, REST/WS puis `fill_cost_ledger` | cout par fill | cout positif ou zero explicite | au fill | fill | complet pour fixtures Fake | non | `fixed_adverse_slippage_bps_v1`, `top_of_book_embedded_spread_v1` | adapter, normalizer et ledger tests |
+| Fake/Paper | funding/borrow/liquidation | lifecycle `extra` explicite fixture | couts normalises | funding credit positif/debit negatif | a la cloture | trade | complet si fourni | non pour certification | `position_trade_analysis_v2` fixture | PostgreSQL view test |
 | Bitmart | order fill price/qty | `OrderDto` / `/contract/private/order*` (`deal_avg_price`, `deal_size`) | brut order | positif | apres fill/order history | ordre | partiel | oui | payload brut metadata | adapter tests existants |
 | Bitmart | fee par fill/devise | `/contract/private/trades` (`paid_fees`, `fee_currency`) | cout fill | provider brut, non normalise garanti | apres REST sync | fill | partiel, pas relie au trade logique complet | oui | `FuturesOrderTrade` | projection tests partiels |
 | Bitmart | realized PnL provider | `/contract/private/transaction-history` flow_type=2 | inconnu brut/net | montant provider | apres cloture | transaction | non certifie | oui | transaction raw | sync tests existants |
@@ -74,6 +75,13 @@ La bascule progressive des consommateurs applicatifs v1 -> v2 est documentee dan
 Il introduit la table `fill_cost_ledger`, reliee au trade logique par `internal_trade_id` lorsque le lineage exact est disponible. L'idempotence est portee par `exchange + market_type + exchange_fill_id` quand l'exchange fournit un identifiant de fill, sinon par un identifiant interne deterministe documente.
 
 Les couts absents restent `NULL`. Les rows sans lineage exact restent visibles avec `quality_flags=["missing_lineage"]` et ne doivent pas etre considerees comme net PnL certifie.
+
+Pour les fills Fake/Paper, les couts de spread et slippage sont produits une seule
+fois par le matching engine puis copies par les surfaces REST/WS. Le ledger ne les
+recalcule pas : il persiste uniquement les valeurs explicites finies et
+non negatives. Une valeur negative, non numerique ou non finie reste `NULL` avec
+`spread_cost_invalid` ou `slippage_cost_invalid`. Le replay exact reste idempotent;
+un meme identifiant de fill avec un cout modifie est un conflit de payload.
 
 La quantite residuelle est calculee par `FillQuantityAggregationService` sur `internal_trade_id + exchange + market_type`. Le certificateur peut consommer le resultat via `certifyWithQuantityAggregation(...)`; si l'agregat n'autorise pas la certification, `net_pnl_usdt` et `realized_net_pnl_R` restent `NULL` meme lorsque les listes de fills passees au calcul semblent equilibrees.
 

--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -215,8 +215,11 @@ Le resultat Fake/Paper impose toujours `dry_run=true`, `permissions_trade=false`
 kill switch actif et ecriture demo/testnet desactivee. Les credentials sont
 `not_required`; le provider bundle Fake est operationnel uniquement pour le
 contexte `fake/perpetual` et ne peut emettre aucun ordre exchange.
-Le modele de slippage additionnel actuellement nul reste visible via le warning
-`fake_paper_slippage_model_zero`.
+Les fills taker publient un cout adverse deterministe de 5 bps sous
+`fixed_adverse_slippage_bps_v1`; les fills maker post-only publient zero. Le prix
+d execution reste le top of book, donc le spread additionnel est explicitement
+zero sous `top_of_book_embedded_spread_v1`. Un modele absent, nul, malforme ou non
+supporte bloque la readiness avec `fake_paper_slippage_model_not_ready`.
 
 Le modele d instrument versionne utilise Brick Math sur les textes decimaux
 exacts. L endpoint HTTP Fake exige des chaines decimales pour `quantity`, `price`
@@ -251,20 +254,18 @@ Une ligne presente dans le catalogue n est pas un PASS. Seul le statut `executab
 avec un test vert constitue une preuve. Les lignes `partial` et `unsupported` ne
 peuvent ni rendre le runtime-check ready, ni autoriser une mutation demo/testnet.
 
-Les neuf scenarios executes dans cette version sont : maker limit rempli, limit IOC
-expire sans fill, partial fill puis cancel, replay du `client_order_id`, timeout
-apres acceptation, attachement SL reussi, gap au SL au prochain prix disponible,
-deconnexion/reprise private WS, et restart avec position protegee ouverte.
+Les treize scenarios executes dans cette version sont : maker limit rempli, limit
+IOC expire sans fill, partial fill puis cancel, market avec slippage 5 bps,
+insufficient balance, precision reject, leverage cap reject, replay du
+`client_order_id`, timeout apres acceptation, attachement SL reussi, gap au SL au
+prochain prix disponible, deconnexion/reprise private WS, et restart avec
+position protegee ouverte.
 
 Les ecarts encore explicites sont :
 
 | Scenario | Statut | Gap stable |
 | --- | --- | --- |
 | fallback taker | `unsupported` | `fallback_taker_not_implemented` |
-| market avec slippage | `partial` | `slippage_model_zero` |
-| insufficient balance | `unsupported` | `balance_margin_validation_not_implemented` |
-| precision reject | `unsupported` | `instrument_precision_validation_not_implemented` |
-| leverage cap reject | `unsupported` | `leverage_cap_validation_not_implemented` |
 | echec attachement SL | `partial` | `stop_attach_failure_compensation_not_integrated` |
 | TP1 puis trailing | `partial` | `trailing_stop_not_implemented` |
 | duplicate/out-of-order event | `partial` | `out_of_order_event_injection_not_implemented` |

--- a/docs/superpowers/plans/2026-07-16-fake-slippage-cost-model-v1.md
+++ b/docs/superpowers/plans/2026-07-16-fake-slippage-cost-model-v1.md
@@ -1,0 +1,373 @@
+# Fake Slippage Cost Model v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Fake/Paper's zero additional slippage placeholder with a deterministic 5 bps taker cost that is propagated through fills, the persistent ledger, close evidence, runtime readiness, and golden scenario 5.
+
+**Architecture:** A small immutable `FakeFillCostModel` owns liquidity classification and monetary calculations. The matching engine records its output once per fill, while REST/WS normalizers and ledger ingestion only transport and validate the explicit metadata. Position metadata aggregates per-fill costs so close evidence subtracts slippage exactly once.
+
+**Tech Stack:** PHP 8.4, Symfony, PHPUnit 11, PHPStan, Brick Math-compatible decimal persistence, existing Fake/Paper state and fill-cost ledger.
+
+---
+
+### Task 1: Add the deterministic fill-cost model
+
+**Files:**
+- Create: `trading-app/src/Exchange/Fake/FakeFillCost.php`
+- Create: `trading-app/src/Exchange/Fake/FakeFillCostModel.php`
+- Create: `trading-app/tests/Exchange/Fake/FakeFillCostModelTest.php`
+
+- [ ] **Step 1: Write failing arithmetic and classification tests**
+
+Cover post-only maker, market taker, crossing-limit taker, protection taker,
+contract size scaling, and invalid non-positive inputs. The core assertion is:
+
+```php
+$cost = (new FakeFillCostModel())->forFill(
+    quantity: 2.0,
+    price: 100.0,
+    contractSize: 3.0,
+    postOnly: false,
+);
+
+self::assertSame('taker', $cost->liquidityRole);
+self::assertSame(0.3, $cost->slippageCostUsdt);
+self::assertSame(0.0, $cost->spreadCostUsdt);
+```
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run:
+
+```bash
+cd trading-app
+php vendor/bin/phpunit tests/Exchange/Fake/FakeFillCostModelTest.php
+```
+
+Expected: failure because `FakeFillCostModel` does not exist.
+
+- [ ] **Step 3: Implement the minimal immutable model**
+
+Expose:
+
+```php
+final readonly class FakeFillCostModel
+{
+    public const MODEL_VERSION = 'fixed_adverse_slippage_bps_v1';
+    public const SPREAD_MODEL_VERSION = 'top_of_book_embedded_spread_v1';
+    public const TAKER_SLIPPAGE_BPS = 5.0;
+
+    public function forFill(
+        float $quantity,
+        float $price,
+        float $contractSize,
+        bool $postOnly,
+    ): FakeFillCost;
+}
+```
+
+`FakeFillCost` contains `liquidityRole`, `spreadCostUsdt`,
+`slippageCostUsdt`, `modelVersion`, and `spreadModelVersion`.
+
+- [ ] **Step 4: Run the test and verify GREEN**
+
+Run the same PHPUnit command. Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add trading-app/src/Exchange/Fake/FakeFillCost.php \
+  trading-app/src/Exchange/Fake/FakeFillCostModel.php \
+  trading-app/tests/Exchange/Fake/FakeFillCostModelTest.php
+git commit -m "feat(fake): add deterministic fill cost model (#196)"
+```
+
+### Task 2: Record and aggregate costs in the matching engine
+
+**Files:**
+- Modify: `trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php`
+- Modify: `trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php`
+- Modify: `trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php`
+
+- [ ] **Step 1: Add failing fill and close-evidence tests**
+
+Add tests proving:
+
+- a market fill keeps the current ask/bid execution price;
+- taker metadata reports 5 bps slippage and zero additional spread;
+- a post-only maker fill reports explicit zero slippage;
+- partial fills aggregate costs per fill;
+- contract size scales slippage;
+- full-close `recorded_pnl_usdt` subtracts entry/exit fees and total slippage.
+
+Expected close formula:
+
+```php
+$expected = $gross
+    - $entryFee
+    - $exitFee
+    - $entrySlippage
+    - $exitSlippage;
+```
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```bash
+cd trading-app
+php vendor/bin/phpunit tests/Exchange/Adapter/FakeExchangeAdapterTest.php \
+  --filter 'Slippage|FillCosts|Certified'
+```
+
+Expected: missing slippage metadata or unchanged recorded PnL.
+
+- [ ] **Step 3: Inject and apply `FakeFillCostModel`**
+
+Calculate cost once in `fillOrder()`, add its fields to the fill event, and pass
+the same cost to entry/exit ledger helpers. Aggregate:
+
+```php
+'entry_slippage_cost_usdt' => previous + $cost->slippageCostUsdt,
+'exit_slippage_cost_usdt' => previous + $cost->slippageCostUsdt,
+'spread_cost_usdt' => 0.0,
+```
+
+Expose total slippage and model versions in `certifiedClosePayload()`. Keep fill
+prices unchanged.
+
+- [ ] **Step 4: Publish runtime metadata from the same model**
+
+Replace the zero-slippage literal in `FakeExchangeAdapter::runtimeModelMetadata()`
+with the model constants and add `slippage_bps` plus `spread_model`.
+
+- [ ] **Step 5: Run adapter tests and verify GREEN**
+
+```bash
+php vendor/bin/phpunit tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php \
+  trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php \
+  trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+git commit -m "feat(fake): propagate fill slippage costs (#196)"
+```
+
+### Task 3: Preserve cost parity through REST, WS, and the ledger
+
+**Files:**
+- Modify: `trading-app/src/Exchange/Fake/FakeExchangeEventNormalizer.php`
+- Modify: `trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php`
+- Modify: `trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php`
+- Modify: `trading-app/tests/Exchange/Event/FakeExchangeEventNormalizerTest.php`
+- Modify: `trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php`
+
+- [ ] **Step 1: Add failing REST/WS parity tests**
+
+Assert both normalized WS and REST snapshots expose:
+
+```php
+$expectedSlippage = $fill->quantity * $fill->price * 5.0 / 10_000.0;
+
+self::assertSame('taker', $fill->metadata['liquidity_role']);
+self::assertSame(0.0, $fill->metadata['spread_cost_usdt']);
+self::assertEqualsWithDelta(
+    $expectedSlippage,
+    $fill->metadata['slippage_cost_usdt'],
+    0.000000000001,
+);
+self::assertSame(
+    'fixed_adverse_slippage_bps_v1',
+    $fill->metadata['cost_model_version'],
+);
+```
+
+Also assert `spread_model_version=top_of_book_embedded_spread_v1`.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```bash
+php vendor/bin/phpunit \
+  tests/Exchange/Event/FakeExchangeEventNormalizerTest.php \
+  tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+```
+
+Expected: metadata keys absent and ledger cost columns `NULL`.
+
+- [ ] **Step 3: Copy explicit event costs into `ExchangeFillDto` metadata**
+
+Both REST and WS mapping must use the same payload keys. Do not recompute costs
+in normalizers.
+
+- [ ] **Step 4: Ingest only valid explicit costs**
+
+Add a helper that returns `NULL` when absent, stores finite non-negative decimal
+values when present, and adds:
+
+```text
+spread_cost_invalid
+slippage_cost_invalid
+```
+
+for invalid values. Keep other providers' missing values `NULL`.
+
+- [ ] **Step 5: Prove replay and conflict behavior**
+
+Test exact replay remains idempotent, while the same exchange fill ID with a
+different slippage payload raises `FillCostLedgerIngestionConflict`.
+
+- [ ] **Step 6: Run focused tests and verify GREEN**
+
+Run the command from Step 2.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add trading-app/src/Exchange/Fake/FakeExchangeEventNormalizer.php \
+  trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php \
+  trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php \
+  trading-app/tests/Exchange/Event/FakeExchangeEventNormalizerTest.php \
+  trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+git commit -m "feat(fake): persist explicit slippage costs (#196)"
+```
+
+### Task 4: Make runtime and golden scenario 5 executable
+
+**Files:**
+- Modify: `trading-app/src/Provider/Fake/FakeRuntimeCheck.php`
+- Modify: `trading-app/tests/Exchange/Readiness/FakeRuntimeCheckTest.php`
+- Modify: `trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json`
+- Modify: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php`
+- Modify: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php`
+- Modify: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php`
+
+- [ ] **Step 1: Add failing runtime assertions**
+
+Assert the new model/version/rate are present and
+`fake_paper_slippage_model_zero` is absent. A malformed, zero, or unsupported
+runtime model must add `fake_paper_slippage_model_not_ready`.
+
+- [ ] **Step 2: Add failing golden catalog assertions**
+
+Change `market_with_slippage` to:
+
+```json
+{
+  "gap_codes": [],
+  "runner": "market_with_slippage",
+  "status": "executable"
+}
+```
+
+Update catalog expectations and require deterministic positive cost evidence.
+
+- [ ] **Step 3: Run runtime and golden tests and verify RED**
+
+```bash
+php vendor/bin/phpunit \
+  tests/Exchange/Readiness/FakeRuntimeCheckTest.php \
+  tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php \
+  tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
+```
+
+- [ ] **Step 4: Implement runtime validation and golden runner**
+
+The runner submits one market order, reads its fill, and returns normalized
+price, notional, liquidity role, basis points, spread cost, slippage cost, and
+model versions. It runs only against fresh in-memory Fake state.
+
+- [ ] **Step 5: Run tests and verify GREEN**
+
+Run the command from Step 3.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add trading-app/src/Provider/Fake/FakeRuntimeCheck.php \
+  trading-app/tests/Exchange/Readiness/FakeRuntimeCheckTest.php \
+  trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json \
+  trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php \
+  trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php \
+  trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
+git commit -m "test(fake): execute market slippage golden scenario (#196)"
+```
+
+### Task 5: Documentation and final verification
+
+**Files:**
+- Modify: `trading-app/docs/exchange/fake-instrument-risk-model-v1.md`
+- Modify: `trading-app/src/Exchange/Fake/README.md`
+- Modify: `docs/handbook/technical/fake-paper-gateway.md`
+- Modify: `docs/handbook/technical/certified-net-pnl-contract.md`
+
+- [ ] **Step 1: Update operator and contract documentation**
+
+Document model versions, 5 bps taker cost, explicit maker zero, embedded spread,
+ledger propagation, PnL formula, rollback, and the reduced golden gap list.
+
+- [ ] **Step 2: Run focused and broad PHPUnit**
+
+```bash
+cd trading-app
+php vendor/bin/phpunit \
+  tests/Exchange/Fake \
+  tests/Exchange/Adapter/FakeExchangeAdapterTest.php \
+  tests/Exchange/Event/FakeExchangeEventNormalizerTest.php \
+  tests/Exchange/Readiness/FakeRuntimeCheckTest.php \
+  tests/Trading/Pnl
+php vendor/bin/phpunit tests/Exchange tests/Provider/Fake tests/TradeEntry/Execution
+```
+
+- [ ] **Step 3: Run static and framework validation**
+
+```bash
+php vendor/bin/phpstan analyse \
+  src/Exchange/Fake/FakeFillCost.php \
+  src/Exchange/Fake/FakeFillCostModel.php \
+  src/Exchange/Fake/FakeExchangeMatchingEngine.php \
+  src/Exchange/Fake/FakeExchangeEventNormalizer.php \
+  src/Exchange/Adapter/FakeExchangeAdapter.php \
+  src/Provider/Fake/FakeRuntimeCheck.php \
+  src/Trading/Pnl/FillCostLedgerIngestionService.php \
+  tests/Exchange/Fake/FakeFillCostModelTest.php \
+  tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php \
+  tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php \
+  tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php \
+  tests/Exchange/Adapter/FakeExchangeAdapterTest.php \
+  tests/Exchange/Event/FakeExchangeEventNormalizerTest.php \
+  tests/Exchange/Readiness/FakeRuntimeCheckTest.php \
+  tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php \
+  --memory-limit=512M
+php -d error_reporting=8191 bin/console lint:container --no-debug
+php -d error_reporting=8191 bin/console lint:yaml config
+```
+
+- [ ] **Step 4: Run documentation and diff checks**
+
+```bash
+cd ..
+python -m mkdocs build --strict
+git diff --check
+git status --short
+```
+
+- [ ] **Step 5: Review safety and commit docs**
+
+Confirm no credential, network call, exchange write, strategy change, silent
+zero for absent generic-provider costs, or unrelated file is present.
+
+```bash
+git add trading-app/docs/exchange/fake-instrument-risk-model-v1.md \
+  trading-app/src/Exchange/Fake/README.md \
+  docs/handbook/technical/fake-paper-gateway.md \
+  docs/handbook/technical/certified-net-pnl-contract.md \
+  docs/superpowers/plans/2026-07-16-fake-slippage-cost-model-v1.md
+git commit -m "docs(fake): document slippage cost model (#196)"
+```
+
+- [ ] **Step 6: Delivery**
+
+Check Codex quota after the commit, push the branch, open a PR with `Part of
+#196`, request one Codex review after CI starts, address every thread, and merge
+only after green CI plus explicit Codex approval.

--- a/docs/superpowers/specs/2026-07-16-fake-slippage-cost-model-v1-design.md
+++ b/docs/superpowers/specs/2026-07-16-fake-slippage-cost-model-v1-design.md
@@ -1,0 +1,112 @@
+# Fake Slippage Cost Model v1 Design
+
+## Scope
+
+This lot closes the `slippage_model_zero` gap of issue #196 for the deterministic
+Fake/Paper exchange. It introduces a versioned, non-zero additional slippage
+cost for taker fills and propagates that cost through Fake events, REST/WS fill
+snapshots, the persistent fill-cost ledger, position close evidence, and the
+golden scenario catalog.
+
+It does not implement funding, maker fallback, depth simulation, trailing stops,
+stop-attachment compensation, liquidation, or exchange writes.
+
+## Cost model
+
+`FakeFillCostModel` is the single deterministic source for Fake fill cost
+classification and calculation:
+
+- model version: `fixed_adverse_slippage_bps_v1`;
+- taker additional slippage: `5` basis points of fill notional;
+- maker additional slippage: explicit `0`;
+- maker classification: `postOnly=true`;
+- taker classification: market, immediately crossing limit, trigger/protection,
+  and any other non-post-only fill;
+- notional: `quantity * fill_price * contract_size`;
+- monetary outputs: rounded to 12 decimal places.
+
+The existing fill price remains the deterministic top-of-book or submitted
+maker price. The model does not worsen the execution price. This prevents the
+same slippage from being represented both in the fill price and as a separate
+cost.
+
+The bid/ask spread is already reflected in top-of-book execution prices. This
+lot does not subtract a second spread cost. `spread_cost_usdt` remains explicit
+`0` for Fake fills under the versioned `top_of_book_embedded_spread_v1` rule.
+
+## Event and fill propagation
+
+Every Fake fill event includes:
+
+- `liquidity_role`;
+- `fill_fee`;
+- `spread_cost_usdt`;
+- `slippage_cost_usdt`;
+- `cost_model_version`;
+- `spread_model_version`;
+- the existing `pnl_source` and completeness metadata.
+
+Both `FakeExchangeEventNormalizer` and `FakeExchangeAdapter::getFillsSnapshot()`
+copy these fields into `ExchangeFillDto::metadata`. REST reconciliation and
+private-WS projection therefore produce the same cost payload and the same
+idempotency fingerprint.
+
+Missing or invalid generic-provider cost metadata remains `NULL` in
+`FillCostLedgerIngestionService`. Only finite, non-negative explicit values are
+accepted for spread and slippage. Invalid values add stable quality flags and
+cannot certify net PnL.
+
+## Position and PnL aggregation
+
+The matching engine accumulates entry and exit slippage separately in position
+metadata alongside fee and notional ledgers. On full close, the payload exposes
+the total `slippage_cost_usdt` and the explicit `spread_cost_usdt`.
+
+The existing certified PnL formula then subtracts the additional slippage once:
+
+```text
+recorded_pnl_usdt =
+  gross_realized_pnl_usdt
+  - entry_fee_usdt
+  - exit_fee_usdt
+  - slippage_cost_usdt
+```
+
+Other existing explicit Fake components are unchanged in this atomic lot.
+Partial fills aggregate cost per fill, and replaying the same fill does not
+create or double-count another ledger entry.
+
+## Runtime and golden evidence
+
+`runtimeModelMetadata()` publishes the new slippage and spread model versions
+plus the configured slippage basis points. `FakeRuntimeCheck` accepts only the
+versioned non-zero model and no longer emits `fake_paper_slippage_model_zero`.
+
+Golden scenario 5, `market_with_slippage`, becomes executable. Its deterministic
+runner proves:
+
+- a market order fills at the existing top of book;
+- the fill is classified as taker;
+- the additional slippage cost is positive and exactly 5 bps of notional;
+- the same scenario run from fresh state produces identical normalized output.
+
+Maker coverage proves explicit zero slippage without classifying an unknown cost
+as zero.
+
+## Tests and safety
+
+Tests cover model arithmetic, maker/taker classification, contract-size scaling,
+partial-fill aggregation, REST/WS parity, ledger persistence, close-event PnL,
+runtime metadata, golden execution, replay idempotence, redaction, and restart
+stability.
+
+The implementation remains local and deterministic. It adds no credential,
+network call, demo/testnet permission, strategy change, or exchange mutation.
+
+## Rollback
+
+Rollback restores the prior `explicit_zero_additional_slippage_v1` runtime
+metadata and returns golden scenario 5 to `partial/slippage_model_zero`. Existing
+state remains readable because costs are stored in additive metadata and the
+persistent state schema is unchanged. Ledger rows already emitted by the new
+model remain immutable audit evidence and must not be rewritten.

--- a/trading-app/docs/exchange/fake-instrument-risk-model-v1.md
+++ b/trading-app/docs/exchange/fake-instrument-risk-model-v1.md
@@ -16,11 +16,27 @@ leverage slice of the local Fake/Paper exchange. It does not complete issue
 | Golden scenario catalog | `fake-paper-golden-v1` |
 | Fee model | `fixed_notional_fee_v1` at `0.0005` |
 | Fill model | `top_of_book_v1` |
-| Additional slippage model | `explicit_zero_additional_slippage_v1` |
+| Additional slippage model | `fixed_adverse_slippage_bps_v1` at `5` bps for taker fills |
+| Spread model | `top_of_book_embedded_spread_v1` |
 
 `FakeExchangeAdapter::runtimeModelMetadata()` publishes the catalog,
 precision, fee, fill, and slippage versions. The margin version is published on
 the canonical USDT balance metadata.
+
+The execution price remains the deterministic top-of-book price. Spread is
+therefore already embedded in that price and is reported as an explicit
+additional `spread_cost_usdt=0`. Post-only fills are classified as maker and
+report `slippage_cost_usdt=0`; every other Fake fill is classified as taker and
+reports:
+
+```text
+slippage_cost_usdt = quantity * fill_price * contract_size * 5 / 10000
+```
+
+The matching engine records these values once in the fill event. REST and
+private-WS normalization copy them without recomputation. Ledger ingestion
+persists finite non-negative explicit values, leaves absent values `NULL`, and
+flags invalid values as `spread_cost_invalid` or `slippage_cost_invalid`.
 
 ## Instrument fixture
 
@@ -171,7 +187,9 @@ When persistence is configured, it must be writable and recovery-ready or the
 runtime reports a blocking error. Market/replay source connectivity, a controlled
 clock, readable state, and the other evaluator inputs still determine the overall
 gate. A residual local order book alone does not prove market-source readiness.
-Zero additional slippage remains a warning.
+The slippage gate requires the exact versioned 5 bps model and embedded-spread
+version; a missing, zero, malformed, or unsupported model reports the blocking
+error `fake_paper_slippage_model_not_ready`.
 
 The runtime contract accepts only `fake/perpetual`. Fake/spot requests fail
 closed: the runtime check rejects that context and canonical order validation
@@ -207,7 +225,7 @@ runtime:
    an incompatible serialized payload.
 4. Clear the application cache, restart local workers, and run
    `app:exchange:runtime-check fake perpetual` before resuming local scenarios.
-5. Restore scenario classifications 6-8 to explicit gaps if their executable
+5. Restore scenario classifications 5-8 to explicit gaps if their executable
    runners are rolled back.
 
 Do not use rollback as a path to live, demo, or testnet trading. No credential,
@@ -221,7 +239,6 @@ golden catalog and readiness evidence:
 - daily loss cap;
 - liquidation guard and liquidation model;
 - maker-timeout fallback taker behavior;
-- non-zero slippage;
 - funding accrual;
 - one-way position conflict handling;
 - TP1-to-trailing-stop behavior;
@@ -230,5 +247,5 @@ golden catalog and readiness evidence:
 - consolidated multi-profile Fake/Paper recipe and exposure behavior.
 
 Trade history completeness and any other cataloged partial behavior also remain
-outside this slice. Therefore this document and scenarios 6-8 are evidence for a
-narrow risk-model increment, not evidence that issue #196 is complete.
+outside this slice. Therefore this document and scenarios 5-8 are evidence for
+narrow deterministic increments, not evidence that issue #196 is complete.

--- a/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
+++ b/trading-app/src/Command/ExchangeRuntimeCheckCommand.php
@@ -147,7 +147,7 @@ final class ExchangeRuntimeCheckCommand extends Command
                     && !\in_array('fake_paper_clock_not_controlled', $fakeBlockingErrors, true);
                 $output->writeln(sprintf('Clock: %s', $clockReady ? 'ready' : 'not_ready'));
                 $output->writeln(sprintf('Fee model: %s', \in_array('fake_paper_fee_model_not_ready', $fakeBlockingErrors, true) ? 'not_ready' : 'ready'));
-                $output->writeln(sprintf('Slippage model: %s', \in_array('fake_paper_slippage_model_zero', $fakeWarnings, true) ? 'explicit_zero' : 'ready'));
+                $output->writeln(sprintf('Slippage model: %s', \in_array('fake_paper_slippage_model_not_ready', $fakeBlockingErrors, true) ? 'not_ready' : 'ready'));
                 $output->writeln(sprintf('Metadata fixtures: %s', $fakeReadinessReport->metadataValid ? 'ready' : 'not_ready'));
                 $output->writeln(sprintf('Precision model: %s', $fakeReadinessReport->precisionValid ? 'ready' : 'not_ready'));
                 $output->writeln(sprintf('Stop loss capability: %s', $fakeReadinessReport->stopLossCapability ? 'yes' : 'no'));

--- a/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
@@ -361,8 +361,30 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
                 'source' => 'fake_exchange_rest_reconciliation',
                 'pnl_source' => 'fake_paper_fill_ledger_v1',
                 'cost_completeness' => 'complete',
+                ...$this->fillCostMetadata($event),
             ],
         );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fillCostMetadata(FakeExchangeEvent $event): array
+    {
+        $metadata = [];
+        foreach ([
+            'liquidity_role',
+            'spread_cost_usdt',
+            'slippage_cost_usdt',
+            'cost_model_version',
+            'spread_model_version',
+        ] as $key) {
+            if (array_key_exists($key, $event->payload)) {
+                $metadata[$key] = $event->payload[$key];
+            }
+        }
+
+        return $metadata;
     }
 
     private function fillFee(float $quantity, float $price): float

--- a/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
+++ b/trading-app/src/Exchange/Adapter/FakeExchangeAdapter.php
@@ -21,6 +21,7 @@ use App\Exchange\Dto\PlaceOrderResult;
 use App\Exchange\Fake\FakeExchangeEvent;
 use App\Exchange\Fake\FakeExchangeFaultOutcome;
 use App\Exchange\Fake\FakeExchangeInjectedException;
+use App\Exchange\Fake\FakeFillCostModel;
 use App\Exchange\Fake\FakeExchangeMatchingEngine;
 use App\Exchange\Fake\FakeExchangeOperation;
 use App\Exchange\Fake\FakeExchangeOrderBook;
@@ -79,7 +80,7 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
     }
 
     /**
-     * @return array{fee_model:string,fee_rate:float,fill_model:string,slippage_model:string,metadata_fixture_version:string,precision_model_version:string}
+     * @return array{fee_model:string,fee_rate:float,fill_model:string,slippage_model:string,slippage_bps:float,spread_model:string,metadata_fixture_version:string,precision_model_version:string}
      */
     public function runtimeModelMetadata(): array
     {
@@ -89,7 +90,9 @@ final readonly class FakeExchangeAdapter implements ExchangeAdapterInterface, Ex
             'fee_model' => 'fixed_notional_fee_v1',
             'fee_rate' => self::FEE_RATE,
             'fill_model' => 'top_of_book_v1',
-            'slippage_model' => 'explicit_zero_additional_slippage_v1',
+            'slippage_model' => FakeFillCostModel::MODEL_VERSION,
+            'slippage_bps' => FakeFillCostModel::TAKER_SLIPPAGE_BPS,
+            'spread_model' => FakeFillCostModel::SPREAD_MODEL_VERSION,
             'metadata_fixture_version' => $catalog->metadataFixtureVersion(),
             'precision_model_version' => $catalog->precisionModelVersion(),
         ];

--- a/trading-app/src/Exchange/Fake/FakeExchangeEventNormalizer.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeEventNormalizer.php
@@ -165,8 +165,30 @@ final readonly class FakeExchangeEventNormalizer implements ExchangeEventNormali
                 'order_status' => $order->status->value,
                 'pnl_source' => 'fake_paper_fill_ledger_v1',
                 'cost_completeness' => 'complete',
+                ...$this->fillCostMetadata($event),
             ],
         );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function fillCostMetadata(FakeExchangeEvent $event): array
+    {
+        $metadata = [];
+        foreach ([
+            'liquidity_role',
+            'spread_cost_usdt',
+            'slippage_cost_usdt',
+            'cost_model_version',
+            'spread_model_version',
+        ] as $key) {
+            if (array_key_exists($key, $event->payload)) {
+                $metadata[$key] = $event->payload[$key];
+            }
+        }
+
+        return $metadata;
     }
 
     /**

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -50,15 +50,19 @@ final readonly class FakeExchangeMatchingEngine
 
     private FakeInstrumentProviderInterface $instruments;
 
+    private FakeFillCostModel $fillCostModel;
+
     public function __construct(
         private FakeExchangeStateStore $stateStore,
         private FakeExchangeOrderBook $orderBook,
         private ClockInterface $clock,
         ?FakeOrderValidator $orderValidator = null,
         ?FakeInstrumentProviderInterface $instruments = null,
+        ?FakeFillCostModel $fillCostModel = null,
     ) {
         $this->instruments = $instruments ?? new FakeInstrumentCatalog();
         $this->orderValidator = $orderValidator ?? new FakeOrderValidator($this->instruments);
+        $this->fillCostModel = $fillCostModel ?? new FakeFillCostModel();
     }
 
     public function submit(PlaceOrderRequest $request): PlaceOrderResult
@@ -233,6 +237,13 @@ final readonly class FakeExchangeMatchingEngine
                 'reduce_only_cancelled_remainder' => true,
             ])
             : $order->metadata;
+        $contractSize = $this->marginContractSize($order->metadata);
+        $fillCost = $this->fillCostModel->forFill(
+            quantity: $fillQuantity,
+            price: $executionPrice,
+            contractSize: $contractSize,
+            postOnly: $order->postOnly,
+        );
 
         $updated = new ExchangeOrderDto(
             exchange: $order->exchange,
@@ -259,7 +270,7 @@ final readonly class FakeExchangeMatchingEngine
         );
 
         $this->stateStore->saveOrder($updated);
-        $this->applyPositionFill($updated, $fillQuantity, $executionPrice);
+        $this->applyPositionFill($updated, $fillQuantity, $executionPrice, $fillCost);
         $this->appendEvent(
             $status === ExchangeOrderStatus::FILLED ? 'order.filled' : 'order.partially_filled',
             $updated,
@@ -269,9 +280,14 @@ final readonly class FakeExchangeMatchingEngine
                 'fill_fee' => $this->fillFee(
                     $fillQuantity,
                     $executionPrice,
-                    $this->marginContractSize($updated->metadata),
+                    $contractSize,
                 ),
                 'fee_currency' => 'USDT',
+                'liquidity_role' => $fillCost->liquidityRole,
+                'spread_cost_usdt' => $fillCost->spreadCostUsdt,
+                'slippage_cost_usdt' => $fillCost->slippageCostUsdt,
+                'cost_model_version' => $fillCost->modelVersion,
+                'spread_model_version' => $fillCost->spreadModelVersion,
                 'pnl_source' => 'fake_paper_fill_ledger_v1',
                 'cost_completeness' => 'complete',
             ],
@@ -551,7 +567,12 @@ final readonly class FakeExchangeMatchingEngine
         );
     }
 
-    private function applyPositionFill(ExchangeOrderDto $order, float $fillQuantity, float $executionPrice): void
+    private function applyPositionFill(
+        ExchangeOrderDto $order,
+        float $fillQuantity,
+        float $executionPrice,
+        FakeFillCost $fillCost,
+    ): void
     {
         if ($order->positionSide === null) {
             return;
@@ -572,6 +593,7 @@ final readonly class FakeExchangeMatchingEngine
                 $executionPrice,
                 $contractSize,
                 $fillFee,
+                $fillCost,
             );
             $remainingSize = max(0.0, $existing->size - $fillQuantity);
             if ($remainingSize <= 0.00000001) {
@@ -639,6 +661,7 @@ final readonly class FakeExchangeMatchingEngine
                 $executionPrice,
                 $contractSize,
                 $fillFee,
+                $fillCost,
             ),
         );
         $this->stateStore->savePosition($position);
@@ -708,6 +731,7 @@ final readonly class FakeExchangeMatchingEngine
         float $price,
         float $contractSize,
         float $fee,
+        FakeFillCost $fillCost,
     ): array
     {
         $entryOrderIds = $this->entryOrderIds($metadata, $orderId);
@@ -720,6 +744,10 @@ final readonly class FakeExchangeMatchingEngine
             'entry_qty' => $this->metadataFloat($metadata, 'entry_qty') + $quantity,
             'entry_notional_usdt' => $this->metadataFloat($metadata, 'entry_notional_usdt') + ($quantity * $price * $contractSize),
             'entry_fee_usdt' => $this->metadataFloat($metadata, 'entry_fee_usdt') + $fee,
+            'entry_spread_cost_usdt' => $this->metadataFloat($metadata, 'entry_spread_cost_usdt') + $fillCost->spreadCostUsdt,
+            'entry_slippage_cost_usdt' => $this->metadataFloat($metadata, 'entry_slippage_cost_usdt') + $fillCost->slippageCostUsdt,
+            'cost_model_version' => $fillCost->modelVersion,
+            'spread_model_version' => $fillCost->spreadModelVersion,
             'pnl_source' => 'fake_paper_fill_ledger_v1',
         ]);
     }
@@ -734,12 +762,17 @@ final readonly class FakeExchangeMatchingEngine
         float $price,
         float $contractSize,
         float $fee,
+        FakeFillCost $fillCost,
     ): array
     {
         return array_replace($metadata, [
             'exit_qty' => $this->metadataFloat($metadata, 'exit_qty') + $quantity,
             'exit_notional_usdt' => $this->metadataFloat($metadata, 'exit_notional_usdt') + ($quantity * $price * $contractSize),
             'exit_fee_usdt' => $this->metadataFloat($metadata, 'exit_fee_usdt') + $fee,
+            'exit_spread_cost_usdt' => $this->metadataFloat($metadata, 'exit_spread_cost_usdt') + $fillCost->spreadCostUsdt,
+            'exit_slippage_cost_usdt' => $this->metadataFloat($metadata, 'exit_slippage_cost_usdt') + $fillCost->slippageCostUsdt,
+            'cost_model_version' => $fillCost->modelVersion,
+            'spread_model_version' => $fillCost->spreadModelVersion,
             'pnl_source' => 'fake_paper_fill_ledger_v1',
         ]);
     }
@@ -756,6 +789,10 @@ final readonly class FakeExchangeMatchingEngine
         $exitNotional = $this->metadataFloat($closeLedger, 'exit_notional_usdt');
         $entryFee = $this->metadataFloat($closeLedger, 'entry_fee_usdt');
         $exitFee = $this->metadataFloat($closeLedger, 'exit_fee_usdt');
+        $spreadCost = $this->metadataFloat($closeLedger, 'entry_spread_cost_usdt')
+            + $this->metadataFloat($closeLedger, 'exit_spread_cost_usdt');
+        $slippageCost = $this->metadataFloat($closeLedger, 'entry_slippage_cost_usdt')
+            + $this->metadataFloat($closeLedger, 'exit_slippage_cost_usdt');
         $entryOrderCount = max(1, (int) round($this->metadataFloat($closeLedger, 'entry_order_count')));
         $lineageSufficient = $entryOrderCount <= 1;
         $gross = $position->side === ExchangePositionSide::SHORT
@@ -764,15 +801,17 @@ final readonly class FakeExchangeMatchingEngine
 
         return $this->lineageMetadata($closeLedger) + [
             'gross_realized_pnl_usdt' => round($gross, 12),
-            'recorded_pnl_usdt' => round($gross - $entryFee - $exitFee, 12),
+            'recorded_pnl_usdt' => round($gross - $entryFee - $exitFee - $spreadCost - $slippageCost, 12),
             'entry_fee_usdt' => round($entryFee, 12),
             'exit_fee_usdt' => round($exitFee, 12),
             'other_trading_fees_usdt' => 0.0,
             'funding_usdt' => 0.0,
-            'spread_cost_usdt' => 0.0,
-            'slippage_cost_usdt' => 0.0,
+            'spread_cost_usdt' => round($spreadCost, 12),
+            'slippage_cost_usdt' => round($slippageCost, 12),
             'borrow_cost_usdt' => 0.0,
             'liquidation_fee_usdt' => 0.0,
+            'cost_model_version' => $this->stringMetadata($closeLedger, 'cost_model_version'),
+            'spread_model_version' => $this->stringMetadata($closeLedger, 'spread_model_version'),
             'entry_qty' => round($entryQty, 12),
             'exit_qty' => round($exitQty, 12),
             'remaining_qty' => 0.0,

--- a/trading-app/src/Exchange/Fake/FakeFillCost.php
+++ b/trading-app/src/Exchange/Fake/FakeFillCost.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+final readonly class FakeFillCost
+{
+    public function __construct(
+        public string $liquidityRole,
+        public float $spreadCostUsdt,
+        public float $slippageCostUsdt,
+        public string $modelVersion,
+        public string $spreadModelVersion,
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeFillCostModel.php
+++ b/trading-app/src/Exchange/Fake/FakeFillCostModel.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+final readonly class FakeFillCostModel
+{
+    public const MODEL_VERSION = 'fixed_adverse_slippage_bps_v1';
+    public const SPREAD_MODEL_VERSION = 'top_of_book_embedded_spread_v1';
+    public const TAKER_SLIPPAGE_BPS = 5.0;
+
+    public function forFill(
+        float $quantity,
+        float $price,
+        float $contractSize,
+        bool $postOnly,
+    ): FakeFillCost {
+        $this->assertPositiveFinite($quantity, 'quantity');
+        $this->assertPositiveFinite($price, 'price');
+        $this->assertPositiveFinite($contractSize, 'contractSize');
+
+        $liquidityRole = $postOnly ? 'maker' : 'taker';
+        $slippageCostUsdt = $postOnly
+            ? 0.0
+            : round($quantity * $price * $contractSize * self::TAKER_SLIPPAGE_BPS / 10_000.0, 12);
+
+        return new FakeFillCost(
+            liquidityRole: $liquidityRole,
+            spreadCostUsdt: 0.0,
+            slippageCostUsdt: $slippageCostUsdt,
+            modelVersion: self::MODEL_VERSION,
+            spreadModelVersion: self::SPREAD_MODEL_VERSION,
+        );
+    }
+
+    private function assertPositiveFinite(float $value, string $field): void
+    {
+        if (!\is_finite($value) || $value <= 0.0) {
+            throw new \InvalidArgumentException(sprintf('%s must be positive and finite', $field));
+        }
+    }
+}

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -96,9 +96,13 @@ creating that file.
 
 The contract is intentionally dry-run only: trade permission is always false,
 the kill switch remains active, and no demo/testnet or live write path can be
-enabled. The current additional slippage model is explicitly zero and is exposed
-as `fake_paper_slippage_model_zero`. The application runtime also reports a
-non-controlled clock and a missing explicit market source as blockers. Until a
-operational Fake provider bundle, versioned instrument metadata, precision
-fixtures, and those runtime inputs are available, `Schedule ready` remains `no`; the adapter must not
-be presented as a complete Paper runtime.
+enabled. Taker fills report a deterministic adverse cost of 5 bps under
+`fixed_adverse_slippage_bps_v1`; post-only maker fills report explicit zero.
+Execution prices remain at top of book, so the separate additional spread cost
+is zero under `top_of_book_embedded_spread_v1`. A missing, zero, malformed, or
+unsupported runtime model adds `fake_paper_slippage_model_not_ready`. The
+application runtime also reports a non-controlled clock and a missing explicit
+market source as blockers. Until an operational Fake provider bundle, versioned
+instrument metadata, precision fixtures, and those runtime inputs are available,
+`Schedule ready` remains `no`; the adapter must not be presented as a complete
+Paper runtime.

--- a/trading-app/src/Provider/Fake/FakeRuntimeCheck.php
+++ b/trading-app/src/Provider/Fake/FakeRuntimeCheck.php
@@ -8,6 +8,7 @@ use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Exchange\Adapter\FakeExchangeAdapter;
 use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Fake\FakeFillCostModel;
 use App\Exchange\Readiness\ExchangeReadinessEvaluator;
 use App\Exchange\Readiness\ExchangeReadinessInput;
 use App\Exchange\Readiness\ExchangeReadinessReport;
@@ -72,8 +73,8 @@ final readonly class FakeRuntimeCheck implements ExchangeRuntimeCheckInterface
         if ($model['fee_model'] !== 'fixed_notional_fee_v1' || $model['fee_rate'] !== 0.0005) {
             $blockingErrors[] = 'fake_paper_fee_model_not_ready';
         }
-        if ($model['slippage_model'] === 'explicit_zero_additional_slippage_v1') {
-            $warnings[] = 'fake_paper_slippage_model_zero';
+        if (!self::slippageModelReady($model)) {
+            $blockingErrors[] = 'fake_paper_slippage_model_not_ready';
         }
         if (!$persistence['configured']) {
             $warnings[] = 'fake_paper_persistence_not_configured';
@@ -158,5 +159,20 @@ final readonly class FakeRuntimeCheck implements ExchangeRuntimeCheckInterface
             warnings: $input->warnings,
             configProfile: $input->configProfile,
         ));
+    }
+
+    /**
+     * @param array<string,mixed> $model
+     * @internal
+     */
+    public static function slippageModelReady(array $model): bool
+    {
+        $slippageBps = $model['slippage_bps'] ?? null;
+
+        return ($model['slippage_model'] ?? null) === FakeFillCostModel::MODEL_VERSION
+            && (\is_int($slippageBps) || \is_float($slippageBps))
+            && \is_finite((float) $slippageBps)
+            && (float) $slippageBps === FakeFillCostModel::TAKER_SLIPPAGE_BPS
+            && ($model['spread_model'] ?? null) === FakeFillCostModel::SPREAD_MODEL_VERSION;
     }
 }

--- a/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
+++ b/trading-app/src/Trading/Pnl/FillCostLedgerIngestionService.php
@@ -50,6 +50,20 @@ final readonly class FillCostLedgerIngestionService
         $feeCurrency = $this->string($fill->feeCurrency);
         $feeCurrency = $feeCurrency !== null ? strtoupper($feeCurrency) : null;
         $feeUsdt = $this->feeUsdt($fill, $metadata, $payload, $qualityFlags);
+        $spreadCostUsdt = $this->nonNegativeCostUsdt(
+            'spread_cost_usdt',
+            'spread_cost_invalid',
+            $metadata,
+            $payload,
+            $qualityFlags,
+        );
+        $slippageCostUsdt = $this->nonNegativeCostUsdt(
+            'slippage_cost_usdt',
+            'slippage_cost_invalid',
+            $metadata,
+            $payload,
+            $qualityFlags,
+        );
         $source = $this->source($metadata, $payload);
         $sourceVersion = $this->string($metadata['source_version'] ?? $payload['source_version'] ?? null)
             ?? $this->string($metadata['pnl_source'] ?? $payload['pnl_source'] ?? null)
@@ -77,8 +91,8 @@ final readonly class FillCostLedgerIngestionService
             'fee_currency' => $feeCurrency,
             'fee_usdt' => $feeUsdt,
             'funding_usdt' => null,
-            'spread_cost_usdt' => null,
-            'slippage_cost_usdt' => null,
+            'spread_cost_usdt' => $spreadCostUsdt,
+            'slippage_cost_usdt' => $slippageCostUsdt,
             'borrow_cost_usdt' => null,
             'liquidation_fee_usdt' => null,
             'occurred_at' => $fill->filledAt->format(\DateTimeInterface::ATOM),
@@ -319,6 +333,43 @@ final readonly class FillCostLedgerIngestionService
         $qualityFlags[] = 'fee_conversion_missing';
 
         return null;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     * @param array<string,mixed> $payload
+     * @param list<string> $qualityFlags
+     */
+    private function nonNegativeCostUsdt(
+        string $key,
+        string $invalidFlag,
+        array $metadata,
+        array $payload,
+        array &$qualityFlags,
+    ): ?string {
+        if (array_key_exists($key, $metadata)) {
+            $value = $metadata[$key];
+        } elseif (array_key_exists($key, $payload)) {
+            $value = $payload[$key];
+        } else {
+            return null;
+        }
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+        if (!is_numeric($value)) {
+            $qualityFlags[] = $invalidFlag;
+            return null;
+        }
+
+        $cost = (float) $value;
+        if (!\is_finite($cost) || $cost < 0.0) {
+            $qualityFlags[] = $invalidFlag;
+            return null;
+        }
+
+        return $this->decimal($cost);
     }
 
     /**

--- a/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
+++ b/trading-app/tests/Command/ExchangeRuntimeCheckCommandTest.php
@@ -107,13 +107,13 @@ final class ExchangeRuntimeCheckCommandTest extends TestCase
         self::assertStringContainsString('Fake/Paper mode: fake', $output);
         self::assertStringContainsString('Readiness level: not_ready', $output);
         self::assertStringContainsString('Readiness blocking errors: public_connectivity_unavailable', $output);
-        self::assertStringContainsString('Readiness warnings: fake_paper_market_source_not_configured, fake_paper_slippage_model_zero, fake_paper_persistence_not_configured', $output);
+        self::assertStringContainsString('Readiness warnings: fake_paper_market_source_not_configured, fake_paper_persistence_not_configured', $output);
         self::assertStringContainsString('State persistence: not_configured', $output);
         self::assertStringContainsString('State writable: not_required', $output);
         self::assertStringContainsString('State recovery: not_required', $output);
         self::assertStringContainsString('Clock: ready', $output);
         self::assertStringContainsString('Fee model: ready', $output);
-        self::assertStringContainsString('Slippage model: explicit_zero', $output);
+        self::assertStringContainsString('Slippage model: ready', $output);
         self::assertStringContainsString('Metadata fixtures: ready', $output);
         self::assertStringContainsString('Precision model: ready', $output);
         self::assertStringContainsString('Schedule ready: no', $output);

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
@@ -838,12 +838,30 @@ final class FakeExchangeAdapterTest extends TestCase
         $exitPrice = (float) ($filledEvents[1]->payload['fill_price'] ?? 0.0);
         $expectedEntryFee = round($entryPrice * 2.0 * 0.0005, 12);
         $expectedExitFee = round($exitPrice * 2.0 * 0.0005, 12);
+        $expectedEntrySlippage = round($entryPrice * 2.0 * 0.0005, 12);
+        $expectedExitSlippage = round($exitPrice * 2.0 * 0.0005, 12);
         $expectedGross = round(($exitPrice - $entryPrice) * 2.0, 12);
+        $expectedRecorded = round(
+            $expectedGross
+            - $expectedEntryFee
+            - $expectedExitFee
+            - $expectedEntrySlippage
+            - $expectedExitSlippage,
+            12,
+        );
 
         self::assertEqualsWithDelta($expectedExitFee, $filledEvents[1]->payload['fill_fee'] ?? null, 0.000001);
+        self::assertEqualsWithDelta($expectedEntrySlippage, $filledEvents[0]->payload['slippage_cost_usdt'] ?? null, 0.000001);
+        self::assertEqualsWithDelta($expectedExitSlippage, $filledEvents[1]->payload['slippage_cost_usdt'] ?? null, 0.000001);
         self::assertEqualsWithDelta($expectedGross, $closedEvents[0]->payload['gross_realized_pnl_usdt'] ?? null, 0.000001);
         self::assertEqualsWithDelta($expectedEntryFee, $closedEvents[0]->payload['entry_fee_usdt'] ?? null, 0.000001);
         self::assertEqualsWithDelta($expectedExitFee, $closedEvents[0]->payload['exit_fee_usdt'] ?? null, 0.000001);
+        self::assertEqualsWithDelta(
+            $expectedEntrySlippage + $expectedExitSlippage,
+            $closedEvents[0]->payload['slippage_cost_usdt'] ?? null,
+            0.000001,
+        );
+        self::assertEqualsWithDelta($expectedRecorded, $closedEvents[0]->payload['recorded_pnl_usdt'] ?? null, 0.000001);
     }
 
     public function testLegacyOpenOrderWithoutContractSizeMetadataFallsBackToOne(): void
@@ -1000,6 +1018,7 @@ final class FakeExchangeAdapterTest extends TestCase
 
     public function testMarketOrderFillsImmediately(): void
     {
+        $expectedAsk = $this->adapter->getOrderBookTop('BTCUSDT')->ask;
         $result = $this->adapter->placeOrder($this->request(
             orderType: ExchangeOrderType::MARKET,
             price: null,
@@ -1010,6 +1029,19 @@ final class FakeExchangeAdapterTest extends TestCase
         self::assertSame(ExchangeOrderStatus::FILLED, $result->status);
         self::assertSame(1.0, $result->order->filledQuantity);
         self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+
+        $events = $this->scenario->events('order.filled');
+        self::assertCount(1, $events);
+        self::assertSame($expectedAsk, $events[0]->payload['fill_price'] ?? null);
+        self::assertSame('taker', $events[0]->payload['liquidity_role'] ?? null);
+        self::assertSame(0.0, $events[0]->payload['spread_cost_usdt'] ?? null);
+        self::assertEqualsWithDelta(
+            round($expectedAsk * 0.0005, 12),
+            $events[0]->payload['slippage_cost_usdt'] ?? null,
+            0.000000000001,
+        );
+        self::assertSame('fixed_adverse_slippage_bps_v1', $events[0]->payload['cost_model_version'] ?? null);
+        self::assertSame('top_of_book_embedded_spread_v1', $events[0]->payload['spread_model_version'] ?? null);
     }
 
     public function testFakeFillsExposeDeterministicUsdtFeesForCertificationFixtures(): void
@@ -1053,11 +1085,39 @@ final class FakeExchangeAdapterTest extends TestCase
         self::assertSame(ExchangeOrderStatus::PARTIALLY_FILLED, $partial->status);
         self::assertEqualsWithDelta(0.4, $partial->filledQuantity, 0.000001);
         self::assertEqualsWithDelta(0.6, $partial->remainingQuantity, 0.000001);
+        $partialEvents = $this->scenario->events('order.partially_filled');
+        self::assertCount(1, $partialEvents);
+        self::assertSame('maker', $partialEvents[0]->payload['liquidity_role'] ?? null);
+        self::assertSame(0.0, $partialEvents[0]->payload['slippage_cost_usdt'] ?? null);
 
         $complete = $this->scenario->fillOrder((string) $placed->exchangeOrderId);
         self::assertSame(ExchangeOrderStatus::FILLED, $complete->status);
         self::assertEqualsWithDelta(1.0, $complete->filledQuantity, 0.000001);
         self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
+    }
+
+    public function testPartialTakerFillsAggregateSlippagePerFill(): void
+    {
+        $placed = $this->adapter->placeOrder($this->request(price: 24950.0, postOnly: false));
+        self::assertNotNull($placed->exchangeOrderId);
+
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+        $position = $this->adapter->getOpenPositions('BTCUSDT')[0];
+        self::assertEqualsWithDelta(4.99, $position->metadata['entry_slippage_cost_usdt'] ?? null, 0.000000000001);
+
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.6, 24960.0);
+        $position = $this->adapter->getOpenPositions('BTCUSDT')[0];
+        self::assertEqualsWithDelta(12.478, $position->metadata['entry_slippage_cost_usdt'] ?? null, 0.000000000001);
+
+        $fillEvents = array_merge(
+            $this->scenario->events('order.partially_filled'),
+            $this->scenario->events('order.filled'),
+        );
+        self::assertCount(2, $fillEvents);
+        self::assertSame(['taker', 'taker'], array_map(
+            static fn ($event): mixed => $event->payload['liquidity_role'] ?? null,
+            $fillEvents,
+        ));
     }
 
     public function testAcceptedAttachedProtectionCreatesReduceOnlyStopOrder(): void

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
@@ -1060,6 +1060,18 @@ final class FakeExchangeAdapterTest extends TestCase
         self::assertGreaterThan(0.0, $fills[0]->fee);
         self::assertSame('fake_paper_fill_ledger_v1', $fills[0]->metadata['pnl_source'] ?? null);
         self::assertSame('complete', $fills[0]->metadata['cost_completeness'] ?? null);
+        self::assertSame('taker', $fills[0]->metadata['liquidity_role'] ?? null);
+        self::assertSame(0.0, $fills[0]->metadata['spread_cost_usdt'] ?? null);
+        self::assertEqualsWithDelta(
+            $fills[0]->quantity * $fills[0]->price * 5.0 / 10_000.0,
+            $fills[0]->metadata['slippage_cost_usdt'] ?? null,
+            0.000000000001,
+        );
+        self::assertSame('fixed_adverse_slippage_bps_v1', $fills[0]->metadata['cost_model_version'] ?? null);
+        self::assertSame(
+            'top_of_book_embedded_spread_v1',
+            $fills[0]->metadata['spread_model_version'] ?? null,
+        );
     }
 
     public function testNonCrossingIocLimitExpiresWithoutResting(): void

--- a/trading-app/tests/Exchange/Event/FakeExchangeEventNormalizerTest.php
+++ b/trading-app/tests/Exchange/Event/FakeExchangeEventNormalizerTest.php
@@ -71,10 +71,50 @@ final class FakeExchangeEventNormalizerTest extends TestCase
         self::assertSame('USDT', $normalized[1]->fill()->feeCurrency);
         self::assertNotNull($normalized[1]->fill()->fee);
         self::assertSame('fake_paper_fill_ledger_v1', $normalized[1]->fill()->metadata['pnl_source'] ?? null);
+        self::assertSame('maker', $normalized[1]->fill()->metadata['liquidity_role'] ?? null);
+        self::assertSame(0.0, $normalized[1]->fill()->metadata['spread_cost_usdt'] ?? null);
+        self::assertSame(0.0, $normalized[1]->fill()->metadata['slippage_cost_usdt'] ?? null);
+        self::assertSame(
+            'fixed_adverse_slippage_bps_v1',
+            $normalized[1]->fill()->metadata['cost_model_version'] ?? null,
+        );
+        self::assertSame(
+            'top_of_book_embedded_spread_v1',
+            $normalized[1]->fill()->metadata['spread_model_version'] ?? null,
+        );
         self::assertSame('BTCUSDT', $normalized[1]->symbol());
         self::assertSame(
             $normalized[1]->fill()->fillId,
             $this->scenarioAdapter()->getFillsSnapshot('BTCUSDT')[0]->fillId,
+        );
+    }
+
+    public function testNormalizesTakerFillWithExplicitSlippageCosts(): void
+    {
+        $this->scenarioAdapter()->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            quantity: 2.0,
+            postOnly: false,
+        ));
+
+        $events = $this->scenario->events('order.filled');
+        $normalized = $this->normalizer->normalize($events[0]);
+
+        self::assertCount(2, $normalized);
+        self::assertInstanceOf(ExchangeFillReceived::class, $normalized[1]);
+        $fill = $normalized[1]->fill();
+        self::assertSame('taker', $fill->metadata['liquidity_role'] ?? null);
+        self::assertSame(0.0, $fill->metadata['spread_cost_usdt'] ?? null);
+        self::assertEqualsWithDelta(
+            $fill->quantity * $fill->price * 5.0 / 10_000.0,
+            $fill->metadata['slippage_cost_usdt'] ?? null,
+            0.000000000001,
+        );
+        self::assertSame('fixed_adverse_slippage_bps_v1', $fill->metadata['cost_model_version'] ?? null);
+        self::assertSame(
+            'top_of_book_embedded_spread_v1',
+            $fill->metadata['spread_model_version'] ?? null,
         );
     }
 

--- a/trading-app/tests/Exchange/Fake/FakeFillCostModelTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeFillCostModelTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Fake;
+
+use App\Exchange\Fake\FakeFillCost;
+use App\Exchange\Fake\FakeFillCostModel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FakeFillCostModel::class)]
+#[CoversClass(FakeFillCost::class)]
+final class FakeFillCostModelTest extends TestCase
+{
+    public function testPostOnlyFillHasExplicitMakerZeroSlippage(): void
+    {
+        $cost = (new FakeFillCostModel())->forFill(
+            quantity: 2.0,
+            price: 100.0,
+            contractSize: 3.0,
+            postOnly: true,
+        );
+
+        self::assertSame('maker', $cost->liquidityRole);
+        self::assertSame(0.0, $cost->spreadCostUsdt);
+        self::assertSame(0.0, $cost->slippageCostUsdt);
+        self::assertSame('fixed_adverse_slippage_bps_v1', $cost->modelVersion);
+        self::assertSame('top_of_book_embedded_spread_v1', $cost->spreadModelVersion);
+    }
+
+    public function testNonPostOnlyFillHasFiveBpsTakerSlippageScaledByContractSize(): void
+    {
+        $cost = (new FakeFillCostModel())->forFill(
+            quantity: 2.0,
+            price: 100.0,
+            contractSize: 3.0,
+            postOnly: false,
+        );
+
+        self::assertSame('taker', $cost->liquidityRole);
+        self::assertSame(0.0, $cost->spreadCostUsdt);
+        self::assertSame(0.3, $cost->slippageCostUsdt);
+        self::assertSame(5.0, FakeFillCostModel::TAKER_SLIPPAGE_BPS);
+    }
+
+    /**
+     * @return iterable<string,array{float,float,float}>
+     */
+    public static function invalidInputProvider(): iterable
+    {
+        yield 'zero quantity' => [0.0, 100.0, 1.0];
+        yield 'negative quantity' => [-1.0, 100.0, 1.0];
+        yield 'non-finite quantity' => [NAN, 100.0, 1.0];
+        yield 'zero price' => [1.0, 0.0, 1.0];
+        yield 'negative price' => [1.0, -100.0, 1.0];
+        yield 'non-finite price' => [1.0, INF, 1.0];
+        yield 'zero contract size' => [1.0, 100.0, 0.0];
+        yield 'negative contract size' => [1.0, 100.0, -1.0];
+        yield 'non-finite contract size' => [1.0, 100.0, INF];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('invalidInputProvider')]
+    public function testRejectsInvalidFillInputs(float $quantity, float $price, float $contractSize): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new FakeFillCostModel())->forFill(
+            quantity: $quantity,
+            price: $price,
+            contractSize: $contractSize,
+            postOnly: false,
+        );
+    }
+}

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
@@ -15,7 +15,7 @@ final class FakePaperGoldenScenarioCatalogTest extends TestCase
         'limit_unfilled_then_expired' => ['executable', []],
         'partial_fill_then_cancel' => ['executable', []],
         'fallback_taker' => ['unsupported', ['fallback_taker_not_implemented']],
-        'market_with_slippage' => ['partial', ['slippage_model_zero']],
+        'market_with_slippage' => ['executable', []],
         'insufficient_balance' => ['executable', []],
         'precision_reject' => ['executable', []],
         'leverage_cap_reject' => ['executable', []],

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
@@ -33,6 +33,16 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             'protection_quantity' => 0.4,
             'remaining_quantity' => 0.6,
         ],
+        'market_with_slippage' => [
+            'cost_model_version' => 'fixed_adverse_slippage_bps_v1',
+            'execution_price' => 25000.5,
+            'liquidity_role' => 'taker',
+            'notional_usdt' => 25000.5,
+            'slippage_bps' => 5.0,
+            'slippage_cost_usdt' => 12.50025,
+            'spread_cost_usdt' => 0.0,
+            'spread_model_version' => 'top_of_book_embedded_spread_v1',
+        ],
         'insufficient_balance' => [
             'accepted' => false,
             'available_margin_unchanged' => true,
@@ -153,7 +163,7 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             ),
         ));
 
-        self::assertCount(12, $catalogKeys);
+        self::assertCount(13, $catalogKeys);
         self::assertSame($catalogKeys, FakePaperGoldenScenarioRunner::keys());
     }
 

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
@@ -35,6 +35,7 @@ final class FakePaperGoldenScenarioRunner
         'limit_maker_full_fill',
         'limit_unfilled_then_expired',
         'partial_fill_then_cancel',
+        'market_with_slippage',
         'insufficient_balance',
         'precision_reject',
         'leverage_cap_reject',
@@ -65,6 +66,7 @@ final class FakePaperGoldenScenarioRunner
             'limit_maker_full_fill' => $this->limitMakerFullFill(),
             'limit_unfilled_then_expired' => $this->limitUnfilledThenExpired(),
             'partial_fill_then_cancel' => $this->partialFillThenCancel(),
+            'market_with_slippage' => $this->marketWithSlippage(),
             'insufficient_balance' => $this->insufficientBalance(),
             'precision_reject' => $this->precisionReject(),
             'leverage_cap_reject' => $this->leverageCapReject(),
@@ -160,6 +162,38 @@ final class FakePaperGoldenScenarioRunner
             'position_size' => $position?->size,
             'protection_quantity' => $protection?->quantity,
             'remaining_quantity' => $cancelled?->remainingQuantity,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function marketWithSlippage(): array
+    {
+        [, $adapter] = $this->exchange();
+        $adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'golden-market-with-slippage',
+        ));
+        $fill = $adapter->getFillsSnapshot('BTCUSDT')[0] ?? null;
+        if ($fill === null) {
+            throw new \LogicException('The market-with-slippage fixture did not produce a fill.');
+        }
+
+        $notional = $fill->quantity * $fill->price;
+        $slippageCost = $fill->metadata['slippage_cost_usdt'] ?? null;
+        if (!is_numeric($slippageCost) || $notional <= 0.0) {
+            throw new \LogicException('The market-with-slippage fixture did not expose a valid cost.');
+        }
+
+        return [
+            'cost_model_version' => $fill->metadata['cost_model_version'] ?? null,
+            'execution_price' => round($fill->price, 6),
+            'liquidity_role' => $fill->metadata['liquidity_role'] ?? null,
+            'notional_usdt' => round($notional, 6),
+            'slippage_bps' => round(((float) $slippageCost / $notional) * 10_000.0, 6),
+            'slippage_cost_usdt' => round((float) $slippageCost, 6),
+            'spread_cost_usdt' => $fill->metadata['spread_cost_usdt'] ?? null,
+            'spread_model_version' => $fill->metadata['spread_model_version'] ?? null,
         ];
     }
 

--- a/trading-app/tests/Exchange/Readiness/FakeRuntimeCheckTest.php
+++ b/trading-app/tests/Exchange/Readiness/FakeRuntimeCheckTest.php
@@ -44,7 +44,8 @@ final class FakeRuntimeCheckTest extends TestCase
         self::assertContains('public_connectivity_unavailable', $report->blockingErrors);
         self::assertContains('fake_paper_market_source_not_configured', $report->warnings);
         self::assertContains('fake_paper_persistence_not_configured', $report->warnings);
-        self::assertContains('fake_paper_slippage_model_zero', $report->warnings);
+        self::assertNotContains('fake_paper_slippage_model_zero', $report->warnings);
+        self::assertNotContains('fake_paper_slippage_model_not_ready', $report->blockingErrors);
     }
 
     public function testRuntimeMetadataUsesCanonicalCatalogVersions(): void
@@ -57,6 +58,28 @@ final class FakeRuntimeCheckTest extends TestCase
 
         self::assertSame('fake-instrument-catalog-v1', $metadata['metadata_fixture_version']);
         self::assertSame('brick-math-exact-multiple-v1', $metadata['precision_model_version']);
+        self::assertSame('fixed_adverse_slippage_bps_v1', $metadata['slippage_model']);
+        self::assertSame(5.0, $metadata['slippage_bps']);
+        self::assertSame('top_of_book_embedded_spread_v1', $metadata['spread_model']);
+    }
+
+    public function testSlippageRuntimeModelValidationFailsClosed(): void
+    {
+        $valid = [
+            'slippage_model' => 'fixed_adverse_slippage_bps_v1',
+            'slippage_bps' => 5.0,
+            'spread_model' => 'top_of_book_embedded_spread_v1',
+        ];
+
+        self::assertTrue(FakeRuntimeCheck::slippageModelReady($valid));
+        self::assertFalse(FakeRuntimeCheck::slippageModelReady(array_replace($valid, ['slippage_bps' => 0.0])));
+        self::assertFalse(FakeRuntimeCheck::slippageModelReady(array_replace($valid, ['slippage_bps' => -5.0])));
+        self::assertFalse(FakeRuntimeCheck::slippageModelReady(array_replace($valid, ['slippage_bps' => 'invalid'])));
+        self::assertFalse(FakeRuntimeCheck::slippageModelReady(array_replace($valid, ['slippage_model' => 'unsupported'])));
+        self::assertFalse(FakeRuntimeCheck::slippageModelReady(array_replace($valid, ['spread_model' => 'unsupported'])));
+        self::assertFalse(FakeRuntimeCheck::slippageModelReady([
+            'slippage_model' => 'fixed_adverse_slippage_bps_v1',
+        ]));
     }
 
     public function testPersistentPaperProbesWritableRecoveryWithoutTouchingActiveState(): void

--- a/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
+++ b/trading-app/tests/Trading/Pnl/FillCostLedgerIngestionServiceTest.php
@@ -93,7 +93,14 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
             price: 100.0,
             fee: 0.125,
             feeCurrency: 'USDT',
-            metadata: ['liquidity_role' => 'maker', 'source' => 'fake_exchange_ws'],
+            metadata: [
+                'liquidity_role' => 'maker',
+                'source' => 'fake_exchange_ws',
+                'spread_cost_usdt' => 0.0,
+                'slippage_cost_usdt' => 0.0125,
+                'cost_model_version' => 'fixed_adverse_slippage_bps_v1',
+                'spread_model_version' => 'top_of_book_embedded_spread_v1',
+            ],
         )));
 
         self::assertTrue($result->inserted);
@@ -115,6 +122,8 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
         self::assertSame('0.125000000000', $entry->getFeeAmount());
         self::assertSame('USDT', $entry->getFeeCurrency());
         self::assertSame('0.125000000000', $entry->getFeeUsdt());
+        self::assertSame('0.000000000000', $entry->getSpreadCostUsdt());
+        self::assertSame('0.012500000000', $entry->getSlippageCostUsdt());
         self::assertSame([], $entry->getQualityFlags());
         self::assertSame([
             'source' => 'fake_exchange_ws',
@@ -280,6 +289,48 @@ final class FillCostLedgerIngestionServiceTest extends KernelTestCase
             fillId: 'fake-fill-conflict',
             price: 101.0,
         )));
+    }
+
+    public function testSameExchangeFillIdWithDifferentSlippageIsRejectedAsConflict(): void
+    {
+        $this->persistLineage('itd-ledger-cost-conflict', 'cid-cost-conflict', 'EX-COST-CONFLICT', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-COST-CONFLICT',
+            clientOrderId: 'cid-cost-conflict',
+            fillId: 'fake-fill-cost-conflict',
+            metadata: ['slippage_cost_usdt' => 0.05],
+        )));
+
+        $this->expectException(FillCostLedgerIngestionConflict::class);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-COST-CONFLICT',
+            clientOrderId: 'cid-cost-conflict',
+            fillId: 'fake-fill-cost-conflict',
+            metadata: ['slippage_cost_usdt' => 0.06],
+        )));
+    }
+
+    public function testInvalidExplicitCostsRemainNullAndAreFlagged(): void
+    {
+        $this->persistLineage('itd-ledger-invalid-costs', 'cid-invalid-costs', 'EX-INVALID-COSTS', null);
+
+        $this->service->ingestExchangeFill(new ExchangeFillReceived($this->fill(
+            exchangeOrderId: 'EX-INVALID-COSTS',
+            clientOrderId: 'cid-invalid-costs',
+            fillId: 'fake-fill-invalid-costs',
+            metadata: [
+                'spread_cost_usdt' => -0.01,
+                'slippage_cost_usdt' => 'not-a-number',
+            ],
+        )));
+
+        $entry = $this->ledger->findByInternalTradeId('itd-ledger-invalid-costs')[0];
+        self::assertNull($entry->getSpreadCostUsdt());
+        self::assertNull($entry->getSlippageCostUsdt());
+        self::assertContains('spread_cost_invalid', $entry->getQualityFlags());
+        self::assertContains('slippage_cost_invalid', $entry->getQualityFlags());
     }
 
     public function testVenueScopedExchangeFillIdsCanBeReusedAcrossExchanges(): void

--- a/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
+++ b/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
@@ -38,13 +38,13 @@
       "status": "unsupported"
     },
     {
-      "evidence": ["tests/Exchange/Readiness/FakeRuntimeCheckTest.php::testInMemoryFakeReportsMissingPaperModelsWithoutClaimingReadiness"],
-      "gap_codes": ["slippage_model_zero"],
+      "evidence": ["tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php::testExecutableScenarioIsDeterministicAndMatchesGoldenFacts"],
+      "gap_codes": [],
       "id": 5,
       "name": "market_with_slippage",
       "requirement": "A market fill applies and reports a deterministic non-zero slippage model.",
-      "runner": null,
-      "status": "partial"
+      "runner": "market_with_slippage",
+      "status": "executable"
     },
     {
       "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testRejectsQuantizedEntryWhenDerivedAvailableBalanceIsInsufficient"],


### PR DESCRIPTION
Part of #196
Related to #190
Related to #278
Related to #279

## Scope
- add a versioned 5 bps adverse taker slippage model with explicit maker zero
- preserve top-of-book execution prices and report embedded spread separately as zero
- propagate explicit costs through Fake events, REST/WS fills, position close evidence, and the persistent ledger
- fail closed in runtime readiness when model metadata is missing or malformed
- promote golden scenario 5 (`market_with_slippage`) to executable
- update Fake/Paper and certified PnL documentation

## Verification
- `php vendor/bin/phpunit tests/Exchange/Fake tests/Exchange/Adapter/FakeExchangeAdapterTest.php tests/Exchange/Event/FakeExchangeEventNormalizerTest.php tests/Exchange/Readiness/FakeRuntimeCheckTest.php tests/Trading/Pnl` (239 tests, 1325 assertions)
- `php vendor/bin/phpunit tests/Exchange tests/Provider/Fake tests/TradeEntry/Execution` (1061 tests, 4516 assertions, 30 skipped)
- PHPStan on all touched PHP files
- `php -d error_reporting=8191 bin/console lint:container --no-debug`
- `php -d error_reporting=8191 bin/console lint:yaml config`
- `python3 -m mkdocs build --strict`
- `git diff --check`

No exchange, demo/testnet, or mainnet write path is added.