### PR TITLE
feat(fake): add end-of-zone taker fallback

### DIFF
--- a/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
+++ b/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
@@ -1,0 +1,1103 @@
+# TradingV3 - Prompts canoniques restants pour Fake/Paper, OKX Demo et Hyperliquid testnet
+
+> Objectif final : terminer le filet de sécurité Fake/Paper, produire des preuves
+> représentatives, puis autoriser uniquement des scénarios contrôlés sur OKX Demo
+> et Hyperliquid testnet.
+>
+> Aucun prompt de ce document n'autorise une écriture mainnet.
+
+<!-- CODEX_ORCHESTRATION_STATE_START -->
+| Ordre | Prompt | Statut | Branche | PR | HEAD validé | Profil final | CI | Revue Codex | Terminé UTC |
+|---:|---|---|---|---:|---|---|---|---|---|
+| 1 | #196 — Fallback taker de fin de zone | done | issue/196-fake-fallback-taker-v1 | #282 | 4186abf243a035af16f7672bc493c225d31112d3 | worker_critical → review_fix | verte | favorable sur 4186abf243 | 2026-07-16T14:18:05Z |
+| 2 | #196 — TP1 puis trailing stop | pending | — | — | — | — | — | — | — |
+| 3 | #196 — Injection out-of-order | pending | — | — | — | — | — | — | — |
+| 4 | #196 — Funding positif/négatif | pending | — | — | — | — | — | — | — |
+| 5 | #196 — Garde One-Way | pending | — | — | — | — | — | — | — |
+| 6 | #196 — Recette Fake multi-profils | pending | — | — | — | — | — | — | — |
+| 7 | #196 — Daily loss cap | pending | — | — | — | — | — | — | — |
+| 8 | #196 — Liquidation guard/model | pending | — | — | — | — | — | — | — |
+| 9 | #196 — Audit final Fake/Paper | pending | — | — | — | — | — | — | — |
+| 10 | #195 — Inventaire statique Bitmart | pending | — | — | — | — | — | — | — |
+| 11 | #195 — Vérification runtime Bitmart | pending | — | — | — | — | — | — | — |
+| 12 | #195 — Matrice de remplacement | pending | — | — | — | — | — | — | — |
+| 13 | #132 — Baseline PnL représentative | pending | — | — | — | — | — | — | — |
+| 14 | #188 — Preuve R1-R16 représentative | pending | — | — | — | — | — | — | — |
+| 15 | DEMO-005 — Réévaluation | pending | — | — | — | — | — | — | — |
+| 16 | OKX-010 — Activation OKX Demo | pending | — | — | — | — | — | — | — |
+| 17 | DEMO-006 — Rapport final | pending | — | — | — | — | — | — | — |
+<!-- CODEX_ORCHESTRATION_STATE_END -->
+
+## 0. Etat actuel au 16 juillet 2026
+
+| Domaine | Etat | Prochaine preuve requise |
+|---|---|---|
+| Fake/Paper #196 | 14 scénarios golden exécutables sur 20 | Implémenter les 6 gaps restants, le daily loss cap et la liquidation, puis auditer `20/20`. |
+| Inventaire Bitmart #195 | Issue ouverte, inventaire global incomplet | Inventaire statique, vérification runtime dry-run, matrice de remplacement. |
+| Baseline PnL #132 | Outillage prêt, dataset local vide | Extraire des lignes certifiées `regular`, `scalper`, `scalper_micro` depuis une base représentative. |
+| Recette orchestrateur #188 | Outillée, scénarios critiques déjà exercés, preuve représentative incomplète | Rejouer R1-R16 sur un vrai jeu et consolider les preuves automatiques/guidées. |
+| DEMO-005 | Rapport mergé avec décision `blocked` | Réévaluer après les preuves #196/#188/#132 et les runtime-checks exchange. |
+| Hyperliquid HL-012 | Code contrôlé mergé, désactivé par défaut | Exécution testnet réelle seulement après décision autorisant la fenêtre. |
+| OKX-010 | Prérequis read-only/observabilité mergés | Activation mutative finale bloquée par DEMO-005. |
+| Kill switch | Actif | Reste actif hors fenêtre demo/testnet explicitement approuvée. |
+
+Gaps golden exacts restant dans #196 :
+
+1. `fallback_taker_not_implemented`
+2. `trailing_stop_not_implemented`
+3. `out_of_order_event_injection_not_implemented`
+4. `funding_model_not_implemented`
+5. `one_way_conflict_guard_not_implemented`
+6. `multi_profile_fake_recipe_not_consolidated`
+
+Le fichier est ordonné : prendre le premier prompt actif dont toutes les
+préconditions sont satisfaites. Les numéros de PR peuvent être décalés ; toujours
+vérifier GitHub avant de créer une branche ou de citer une PR.
+
+---
+
+## 1. Terminologie obligatoire
+
+| Terme | Sens |
+|---|---|
+| `local_dry_run` | Simulation locale, aucun ordre exchange. |
+| `demo` | Environnement OKX Demo avec argent simulé. |
+| `testnet` | Environnement Hyperliquid testnet avec fonds fictifs. |
+| `mainnet` | Interdit en écriture. |
+| `dry_run=true` | Aucun ordre envoyé à l'exchange. |
+| `dry_run=false + demo/testnet` | Mutatif seulement si tous les gates passent. |
+| `dry_run=false + mainnet` | Toujours interdit. |
+| `mainnet_write_enabled` | Toujours `false`. |
+| `demo_testnet_write_enabled` | `false` par défaut ; fenêtre explicite uniquement. |
+| `OKX_DEMO_*` | Secrets dédiés à OKX Demo, jamais mainnet. |
+| `x-simulated-trading: 1` | Header obligatoire pour toute écriture OKX Demo. |
+| `HYPERLIQUID_TESTNET_*` | Secrets dédiés au testnet Hyperliquid. |
+| `agent/API wallet` | Wallet de signature testnet dédié au bot. |
+
+---
+
+## 2. Socle obligatoire pour tous les prompts
+
+Chaque prompt détaillé ci-dessous inclut intégralement les règles de cette
+section. L'agent doit les lire avant toute action.
+
+~~~text
+Tu travailles sur le repo pivox/tradingV3.
+
+Langue de réponse : français.
+
+Objectifs :
+- réduire les mauvais trades ;
+- fiabiliser l'exécution et la donnée ;
+- mesurer l'expectancy nette ;
+- ne jamais optimiser par "plus de trades".
+
+Contraintes absolues :
+- aucun ordre mainnet et aucun fonds réel ;
+- OKX mutatif uniquement en environnement demo ;
+- Hyperliquid mutatif uniquement en environnement testnet ;
+- `mainnet_write_enabled=false` sans exception ;
+- aucune écriture demo/testnet sans activation explicite, whitelist, notional
+  minimal, kill switch, SL ou compensation fail-safe, audit et rollback ;
+- aucun secret mainnet demandé, lu, stocké, loggé ou documenté ;
+- aucun secret dans Git, les logs, fixtures, captures ou documents ;
+- aucun fallback silencieux vers Bitmart ;
+- aucune donnée incomplète transformée en résultat certifié ;
+- aucun changement stratégie, MTF, EntryZone ou fréquence, sauf demande
+  explicite du prompt ;
+- migrations additives et rollback documenté ;
+- une capability absente échoue explicitement ;
+- un coût absent ou inconnu ne devient jamais zéro implicitement.
+
+Avant de commencer :
+1. Lire entièrement les issues et documents référencés.
+2. Vérifier `main` à jour et les dépendances réellement mergées.
+3. Vérifier qu'aucune autre PR d'implémentation du même lot n'est active.
+4. Auditer le code, les tests, les contrats et la documentation existants.
+5. Vérifier les numéros réels des PRs : ils peuvent être décalés.
+6. Préserver tous les changements locaux non liés et tous les fichiers non suivis.
+
+Workflow GitHub :
+1. Une branche et une PR atomiques par prompt.
+2. Tests ciblés puis tests élargis proportionnels au risque.
+3. Après chaque commit, lancer Codex en TTY et vérifier le quota affiché.
+4. Si le quota des cinq heures est épuisé ou proche de 3 %, attendre la
+   réinitialisation avant de poursuivre.
+5. Après ouverture de la PR, attendre environ 90 secondes avant le premier
+   `@codex review` pour éviter une double revue automatique.
+6. Lire tous les threads. Corriger les retours pertinents, répondre dans chaque
+   thread puis le résoudre.
+7. Un retour non applicable reçoit une justification factuelle avant résolution.
+8. Après un push de correction, attendre une éventuelle re-review automatique
+   avant de redemander une seule review.
+9. Ne merger que si la CI est verte, la PR est mergeable, aucun thread n'est
+   ouvert et Codex a réagi avec 👍 ou écrit explicitement qu'il ne trouve pas
+   de problème majeur sur le head courant.
+10. Après merge, mettre `main` local à jour et commenter l'issue avec le livré,
+    les tests, les gaps restants et l'absence d'ordre exchange si applicable.
+11. Ne fermer une issue que si tous ses critères sont objectivement satisfaits.
+
+Compression :
+- dès que le contexte atteint 80 %, compresser en conservant :
+  objectif, branche, PR, commits, fichiers, décisions, tests, état CI, threads,
+  quota, risques, rollback et prochaine action.
+
+Definition of Done commune :
+- tests unitaires ciblés ;
+- tests d'intégration si une frontière runtime/DB/HTTP est touchée ;
+- PHPStan ou Pytest sur tout le périmètre touché ;
+- `php bin/console lint:container --no-debug` si Symfony/DI est touché ;
+- `php bin/console lint:yaml config` si YAML est touché ;
+- tests PostgreSQL sur une base `test` ou suffixée `_test` si le schéma réel
+  intervient ;
+- `python3 -m mkdocs build --strict` si la documentation est touchée ;
+- scan de secrets/redaction ;
+- `git diff --check`.
+~~~
+
+---
+
+## 3. Ordre strict des prompts actifs
+
+| Ordre | Prompt | Dépendance de sortie |
+|---:|---|---|
+| 1 | #196 - Fallback taker de fin de zone | Golden 4 exécutable |
+| 2 | #196 - TP1 puis trailing stop | Golden 13 exécutable |
+| 3 | #196 - Injection out-of-order | Golden 16 exécutable |
+| 4 | #196 - Funding positif/négatif | Golden 18 exécutable |
+| 5 | #196 - Garde One-Way | Golden 19 exécutable |
+| 6 | #196 - Recette Fake multi-profils | Golden 20 exécutable |
+| 7 | #196 - Daily loss cap | Risque journalier Fake fail-closed |
+| 8 | #196 - Liquidation guard/model | Liquidation déterministe et auditée |
+| 9 | #196 - Audit final Fake/Paper | Catalogue golden `20/20` ou gaps explicites |
+| 10 | #195 - Inventaire statique Bitmart | Rapport et diagrammes |
+| 11 | #195 - Vérification runtime Bitmart | Usages réels dry-run confirmés |
+| 12 | #195 - Matrice de remplacement | Issues filles et conditions de retrait |
+| 13 | #132 - Baseline PnL représentative | Métriques certifiées par profil |
+| 14 | #188 - Preuve R1-R16 représentative | Rapport consolidé et rollback |
+| 15 | DEMO-005 - Réévaluation | Décision pré-mutative formelle |
+| 16 | OKX-010 - Activation OKX Demo | Ordre demo minimal protégé |
+| 17 | DEMO-006 - Rapport final | Décision demo/testnet finale |
+
+Ne pas sauter directement à OKX-010 parce que son prompt est disponible. Il
+reste bloqué tant que DEMO-005 ne rend pas
+`ready_for_demo_testnet_trading_attempt`.
+
+---
+
+# Prompts détaillés
+
+## Prompt 1 - #196 Fallback taker de fin de zone
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+Références : golden scenario 4 `fallback_taker`, PRs #278 à #281.
+
+Objectif :
+Implémenter dans Fake/Paper un fallback taker déterministe lorsqu'un ordre maker
+arrive en fin de zone ou expire selon une politique explicitement configurée.
+
+Préconditions :
+- PR #281 mergée dans `main` ;
+- aucun autre lot #196 actif sur le fallback taker ;
+- catalogue golden toujours à 14/20 au début du lot.
+
+Comportement attendu :
+- l'ordre maker initial reste visible avec son fill partiel éventuel ;
+- le reliquat, jamais la quantité initiale complète, peut être converti en ordre
+  MARKET taker ;
+- l'ordre fallback possède un `client_order_id` déterministe lié au parent ;
+- le fallback suit les validations de marge, précision, slippage, coûts,
+  idempotence, lineage et protection ordinaires ;
+- le fallback est interdit si le signal/ordre est annulé, si le reliquat est nul,
+  si la zone est invalide ou si le slippage maximal est dépassé ;
+- un replay ne crée ni second ordre ni second fill ;
+- aucune politique probabiliste dans ce lot.
+
+Livrables :
+- politique/config Fake documentée ;
+- service ou branche de matching réutilisant le chemin normal de submit/fill ;
+- metadata parent/fallback redacted ;
+- golden scenario 4 exécutable ;
+- documentation opérateur et rollback.
+
+Tests minimum :
+- maker non fillé puis fallback complet ;
+- maker partiellement fillé puis fallback du reliquat exact ;
+- reliquat nul ;
+- slippage guard ;
+- marge devenue insuffisante ;
+- replay idempotent ;
+- restart entre maker et fallback ;
+- coûts maker/taker séparés ;
+- protection couvrant la taille réellement ouverte.
+
+GitHub :
+- PR `Part of #196`, références #278, #279, #280, #281 ;
+- après merge, commenter #196 et laisser l'issue ouverte.
+~~~
+
+## Prompt 2 - #196 TP1 puis trailing stop
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+Référence : golden scenario 13 `tp1_then_trailing`.
+
+Objectif :
+Ajouter un trailing stop déterministe Fake/Paper activé uniquement après
+l'exécution de TP1, sans modifier les règles de stratégie ou les profils live.
+
+Préconditions :
+- Prompt 1 mergé ;
+- audit des ordres TAKE_PROFIT, STOP_LOSS et TRIGGER existants ;
+- politique exacte de TP1 déjà portée par les fixtures Fake.
+
+Comportement attendu :
+- TP1 réduit la position de la quantité configurée ;
+- le stop initial du reliquat est annulé/remplacé atomiquement ;
+- le trailing utilise un sommet/plancher favorable persistant et un offset fixe
+  explicite dans la fixture ;
+- long : le stop ne peut que monter ; short : il ne peut que descendre ;
+- un mouvement défavorable sans nouveau sommet/plancher ne desserre jamais le stop ;
+- le déclenchement ferme uniquement le reliquat reduce-only ;
+- fermeture complète : annulation des protections restantes ;
+- restart/replay conservent le watermark et ne doublonnent aucun événement.
+
+Livrables :
+- état trailing versionné et persistant ;
+- transitions lifecycle normalisées ;
+- fixtures long et short ;
+- golden scenario 13 exécutable ;
+- documentation de l'algorithme et rollback.
+
+Tests minimum :
+- TP1 partiel puis création trailing ;
+- progression favorable long/short ;
+- absence de desserrage ;
+- gap au niveau trailing ;
+- duplicate price event ;
+- restart avec trailing actif ;
+- race TP1/SL ;
+- clôture et nettoyage des ordres ;
+- coûts/PnL sans double comptage.
+
+GitHub :
+- PR `Part of #196` ;
+- commenter #196 après merge, sans fermer l'issue.
+~~~
+
+## Prompt 3 - #196 Injection d'événements out-of-order
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+Référence : golden scenario 16 `duplicate_out_of_order_event`.
+
+Objectif :
+Etendre le simulateur private WS Fake pour injecter des événements dupliqués et
+hors ordre, puis prouver une resynchronisation déterministe sans perte.
+
+Préconditions :
+- Prompt 2 mergé ;
+- conserver le protocole de séquence/resync livré par #274 ;
+- auditer normalizer, projector, state store et acquittement.
+
+Comportement attendu :
+- fixture explicite pour permuter une séquence finie d'événements ;
+- un doublon exact est idempotent ;
+- un événement futur crée un gap et impose `resync_required` ;
+- aucun événement après gap n'est projeté avant snapshot/resync ;
+- le snapshot REST simulé reconstruit l'état canonique ;
+- les événements déjà projetés ne sont pas dupliqués ;
+- un payload conflictuel portant la même séquence échoue explicitement ;
+- aucun tri arbitraire par timestamp seul.
+
+Livrables :
+- DSL/fixture out-of-order persistable ;
+- métriques/audit gap, duplicate, conflict et resync ;
+- golden scenario 16 exécutable ;
+- documentation opérateur.
+
+Tests minimum :
+- duplicate exact ;
+- 1,3,2 avec resync ;
+- même séquence, payload conflictuel ;
+- crash avant acquittement ;
+- retry après rollback DB ;
+- batch multi-projections atomique ;
+- restart avec `resync_required`.
+
+GitHub :
+- PR `Part of #196`, référence #274 ;
+- laisser #196 ouverte après merge.
+~~~
+
+## Prompt 4 - #196 Modèle de funding
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+Référence : golden scenario 18 `funding`.
+
+Objectif :
+Ajouter un modèle de funding déterministe, exchange-neutral et persistant pour
+les positions perpétuelles Fake/Paper.
+
+Préconditions :
+- Prompt 3 mergé ;
+- auditer `fill_cost_ledger`, DTOs de funding et conventions de signe/de devise ;
+- utiliser l'horloge contrôlée Fake.
+
+Comportement attendu :
+- événements de funding à échéances explicites, jamais dérivés d'une fenêtre
+  temporelle approximative ;
+- montant basé sur notional de position, taux connu et intervalle connu ;
+- convention : montant positif crédité, montant négatif débité ;
+- long et short couverts ;
+- funding absent reste inconnu, pas zéro ;
+- idempotence exacte par position + échéance + version de modèle ;
+- funding persisté dans le ledger avec lineage `internal_trade_id` si disponible ;
+- funding ne crée pas de fill d'entrée/sortie ;
+- restart et événements en retard ne doublonnent pas le coût.
+
+Livrables :
+- modèle/config versionnés ;
+- projection ledger et événements normalisés ;
+- fixtures funding positif, négatif et absent ;
+- golden scenario 18 exécutable ;
+- documentation conventions monétaires.
+
+Tests minimum :
+- long paie/reçoit ;
+- short paie/reçoit ;
+- position partielle à l'échéance ;
+- aucune position ;
+- duplicate et out-of-order ;
+- devise connue/inconnue ;
+- restart/relecture ;
+- impact PnL net sans double comptage.
+
+GitHub :
+- PR `Part of #196`, `Related to #190` ;
+- laisser #196 ouverte après merge.
+~~~
+
+## Prompt 5 - #196 Garde de conflit One-Way
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+Référence : golden scenario 19 `one_way_conflict`.
+
+Objectif :
+Faire respecter un mode One-Way déterministe par `exchange + market_type +
+symbol`, sans hedge implicite.
+
+Préconditions :
+- Prompt 4 mergé ;
+- auditer les clés de position et la résolution `positionSide`.
+
+Comportement attendu :
+- une position LONG ouverte bloque une nouvelle entrée SHORT non reduce-only ;
+- une position SHORT ouverte bloque une nouvelle entrée LONG non reduce-only ;
+- les ordres reduce-only du côté de sortie restent autorisés ;
+- une position plate permet ensuite le côté opposé ;
+- les ordres actifs incompatibles participent au conflit ;
+- le rejet précède toute réservation de marge ou création d'ordre ;
+- le rejet est structuré, persisté, redacted et idempotent ;
+- aucun netting arbitraire et aucun fallback hedge.
+
+Livrables :
+- garde centrale Fake/Paper ;
+- raison stable de rejet ;
+- golden scenario 19 exécutable ;
+- documentation du mode supporté.
+
+Tests minimum :
+- long puis short rejeté ;
+- short puis long rejeté ;
+- reduce-only autorisé ;
+- ordre opposé après clôture ;
+- ordre actif sans position ;
+- replay du rejet ;
+- restart ;
+- symboles différents indépendants.
+
+GitHub :
+- PR `Part of #196` ;
+- laisser #196 ouverte après merge.
+~~~
+
+## Prompt 6 - #196 Recette Fake multi-profils
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+Références : golden scenario 20 `dry_run_multi_profiles_same_symbol`, #188.
+
+Objectif :
+Consolider une recette reproductible où `regular`, `scalper` et
+`scalper_micro` ciblent le même symbole Fake en dry-run, sans collision ni effet
+exchange.
+
+Préconditions :
+- Prompt 5 mergé ;
+- runner #188 et fixtures multi-profils disponibles ;
+- `dry_run=true` forcé.
+
+Comportement attendu :
+- trois sets distincts avec lineage/config hash propres ;
+- locks orchestration et métier visibles séparément ;
+- aucun set perdu et aucun résultat masqué ;
+- conflits d'activité explicitement `skipped` ou `blocked` selon le contrat ;
+- deux dry-runs sans effet de bord peuvent coexister si le contrat le permet ;
+- aucune écriture vers OKX, Hyperliquid ou Bitmart ;
+- rapport agrégé déterministe et redacted ;
+- replay idempotent.
+
+Livrables :
+- fixture et commande uniques ;
+- rapport JSON/Markdown de recette ;
+- golden scenario 20 exécutable ;
+- documentation des règles de contention.
+
+Tests minimum :
+- trois profils même symbole ;
+- symboles distincts ;
+- set désactivé ;
+- conflit lock ;
+- replay ;
+- exécution parallèle bornée ;
+- preuve d'absence d'appel exchange ;
+- restart du runner.
+
+GitHub :
+- PR `Part of #196`, `Related to #188` ;
+- laisser #196 ouverte après merge.
+~~~
+
+## Prompt 7 - #196 Daily loss cap Fake/Paper
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+
+Objectif :
+Ajouter un daily loss cap déterministe au compte Fake/Paper, appliqué avant toute
+nouvelle augmentation d'exposition.
+
+Préconditions :
+- Prompt 6 mergé ;
+- auditer le PnL réalisé, les coûts certifiés et l'horloge Fake.
+
+Comportement attendu :
+- journée définie en UTC par l'horloge contrôlée ;
+- perte journalière basée uniquement sur PnL réalisé net et coûts connus ;
+- si un coût nécessaire est inconnu, état `not_computable` et blocage fail-closed ;
+- le cap bloque les nouvelles entrées et augmentations ;
+- les réductions, SL, TP et fermetures d'urgence restent autorisés ;
+- cap et consommation persistés/reconstruits depuis les événements, sans compteur
+  mutable non auditable ;
+- nouveau jour UTC réinitialise la fenêtre, pas l'historique ;
+- rejet structuré avec limite, consommation et date, sans secret.
+
+Livrables :
+- policy/config versionnée ;
+- runtime-check exposant ready/not-ready ;
+- audit et métriques ;
+- documentation opérateur et rollback.
+
+Tests minimum :
+- sous le cap ;
+- cap exactement atteint ;
+- cap dépassé par PnL ;
+- cap dépassé par frais/funding ;
+- coût inconnu ;
+- réduction autorisée ;
+- passage minuit UTC ;
+- restart et replay.
+
+GitHub :
+- PR `Part of #196` ;
+- laisser #196 ouverte après merge.
+~~~
+
+## Prompt 8 - #196 Liquidation guard et modèle de liquidation
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+
+Objectif :
+Ajouter pour Fake/Paper un modèle de liquidation v1 déterministe et un guard
+préventif basé sur les metadata instrument déjà disponibles.
+
+Préconditions :
+- Prompt 7 mergé ;
+- `maintenance_margin_rate`, leverage, contract size et balances connus ;
+- horloge et prix mark Fake contrôlables.
+
+Décision de modèle v1 :
+- supporter le calcul de liquidation pour marge isolée ;
+- déclarer explicitement le calcul cross `unsupported` tant qu'un modèle de
+  portefeuille n'est pas livré ;
+- utiliser le mark price, jamais le dernier trade seul ;
+- maintenir un buffer de guard distinct du seuil de liquidation ;
+- tous les montants sont calculés avec les primitives décimales du projet.
+
+Comportement attendu :
+- préflight refuse une entrée dont le prix de liquidation ou le buffer est
+  invalide/inconnu ;
+- mouvement du mark dans la zone guard produit une alerte sans liquider ;
+- franchissement du seuil liquide la position via un événement/fill dédié ;
+- liquidation fee connue séparée des autres coûts ;
+- annulation des protections devenues obsolètes ;
+- lifecycle, ledger, balance et position restent atomiques ;
+- replay/restart ne créent pas une seconde liquidation.
+
+Livrables :
+- calculateur et policy versionnés ;
+- événements/ledger `liquidation` ;
+- runtime-check ;
+- documentation des limites isolé/cross et rollback.
+
+Tests minimum :
+- liquidation long et short ;
+- zone guard sans liquidation ;
+- gap au-delà du seuil ;
+- frais de liquidation ;
+- cross explicitement unsupported ;
+- metadata inconnue ;
+- protections nettoyées ;
+- restart/replay ;
+- coût/PnL net sans double comptage.
+
+GitHub :
+- PR `Part of #196` ;
+- laisser #196 ouverte après merge.
+~~~
+
+## Prompt 9 - #196 Audit final Fake/Paper et golden 20/20
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #196
+Référence : #195.
+
+Objectif :
+Auditer l'ensemble Fake/Paper après les Prompts 1 à 8, rendre les vingt scénarios
+golden réellement exécutables ou documenter factuellement tout critère restant.
+
+Préconditions :
+- Prompts 1 à 8 mergés ;
+- aucune PR #196 active ;
+- `main` et le catalogue golden à jour.
+
+Scope :
+- exécuter deux fois chaque scénario depuis un état frais avec seed/horloge fixes ;
+- vérifier restart, idempotence, coûts, protections, redaction et absence réseau ;
+- vérifier la capability matrix, runtime-check, documentation et rollback ;
+- auditer lifecycle/fills/coûts/protections contre les critères complets de #196 ;
+- produire une matrice critère -> preuve -> statut ;
+- ne pas passer un scénario en executable si sa preuve n'exerce pas réellement le
+  comportement.
+
+Livrables :
+- catalogue golden `20/20` si objectivement atteint ;
+- rapport final Fake/Paper ;
+- liste exacte des divergences et follow-ups ;
+- mise à jour de #196 et entrée pour la matrice #195.
+
+Tests :
+- suites Exchange/Fake/Provider/TradeEntry/TradingCore ;
+- PHPStan tous fichiers touchés ;
+- lint container/YAML ;
+- MkDocs strict ;
+- scan réseau/secrets ;
+- restart sur état fichier ;
+- PostgreSQL si ledger réel.
+
+GitHub :
+- PR `Part of #196`, `Related to #195` ;
+- fermer #196 uniquement si tous les critères sont couverts ;
+- sinon commenter la liste exacte restante et laisser ouverte.
+~~~
+
+## Prompt 10 - #195 Inventaire statique Bitmart
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #195
+Références : #173, #187, #196.
+
+Objectif :
+Inventorier statiquement toutes les dépendances Bitmart sans supprimer ni
+modifier le comportement runtime.
+
+Préconditions :
+- Prompt 9 mergé ou état final #196 explicitement documenté ;
+- lire entièrement #195 et les documents d'architecture.
+
+Scope :
+- registry/DI, REST public/privé, WS public/privé, metadata/précision ;
+- lifecycle ordre/position/SL/TP ;
+- risk/leverage/liquidation ;
+- Temporal, Messenger, CLI, cron et scripts ;
+- persistance, audit, frontend, YAML/env et tests ;
+- recherche texte et usages indirects via interfaces/aliases.
+
+Classification obligatoire :
+`BITMART_CORE_REQUIRED`, `BITMART_GATEWAY_SPECIFIC`,
+`SHARED_BUT_LEAKING_BITMART`, `LEGACY_ACTIVE`, `LEGACY_UNUSED`,
+`DEAD_CODE_CANDIDATE`, `UNKNOWN_REQUIRES_RUNTIME_CHECK`.
+
+Livrables :
+- rapport d'inventaire ;
+- table usage, criticité, consommateurs, remplacement, condition de retrait ;
+- diagrammes PlantUML provider, ordre/position, WS/REST, config, workflows ;
+- liste des fallbacks implicites ;
+- aucun changement runtime.
+
+Tests/validation :
+- recherche `bitmart` expliquée pour chaque usage pertinent ;
+- validation des liens/classes/services ;
+- MkDocs strict ;
+- scan secrets ;
+- diff check.
+
+GitHub :
+- PR documentation `Part of #195`, `Related to #196` ;
+- laisser #195 ouverte.
+~~~
+
+## Prompt 11 - #195 Vérification runtime Bitmart en dry-run
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #195
+Références : Prompt 10, #188.
+
+Objectif :
+Compléter l'inventaire statique par une observation runtime strictement dry-run.
+
+Préconditions :
+- Prompt 10 mergé ;
+- stack Docker/Temporal/Symfony disponible ;
+- aucune credential mainnet nécessaire à la recette ;
+- kill switch actif.
+
+Scope :
+- tracer services instanciés, providers résolus, endpoints/commands appelés ;
+- configs effectivement chargées, tables écrites, topics WS, fallbacks et erreurs ;
+- relier chaque observation à une ligne de l'inventaire statique ;
+- utiliser des traces redacted et des corrélations de run ;
+- aucun submit/cancel exchange réel.
+
+Livrables :
+- rapport runtime et preuves redacted ;
+- écarts static/runtime ;
+- usages dynamiques confirmés ;
+- éléments inconnus classés ;
+- procédure de reproduction et nettoyage.
+
+Tests/validation :
+- preuve que `dry_run=true` est forcé ;
+- preuve qu'aucun transport write n'est appelé ;
+- cohérence des run IDs et timestamps ;
+- vérification des fichiers de preuve sans secret ;
+- MkDocs strict et diff check.
+
+GitHub :
+- PR `Part of #195`, `Related to #188` ;
+- laisser #195 ouverte.
+~~~
+
+## Prompt 12 - #195 Matrice de remplacement et issues filles
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #195
+Références : Prompts 10-11, #196, #197, #198.
+
+Objectif :
+Produire la matrice de remplacement Bitmart vers TradingCore, Fake/Paper, OKX et
+Hyperliquid, puis créer les issues atomiques nécessaires. Ne supprimer aucun code.
+
+Préconditions :
+- Prompts 10 et 11 mergés ;
+- preuves runtime relues ;
+- état final #196 connu.
+
+Matrice minimale :
+contracts, market data, balance, leverage, submit/cancel, order status, fills,
+positions, stop, TP, funding, WS public/private, precision, runtime-check, rate
+limit, idempotence, audit.
+
+Pour chaque capability :
+- implémentation Bitmart ;
+- port TradingCore ;
+- couverture Fake/OKX/Hyperliquid ;
+- divergence ;
+- criticité ;
+- issue bloquante ;
+- condition de migration et rollback.
+
+Livrables :
+- matrice versionnée ;
+- conditions de retrait ;
+- liste ordonnée d'issues filles ;
+- documentation opérateur finale #195 ;
+- aucune suppression et aucun changement de défaut exchange.
+
+Tests/validation :
+- chaque capability critique possède une ligne, une preuve et un statut ;
+- chaque gap bloquant pointe vers une issue existante ou nouvellement créée ;
+- aucun remplacement `complete` si la preuve Fake/OKX/Hyperliquid est partielle ;
+- liens, diagrammes et références validés ;
+- scan secrets, MkDocs strict et diff check.
+
+GitHub :
+- PR documentation `Part of #195` ;
+- fermer #195 uniquement si l'inventaire, la vérification runtime et la matrice
+  couvrent tous les critères ; sinon laisser ouverte avec gaps exacts.
+~~~
+
+## Prompt 13 - #132 Baseline PnL sur données certifiées
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #132
+Références : #190, #188, rapports baseline existants.
+
+Objectif :
+Exécuter l'export déjà livré sur une base contenant des données certifiées
+représentatives, puis quantifier les résultats sans tuning dans cette PR.
+
+Précondition bloquante :
+- une base PostgreSQL représentant réellement `regular`, `scalper` et
+  `scalper_micro` avec lineage, lifecycle et coûts exploitables ;
+- si les lignes certifiées sont absentes, produire `blocked` et ne pas inventer
+  de métriques.
+
+Scope :
+- extraction v2/ledger certifiée, sans rapprochement symbole/temps ;
+- génération Markdown/JSON/CSV redacted ;
+- winrate et intervalle de Wilson ;
+- expectancy nette, profit factor, drawdown, MFE/MAE ;
+- coûts, maker/taker, direction, profil, exchange et causes de pertes ;
+- segmentation explicite des lignes exclues/partielles/inconnues ;
+- Monte Carlo uniquement si l'échantillon est suffisant selon l'outil existant.
+
+Livrables :
+- artefacts datés et reproductibles ;
+- résumé des limites de l'échantillon ;
+- issues filles pour les causes réellement quantifiées ;
+- aucun changement YAML/stratégie dans cette PR.
+
+Tests :
+- exécuter les tests du générateur ;
+- valider JSON/CSV ;
+- PostgreSQL sur copie/read-only ou base dédiée ;
+- scan secrets ;
+- MkDocs strict et diff check.
+
+GitHub :
+- PR `Part of #132`, références #188/#190 ;
+- fermer #132 uniquement si les trois profils sont couverts avec données
+  certifiées et conclusions relues.
+~~~
+
+## Prompt 14 - #188 Preuve R1-R16 sur stack représentative
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Issue principale : #188
+Références : #132, #196, runner `runtime_recipe_runner.py`.
+
+Objectif :
+Rejouer R1-R16 sur une stack représentative et consolider les preuves
+automatiques et guidées dans un rapport versionné.
+
+Préconditions :
+- dataset représentatif disponible ;
+- Docker, orchestrateur, Symfony, PostgreSQL et Temporal disponibles ;
+- migrations appliquées ;
+- sets `regular`, `scalper`, `scalper_micro` en `dry_run=true` ;
+- aucun secret live requis.
+
+Scope :
+- exécuter R1-R16 avec le runner mergé ;
+- R6 : panne Symfony contrôlée ;
+- R10 : crash/reclaim réel, sans modifier arbitrairement la production ;
+- R15 : schedule Temporal réel, paused/dry-run ;
+- R16 : pause/reprise/rollback mesuré ;
+- collecter run IDs, run_sets, cockpit, Temporal et exports redacted ;
+- relier le rapport automatique aux preuves guidées ;
+- créer des issues atomiques pour tout écart.
+
+Décisions possibles :
+`blocked`, `ready_for_parallel_observation`, `ready_to_replace_legacy`.
+
+Contraintes :
+- aucun scénario mutatif exchange ;
+- aucun PASS si le scénario n'a pas été réellement exécuté ;
+- garder les anciens schedules actifs tant que la décision ne le permet pas.
+
+Livrables :
+- rapport automatique R1-R16 et preuves guidées consolidées ;
+- exports JSON redacted, run IDs et références cockpit/Temporal ;
+- chronologie du rollback avec durée mesurée ;
+- matrice scénario -> preuve -> statut -> écart ;
+- décision finale et issues atomiques pour les écarts.
+
+Tests/validation :
+- runner et fixtures Pytest ;
+- santé Docker/Temporal/Symfony avant recette ;
+- vérification PostgreSQL des runs, run_sets, claims et locks ;
+- validation JSON et scan secrets ;
+- MkDocs strict et diff check.
+
+GitHub :
+- PR de rapport `Part of #188`, `Related to #132`, `Related to #196` ;
+- fermer #188 uniquement si les critères d'acceptation sont couverts.
+~~~
+
+## Prompt 15 - DEMO-005 Réévaluation de la décision pré-mutative
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Références : DEMO-005 mergée par #254, #188, #196, #197, #198.
+
+Objectif :
+Réévaluer le rapport pré-mutatif existant avec les preuves actuelles. Cette PR
+est documentaire et read-only.
+
+Préconditions :
+- Prompt 9 audité ;
+- Prompt 14 terminé avec rapport relu ;
+- runtime-checks OKX et Hyperliquid rejoués avec credentials dédiés ;
+- kill switch et rollback testés ;
+- observabilité privée confirmée.
+
+Scope :
+- recalculer le hash de preuve ;
+- vérifier Fake/Paper, R1-R16, readiness, credentials, whitelist, notional,
+  SL/compensation, observabilité, audit et rollback ;
+- distinguer OKX et Hyperliquid ;
+- conserver chaque manque en `blocked`, jamais en PASS implicite.
+
+Décisions possibles :
+- `blocked`
+- `ready_for_demo_testnet_trading_attempt`
+
+Livrables :
+- rapport Markdown et JSON redacted ;
+- matrice gate -> preuve -> statut ;
+- décision signée par le commit/config hash ;
+- prochaine action et rollback.
+
+Tests :
+- générateur/validation du rapport ;
+- absence de secret ;
+- aucune mention mainnet-ready ;
+- MkDocs strict et diff check.
+
+GitHub :
+- PR `Related to #188`, `Related to #196`, `Related to #197`, `Related to #198` ;
+- ne lancer OKX-010 que si la décision exacte est
+  `ready_for_demo_testnet_trading_attempt`.
+~~~
+
+## Prompt 16 - OKX-010 Activation mutative finale OKX Demo
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Objectif :
+Autoriser un ordre minimal contrôlé sur OKX Demo uniquement, jamais mainnet.
+
+Préconditions obligatoires :
+- Prompt 15 = `ready_for_demo_testnet_trading_attempt` ;
+- #188 couvert sur stack représentative ;
+- runtime-check OKX = `demo_testnet_candidate` ;
+- credentials `OKX_DEMO_*` disponibles ;
+- private WS/read reconciliation opérationnels ;
+- whitelist et max_notional minimal définis ;
+- kill switch testé ;
+- fenêtre opérateur explicitement validée.
+
+Activation requise :
+- `DEMO_TRADING_ENABLED=true`
+- `OKX_DEMO_TRADING_ENABLED=true`
+- `environment=demo`
+- `mainnet_write_enabled=false`
+- `demo_testnet_write_enabled=true`
+- kill switch OKX explicitement désactivé pour la fenêtre
+- `x-simulated-trading: 1` sur chaque requête
+
+Scope :
+- submit/cancel minimal nécessaire à la recette ;
+- URL et flags production refusés avant transport ;
+- client order ID et idempotence obligatoires ;
+- SL immédiatement attaché ou compensation fail-safe ;
+- audit redacted complet ;
+- reconciliation REST/private WS ;
+- rollback immédiat réactivant le kill switch et les flags false.
+
+Livrables :
+- transport write OKX Demo gardé et audité ;
+- commande/runbook start, vérification, stop et rollback ;
+- preuve redacted de l'ordre minimal et de sa protection ;
+- IDs de corrélation permettant la reconciliation ;
+- rapport d'incident si la tentative échoue.
+
+Tests :
+- mainnet toujours bloqué ;
+- mauvais endpoint/header/credentials bloqués ;
+- kill switch, whitelist, notional, SL et observabilité bloquants ;
+- fake transport complet ;
+- une tentative réelle OKX Demo uniquement après validation opérateur ;
+- fill/cancel/protection/reconciliation ;
+- restart/replay.
+
+GitHub :
+- ne merger qu'avec preuves de la fenêtre, CI verte et validation Codex ;
+- commenter les issues liées avec les IDs redacted et le résultat ;
+- aucun secret dans la PR.
+~~~
+
+## Prompt 17 - DEMO-006 Rapport final d'exécution demo/testnet
+
+~~~text
+Applique intégralement le socle obligatoire de la section 2.
+
+Objectif :
+Produire le rapport final après les tentatives contrôlées OKX Demo et
+Hyperliquid testnet.
+
+Préconditions :
+- Prompt 16 terminé ;
+- HL-012 activé uniquement dans une fenêtre testnet validée ;
+- preuves de tentative disponibles pour les deux exchanges ou blocage explicite.
+
+Rapport Markdown et JSON :
+- version code et config hash ;
+- exchange/environment ;
+- runtime-check avant/après ;
+- état kill switch ;
+- ordre minimal, fill/cancel ;
+- SL attaché ou compensation/quarantaine ;
+- reconciliation REST/WS ;
+- lineage/audit IDs ;
+- coûts connus/inconnus ;
+- rollback testé et durée ;
+- incidents et écarts ;
+- aucune valeur secrète.
+
+Décisions possibles :
+- `blocked`
+- `demo_testnet_execution_validated`
+- `demo_testnet_execution_failed`
+- `needs_fix_before_next_run`
+
+Contraintes :
+- aucun statut mainnet-ready ;
+- ne pas agréger deux exchanges si l'un manque de preuve ;
+- une tentative non exécutée reste `blocked` ;
+- relier à `position_trade_analysis_v2` uniquement si la certification est
+  réellement disponible.
+
+Tests :
+- schéma JSON ;
+- scan secrets ;
+- cohérence IDs/hash ;
+- MkDocs strict ;
+- diff check.
+
+GitHub :
+- PR documentation finale ;
+- mettre à jour les issues concernées ;
+- ne fermer la roadmap demo/testnet que si toutes les preuves sont complètes.
+~~~
+
+---
+
+## 4. Etat final attendu
+
+~~~text
+- Fake/Paper couvre réellement les 20 scénarios golden.
+- Les capacités et divergences Bitmart sont inventoriées sans suppression.
+- Une baseline PnL factuelle existe pour les trois profils.
+- R1-R16 sont prouvés sur une stack représentative.
+- DEMO-005 autorise ou bloque explicitement la tentative.
+- OKX ne peut écrire qu'en Demo avec le header simulé.
+- Hyperliquid ne peut écrire qu'en testnet avec un agent dédié.
+- Aucun chemin mainnet write n'existe.
+- Toute position demo/testnet possède un SL ou une compensation fail-safe.
+- Le rapport final ne déclare jamais mainnet-ready.
+~~~
+
+---
+
+## 5. Non-objectifs
+
+~~~text
+- trading mainnet ;
+- fonds réels ;
+- augmentation de fréquence ;
+- tuning stratégie avant baseline factuelle ;
+- suppression Bitmart dans ces prompts ;
+- promesse de rentabilité ;
+- PnL certifié à partir de données incomplètes ;
+- contournement d'un gate pour obtenir un PASS.
+~~~
+
+---
+
+## 6. Références officielles pour les docs opérateur
+
+- OKX API Demo Trading : https://my.okx.com/docs-v5/en/
+- OKX FAQ clés API demo : https://www.okx.com/en-eu/help/api-faq
+- Hyperliquid API testnet : https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api
+- Hyperliquid nonces/API wallets : https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/nonces-and-api-wallets
+- Hyperliquid exchange endpoint : https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint
+- Hyperliquid info endpoint : https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint
+
+---
+
+# Annexe A - Historique compact des lots mergés
+
+Cette annexe est informative. Aucun lot ci-dessous ne doit redevenir un prompt
+actif sans nouveau gap factuel.
+
+| Série | PRs / merges | Résultat compact |
+|---|---|---|
+| Socle commun | #221 `45ff518`, #222 `9cb132f`, #223 `b801a6b`, #224 `0e61c01`, #225 `49d45fb`, #226 `280837e` | Safety envelope, config effective, readiness, kill switch, observabilité privée et minimum Fake/Paper. |
+| OKX read-only/dry-run | #227 `6313c55` à #235 `c103c1b` | Capabilities, providers, REST public/privé, metadata, normalizers, payload preview, runtime-check et recette orchestrateur. |
+| Hyperliquid read-only/dry-run | #236 `5724aab` à #249 `0b62049` hors numéros réservés | Capabilities, providers, market/account reads, signer isolé, nonce, metadata, lifecycle, preview et recette orchestrateur. |
+| Demo orchestration | #250 `d90b3dd`, #251 `e524424`, #252 `79acc0c`, #253 `0026613`, #254 `221f25c` | Fixtures, recette double exchange, runbook, schedule gardé et rapport DEMO-005 `blocked`. |
+| Hyperliquid contrôlé | #259 `ede6c98` | HL-012 mergé, désactivé par défaut, aucune tentative réelle prouvée dans ce lot. |
+| OKX prérequis | #260 `6ac0840`, #261 `a736a875`, #262 `a659f5a5` | Candidate read-only, private WS/reconciliation et endpoint EEA validés sans ordre. |
+| Prépreuve data | #263 `da94f19c` | Bases de test isolées et schéma restauré ; dataset représentatif toujours absent. |
+| Fake/Paper #196 | #274 `d7f93c13`, #275 `a7216f1c`, #276 `75c85254`, #277 `0c513bfe`, #278 `685bb926`, #279 `d0ee8fb4`, #280 `c19cd1f0`, #281 `a7bbad86` | WS/resync, recovery, faults, runtime-check, golden suite, instrument/risk, slippage et compensation SL ; état 14/20. |
+
+Note de numérotation : #244 et #247 sont des PRs documentation/roadmap hors
+prompts actifs. Toujours vérifier l'état GitHub réel avant de citer une nouvelle
+PR.

--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -256,6 +256,47 @@ pas disponibles. La marge d un SELL limit crossing est verifiee avec le meilleur
 bid executable, et un `LIMIT` legacy accompagne d un `stopPrice` reste un ordre
 declenche au lieu d etre rempli immediatement.
 
+## Fallback taker deterministe de fin de zone
+
+Le moteur Fake/Paper supporte une politique opt-in versionnee
+`fake-fallback-taker-v1`, persistee dans les metadata d un ordre parent `LIMIT`
+post-only. Elle contient un flag d activation, les bornes de zone valides et le
+slippage adverse maximal en points de base. La politique absente, malformee ou
+desactivee echoue fermee. Seuls les cinq champs types de cette politique
+traversent les metadata d une requete ordinaire ; les identifiants parent, le
+reliquat, la quantite de protection, le trigger et le slippage mesure sont
+derives et injectes par le moteur.
+
+Quand la zone se termine,
+`FakeExchangeScenarioService::fallbackTaker(exchange_order_id)` execute une
+transition atomique locale :
+
+- le parent actif expire une seule fois ; un parent deja expire avant restart
+  peut reprendre sans dupliquer l evenement d expiration ;
+- la quantite deja remplie en maker reste acquise et seul le reliquat decimal
+  exact est soumis en `MARKET` ;
+- le `client_order_id` enfant derive deterministement de l identite du parent ;
+- le prix top-of-book executable doit rester dans la zone et sous le seuil de
+  slippage adverse total, qui additionne le deplacement depuis la limite maker
+  et les 5 bps du modele taker versionne ;
+- precision, marge, rejet persiste, fill, frais et position passent par les
+  chemins ordinaires du moteur Fake ;
+- le cout maker reste separe du cout taker et la protection couvre la quantite
+  logique totale parent plus enfant ;
+- si l attachement de protection echoue, la compensation reduce-only ferme cette
+  meme quantite logique totale.
+
+Un parent annule ou sans reliquat ne genere aucun enfant. Si une annulation ou un
+rejet zone/slippage/marge/validation laisse un fill maker partiel, son exposition
+exacte recoit le SL/TP attache ; un rejet de cette protection compense ce fill
+partiel. Le replay d un succes, d un rejet de garde ou d un restart persiste ne
+cree aucun second ordre, fill, frais, evenement ou stop. Un enfant persiste n est
+reconnu qu apres comparaison de son intention immutable complete et des metadata
+terminales du parent. Les mutations directes du service de scenario rechargent
+l etat persiste sous le meme verrou avant modification. Ce trigger est une
+fixture Fake/Paper locale : il n appelle aucun provider, ne lit aucun credential
+et ne peut ecrire ni en mainnet, ni en demo, ni en testnet.
+
 ## Golden suite Fake/Paper v1
 
 Le catalogue versionne des 20 scenarios obligatoires de #196 est disponible dans :
@@ -277,19 +318,18 @@ Une ligne presente dans le catalogue n est pas un PASS. Seul le statut `executab
 avec un test vert constitue une preuve. Les lignes `partial` et `unsupported` ne
 peuvent ni rendre le runtime-check ready, ni autoriser une mutation demo/testnet.
 
-Les quatorze scenarios executes dans cette version sont : maker limit rempli, limit
-IOC expire sans fill, partial fill puis cancel, market avec slippage 5 bps,
-insufficient balance, precision reject, leverage cap reject, replay du
-`client_order_id`, timeout apres acceptation, attachement SL reussi, echec
-d attachement SL compense par fermeture market reduce-only, gap au SL au prochain
-prix disponible, deconnexion/reprise private WS, et restart avec position
-protegee ouverte.
+Les quinze scenarios executes dans cette version sont : maker limit rempli, limit
+IOC expire sans fill, partial fill puis cancel, fallback taker de fin de zone sur
+le reliquat exact, market avec slippage 5 bps, insufficient balance, precision
+reject, leverage cap reject, replay du `client_order_id`, timeout apres
+acceptation, attachement SL reussi, echec d attachement SL compense par fermeture
+market reduce-only, gap au SL au prochain prix disponible, deconnexion/reprise
+private WS, et restart avec position protegee ouverte.
 
 Les ecarts encore explicites sont :
 
 | Scenario | Statut | Gap stable |
 | --- | --- | --- |
-| fallback taker | `unsupported` | `fallback_taker_not_implemented` |
 | TP1 puis trailing | `partial` | `trailing_stop_not_implemented` |
 | duplicate/out-of-order event | `partial` | `out_of_order_event_injection_not_implemented` |
 | funding | `unsupported` | `funding_model_not_implemented` |
@@ -321,6 +361,12 @@ Le rollback de la compensation adapter doit aussi restaurer le scenario golden
 12 en `partial` avec un `gap_code` explicite. Le fichier d etat Fake doit etre
 archive puis retire ou valide contre la revision cible avant reprise locale ; il
 ne doit jamais etre reutilise silencieusement par une version incompatible.
+
+Le rollback du fallback taker doit retirer la politique et le trigger locaux,
+puis restaurer le scenario golden 4 en `unsupported` avec
+`fallback_taker_not_implemented`. Le fichier d etat doit etre archive ou
+quarantaine avant de lancer une revision qui ne connait pas ses metadata
+additives. Ce rollback ne doit jamais servir a activer une ecriture exchange.
 
 ## Suite
 

--- a/trading-app/docs/exchange/fake-instrument-risk-model-v1.md
+++ b/trading-app/docs/exchange/fake-instrument-risk-model-v1.md
@@ -232,6 +232,34 @@ Explicit mutation persists when a state path is configured. Examples include
 queueing a fault, and accepting a leverage update. In-memory stores keep the same
 deterministic behavior without filesystem persistence.
 
+## End-of-zone fallback taker
+
+`fake-fallback-taker-v1` is an opt-in policy persisted in the parent post-only
+maker order metadata. It records the valid entry-zone bounds and maximum adverse
+slippage. The local scenario trigger expires an active parent once, accepts an
+already expired parent after restart, and converts only its exact unfilled
+decimal remainder to a deterministic child `MARKET` order. The bounded adverse
+total combines maker-limit-to-book displacement with the versioned 5 bps taker
+cost.
+
+The child uses the normal validation, margin, fill, cost, position, and
+protection paths. A partial maker fill retains explicit zero maker slippage while
+the fallback fill retains the versioned 5 bps taker cost. The attached protection
+and compensation invariant covers the aggregate parent-plus-child quantity.
+Deterministic parent/child identifiers and terminal audit metadata make success,
+guard rejection, and persisted restart replay idempotent.
+
+The trigger rejects or no-ops for a missing/disabled policy, invalid zone,
+excessive adverse slippage, cancelled parent, or zero remainder. Any partial
+maker exposure left by cancellation or a fallback rejection is protected for its
+actual filled quantity; a protection-fixture rejection compensates that exact
+partial exposure. Generic request metadata can persist only the five typed
+policy fields. Derived parent, remainder, trigger, measured-slippage, and
+aggregate-protection metadata is engine-owned, and replay validates the complete
+persisted child intent before accepting it. This capability exists only inside
+the Fake/Paper matching engine and introduces no live, demo, testnet, provider,
+or network write path.
+
 ## Rollback
 
 This model has no external exchange side effects. To roll back a local Fake/Paper
@@ -247,6 +275,9 @@ runtime:
    `app:exchange:runtime-check fake perpetual` before resuming local scenarios.
 5. Restore golden scenario 12 to an explicit gap if the attached-protection
    compensation runner is rolled back.
+6. Restore golden scenario 4 to `unsupported` with
+   `fallback_taker_not_implemented` if the fallback policy and trigger are rolled
+   back.
 
 Do not use rollback as a path to live, demo, or testnet trading. No credential,
 exchange endpoint, or network operation is part of this model.
@@ -258,7 +289,6 @@ golden catalog and readiness evidence:
 
 - daily loss cap;
 - liquidation guard and liquidation model;
-- maker-timeout fallback taker behavior;
 - funding accrual;
 - one-way position conflict handling;
 - TP1-to-trailing-stop behavior;

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -45,6 +45,16 @@ final readonly class FakeExchangeMatchingEngine
         'attempt_number',
         'decision_key',
     ];
+    /**
+     * @var string[]
+     */
+    private const FALLBACK_POLICY_METADATA_KEYS = [
+        FakeFallbackTakerPolicy::VERSION_KEY,
+        FakeFallbackTakerPolicy::ENABLED_KEY,
+        FakeFallbackTakerPolicy::ZONE_MIN_KEY,
+        FakeFallbackTakerPolicy::ZONE_MAX_KEY,
+        FakeFallbackTakerPolicy::MAX_SLIPPAGE_BPS_KEY,
+    ];
 
     private FakeOrderValidator $orderValidator;
 
@@ -66,6 +76,17 @@ final readonly class FakeExchangeMatchingEngine
     }
 
     public function submit(PlaceOrderRequest $request): PlaceOrderResult
+    {
+        return $this->submitWithTrustedFallbackMetadata($request);
+    }
+
+    /**
+     * @param array<string, bool|float|int|string|null> $trustedFallbackMetadata
+     */
+    private function submitWithTrustedFallbackMetadata(
+        PlaceOrderRequest $request,
+        array $trustedFallbackMetadata = [],
+    ): PlaceOrderResult
     {
         $this->assertRequestContext($request);
         $this->assertRequestIntent($request);
@@ -107,13 +128,14 @@ final readonly class FakeExchangeMatchingEngine
             return $this->rejectOrder(
                 $request,
                 $validation->reason ?? 'order_validation_failed',
+                $trustedFallbackMetadata,
                 $validation->metadata,
                 $validationMetadata,
             );
         }
 
         if ($request->postOnly && $this->wouldCross($request)) {
-            return $this->rejectOrder($request, 'post_only_would_cross');
+            return $this->rejectOrder($request, 'post_only_would_cross', $trustedFallbackMetadata);
         }
 
         $instrument = $this->instruments->find($request->symbol);
@@ -122,9 +144,15 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         if ($this->isStandaloneProtection($request) && $this->stateStore->consumeProtectionRejectionFlag()) {
-            $order = $this->buildOrder($request, ExchangeOrderStatus::REJECTED, array_replace($this->requestMetadata($request), [
-                'reason' => 'protection_rejected_by_scenario',
-            ]));
+            $order = $this->buildOrder(
+                $request,
+                ExchangeOrderStatus::REJECTED,
+                array_replace(
+                    $this->requestMetadata($request),
+                    $trustedFallbackMetadata,
+                    ['reason' => 'protection_rejected_by_scenario'],
+                ),
+            );
             $this->stateStore->saveOrder($order);
             $this->appendEvent('protection_order.rejected', $order, ['reason' => 'protection_rejected_by_scenario']);
 
@@ -134,7 +162,10 @@ final readonly class FakeExchangeMatchingEngine
         $order = $this->buildOrder(
             $request,
             ExchangeOrderStatus::OPEN,
-            $this->requestMetadata($request, $referencePrice, $instrument->contractSize),
+            array_replace(
+                $this->requestMetadata($request, $referencePrice, $instrument->contractSize),
+                $trustedFallbackMetadata,
+            ),
         );
         $this->stateStore->saveOrder($order);
         $this->appendEvent('order.created', $order);
@@ -200,6 +231,13 @@ final readonly class FakeExchangeMatchingEngine
         );
     }
 
+    public function fallbackTaker(string $exchangeOrderId): FakeFallbackTakerResult
+    {
+        return $this->stateStore->runAtomically(
+            fn (): FakeFallbackTakerResult => $this->fallbackTakerFromCurrentState($exchangeOrderId),
+        );
+    }
+
     public function fillOrder(string $exchangeOrderId, ?float $quantity = null, ?float $price = null): ?ExchangeOrderDto
     {
         $order = $this->stateStore->getOrder($exchangeOrderId);
@@ -227,16 +265,36 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         $executionPrice = $price ?? $this->executionPrice($order);
-        $newFilled = $order->filledQuantity + $fillQuantity;
-        $newRemaining = max(0.0, $order->quantity - $newFilled);
+        $quantityDecimal = $this->orderQuantityDecimal($order);
+        $previousFilledDecimal = $this->orderFilledQuantityDecimal($order);
+        $fillQuantityDecimal = self::canonicalFloat($fillQuantity);
+        try {
+            $newFilledDecimal = (string) BigDecimal::of($previousFilledDecimal)
+                ->plus($fillQuantityDecimal)
+                ->stripTrailingZeros();
+            $newRemainingDecimal = (string) BigDecimal::of($quantityDecimal)
+                ->minus($newFilledDecimal)
+                ->stripTrailingZeros();
+        } catch (MathException) {
+            throw new \LogicException('fake_fill_quantity_decimal_invalid');
+        }
+        $newFilled = (float) $newFilledDecimal;
+        $newRemaining = max(0.0, (float) $newRemainingDecimal);
         $averagePrice = $this->averagePrice($order, $fillQuantity, $executionPrice, $newFilled);
         $status = $this->fillStatus($newRemaining, $cancelReduceRemainder);
+        $metadata = array_replace(
+            $order->metadata,
+            [
+                'filled_quantity_decimal' => $newFilledDecimal,
+                'remaining_quantity_decimal' => $newRemainingDecimal,
+            ],
+        );
         $metadata = $cancelReduceRemainder
-            ? array_replace($order->metadata, [
+            ? array_replace($metadata, [
                 'reason' => 'reduce_only_position_size_capped',
                 'reduce_only_cancelled_remainder' => true,
             ])
-            : $order->metadata;
+            : $metadata;
         $contractSize = $this->marginContractSize($order->metadata);
         $fillCost = $this->fillCostModel->forFill(
             quantity: $fillQuantity,
@@ -302,6 +360,277 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         return $updated;
+    }
+
+    private function fallbackTakerFromCurrentState(string $exchangeOrderId): FakeFallbackTakerResult
+    {
+        $parent = $this->stateStore->getOrder($exchangeOrderId);
+        if (!$parent instanceof ExchangeOrderDto) {
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: false,
+                reason: 'fallback_parent_not_found',
+                parentOrder: null,
+                fallbackOrder: null,
+            );
+        }
+        if ($parent->remainingQuantity <= 0.00000001) {
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: false,
+                reason: 'fallback_remainder_zero',
+                parentOrder: $parent,
+                fallbackOrder: null,
+            );
+        }
+        $fallbackClientOrderId = $this->fallbackClientOrderId($parent);
+        $existingFallback = $this->stateStore->getOrderByClientOrderId(
+            $parent->symbol,
+            $fallbackClientOrderId,
+        );
+        if ($existingFallback instanceof ExchangeOrderDto) {
+            if (!$this->fallbackChildMatchesParent($parent, $existingFallback)) {
+                throw new \LogicException('fake_fallback_client_order_id_conflict');
+            }
+
+            $completed = $existingFallback->status === ExchangeOrderStatus::FILLED;
+
+            return new FakeFallbackTakerResult(
+                executed: $completed,
+                idempotentReplay: true,
+                reason: $completed
+                    ? 'fallback_completed'
+                    : ($this->stringMetadata($existingFallback->metadata, 'reason') ?? 'fallback_order_rejected'),
+                parentOrder: $parent,
+                fallbackOrder: $existingFallback,
+                slippageBps: $this->floatMetadata($parent->metadata, 'fallback_slippage_bps'),
+            );
+        }
+        if (($parent->metadata['fallback_status'] ?? null) === 'rejected') {
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: true,
+                reason: $this->stringMetadata($parent->metadata, 'fallback_reason')
+                    ?? 'fallback_rejected',
+                parentOrder: $parent,
+                fallbackOrder: null,
+                slippageBps: $this->floatMetadata($parent->metadata, 'fallback_slippage_bps'),
+            );
+        }
+        if ($parent->status === ExchangeOrderStatus::CANCELLED) {
+            $parent = $this->protectFallbackParentExposure($parent);
+
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: false,
+                reason: 'fallback_parent_cancelled',
+                parentOrder: $parent,
+                fallbackOrder: null,
+            );
+        }
+        $parentAlreadyExpired = $parent->status === ExchangeOrderStatus::EXPIRED;
+        if (
+            $parent->orderType !== ExchangeOrderType::LIMIT
+            || !$parent->postOnly
+            || !$parent->positionSide instanceof ExchangePositionSide
+            || (!$this->isActiveStatus($parent->status) && !$parentAlreadyExpired)
+            || $parent->price === null
+        ) {
+            throw new \LogicException('fake_fallback_parent_not_eligible');
+        }
+
+        $policy = FakeFallbackTakerPolicy::fromMetadata($parent->metadata);
+        if (!$policy instanceof FakeFallbackTakerPolicy) {
+            throw new \LogicException('fake_fallback_policy_unavailable');
+        }
+        if (!$policy->enabled) {
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: false,
+                reason: 'fallback_disabled',
+                parentOrder: $parent,
+                fallbackOrder: null,
+            );
+        }
+
+        $top = $this->orderBook->top($parent->symbol);
+        $executionPrice = $parent->side === ExchangeOrderSide::BUY ? $top->ask : $top->bid;
+        $slippageBps = $this->fallbackSlippageBps($parent, $executionPrice);
+        $fallbackTrigger = $parentAlreadyExpired ? 'expired' : 'end_of_zone';
+
+        $parent = $this->withOrderStatus(
+            $parent,
+            ExchangeOrderStatus::EXPIRED,
+            array_replace(
+                $parent->metadata,
+                $parentAlreadyExpired ? [] : ['reason' => 'fallback_taker_triggered'],
+                [
+                    'fallback_status' => 'pending',
+                    'fallback_slippage_bps' => $slippageBps,
+                    'fallback_trigger' => $fallbackTrigger,
+                ],
+            ),
+        );
+        $this->stateStore->saveOrder($parent);
+        if (!$parentAlreadyExpired) {
+            $this->appendEvent('order.expired', $parent, ['reason' => 'fallback_taker_triggered']);
+        }
+        if ($executionPrice < $policy->zoneMin || $executionPrice > $policy->zoneMax) {
+            $parent = $this->withOrderStatus($parent, $parent->status, array_replace(
+                $parent->metadata,
+                [
+                    'fallback_status' => 'rejected',
+                    'fallback_reason' => 'fallback_price_outside_zone',
+                ],
+            ));
+            $this->stateStore->saveOrder($parent);
+            $this->appendEvent('fallback_taker.rejected', $parent, [
+                'reason' => 'fallback_price_outside_zone',
+                'slippage_bps' => $slippageBps,
+            ]);
+            $parent = $this->protectFallbackParentExposure($parent);
+
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: false,
+                reason: 'fallback_price_outside_zone',
+                parentOrder: $parent,
+                fallbackOrder: null,
+                slippageBps: $slippageBps,
+            );
+        }
+        if ($slippageBps > $policy->maxSlippageBps) {
+            $parent = $this->withOrderStatus($parent, $parent->status, array_replace(
+                $parent->metadata,
+                [
+                    'fallback_status' => 'rejected',
+                    'fallback_reason' => 'fallback_slippage_exceeded',
+                ],
+            ));
+            $this->stateStore->saveOrder($parent);
+            $this->appendEvent('fallback_taker.rejected', $parent, [
+                'reason' => 'fallback_slippage_exceeded',
+                'slippage_bps' => $slippageBps,
+            ]);
+            $parent = $this->protectFallbackParentExposure($parent);
+
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: false,
+                reason: 'fallback_slippage_exceeded',
+                parentOrder: $parent,
+                fallbackOrder: null,
+                slippageBps: $slippageBps,
+            );
+        }
+
+        $fallbackQuantityDecimal = $this->orderRemainingQuantityDecimal($parent);
+        $fallbackQuantity = (float) $fallbackQuantityDecimal;
+        $parentFilledQuantityDecimal = $this->orderFilledQuantityDecimal($parent);
+        $protectionQuantityDecimal = $this->orderQuantityDecimal($parent);
+        $fallbackResult = $this->submitWithTrustedFallbackMetadata(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: $parent->marketType,
+            symbol: $parent->symbol,
+            side: $parent->side,
+            positionSide: $parent->positionSide,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: $fallbackQuantity,
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: $this->positiveIntMetadata($parent->metadata, 'leverage'),
+            marginMode: $this->fallbackMarginMode($parent),
+            clientOrderId: $fallbackClientOrderId,
+            attachedStopLossPrice: $this->floatMetadata($parent->metadata, 'attached_stop_loss_price'),
+            attachedTakeProfitPrice: $this->floatMetadata($parent->metadata, 'attached_take_profit_price'),
+            metadata: $this->lineageMetadata($parent->metadata)
+                + $policy->toMetadata(),
+            quantityDecimal: $fallbackQuantityDecimal,
+            attachedStopLossPriceDecimal: $this->stringMetadata(
+                $parent->metadata,
+                'attached_stop_loss_price_decimal',
+            ),
+            attachedTakeProfitPriceDecimal: $this->stringMetadata(
+                $parent->metadata,
+                'attached_take_profit_price_decimal',
+            ),
+        ), [
+            'fallback_parent_order_id' => $parent->exchangeOrderId,
+            'fallback_parent_client_order_id' => $parent->clientOrderId,
+            'fallback_parent_filled_quantity' => $parent->filledQuantity,
+            'fallback_parent_filled_quantity_decimal' => $parentFilledQuantityDecimal,
+            'fallback_remainder_quantity' => $fallbackQuantity,
+            'fallback_remainder_quantity_decimal' => $fallbackQuantityDecimal,
+            'fallback_protection_quantity' => $parent->filledQuantity + $fallbackQuantity,
+            'fallback_protection_quantity_decimal' => $protectionQuantityDecimal,
+            'fallback_slippage_bps' => $slippageBps,
+            'fallback_trigger' => $fallbackTrigger,
+        ]);
+        $fallback = $fallbackResult->order;
+        if (!$fallback instanceof ExchangeOrderDto) {
+            throw new \LogicException('fake_fallback_order_failed');
+        }
+        if (!$fallbackResult->accepted) {
+            $reason = $this->stringMetadata($fallback->metadata, 'reason') ?? 'fallback_order_rejected';
+            $parent = $this->withOrderStatus($parent, $parent->status, array_replace(
+                $parent->metadata,
+                [
+                    'fallback_status' => 'rejected',
+                    'fallback_reason' => $reason,
+                    'fallback_order_id' => $fallback->exchangeOrderId,
+                    'fallback_client_order_id' => $fallback->clientOrderId,
+                    'fallback_quantity' => $fallbackQuantity,
+                ],
+            ));
+            $this->stateStore->saveOrder($parent);
+            $this->appendEvent('fallback_taker.rejected', $parent, [
+                'reason' => $reason,
+                'fallback_order_id' => $fallback->exchangeOrderId,
+                'fallback_quantity' => $fallbackQuantity,
+                'slippage_bps' => $slippageBps,
+            ]);
+            $parent = $this->protectFallbackParentExposure($parent);
+
+            return new FakeFallbackTakerResult(
+                executed: false,
+                idempotentReplay: false,
+                reason: $reason,
+                parentOrder: $parent,
+                fallbackOrder: $fallback,
+                slippageBps: $slippageBps,
+            );
+        }
+        if ($fallback->status !== ExchangeOrderStatus::FILLED) {
+            throw new \LogicException('fake_fallback_order_failed');
+        }
+
+        $parent = $this->withOrderStatus($parent, $parent->status, array_replace(
+            $parent->metadata,
+            [
+                'fallback_status' => 'completed',
+                'fallback_order_id' => $fallback->exchangeOrderId,
+                'fallback_client_order_id' => $fallback->clientOrderId,
+                'fallback_quantity' => $fallbackQuantity,
+            ],
+        ));
+        $this->stateStore->saveOrder($parent);
+        $this->appendEvent('fallback_taker.completed', $parent, [
+            'fallback_order_id' => $fallback->exchangeOrderId,
+            'fallback_quantity' => $fallbackQuantity,
+            'slippage_bps' => $slippageBps,
+        ]);
+
+        return new FakeFallbackTakerResult(
+            executed: true,
+            idempotentReplay: false,
+            reason: 'fallback_completed',
+            parentOrder: $parent,
+            fallbackOrder: $fallback,
+            slippageBps: $slippageBps,
+        );
     }
 
     /**
@@ -374,6 +703,8 @@ final readonly class FakeExchangeMatchingEngine
             'attached_stop_loss_price' => $request->attachedStopLossPrice,
             'attached_take_profit_price' => $request->attachedTakeProfitPrice,
             'quantity_decimal' => $request->exactQuantity(),
+            'filled_quantity_decimal' => '0',
+            'remaining_quantity_decimal' => $request->exactQuantity(),
             'price_decimal' => $request->exactPrice(),
             'stop_price_decimal' => $request->exactStopPrice(),
             'attached_stop_loss_price_decimal' => $request->exactAttachedStopLossPrice(),
@@ -381,16 +712,27 @@ final readonly class FakeExchangeMatchingEngine
             'margin_reference_price' => $marginReferencePrice,
             'margin_reference_source' => $marginReferencePrice !== null ? 'top_of_book' : null,
             'margin_contract_size' => $marginContractSize,
-        ], static fn (mixed $value): bool => $value !== null) + $this->lineageMetadata($request->metadata);
+        ], static fn (mixed $value): bool => $value !== null)
+            + $this->lineageMetadata($request->metadata)
+            + $this->fallbackPolicyMetadata($request->metadata);
     }
 
     /**
+     * @param array<string, bool|float|int|string|null> $trustedFallbackMetadata
      * @param array<string,mixed> ...$metadata
      */
-    private function rejectOrder(PlaceOrderRequest $request, string $reason, array ...$metadata): PlaceOrderResult
-    {
+    private function rejectOrder(
+        PlaceOrderRequest $request,
+        string $reason,
+        array $trustedFallbackMetadata = [],
+        array ...$metadata,
+    ): PlaceOrderResult {
         $metadata[] = ['reason' => $reason];
-        $rejectionMetadata = array_replace($this->requestMetadata($request), ...$metadata);
+        $rejectionMetadata = array_replace(
+            $this->requestMetadata($request),
+            $trustedFallbackMetadata,
+            ...$metadata,
+        );
         $order = $this->buildOrder($request, ExchangeOrderStatus::REJECTED, $rejectionMetadata);
         $this->stateStore->saveOrder($order);
         $this->appendEvent('order.rejected', $order, array_replace(...$metadata));
@@ -465,6 +807,15 @@ final readonly class FakeExchangeMatchingEngine
         return $updated;
     }
 
+    private function protectFallbackParentExposure(ExchangeOrderDto $parent): ExchangeOrderDto
+    {
+        if ($parent->filledQuantity <= 0.00000001) {
+            return $parent;
+        }
+
+        return $this->createAttachedProtectionOrders($parent);
+    }
+
     private function compensateRejectedProtection(ExchangeOrderDto $entryOrder): ExchangeOrderDto
     {
         if (!$entryOrder->positionSide instanceof ExchangePositionSide) {
@@ -476,7 +827,7 @@ final readonly class FakeExchangeMatchingEngine
             throw new \LogicException('fake_protection_compensation_position_unavailable');
         }
         $positionSizeBeforeCompensation = $position->size;
-        $compensationQuantity = $entryOrder->filledQuantity;
+        $compensationQuantity = $this->protectionQuantity($entryOrder);
         if ($compensationQuantity <= 0.00000001) {
             throw new \LogicException('fake_protection_compensation_quantity_unavailable');
         }
@@ -612,7 +963,7 @@ final readonly class FakeExchangeMatchingEngine
         if (\array_key_exists('margin_contract_size', $entryOrder->metadata)) {
             $metadata['margin_contract_size'] = $entryOrder->metadata['margin_contract_size'];
         }
-
+        $protectionQuantity = $this->protectionQuantity($entryOrder);
         $order = new ExchangeOrderDto(
             exchange: Exchange::FAKE,
             marketType: MarketType::PERPETUAL,
@@ -623,9 +974,9 @@ final readonly class FakeExchangeMatchingEngine
             positionSide: $entryOrder->positionSide,
             orderType: $type,
             status: ExchangeOrderStatus::OPEN,
-            quantity: $entryOrder->filledQuantity,
+            quantity: $protectionQuantity,
             filledQuantity: 0.0,
-            remainingQuantity: $entryOrder->filledQuantity,
+            remainingQuantity: $protectionQuantity,
             price: null,
             averagePrice: null,
             stopPrice: $stopPrice,
@@ -1003,6 +1354,87 @@ final readonly class FakeExchangeMatchingEngine
 
     /**
      * @param array<string,mixed> $metadata
+     * @return array<string,mixed>
+     */
+    private function fallbackPolicyMetadata(array $metadata): array
+    {
+        $fallback = [];
+        foreach (self::FALLBACK_POLICY_METADATA_KEYS as $key) {
+            if (!\array_key_exists($key, $metadata)) {
+                continue;
+            }
+
+            $value = $metadata[$key];
+            if ($value === null || \is_scalar($value)) {
+                $fallback[$key] = $value;
+            }
+        }
+
+        return $fallback;
+    }
+
+    private function protectionQuantity(ExchangeOrderDto $entryOrder): float
+    {
+        $fallbackParentOrderId = $this->stringMetadata(
+            $entryOrder->metadata,
+            'fallback_parent_order_id',
+        );
+        if ($fallbackParentOrderId === null) {
+            $quantity = $entryOrder->filledQuantity;
+        } else {
+            $parent = $this->stateStore->getOrder($fallbackParentOrderId);
+            if (
+                !$parent instanceof ExchangeOrderDto
+                || $entryOrder->clientOrderId !== $this->fallbackClientOrderId($parent)
+                || $entryOrder->symbol !== $parent->symbol
+                || $entryOrder->marketType !== $parent->marketType
+                || $entryOrder->side !== $parent->side
+                || $entryOrder->positionSide !== $parent->positionSide
+                || $entryOrder->orderType !== ExchangeOrderType::MARKET
+                || $entryOrder->reduceOnly
+                || $entryOrder->postOnly
+                || !self::sameDecimal(
+                    $this->decimalMetadata(
+                        $entryOrder->metadata,
+                        'fallback_parent_filled_quantity_decimal',
+                    ) ?? '',
+                    $this->orderFilledQuantityDecimal($parent),
+                )
+                || !self::sameDecimal(
+                    $this->decimalMetadata(
+                        $entryOrder->metadata,
+                        'fallback_remainder_quantity_decimal',
+                    ) ?? '',
+                    $this->orderQuantityDecimal($entryOrder),
+                )
+                || !self::sameDecimal(
+                    $this->decimalMetadata(
+                        $entryOrder->metadata,
+                        'fallback_protection_quantity_decimal',
+                    ) ?? '',
+                    $this->orderQuantityDecimal($parent),
+                )
+            ) {
+                throw new \LogicException('fake_fallback_protection_lineage_invalid');
+            }
+
+            try {
+                $quantity = (float) (string) BigDecimal::of($this->orderFilledQuantityDecimal($parent))
+                    ->plus($this->orderFilledQuantityDecimal($entryOrder))
+                    ->stripTrailingZeros();
+            } catch (MathException) {
+                throw new \LogicException('fake_fallback_protection_quantity_invalid');
+            }
+        }
+        if (!\is_finite($quantity) || $quantity <= 0.00000001) {
+            throw new \LogicException('fake_protection_quantity_unavailable');
+        }
+
+        return $quantity;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
      */
     private function metadataFloat(array $metadata, string $key): float
     {
@@ -1022,6 +1454,230 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         return (float) $value;
+    }
+
+    private function orderQuantityDecimal(ExchangeOrderDto $order): string
+    {
+        return $this->decimalMetadata($order->metadata, 'quantity_decimal')
+            ?? self::canonicalFloat($order->quantity);
+    }
+
+    private function orderFilledQuantityDecimal(ExchangeOrderDto $order): string
+    {
+        return $this->decimalMetadata($order->metadata, 'filled_quantity_decimal')
+            ?? self::canonicalFloat($order->filledQuantity);
+    }
+
+    private function orderRemainingQuantityDecimal(ExchangeOrderDto $order): string
+    {
+        $persisted = $this->decimalMetadata($order->metadata, 'remaining_quantity_decimal');
+        if ($persisted !== null) {
+            return $persisted;
+        }
+
+        try {
+            return (string) BigDecimal::of($this->orderQuantityDecimal($order))
+                ->minus($this->orderFilledQuantityDecimal($order))
+                ->stripTrailingZeros();
+        } catch (MathException) {
+            throw new \LogicException('fake_order_remaining_quantity_decimal_invalid');
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function decimalMetadata(array $metadata, string $key): ?string
+    {
+        $value = $this->stringMetadata($metadata, $key);
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return (string) BigDecimal::of($value)->stripTrailingZeros();
+        } catch (MathException) {
+            return null;
+        }
+    }
+
+    private function fallbackSlippageBps(ExchangeOrderDto $parent, float $executionPrice): float
+    {
+        if ($parent->price === null || $parent->price <= 0.0) {
+            throw new \LogicException('fake_fallback_reference_price_unavailable');
+        }
+
+        $adverseDifference = $parent->side === ExchangeOrderSide::BUY
+            ? max(0.0, $executionPrice - $parent->price)
+            : max(0.0, $parent->price - $executionPrice);
+
+        return round(
+            (($adverseDifference / $parent->price) * 10_000.0)
+            + FakeFillCostModel::TAKER_SLIPPAGE_BPS,
+            12,
+        );
+    }
+
+    private function fallbackClientOrderId(ExchangeOrderDto $parent): string
+    {
+        return 'fake-fallback-' . substr(hash(
+            'sha256',
+            $parent->exchangeOrderId . ':' . ($parent->clientOrderId ?? ''),
+        ), 0, 32);
+    }
+
+    private function fallbackMarginMode(ExchangeOrderDto $parent): string
+    {
+        $marginMode = $this->stringMetadata($parent->metadata, 'margin_mode');
+
+        return \in_array($marginMode, ['isolated', 'cross'], true) ? $marginMode : 'isolated';
+    }
+
+    private function fallbackChildMatchesParent(
+        ExchangeOrderDto $parent,
+        ExchangeOrderDto $fallback,
+    ): bool {
+        $parentFilledQuantity = $this->floatMetadata(
+            $fallback->metadata,
+            'fallback_parent_filled_quantity',
+        );
+        $remainderQuantity = $this->floatMetadata(
+            $fallback->metadata,
+            'fallback_remainder_quantity',
+        );
+        $protectionQuantity = $this->floatMetadata(
+            $fallback->metadata,
+            'fallback_protection_quantity',
+        );
+        $parentFilledQuantityDecimal = $this->decimalMetadata(
+            $fallback->metadata,
+            'fallback_parent_filled_quantity_decimal',
+        );
+        $remainderQuantityDecimal = $this->decimalMetadata(
+            $fallback->metadata,
+            'fallback_remainder_quantity_decimal',
+        );
+        $protectionQuantityDecimal = $this->decimalMetadata(
+            $fallback->metadata,
+            'fallback_protection_quantity_decimal',
+        );
+        $expectedParentFilledQuantityDecimal = $this->orderFilledQuantityDecimal($parent);
+        $expectedRemainderQuantityDecimal = $this->orderRemainingQuantityDecimal($parent);
+        $expectedProtectionQuantityDecimal = $this->orderQuantityDecimal($parent);
+        if (
+            $parentFilledQuantity === null
+            || $remainderQuantity === null
+            || $protectionQuantity === null
+            || $parentFilledQuantityDecimal === null
+            || $remainderQuantityDecimal === null
+            || $protectionQuantityDecimal === null
+            || $fallback->clientOrderId !== $this->fallbackClientOrderId($parent)
+            || $fallback->symbol !== $parent->symbol
+            || $fallback->marketType !== $parent->marketType
+            || $fallback->side !== $parent->side
+            || $fallback->positionSide !== $parent->positionSide
+            || $fallback->orderType !== ExchangeOrderType::MARKET
+            || $fallback->timeInForce !== ExchangeTimeInForce::GTC
+            || $fallback->reduceOnly
+            || $fallback->postOnly
+            || $fallback->price !== null
+            || $fallback->stopPrice !== null
+            || abs($fallback->quantity - $parent->remainingQuantity) > 0.00000001
+            || !self::sameDecimal(
+                $this->orderQuantityDecimal($fallback),
+                $expectedRemainderQuantityDecimal,
+            )
+            || $this->stringMetadata($fallback->metadata, 'fallback_parent_order_id')
+                !== $parent->exchangeOrderId
+            || $this->stringMetadata($fallback->metadata, 'fallback_parent_client_order_id')
+                !== $parent->clientOrderId
+            || abs($parentFilledQuantity - $parent->filledQuantity) > 0.00000001
+            || abs($remainderQuantity - $parent->remainingQuantity) > 0.00000001
+            || abs(
+                $protectionQuantity - ($parent->filledQuantity + $parent->remainingQuantity),
+            ) > 0.00000001
+            || !self::sameDecimal(
+                $parentFilledQuantityDecimal,
+                $expectedParentFilledQuantityDecimal,
+            )
+            || !self::sameDecimal($remainderQuantityDecimal, $expectedRemainderQuantityDecimal)
+            || !self::sameDecimal($protectionQuantityDecimal, $expectedProtectionQuantityDecimal)
+            || $this->positiveIntMetadata($fallback->metadata, 'leverage')
+                !== $this->positiveIntMetadata($parent->metadata, 'leverage')
+            || $this->fallbackMarginMode($fallback) !== $this->fallbackMarginMode($parent)
+            || !$this->sameOptionalDecimalMetadata(
+                $fallback->metadata,
+                $parent->metadata,
+                'attached_stop_loss_price_decimal',
+            )
+            || !$this->sameOptionalDecimalMetadata(
+                $fallback->metadata,
+                $parent->metadata,
+                'attached_take_profit_price_decimal',
+            )
+        ) {
+            return false;
+        }
+
+        $parentPolicy = FakeFallbackTakerPolicy::fromMetadata($parent->metadata);
+        $fallbackPolicy = FakeFallbackTakerPolicy::fromMetadata($fallback->metadata);
+        if (!$parentPolicy instanceof FakeFallbackTakerPolicy || !$fallbackPolicy instanceof FakeFallbackTakerPolicy) {
+            return false;
+        }
+        if (
+            $parentPolicy->enabled !== $fallbackPolicy->enabled
+            || $parentPolicy->zoneMin !== $fallbackPolicy->zoneMin
+            || $parentPolicy->zoneMax !== $fallbackPolicy->zoneMax
+            || $parentPolicy->maxSlippageBps !== $fallbackPolicy->maxSlippageBps
+        ) {
+            return false;
+        }
+
+        $terminalStatusMatches = match ($fallback->status) {
+            ExchangeOrderStatus::FILLED => ($parent->metadata['fallback_status'] ?? null) === 'completed'
+                && abs($fallback->filledQuantity - $fallback->quantity) <= 0.00000001,
+            ExchangeOrderStatus::REJECTED => ($parent->metadata['fallback_status'] ?? null) === 'rejected'
+                && $fallback->filledQuantity <= 0.00000001,
+            default => false,
+        };
+
+        return $parent->status === ExchangeOrderStatus::EXPIRED
+            && $terminalStatusMatches
+            && $this->stringMetadata($parent->metadata, 'fallback_order_id') === $fallback->exchangeOrderId
+            && $this->stringMetadata($parent->metadata, 'fallback_client_order_id') === $fallback->clientOrderId
+            && $this->stringMetadata($parent->metadata, 'fallback_trigger')
+                === $this->stringMetadata($fallback->metadata, 'fallback_trigger');
+    }
+
+    /**
+     * @param array<string,mixed> $left
+     * @param array<string,mixed> $right
+     */
+    private function sameOptionalDecimalMetadata(array $left, array $right, string $key): bool
+    {
+        $leftValue = $this->stringMetadata($left, $key);
+        $rightValue = $this->stringMetadata($right, $key);
+        if ($leftValue === null || $rightValue === null) {
+            return $leftValue === $rightValue;
+        }
+
+        return self::sameDecimal($leftValue, $rightValue);
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function positiveIntMetadata(array $metadata, string $key): ?int
+    {
+        $value = $metadata[$key] ?? null;
+        if (\is_int($value) && $value > 0) {
+            return $value;
+        }
+        if (\is_string($value) && ctype_digit($value) && (int) $value > 0) {
+            return (int) $value;
+        }
+
+        return null;
     }
 
     private function placeResult(bool $accepted, PlaceOrderRequest $request, ExchangeOrderDto $order): PlaceOrderResult

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -453,6 +453,7 @@ final readonly class FakeExchangeMatchingEngine
             );
         }
 
+        $fallbackLeverage = $this->positiveIntMetadata($parent->metadata, 'leverage') ?? 1;
         $top = $this->orderBook->top($parent->symbol);
         $executionPrice = $parent->side === ExchangeOrderSide::BUY ? $top->ask : $top->bid;
         $slippageBps = $this->fallbackSlippageBps($parent, $executionPrice);
@@ -465,6 +466,7 @@ final readonly class FakeExchangeMatchingEngine
                 $parent->metadata,
                 $parentAlreadyExpired ? [] : ['reason' => 'fallback_taker_triggered'],
                 [
+                    'leverage' => $fallbackLeverage,
                     'fallback_status' => 'pending',
                     'fallback_slippage_bps' => $slippageBps,
                     'fallback_trigger' => $fallbackTrigger,
@@ -541,7 +543,7 @@ final readonly class FakeExchangeMatchingEngine
             stopPrice: null,
             reduceOnly: false,
             postOnly: false,
-            leverage: $this->positiveIntMetadata($parent->metadata, 'leverage'),
+            leverage: $fallbackLeverage,
             marginMode: $this->fallbackMarginMode($parent),
             clientOrderId: $fallbackClientOrderId,
             attachedStopLossPrice: $this->floatMetadata($parent->metadata, 'attached_stop_loss_price'),

--- a/trading-app/src/Exchange/Fake/FakeExchangeScenarioService.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeScenarioService.php
@@ -18,7 +18,9 @@ final readonly class FakeExchangeScenarioService
 
     public function reset(): void
     {
-        $this->stateStore->reset();
+        $this->stateStore->runAtomically(function (): void {
+            $this->stateStore->reset();
+        });
     }
 
     /**
@@ -26,27 +28,44 @@ final readonly class FakeExchangeScenarioService
      */
     public function movePrice(string $symbol, float $midPrice, float $spreadBps = 2.0): array
     {
-        $book = $this->orderBook->movePrice($symbol, $midPrice, $spreadBps);
+        return $this->stateStore->runAtomically(function () use ($symbol, $midPrice, $spreadBps): array {
+            $book = $this->orderBook->movePrice($symbol, $midPrice, $spreadBps);
 
-        return [
-            'book' => $book,
-            'matched_orders' => $this->matchingEngine->matchOpenOrders($symbol),
-        ];
+            return [
+                'book' => $book,
+                'matched_orders' => $this->matchingEngine->matchOpenOrders($symbol),
+            ];
+        });
     }
 
     public function fillOrder(string $exchangeOrderId, ?float $quantity = null, ?float $price = null): ?ExchangeOrderDto
     {
-        return $this->matchingEngine->fillOrder($exchangeOrderId, $quantity, $price);
+        return $this->stateStore->runAtomically(
+            fn (): ?ExchangeOrderDto => $this->matchingEngine->fillOrder(
+                $exchangeOrderId,
+                $quantity,
+                $price,
+            ),
+        );
+    }
+
+    public function fallbackTaker(string $exchangeOrderId): FakeFallbackTakerResult
+    {
+        return $this->matchingEngine->fallbackTaker($exchangeOrderId);
     }
 
     public function rejectNextProtectionOrder(): void
     {
-        $this->stateStore->rejectNextProtectionOrder();
+        $this->stateStore->runAtomically(function (): void {
+            $this->stateStore->rejectNextProtectionOrder();
+        });
     }
 
     public function failNext(FakeExchangeFault $fault): void
     {
-        $this->stateStore->queueFault($fault);
+        $this->stateStore->runAtomically(function () use ($fault): void {
+            $this->stateStore->queueFault($fault);
+        });
     }
 
     /**

--- a/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeStateStore.php
@@ -559,6 +559,16 @@ class FakeExchangeStateStore
         });
     }
 
+    /**
+     * @template TResult
+     * @param callable(): TResult $operationCallback
+     * @return TResult
+     */
+    public function runAtomically(callable $operationCallback): mixed
+    {
+        return $this->transactional($operationCallback);
+    }
+
     private function firstFaultIndex(FakeExchangeOperation $operation): ?int
     {
         foreach ($this->pendingFaults as $index => $payload) {

--- a/trading-app/src/Exchange/Fake/FakeFallbackTakerPolicy.php
+++ b/trading-app/src/Exchange/Fake/FakeFallbackTakerPolicy.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+final readonly class FakeFallbackTakerPolicy
+{
+    public const VERSION = 'fake-fallback-taker-v1';
+    public const VERSION_KEY = 'fake_fallback_policy_version';
+    public const ENABLED_KEY = 'fake_fallback_enabled';
+    public const ZONE_MIN_KEY = 'fake_fallback_zone_min';
+    public const ZONE_MAX_KEY = 'fake_fallback_zone_max';
+    public const MAX_SLIPPAGE_BPS_KEY = 'fake_fallback_max_slippage_bps';
+
+    public function __construct(
+        public bool $enabled,
+        public float $zoneMin,
+        public float $zoneMax,
+        public float $maxSlippageBps,
+    ) {
+        if (
+            !\is_finite($this->zoneMin)
+            || !\is_finite($this->zoneMax)
+            || $this->zoneMin <= 0.0
+            || $this->zoneMax < $this->zoneMin
+        ) {
+            throw new \InvalidArgumentException('fake_fallback_zone_invalid');
+        }
+        if (!\is_finite($this->maxSlippageBps) || $this->maxSlippageBps < 0.0) {
+            throw new \InvalidArgumentException('fake_fallback_max_slippage_invalid');
+        }
+    }
+
+    /**
+     * @return array<string, bool|float|string>
+     */
+    public function toMetadata(): array
+    {
+        return [
+            self::VERSION_KEY => self::VERSION,
+            self::ENABLED_KEY => $this->enabled,
+            self::ZONE_MIN_KEY => $this->zoneMin,
+            self::ZONE_MAX_KEY => $this->zoneMax,
+            self::MAX_SLIPPAGE_BPS_KEY => $this->maxSlippageBps,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public static function fromMetadata(array $metadata): ?self
+    {
+        if (($metadata[self::VERSION_KEY] ?? null) !== self::VERSION) {
+            return null;
+        }
+        if (!\is_bool($metadata[self::ENABLED_KEY] ?? null)) {
+            return null;
+        }
+        foreach ([self::ZONE_MIN_KEY, self::ZONE_MAX_KEY, self::MAX_SLIPPAGE_BPS_KEY] as $key) {
+            if (!\is_int($metadata[$key] ?? null) && !\is_float($metadata[$key] ?? null)) {
+                return null;
+            }
+        }
+
+        try {
+            return new self(
+                enabled: $metadata[self::ENABLED_KEY],
+                zoneMin: (float) $metadata[self::ZONE_MIN_KEY],
+                zoneMax: (float) $metadata[self::ZONE_MAX_KEY],
+                maxSlippageBps: (float) $metadata[self::MAX_SLIPPAGE_BPS_KEY],
+            );
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+    }
+}

--- a/trading-app/src/Exchange/Fake/FakeFallbackTakerResult.php
+++ b/trading-app/src/Exchange/Fake/FakeFallbackTakerResult.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+use App\Exchange\Dto\ExchangeOrderDto;
+
+final readonly class FakeFallbackTakerResult
+{
+    public function __construct(
+        public bool $executed,
+        public bool $idempotentReplay,
+        public string $reason,
+        public ?ExchangeOrderDto $parentOrder,
+        public ?ExchangeOrderDto $fallbackOrder,
+        public ?float $slippageBps = null,
+    ) {
+    }
+}

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -7,6 +7,8 @@ Supported scenarios:
 - place a maker limit order and fill it later with `FakeExchangeScenarioService::movePrice()`;
 - place a market order and fill it immediately;
 - partially fill and then complete an order with `fillOrder()`;
+- convert the exact remainder of an end-of-zone maker order to a deterministic
+  market fallback with `fallbackTaker()`;
 - create local positions after entry fills;
 - create or reject attached SL/TP protection orders;
 - close a fully filled entry with an immediate reduce-only market order when
@@ -27,6 +29,49 @@ curl http://localhost:8082/fake-exchange/events
 ```
 
 The HTTP service state is stored in `var/fake_exchange_state.dat` so multi-step curl scenarios survive PHP-FPM request boundaries. Tests can instantiate `FakeExchangeStateStore` without a file path for isolated in-memory state, and should call `reset()` before each scenario when sharing a store.
+
+## Deterministic end-of-zone taker fallback
+
+The local scenario API can arm a post-only maker `LIMIT` order with
+`FakeFallbackTakerPolicy::toMetadata()`, then explicitly trigger
+`FakeExchangeScenarioService::fallbackTaker()` when the entry zone ends. The
+policy persists a version, an enabled flag, the valid zone bounds, and the
+maximum adverse slippage in basis points. Missing, malformed, or disabled policy
+metadata fails closed. Only those typed policy fields may cross the ordinary
+request-metadata boundary; parent IDs, exact remainder, aggregate protection,
+trigger, and measured slippage are injected by the engine as trusted derived
+metadata.
+
+The trigger runs atomically with the persisted Fake state. An active maker is
+expired exactly once; a maker already expired before a process restart resumes
+without creating another expiration event. Any maker fill remains recorded, and
+only the exact decimal `quantity - filledQuantity` is submitted as the child
+`MARKET` order. Its
+`clientOrderId` is derived from the parent identity, so replay returns the same
+child only after its complete immutable intent and the parent's terminal audit
+metadata match. A mismatched persisted child fails as an ID conflict. A
+cancelled parent and a zero remainder never create a child.
+
+The current executable top-of-book price must remain inside the persisted zone
+and within the policy's total adverse-slippage limit. That limit includes both
+the displacement from the maker limit to top of book and the fixed 5 bps taker
+cost from `fixed_adverse_slippage_bps_v1`. A guard rejection is audited on the
+parent and is itself replay-idempotent. Once the guards pass, the child goes
+through the ordinary `submit()` and `fillOrder()` path: precision, margin, fee,
+fixed taker slippage, position updates, and rejection persistence are not
+bypassed. Maker and taker costs therefore stay separate.
+
+Attached SL/TP metadata and lineage are copied to the child. Protection uses the
+logical entry quantity, equal to the maker fill plus the fallback remainder, so
+a partial maker fill followed by a fallback is protected for the complete
+position. If protection is rejected, the deterministic reduce-only fail-safe
+also closes that complete logical quantity. If a zone/slippage/margin/validation
+rejection or prior cancellation leaves only a partial maker fill, that exact
+maker exposure is protected; a rejected protection compensates that partial
+exposure. Scenario reset, price movement, direct fill, fault injection, and
+protection-rejection fixtures use the same persisted-state transaction boundary,
+so stale scenario instances reload before mutation. No network client,
+credential, or exchange adapter write path is involved.
 
 ## Attached-protection fail-safe
 

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
@@ -1681,6 +1681,42 @@ final class FakeExchangeAdapterTest extends TestCase
         self::assertCount($eventCountBeforeReplay, $this->scenario->events());
     }
 
+    public function testFallbackTakerFreezesImplicitParentLeverageAcrossSettingMutationAndReplay(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-implicit-leverage',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+            leverage: null,
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        self::assertTrue($this->adapter->setLeverage('BTCUSDT', 25, 'isolated'));
+
+        $first = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        $replay = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertTrue($first->executed);
+        self::assertFalse($first->idempotentReplay);
+        self::assertSame(1, $first->parentOrder?->metadata['leverage'] ?? null);
+        self::assertSame(1, $first->fallbackOrder?->metadata['leverage'] ?? null);
+        self::assertTrue($replay->executed);
+        self::assertTrue($replay->idempotentReplay);
+        self::assertSame($first->fallbackOrder?->exchangeOrderId, $replay->fallbackOrder?->exchangeOrderId);
+        self::assertSame(1, $replay->parentOrder?->metadata['leverage'] ?? null);
+        self::assertSame(1, $replay->fallbackOrder?->metadata['leverage'] ?? null);
+        self::assertSame(
+            ['leverage' => 25, 'margin_mode' => 'isolated'],
+            $this->state->getLeverageSetting('BTCUSDT'),
+        );
+    }
+
     public function testFallbackTakerRestartsFromPersistedExpiredMakerWithoutDuplicateExpiration(): void
     {
         $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_fallback_restart_');

--- a/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
+++ b/trading-app/tests/Exchange/Adapter/FakeExchangeAdapterTest.php
@@ -22,6 +22,7 @@ use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeScenarioService;
 use App\Exchange\Fake\FakeExchangeStateCorruptedException;
 use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Fake\FakeFallbackTakerPolicy;
 use App\Exchange\Fake\FakeInstrument;
 use App\Exchange\Fake\FakeInstrumentProviderInterface;
 use App\Exchange\Fake\FakeOrderValidator;
@@ -1108,6 +1109,849 @@ final class FakeExchangeAdapterTest extends TestCase
         self::assertCount(1, $this->adapter->getOpenPositions('BTCUSDT'));
     }
 
+    public function testFallbackTakerConvertsUnfilledMakerRemainderThroughNormalMarketAndProtectionPath(): void
+    {
+        self::assertTrue(
+            class_exists(FakeFallbackTakerPolicy::class),
+            'The Fake/Paper fallback must expose a typed deterministic policy.',
+        );
+        self::assertTrue(
+            method_exists($this->scenario, 'fallbackTaker'),
+            'The Fake/Paper scenario service must expose the deterministic fallback trigger.',
+        );
+
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-full',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata() + ['internal_trade_id' => 'itd-fallback-full'],
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertTrue($result->executed);
+        self::assertFalse($result->idempotentReplay);
+        self::assertSame('fallback_completed', $result->reason);
+        self::assertNotNull($result->parentOrder);
+        self::assertNotNull($result->fallbackOrder);
+        self::assertSame(ExchangeOrderStatus::EXPIRED, $result->parentOrder->status);
+        self::assertSame(0.0, $result->parentOrder->filledQuantity);
+        self::assertSame(1.0, $result->parentOrder->remainingQuantity);
+        self::assertSame(ExchangeOrderType::MARKET, $result->fallbackOrder->orderType);
+        self::assertSame(ExchangeOrderStatus::FILLED, $result->fallbackOrder->status);
+        self::assertSame(1.0, $result->fallbackOrder->quantity);
+        self::assertSame(1.0, $result->fallbackOrder->filledQuantity);
+        self::assertStringStartsWith('fake-fallback-', (string) $result->fallbackOrder->clientOrderId);
+        self::assertSame(
+            $placed->exchangeOrderId,
+            $result->fallbackOrder->metadata['fallback_parent_order_id'] ?? null,
+        );
+        self::assertSame(
+            'cid-fallback-full',
+            $result->fallbackOrder->metadata['fallback_parent_client_order_id'] ?? null,
+        );
+        self::assertSame(
+            'itd-fallback-full',
+            $result->fallbackOrder->metadata['internal_trade_id'] ?? null,
+        );
+
+        $positions = $this->adapter->getOpenPositions('BTCUSDT');
+        $openOrders = $this->adapter->getOpenOrders('BTCUSDT');
+        self::assertCount(1, $positions);
+        self::assertSame(1.0, $positions[0]->size);
+        self::assertCount(1, $openOrders);
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $openOrders[0]->orderType);
+        self::assertSame(1.0, $openOrders[0]->quantity);
+        self::assertTrue($openOrders[0]->reduceOnly);
+    }
+
+    public function testOrdinaryOrderMetadataCannotForgeFallbackProtectionQuantity(): void
+    {
+        $result = $this->adapter->placeOrder($this->request(
+            orderType: ExchangeOrderType::MARKET,
+            price: null,
+            clientOrderId: 'cid-forged-fallback-protection',
+            postOnly: false,
+            attachedStopLossPrice: 24800.0,
+            metadata: [
+                'fallback_parent_order_id' => 'fake-forged-parent',
+                'fallback_parent_filled_quantity' => 4.0,
+                'fallback_remainder_quantity' => 1.0,
+                'fallback_protection_quantity' => 5.0,
+                'fallback_trigger' => 'forged',
+            ],
+        ));
+
+        self::assertTrue($result->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $result->status);
+        self::assertArrayNotHasKey('fallback_parent_order_id', $result->order->metadata);
+        self::assertArrayNotHasKey('fallback_protection_quantity', $result->order->metadata);
+
+        $position = $this->adapter->getOpenPositions('BTCUSDT')[0] ?? null;
+        $protection = $this->adapter->getOpenOrders('BTCUSDT')[0] ?? null;
+        self::assertNotNull($position);
+        self::assertNotNull($protection);
+        self::assertSame(1.0, $position->size);
+        self::assertSame(1.0, $protection->quantity);
+        self::assertSame(1.0, $protection->remainingQuantity);
+    }
+
+    public function testFallbackReplayRejectsPersistedChildWhoseIntentDoesNotMatchExactRemainder(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-replay-conflict',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        self::assertNotNull($placed->order);
+        $fallbackClientOrderId = 'fake-fallback-' . substr(hash(
+            'sha256',
+            $placed->exchangeOrderId . ':' . $placed->clientOrderId,
+        ), 0, 32);
+        $this->state->saveOrder(new ExchangeOrderDto(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: $this->state->nextOrderId(),
+            clientOrderId: $fallbackClientOrderId,
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::MARKET,
+            status: ExchangeOrderStatus::FILLED,
+            quantity: 0.2,
+            filledQuantity: 0.2,
+            remainingQuantity: 0.0,
+            price: null,
+            averagePrice: 25000.5,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            timeInForce: ExchangeTimeInForce::GTC,
+            createdAt: $placed->order->createdAt,
+            updatedAt: $placed->order->updatedAt,
+            metadata: [
+                'fallback_parent_order_id' => $placed->exchangeOrderId,
+                'quantity_decimal' => '0.2',
+            ],
+        ));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('fake_fallback_client_order_id_conflict');
+
+        $this->scenario->fallbackTaker($placed->exchangeOrderId);
+    }
+
+    public function testFallbackTakerConvertsOnlyTheExactPartiallyFilledMakerRemainder(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-partial',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertTrue($result->executed);
+        self::assertNotNull($result->parentOrder);
+        self::assertNotNull($result->fallbackOrder);
+        self::assertSame(0.4, $result->parentOrder->filledQuantity);
+        self::assertSame(0.6, $result->parentOrder->remainingQuantity);
+        self::assertSame(0.6, $result->fallbackOrder->quantity);
+        self::assertSame(0.6, $result->fallbackOrder->filledQuantity);
+        self::assertSame(1.0, $this->adapter->getOpenPositions('BTCUSDT')[0]->size ?? null);
+    }
+
+    public function testFallbackTakerComputesExactDecimalRemainderAfterPointSevenFill(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-decimal-remainder',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.7, 24950.0);
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertTrue($result->executed);
+        self::assertNotNull($result->fallbackOrder);
+        self::assertSame(ExchangeOrderStatus::FILLED, $result->fallbackOrder->status);
+        self::assertSame(0.3, $result->fallbackOrder->quantity);
+        self::assertSame(0.3, $result->fallbackOrder->filledQuantity);
+        self::assertSame('0.3', $result->fallbackOrder->metadata['quantity_decimal'] ?? null);
+        self::assertSame(1.0, $this->adapter->getOpenPositions('BTCUSDT')[0]->size ?? null);
+    }
+
+    public function testFallbackTakerSupportsShortMakerRemainderAndBuySideProtection(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 25050.0,
+            clientOrderId: 'cid-fallback-short',
+            positionSide: ExchangePositionSide::SHORT,
+            side: ExchangeOrderSide::SELL,
+            postOnly: true,
+            attachedStopLossPrice: 25200.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 25050.0);
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertTrue($result->executed);
+        self::assertNotNull($result->fallbackOrder);
+        self::assertSame(ExchangeOrderSide::SELL, $result->fallbackOrder->side);
+        self::assertSame(ExchangePositionSide::SHORT, $result->fallbackOrder->positionSide);
+        self::assertSame(0.6, $result->fallbackOrder->quantity);
+        $position = $this->adapter->getOpenPositions('BTCUSDT')[0] ?? null;
+        $protection = $this->adapter->getOpenOrders('BTCUSDT')[0] ?? null;
+        self::assertNotNull($position);
+        self::assertNotNull($protection);
+        self::assertSame(ExchangePositionSide::SHORT, $position->side);
+        self::assertSame(1.0, $position->size);
+        self::assertSame(ExchangeOrderSide::BUY, $protection->side);
+        self::assertSame(1.0, $protection->quantity);
+    }
+
+    public function testFallbackTakerProtectionCoversMakerAndTakerExposureAfterPartialFill(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-partial-protection',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+
+        $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        $position = $this->adapter->getOpenPositions('BTCUSDT')[0] ?? null;
+        $protection = $this->adapter->getOpenOrders('BTCUSDT')[0] ?? null;
+        self::assertNotNull($position);
+        self::assertNotNull($protection);
+        self::assertSame(1.0, $position->size);
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $protection->orderType);
+        self::assertTrue($protection->reduceOnly);
+        self::assertSame(1.0, $protection->quantity);
+        self::assertSame(1.0, $protection->remainingQuantity);
+    }
+
+    public function testFallbackTakerDoesNothingWhenMakerHasNoRemainder(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-no-remainder',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId);
+        $orderCountBefore = \count($this->adapter->getOrdersSnapshot('BTCUSDT'));
+        $fillCountBefore = \count($this->adapter->getFillsSnapshot('BTCUSDT'));
+
+        try {
+            $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('A zero remainder must be a deterministic no-op, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertFalse($result->executed);
+        self::assertFalse($result->idempotentReplay);
+        self::assertSame('fallback_remainder_zero', $result->reason);
+        self::assertSame(ExchangeOrderStatus::FILLED, $result->parentOrder?->status);
+        self::assertNull($result->fallbackOrder);
+        self::assertCount($orderCountBefore, $this->adapter->getOrdersSnapshot('BTCUSDT'));
+        self::assertCount($fillCountBefore, $this->adapter->getFillsSnapshot('BTCUSDT'));
+    }
+
+    public function testFallbackTakerExpiresMakerWithoutChildWhenSlippageBudgetIsExceeded(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 10.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-slippage-guard',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+
+        try {
+            $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('The slippage guard must return an audited rejection, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertFalse($result->executed);
+        self::assertFalse($result->idempotentReplay);
+        self::assertSame('fallback_slippage_exceeded', $result->reason);
+        self::assertNotNull($result->slippageBps);
+        self::assertGreaterThan(10.0, $result->slippageBps);
+        self::assertSame(ExchangeOrderStatus::EXPIRED, $result->parentOrder?->status);
+        self::assertNull($result->fallbackOrder);
+        self::assertCount(1, $this->adapter->getOrdersSnapshot('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getFillsSnapshot('BTCUSDT'));
+        self::assertCount(1, $this->scenario->events('fallback_taker.rejected'));
+        self::assertSame(
+            'fallback_slippage_exceeded',
+            $this->scenario->events('fallback_taker.rejected')[0]->payload['reason'] ?? null,
+        );
+    }
+
+    public function testFallbackSlippageGuardIncludesDeterministicTakerCostModel(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 22.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-total-slippage-guard',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertFalse($result->executed);
+        self::assertSame('fallback_slippage_exceeded', $result->reason);
+        self::assertNotNull($result->slippageBps);
+        self::assertGreaterThan(22.0, $result->slippageBps);
+        self::assertEqualsWithDelta(25.240480961924, $result->slippageBps, 0.000000000001);
+        self::assertNull($result->fallbackOrder);
+        self::assertCount(0, $this->adapter->getFillsSnapshot('BTCUSDT'));
+    }
+
+    public function testFallbackTakerGuardRejectionReplayDoesNotDuplicateAuditEvent(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 10.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-guard-replay',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $first = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        $eventCountBeforeReplay = \count($this->scenario->events());
+
+        $replay = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertFalse($first->executed);
+        self::assertFalse($replay->executed);
+        self::assertTrue($replay->idempotentReplay);
+        self::assertSame('fallback_slippage_exceeded', $replay->reason);
+        self::assertSame($first->parentOrder?->exchangeOrderId, $replay->parentOrder?->exchangeOrderId);
+        self::assertNull($replay->fallbackOrder);
+        self::assertCount($eventCountBeforeReplay, $this->scenario->events());
+        self::assertCount(1, $this->scenario->events('fallback_taker.rejected'));
+    }
+
+    public function testFallbackGuardRejectionProtectsExistingMakerPartialFill(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 10.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-guard-partial-protection',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertFalse($result->executed);
+        self::assertSame('fallback_slippage_exceeded', $result->reason);
+        self::assertSame(0.4, $this->adapter->getOpenPositions('BTCUSDT')[0]->size ?? null);
+        $protection = $this->adapter->getOpenOrders('BTCUSDT')[0] ?? null;
+        self::assertNotNull($protection);
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $protection->orderType);
+        self::assertSame(0.4, $protection->quantity);
+        self::assertSame(0.4, $protection->remainingQuantity);
+    }
+
+    public function testFallbackTakerPersistsOrdinaryRejectionWhenMarginBecameInsufficient(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-margin',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->replaceUsdtBalance(total: 1000.0, equity: 1000.0);
+
+        try {
+            $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('A fallback margin rejection must remain persisted, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertFalse($result->executed);
+        self::assertFalse($result->idempotentReplay);
+        self::assertSame('insufficient_balance', $result->reason);
+        self::assertSame(ExchangeOrderStatus::EXPIRED, $result->parentOrder?->status);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $result->fallbackOrder?->status);
+        self::assertSame('insufficient_balance', $result->fallbackOrder?->metadata['reason'] ?? null);
+        self::assertCount(2, $this->adapter->getOrdersSnapshot('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getFillsSnapshot('BTCUSDT'));
+        self::assertCount(1, $this->scenario->events('order.rejected'));
+        self::assertCount(1, $this->scenario->events('fallback_taker.rejected'));
+    }
+
+    public function testFallbackMarginRejectionProtectsExistingMakerPartialFill(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-margin-partial-protection',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+        $this->replaceUsdtBalance(total: 4000.0, equity: 4000.0);
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertFalse($result->executed);
+        self::assertSame('insufficient_balance', $result->reason);
+        self::assertNotNull($result->fallbackOrder);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $result->fallbackOrder->status);
+        self::assertSame(0.4, $this->adapter->getOpenPositions('BTCUSDT')[0]->size ?? null);
+        $protection = $this->adapter->getOpenOrders('BTCUSDT')[0] ?? null;
+        self::assertNotNull($protection);
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $protection->orderType);
+        self::assertSame(0.4, $protection->quantity);
+        self::assertSame(0.4, $protection->remainingQuantity);
+    }
+
+    public function testFallbackRejectionProtectionFailureCompensatesExistingMakerPartialFill(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 10.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-rejection-partial-compensation',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+        $this->scenario->rejectNextProtectionOrder();
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertFalse($result->executed);
+        self::assertSame('fallback_slippage_exceeded', $result->reason);
+        self::assertSame('rejected', $result->parentOrder?->metadata['protection_status'] ?? null);
+        self::assertSame('completed', $result->parentOrder?->metadata['compensation_status'] ?? null);
+        self::assertSame(0.4, $result->parentOrder?->metadata['compensation_quantity'] ?? null);
+        self::assertSame(0.0, $result->parentOrder?->metadata['position_size_after_compensation'] ?? null);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+    }
+
+    public function testFallbackTakerReplayReturnsSameChildWithoutSecondOrderOrFill(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-replay',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $first = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        $orderCountBeforeReplay = \count($this->adapter->getOrdersSnapshot('BTCUSDT'));
+        $fillCountBeforeReplay = \count($this->adapter->getFillsSnapshot('BTCUSDT'));
+        $eventCountBeforeReplay = \count($this->scenario->events());
+
+        try {
+            $replay = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('Fallback replay must return the existing child, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertTrue($replay->executed);
+        self::assertTrue($replay->idempotentReplay);
+        self::assertSame('fallback_completed', $replay->reason);
+        self::assertSame($first->parentOrder?->exchangeOrderId, $replay->parentOrder?->exchangeOrderId);
+        self::assertSame($first->fallbackOrder?->exchangeOrderId, $replay->fallbackOrder?->exchangeOrderId);
+        self::assertSame($first->fallbackOrder?->clientOrderId, $replay->fallbackOrder?->clientOrderId);
+        self::assertCount($orderCountBeforeReplay, $this->adapter->getOrdersSnapshot('BTCUSDT'));
+        self::assertCount($fillCountBeforeReplay, $this->adapter->getFillsSnapshot('BTCUSDT'));
+        self::assertCount($eventCountBeforeReplay, $this->scenario->events());
+    }
+
+    public function testFallbackTakerRestartsFromPersistedExpiredMakerWithoutDuplicateExpiration(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_fallback_restart_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            $policy = new FakeFallbackTakerPolicy(
+                enabled: true,
+                zoneMin: 24900.0,
+                zoneMax: 25100.0,
+                maxSlippageBps: 30.0,
+            );
+            $state = new FakeExchangeStateStore($stateFile);
+            $book = new FakeExchangeOrderBook($state);
+            $engine = new FakeExchangeMatchingEngine($state, $book, $this->fixedClock());
+            $adapter = new FakeExchangeAdapter($state, $book, $engine, $this->fixedClock());
+            $placed = $adapter->placeOrder($this->request(
+                price: 24950.0,
+                clientOrderId: 'cid-fallback-restart',
+                postOnly: true,
+                timeInForce: ExchangeTimeInForce::IOC,
+                attachedStopLossPrice: 24800.0,
+                metadata: $policy->toMetadata(),
+            ));
+            self::assertSame(ExchangeOrderStatus::EXPIRED, $placed->status);
+            self::assertCount(1, $state->events('order.expired'));
+
+            $restoredState = new FakeExchangeStateStore($stateFile);
+            $restoredBook = new FakeExchangeOrderBook($restoredState);
+            $restoredEngine = new FakeExchangeMatchingEngine(
+                $restoredState,
+                $restoredBook,
+                $this->fixedClock(),
+            );
+            $restoredAdapter = new FakeExchangeAdapter(
+                $restoredState,
+                $restoredBook,
+                $restoredEngine,
+                $this->fixedClock(),
+            );
+            $restoredScenario = new FakeExchangeScenarioService(
+                $restoredState,
+                $restoredBook,
+                $restoredEngine,
+            );
+
+            try {
+                $result = $restoredScenario->fallbackTaker((string) $placed->exchangeOrderId);
+            } catch (\LogicException $exception) {
+                self::fail(sprintf('Expired maker restart must remain eligible, got "%s".', $exception->getMessage()));
+            }
+
+            self::assertTrue($restoredState->recoveryMetadata()['restored']);
+            self::assertTrue($result->executed);
+            self::assertSame(ExchangeOrderStatus::EXPIRED, $result->parentOrder?->status);
+            self::assertSame(ExchangeOrderStatus::FILLED, $result->fallbackOrder?->status);
+            self::assertSame('expired', $result->fallbackOrder?->metadata['fallback_trigger'] ?? null);
+            self::assertCount(1, $restoredState->events('order.expired'));
+            self::assertCount(1, $restoredAdapter->getOpenPositions('BTCUSDT'));
+            self::assertCount(1, $restoredAdapter->getOpenOrders('BTCUSDT'));
+
+            $restartedAgainState = new FakeExchangeStateStore($stateFile);
+            $restartedAgainBook = new FakeExchangeOrderBook($restartedAgainState);
+            $restartedAgainEngine = new FakeExchangeMatchingEngine(
+                $restartedAgainState,
+                $restartedAgainBook,
+                $this->fixedClock(),
+            );
+            $replay = (new FakeExchangeScenarioService(
+                $restartedAgainState,
+                $restartedAgainBook,
+                $restartedAgainEngine,
+            ))->fallbackTaker((string) $placed->exchangeOrderId);
+
+            self::assertTrue($replay->idempotentReplay);
+            self::assertNotNull($result->fallbackOrder);
+            self::assertNotNull($replay->fallbackOrder);
+            self::assertSame($result->fallbackOrder->exchangeOrderId, $replay->fallbackOrder->exchangeOrderId);
+            self::assertCount(1, $restartedAgainState->events('order.expired'));
+        } finally {
+            @unlink($stateFile);
+            @unlink($stateFile . '.lock');
+            foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+                @unlink($temporaryFile);
+            }
+        }
+    }
+
+    public function testFallbackTakerExpiresMakerWithoutChildWhenCurrentPriceLeftConfiguredZone(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 24990.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-outside-zone',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+
+        try {
+            $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('An out-of-zone fallback must return an audited rejection, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertFalse($result->executed);
+        self::assertSame('fallback_price_outside_zone', $result->reason);
+        self::assertSame(ExchangeOrderStatus::EXPIRED, $result->parentOrder?->status);
+        self::assertNull($result->fallbackOrder);
+        self::assertCount(1, $this->adapter->getOrdersSnapshot('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getFillsSnapshot('BTCUSDT'));
+        self::assertCount(1, $this->scenario->events('fallback_taker.rejected'));
+        self::assertSame(
+            'fallback_price_outside_zone',
+            $this->scenario->events('fallback_taker.rejected')[0]->payload['reason'] ?? null,
+        );
+    }
+
+    public function testFallbackTakerIsForbiddenAfterMakerCancellation(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-cancelled',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: $placed->exchangeOrderId,
+            clientOrderId: $placed->clientOrderId,
+        ));
+
+        try {
+            $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('A cancelled maker must produce a deterministic no-op, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertFalse($result->executed);
+        self::assertSame('fallback_parent_cancelled', $result->reason);
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $result->parentOrder?->status);
+        self::assertNull($result->fallbackOrder);
+        self::assertCount(1, $this->adapter->getOrdersSnapshot('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getFillsSnapshot('BTCUSDT'));
+    }
+
+    public function testFallbackAfterPartialMakerCancellationProtectsExistingExposureWithoutChild(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-cancelled-partial',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+        $this->adapter->cancelOrder(new CancelOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: $placed->exchangeOrderId,
+            clientOrderId: $placed->clientOrderId,
+        ));
+
+        $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+
+        self::assertFalse($result->executed);
+        self::assertSame('fallback_parent_cancelled', $result->reason);
+        self::assertNull($result->fallbackOrder);
+        self::assertSame(0.4, $this->adapter->getOpenPositions('BTCUSDT')[0]->size ?? null);
+        $protection = $this->adapter->getOpenOrders('BTCUSDT')[0] ?? null;
+        self::assertNotNull($protection);
+        self::assertSame(ExchangeOrderType::STOP_LOSS, $protection->orderType);
+        self::assertSame(0.4, $protection->quantity);
+    }
+
+    public function testFallbackTakerProtectionFailureCompensatesFullMakerAndTakerExposure(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-protection-failure',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+        $this->scenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+        $this->scenario->rejectNextProtectionOrder();
+
+        try {
+            $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('Protection fail-safe must cover the full fallback exposure, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertTrue($result->executed);
+        self::assertSame('rejected', $result->fallbackOrder?->metadata['protection_status'] ?? null);
+        self::assertSame('completed', $result->fallbackOrder?->metadata['compensation_status'] ?? null);
+        self::assertSame('position_closed', $result->fallbackOrder?->metadata['compensation_outcome'] ?? null);
+        self::assertSame(1.0, $result->fallbackOrder?->metadata['compensation_quantity'] ?? null);
+        self::assertSame(1.0, $result->fallbackOrder?->metadata['position_size_before_compensation'] ?? null);
+        self::assertSame(0.0, $result->fallbackOrder?->metadata['position_size_after_compensation'] ?? null);
+        self::assertCount(0, $this->adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(1, $this->scenario->events('protection_order.rejected'));
+        self::assertCount(1, $this->scenario->events('position.closed'));
+    }
+
+    public function testFallbackTakerIsForbiddenWhenPersistedPolicyIsDisabled(): void
+    {
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: false,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $this->adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'cid-fallback-disabled',
+            postOnly: true,
+            metadata: $policy->toMetadata(),
+        ));
+        self::assertNotNull($placed->exchangeOrderId);
+
+        try {
+            $result = $this->scenario->fallbackTaker($placed->exchangeOrderId);
+        } catch (\LogicException $exception) {
+            self::fail(sprintf('A disabled fallback policy must be an explicit no-op, got "%s".', $exception->getMessage()));
+        }
+
+        self::assertFalse($result->executed);
+        self::assertSame('fallback_disabled', $result->reason);
+        self::assertSame(ExchangeOrderStatus::OPEN, $result->parentOrder?->status);
+        self::assertNull($result->fallbackOrder);
+        self::assertCount(1, $this->adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(1, $this->adapter->getOrdersSnapshot('BTCUSDT'));
+        self::assertCount(0, $this->adapter->getFillsSnapshot('BTCUSDT'));
+        self::assertCount(0, $this->scenario->events('fallback_taker.completed'));
+        self::assertCount(0, $this->scenario->events('fallback_taker.rejected'));
+    }
+
     public function testPartialTakerFillsAggregateSlippagePerFill(): void
     {
         $placed = $this->adapter->placeOrder($this->request(price: 24950.0, postOnly: false));
@@ -1861,6 +2705,44 @@ final class FakeExchangeAdapterTest extends TestCase
             $restored = $this->adapterForState(new FakeExchangeStateStore($stateFile));
             self::assertCount(0, $restored->getOpenOrders('BTCUSDT'));
             self::assertSame(ExchangeOrderStatus::CANCELLED, $restored->getOrdersSnapshot('BTCUSDT')[0]->status);
+        } finally {
+            @unlink($stateFile);
+            @unlink($stateFile . '.lock');
+        }
+    }
+
+    public function testStaleScenarioReloadsBeforePartialFillTransaction(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_exchange_scenario_fill_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            $primaryState = new FakeExchangeStateStore($stateFile);
+            $staleState = new FakeExchangeStateStore($stateFile);
+            $staleBook = new FakeExchangeOrderBook($staleState);
+            $staleScenario = new FakeExchangeScenarioService(
+                $staleState,
+                $staleBook,
+                new FakeExchangeMatchingEngine($staleState, $staleBook, $this->fixedClock()),
+            );
+            $placed = $this->adapterForState($primaryState)->placeOrder($this->request(
+                clientOrderId: 'stale-scenario-fill',
+                postOnly: true,
+            ));
+            self::assertNotNull($placed->exchangeOrderId);
+
+            $partial = $staleScenario->fillOrder($placed->exchangeOrderId, 0.4, 24950.0);
+
+            self::assertNotNull($partial);
+            self::assertSame(ExchangeOrderStatus::PARTIALLY_FILLED, $partial->status);
+            self::assertSame(0.4, $partial->filledQuantity);
+            self::assertSame(0.6, $partial->remainingQuantity);
+            $restored = $this->adapterForState(new FakeExchangeStateStore($stateFile));
+            self::assertSame(
+                ExchangeOrderStatus::PARTIALLY_FILLED,
+                $restored->getOrdersSnapshot('BTCUSDT')[0]->status ?? null,
+            );
         } finally {
             @unlink($stateFile);
             @unlink($stateFile . '.lock');

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
@@ -14,7 +14,7 @@ final class FakePaperGoldenScenarioCatalogTest extends TestCase
         'limit_maker_full_fill' => ['executable', []],
         'limit_unfilled_then_expired' => ['executable', []],
         'partial_fill_then_cancel' => ['executable', []],
-        'fallback_taker' => ['unsupported', ['fallback_taker_not_implemented']],
+        'fallback_taker' => ['executable', []],
         'market_with_slippage' => ['executable', []],
         'insufficient_balance' => ['executable', []],
         'precision_reject' => ['executable', []],

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
@@ -33,6 +33,26 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             'protection_quantity' => 0.4,
             'remaining_quantity' => 0.6,
         ],
+        'fallback_taker' => [
+            'fallback_client_linked' => true,
+            'fallback_quantity' => 0.6,
+            'fallback_status' => 'filled',
+            'fallback_trigger' => 'end_of_zone',
+            'fallback_type' => 'market',
+            'maker_liquidity_role' => 'maker',
+            'maker_slippage_cost_usdt' => 0.0,
+            'metadata_redacted' => true,
+            'parent_filled_quantity' => 0.4,
+            'parent_remaining_quantity' => 0.6,
+            'parent_status' => 'expired',
+            'position_entry_order_count' => 2,
+            'position_size' => 1.0,
+            'protection_quantity' => 1.0,
+            'slippage_guard_bps' => 25.240481,
+            'taker_liquidity_role' => 'taker',
+            'taker_slippage_bps' => 5.0,
+            'taker_slippage_cost_usdt' => 7.50015,
+        ],
         'market_with_slippage' => [
             'cost_model_version' => 'fixed_adverse_slippage_bps_v1',
             'execution_price' => 25000.5,
@@ -176,7 +196,7 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             ),
         ));
 
-        self::assertCount(14, $catalogKeys);
+        self::assertCount(15, $catalogKeys);
         self::assertSame($catalogKeys, FakePaperGoldenScenarioRunner::keys());
     }
 

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
@@ -25,6 +25,7 @@ use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeScenarioService;
 use App\Exchange\Fake\FakeExchangeStateStore;
 use App\Exchange\Fake\FakeExchangeWsClient;
+use App\Exchange\Fake\FakeFallbackTakerPolicy;
 use App\Exchange\Fake\FakePrivateWsException;
 use App\Exchange\Fake\FakeInstrumentCatalog;
 use Psr\Clock\ClockInterface;
@@ -35,6 +36,7 @@ final class FakePaperGoldenScenarioRunner
         'limit_maker_full_fill',
         'limit_unfilled_then_expired',
         'partial_fill_then_cancel',
+        'fallback_taker',
         'market_with_slippage',
         'insufficient_balance',
         'precision_reject',
@@ -67,6 +69,7 @@ final class FakePaperGoldenScenarioRunner
             'limit_maker_full_fill' => $this->limitMakerFullFill(),
             'limit_unfilled_then_expired' => $this->limitUnfilledThenExpired(),
             'partial_fill_then_cancel' => $this->partialFillThenCancel(),
+            'fallback_taker' => $this->fallbackTaker(),
             'market_with_slippage' => $this->marketWithSlippage(),
             'insufficient_balance' => $this->insufficientBalance(),
             'precision_reject' => $this->precisionReject(),
@@ -164,6 +167,76 @@ final class FakePaperGoldenScenarioRunner
             'position_size' => $position?->size,
             'protection_quantity' => $protection?->quantity,
             'remaining_quantity' => $cancelled?->remainingQuantity,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function fallbackTaker(): array
+    {
+        [, $adapter, $scenario] = $this->exchange();
+        $policy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $placed = $adapter->placeOrder($this->request(
+            price: 24950.0,
+            clientOrderId: 'golden-fallback-taker',
+            postOnly: true,
+            attachedStopLossPrice: 24800.0,
+            metadata: $policy->toMetadata() + [
+                'internal_trade_id' => 'golden-fallback-trade',
+                'api_key' => 'TOP-SECRET',
+                'raw_payload' => ['authorization' => 'Bearer SECRET'],
+            ],
+        ));
+        $scenario->fillOrder((string) $placed->exchangeOrderId, 0.4, 24950.0);
+        $result = $scenario->fallbackTaker((string) $placed->exchangeOrderId);
+        $fills = $adapter->getFillsSnapshot('BTCUSDT');
+        $makerFill = $fills[0] ?? null;
+        $takerFill = $fills[1] ?? null;
+        $position = $adapter->getOpenPositions('BTCUSDT')[0] ?? null;
+        $protection = $adapter->getOpenOrders('BTCUSDT')[0] ?? null;
+        $serialized = json_encode([
+            $result->parentOrder?->metadata,
+            $result->fallbackOrder?->metadata,
+            array_map(static fn (FakeExchangeEvent $event): array => $event->toArray(), $scenario->events()),
+        ], JSON_THROW_ON_ERROR);
+        $takerNotional = ($takerFill?->quantity ?? 0.0) * ($takerFill?->price ?? 0.0);
+        $takerSlippageCost = $takerFill?->metadata['slippage_cost_usdt'] ?? null;
+
+        return [
+            'fallback_client_linked' => $result->fallbackOrder?->clientOrderId !== null
+                && str_starts_with($result->fallbackOrder->clientOrderId, 'fake-fallback-')
+                && ($result->fallbackOrder->metadata['fallback_parent_order_id'] ?? null)
+                    === $result->parentOrder?->exchangeOrderId,
+            'fallback_quantity' => $result->fallbackOrder?->quantity,
+            'fallback_status' => $result->fallbackOrder?->status->value,
+            'fallback_trigger' => $result->fallbackOrder?->metadata['fallback_trigger'] ?? null,
+            'fallback_type' => $result->fallbackOrder?->orderType->value,
+            'maker_liquidity_role' => $makerFill?->metadata['liquidity_role'] ?? null,
+            'maker_slippage_cost_usdt' => $makerFill?->metadata['slippage_cost_usdt'] ?? null,
+            'metadata_redacted' => !str_contains($serialized, 'TOP-SECRET')
+                && !str_contains($serialized, 'Bearer SECRET')
+                && !str_contains($serialized, 'api_key')
+                && !str_contains($serialized, 'raw_payload'),
+            'parent_filled_quantity' => $result->parentOrder?->filledQuantity,
+            'parent_remaining_quantity' => $result->parentOrder?->remainingQuantity,
+            'parent_status' => $result->parentOrder?->status->value,
+            'position_entry_order_count' => $position?->metadata['entry_order_count'] ?? null,
+            'position_size' => $position?->size,
+            'protection_quantity' => $protection?->quantity,
+            'slippage_guard_bps' => $result->slippageBps !== null
+                ? round($result->slippageBps, 6)
+                : null,
+            'taker_liquidity_role' => $takerFill?->metadata['liquidity_role'] ?? null,
+            'taker_slippage_bps' => is_numeric($takerSlippageCost) && $takerNotional > 0.0
+                ? round(((float) $takerSlippageCost / $takerNotional) * 10_000.0, 6)
+                : null,
+            'taker_slippage_cost_usdt' => is_numeric($takerSlippageCost)
+                ? round((float) $takerSlippageCost, 6)
+                : null,
         ];
     }
 
@@ -549,6 +622,9 @@ final class FakePaperGoldenScenarioRunner
         ];
     }
 
+    /**
+     * @param array<string,mixed> $metadata
+     */
     private function request(
         string $symbol = 'BTCUSDT',
         ExchangeOrderType $orderType = ExchangeOrderType::LIMIT,
@@ -559,6 +635,7 @@ final class FakePaperGoldenScenarioRunner
         ?float $attachedStopLossPrice = null,
         float $quantity = 1.0,
         ?int $leverage = 3,
+        array $metadata = [],
     ): PlaceOrderRequest {
         return new PlaceOrderRequest(
             exchange: Exchange::FAKE,
@@ -577,6 +654,7 @@ final class FakePaperGoldenScenarioRunner
             marginMode: 'isolated',
             clientOrderId: $clientOrderId,
             attachedStopLossPrice: $attachedStopLossPrice,
+            metadata: $metadata,
         );
     }
 

--- a/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
+++ b/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
@@ -29,13 +29,17 @@
       "status": "executable"
     },
     {
-      "evidence": ["docs/handbook/technical/fake-paper-gateway.md#limites-restantes"],
-      "gap_codes": ["fallback_taker_not_implemented"],
+      "evidence": [
+        "tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testFallbackTakerConvertsOnlyTheExactPartiallyFilledMakerRemainder",
+        "tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testFallbackTakerReplayReturnsSameChildWithoutSecondOrderOrFill",
+        "tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testFallbackTakerRestartsFromPersistedExpiredMakerWithoutDuplicateExpiration"
+      ],
+      "gap_codes": [],
       "id": 4,
       "name": "fallback_taker",
       "requirement": "An expired maker attempt can be replaced by a bounded taker fallback.",
-      "runner": null,
-      "status": "unsupported"
+      "runner": "fallback_taker",
+      "status": "executable"
     },
     {
       "evidence": ["tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php::testExecutableScenarioIsDeterministicAndMatchesGoldenFacts"],


### PR DESCRIPTION
## Summary
- implement deterministic Fake/Paper end-of-zone taker fallback
- submit only the exact maker remainder through normal validation/fill paths
- cover idempotence, replay, slippage, margin, protection and compensation
- promote golden scenario 4 to executable and document the contract

## References
- Part of #196
- Related to #278
- Related to #279
- Related to #280
- Related to #281

## Validation
- 1091 tests, 4877 assertions, 30 expected skips
- PHPStan: 0 errors with 1GiB
- `python3 -m mkdocs build --strict`
- Symfony container/YAML lint: 55 YAML valid
- PHP syntax, JSON fixture and `git diff --check`

## Safety
- Fake/Paper only; no exchange access or orders
- no mainnet/demo/testnet writes
- #196 remains open with documented gaps

## Known non-blocking limits
- explicit opt-in trigger, not an automatic scheduler
- top-of-book model with fixed 5 bps taker slippage, no historical L2 depth
- remaining #196 gaps: trailing, out-of-order, funding, One-Way, multi-profile, daily loss cap and liquidation