### PR TITLE
feat(fake): add deterministic TP1 trailing state machine (#196)

### DIFF
--- a/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
+++ b/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
@@ -10,7 +10,7 @@
 | Ordre | Prompt | Statut | Branche | PR | HEAD validé | Profil final | CI | Revue Codex | Terminé UTC |
 |---:|---|---|---|---:|---|---|---|---|---|
 | 1 | #196 — Fallback taker de fin de zone | done | issue/196-fake-fallback-taker-v1 | #282 | 4186abf243a035af16f7672bc493c225d31112d3 | worker_critical → review_fix | verte | favorable sur 4186abf243 | 2026-07-16T14:18:05Z |
-| 2 | #196 — TP1 puis trailing stop | pending | — | — | — | — | — | — | — |
+| 2 | #196 — TP1 puis trailing stop | in_progress | issue/196-fake-tp1-trailing-v1 | — | — | worker_critical | — | — | — |
 | 3 | #196 — Injection out-of-order | pending | — | — | — | — | — | — | — |
 | 4 | #196 — Funding positif/négatif | pending | — | — | — | — | — | — | — |
 | 5 | #196 — Garde One-Way | pending | — | — | — | — | — | — | — |

--- a/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
+++ b/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
@@ -10,7 +10,7 @@
 | Ordre | Prompt | Statut | Branche | PR | HEAD validé | Profil final | CI | Revue Codex | Terminé UTC |
 |---:|---|---|---|---:|---|---|---|---|---|
 | 1 | #196 — Fallback taker de fin de zone | done | issue/196-fake-fallback-taker-v1 | #282 | 4186abf243a035af16f7672bc493c225d31112d3 | worker_critical → review_fix | verte | favorable sur 4186abf243 | 2026-07-16T14:18:05Z |
-| 2 | #196 — TP1 puis trailing stop | done | issue/196-fake-tp1-trailing-v1 | #283 | 39b92b9f051d5e423c75fc0ac0964f462b39530e | worker_critical → review_fix → review_escalated | verte | favorable sur 39b92b9f05 | 2026-07-16T19:11:21Z |
+| 2 | #196 — TP1 puis trailing stop | done | issue/196-fake-tp1-trailing-v1 | #283 | 806f92dc1a162b50515a44e42a825f976f0610cb | worker_critical → review_fix → review_escalated | verte | favorable sur 806f92dc1a | 2026-07-16T19:32:05Z |
 | 3 | #196 — Injection out-of-order | pending | — | — | — | — | — | — | — |
 | 4 | #196 — Funding positif/négatif | pending | — | — | — | — | — | — | — |
 | 5 | #196 — Garde One-Way | pending | — | — | — | — | — | — | — |

--- a/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
+++ b/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
@@ -10,7 +10,7 @@
 | Ordre | Prompt | Statut | Branche | PR | HEAD validé | Profil final | CI | Revue Codex | Terminé UTC |
 |---:|---|---|---|---:|---|---|---|---|---|
 | 1 | #196 — Fallback taker de fin de zone | done | issue/196-fake-fallback-taker-v1 | #282 | 4186abf243a035af16f7672bc493c225d31112d3 | worker_critical → review_fix | verte | favorable sur 4186abf243 | 2026-07-16T14:18:05Z |
-| 2 | #196 — TP1 puis trailing stop | in_progress | issue/196-fake-tp1-trailing-v1 | — | — | worker_critical | — | — | — |
+| 2 | #196 — TP1 puis trailing stop | done | issue/196-fake-tp1-trailing-v1 | #283 | 39b92b9f051d5e423c75fc0ac0964f462b39530e | worker_critical → review_fix → review_escalated | verte | favorable sur 39b92b9f05 | 2026-07-16T19:11:21Z |
 | 3 | #196 — Injection out-of-order | pending | — | — | — | — | — | — | — |
 | 4 | #196 — Funding positif/négatif | pending | — | — | — | — | — | — | — |
 | 5 | #196 — Garde One-Way | pending | — | — | — | — | — | — | — |

--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -297,6 +297,59 @@ l etat persiste sous le meme verrou avant modification. Ce trigger est une
 fixture Fake/Paper locale : il n appelle aucun provider, ne lit aucun credential
 et ne peut ecrire ni en mainnet, ni en demo, ni en testnet.
 
+## TP1 partiel puis trailing deterministe
+
+Le moteur Fake/Paper accepte la politique opt-in versionnee
+`fake-tp1-trailing-v1`. Elle est fournie uniquement par une fixture locale et
+contient un flag actif, une quantite TP1 decimale exacte et un offset trailing
+absolu en unite de prix. Elle n est lue dans aucun profil de strategie. Une
+capability demandee mais incomplete, desactivee, malformee, sans SL/TP attaches,
+ou dont la quantite TP1 n est pas strictement inferieure a la quantite d entree
+echoue explicitement avant mutation. Sans aucune cle de cette politique, le
+comportement SL/TP historique reste inchange.
+
+Le SL initial couvre toute l exposition et TP1 couvre seulement la quantite
+declaree par la fixture. Un fill incomplet de l ordre TP1 conserve le SL. Quand
+TP1 atteint sa quantite configuree, la transaction fichier existante enchaine le
+fill reduce-only, le ledger de couts, le reliquat decimal exact, l annulation du
+SL avec `tp1_replaced_by_trailing`, puis la creation d un `TRIGGER` reduce-only
+sur ce reliquat. La transition normalisee `trailing_stop.armed` porte le lineage
+derive et redacted.
+
+Le `TRIGGER` est l etat trailing versionne et persistant : ses metadata portent
+la version, le statut `active` ou `triggered`, l ordre TP1 d activation, le
+watermark favorable, l offset fixe et les decimaux derives. Aucun registre BDD ni
+migration n est ajoute. Un restart restaure donc watermark, stop, ordre, position
+et sequence d evenements depuis `fake-paper-state-v1`.
+
+L algorithme est monotone :
+
+- long : `watermark = max(watermark, mid)` et
+  `stop = watermark - offset` ; le stop ne peut que monter ;
+- short : `watermark = min(watermark, mid)` et
+  `stop = watermark + offset` ; le stop ne peut que descendre ;
+- prix adverse ou duplique : aucune reecriture et aucun evenement ;
+- nouveau watermark : une seule transition `trailing_stop.updated`.
+
+Un gap au-dela du stop remplit au prochain bid/ask Fake disponible par le chemin
+de fill ordinaire, ferme seulement le reliquat reduce-only, puis emet une seule
+transition `trailing_stop.triggered`. La fermeture complete annule les
+protections residuelles. Entree, TP1 et trailing gardent les frais, slippage,
+spread, PnL et versions de modele du ledger normal ; un cout inconnu ne devient
+pas zero silencieusement.
+
+La race est serialisee par le verrou d etat. SL-first ferme et annule TP1 ; TP1
+devient ensuite un no-op. TP1-first remplace atomiquement le SL ; le SL stale
+devient un no-op. Une exception pendant le remplacement restaure ensemble
+position, ordres, evenements et ledger. Les replays d entree comparent aussi la
+politique immutable ; TP1, prix, gap ou fill terminal rejoues ne dupliquent ni
+ordre, ni evenement, ni cout, ni PnL.
+
+Les cas long et short sont explicites dans
+`trading-app/tests/fixtures/fake-paper/tp1-trailing-v1.json`. Ils ne contactent
+aucun reseau, ne lisent aucun secret et n activent ni demo, ni testnet, ni
+mainnet.
+
 ## Golden suite Fake/Paper v1
 
 Le catalogue versionne des 20 scenarios obligatoires de #196 est disponible dans :
@@ -318,19 +371,19 @@ Une ligne presente dans le catalogue n est pas un PASS. Seul le statut `executab
 avec un test vert constitue une preuve. Les lignes `partial` et `unsupported` ne
 peuvent ni rendre le runtime-check ready, ni autoriser une mutation demo/testnet.
 
-Les quinze scenarios executes dans cette version sont : maker limit rempli, limit
+Les seize scenarios executes dans cette version sont : maker limit rempli, limit
 IOC expire sans fill, partial fill puis cancel, fallback taker de fin de zone sur
 le reliquat exact, market avec slippage 5 bps, insufficient balance, precision
 reject, leverage cap reject, replay du `client_order_id`, timeout apres
 acceptation, attachement SL reussi, echec d attachement SL compense par fermeture
-market reduce-only, gap au SL au prochain prix disponible, deconnexion/reprise
-private WS, et restart avec position protegee ouverte.
+market reduce-only, TP1 partiel puis trailing persistant long/short, gap au SL au
+prochain prix disponible, deconnexion/reprise private WS, et restart avec
+position protegee ouverte.
 
 Les ecarts encore explicites sont :
 
 | Scenario | Statut | Gap stable |
 | --- | --- | --- |
-| TP1 puis trailing | `partial` | `trailing_stop_not_implemented` |
 | duplicate/out-of-order event | `partial` | `out_of_order_event_injection_not_implemented` |
 | funding | `unsupported` | `funding_model_not_implemented` |
 | One-Way conflict | `unsupported` | `one_way_conflict_guard_not_implemented` |
@@ -367,6 +420,14 @@ puis restaurer le scenario golden 4 en `unsupported` avec
 `fallback_taker_not_implemented`. Le fichier d etat doit etre archive ou
 quarantaine avant de lancer une revision qui ne connait pas ses metadata
 additives. Ce rollback ne doit jamais servir a activer une ecriture exchange.
+
+Le rollback de TP1/trailing doit retirer `FakeTp1TrailingPolicy`, les transitions
+locales d armement/ratchet/trigger et la fixture long/short, puis restaurer le
+scenario golden 13 en `partial` avec `trailing_stop_not_implemented`. Tout fichier
+d etat Fake contenant `fake-tp1-trailing-v1` doit etre archive ou place en
+quarantaine avant une revision qui ne connait pas ces metadata additives. Il ne
+doit jamais etre reutilise silencieusement ni servir a activer demo, testnet ou
+mainnet.
 
 ## Suite
 

--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -316,6 +316,13 @@ SL avec `tp1_replaced_by_trailing`, puis la creation d un `TRIGGER` reduce-only
 sur ce reliquat. La transition normalisee `trailing_stop.armed` porte le lineage
 derive et redacted.
 
+Si une sortie reduce-only manuelle a deja diminue la position avant la fin de
+TP1, la quantite trailing est le minimum entre le reliquat protege planifie et
+l exposition agregee encore ouverte apres TP1. Elle ne peut donc ni depasser la
+position courante, ni absorber une exposition anterieure au-dela du reliquat de
+l entree protegee. Le modele Fake agrege les positions par symbole et cote : il
+ne pretend pas attribuer cette reduction manuelle a un lot d entree precis.
+
 Si l entree utilise aussi le fallback taker de fin de zone, la politique trailing
 est propagee a l enfant `MARKET`. La quantite TP1 est alors validee contre
 l exposition logique totale parent plus enfant, jamais contre le seul petit

--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -316,6 +316,11 @@ SL avec `tp1_replaced_by_trailing`, puis la creation d un `TRIGGER` reduce-only
 sur ce reliquat. La transition normalisee `trailing_stop.armed` porte le lineage
 derive et redacted.
 
+Si l entree utilise aussi le fallback taker de fin de zone, la politique trailing
+est propagee a l enfant `MARKET`. La quantite TP1 est alors validee contre
+l exposition logique totale parent plus enfant, jamais contre le seul petit
+reliquat fallback. Le replay de l enfant compare les deux politiques persistantes.
+
 Le `TRIGGER` est l etat trailing versionne et persistant : ses metadata portent
 la version, le statut `active` ou `triggered`, l ordre TP1 d activation, le
 watermark favorable, l offset fixe et les decimaux derives. Aucun registre BDD ni

--- a/docs/superpowers/plans/2026-07-16-fake-tp1-trailing-v1.md
+++ b/docs/superpowers/plans/2026-07-16-fake-tp1-trailing-v1.md
@@ -1,0 +1,173 @@
+# Fake/Paper TP1 Then Trailing v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic, restart-safe Fake/Paper trailing stop that arms only after an explicitly configured partial TP1 fill.
+
+**Architecture:** A typed Fake-only metadata policy supplies the exact TP1 quantity and fixed absolute offset. The active reduce-only `TRIGGER` order is the sole persisted trailing state, so the existing file transaction atomically covers position reduction, SL replacement, watermark changes, lifecycle events, replay, and rollback.
+
+**Tech Stack:** PHP 8.3, Symfony DTO/services, PHPUnit 11, Brick Math decimal validation, JSON fixtures, MkDocs.
+
+---
+
+## File Structure
+
+- Create `trading-app/src/Exchange/Fake/FakeTp1TrailingPolicy.php`: validate and serialize the trusted Fake-only fixture policy.
+- Modify `trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php`: validate policy use, size TP1, arm/update/trigger the persistent trailing order, and normalize lifecycle transitions.
+- Create `trading-app/tests/fixtures/fake-paper/tp1-trailing-v1.json`: explicit long and short prices, quantities, offset, favorable/adverse moves, and gap.
+- Create `trading-app/tests/Exchange/Fake/FakeTp1TrailingPolicyTest.php`: policy contract and fail-closed validation.
+- Create `trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php`: focused integration coverage for every mandatory behavior and state restart.
+- Modify `trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json`: promote scenario 13.
+- Modify `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php`: freeze the executable classification.
+- Modify `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php`: freeze normalized scenario 13 facts.
+- Modify `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php`: execute both direction fixtures deterministically.
+- Modify `trading-app/src/Exchange/Fake/README.md` and `docs/handbook/technical/fake-paper-gateway.md`: document algorithm, persistence, lifecycle, safety, and rollback.
+
+### Task 1: Typed Policy Contract
+
+- [ ] **Step 1: Write the failing policy tests**
+
+Create `FakeTp1TrailingPolicyTest` with a valid round-trip and invalid providers for missing version, disabled capability, non-decimal TP1 quantity, and non-positive offset. The desired API is:
+
+```php
+$policy = new FakeTp1TrailingPolicy('0.4', '100.0');
+self::assertEquals($policy, FakeTp1TrailingPolicy::fromMetadata($policy->toMetadata()));
+```
+
+- [ ] **Step 2: Run RED**
+
+Run the policy test in the required ephemeral container. Expected: error because `FakeTp1TrailingPolicy` does not exist.
+
+- [ ] **Step 3: Implement the minimum policy value object**
+
+Expose four metadata keys, the fixed version, strict unsigned decimal parsing through `BigDecimal`, `toMetadata()`, `fromMetadata()`, float projections, and explicit `fake_tp1_trailing_policy_invalid` / `fake_tp1_trailing_policy_disabled` failures. Return `null` only when none of the policy keys is present.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the same test. Expected: all policy tests pass.
+
+### Task 2: TP1 Sizing, Atomic SL Replacement, and Persistent Arming
+
+- [ ] **Step 1: Add the long/short JSON fixture and failing integration tests**
+
+The fixture uses total quantity `1.0`, TP1 quantity `0.4`, and absolute offset `100.0`. Add focused tests proving:
+
+- attached TP1 quantity is exactly `0.4` while initial SL is `1.0`;
+- filling TP1 leaves position `0.6`, cancels the initial SL, and creates one reduce-only `TRIGGER` of `0.6`;
+- TP1 activation emits one `trailing_stop.armed` transition and persists version, active state, watermark, offset, parent, and activation IDs;
+- incomplete policy metadata fails explicitly before any order or position mutation;
+- replaying the TP1 fill creates no second trailing order or event;
+- restart restores the active trigger, watermark, redacted lineage, and event sequence;
+- SL-first and TP1-first race orderings are deterministic;
+- a forced failure while saving the trigger rolls the TP1 fill, position change, cancellation, and events back together.
+
+- [ ] **Step 2: Run RED**
+
+Run only `FakeTp1TrailingTest`. Expected: failures because TP remains full-size, closes the position, and no trailing trigger or lifecycle state exists.
+
+- [ ] **Step 3: Implement policy propagation and atomic arming**
+
+In the matching engine:
+
+- whitelist only policy keys alongside existing lineage/fallback keys;
+- invoke the policy parser during request-intent validation;
+- require a non-reduce entry with both attached protections and `0 < tp1 < entry quantity`;
+- create opted-in TP as suffix/kind `tp1` with exact configured quantity;
+- retain full-size initial SL;
+- on a completely filled TP1 with remaining position, cancel the initial SL using `tp1_replaced_by_trailing` and create a deterministic reduce-only `TRIGGER` whose metadata owns versioned state;
+- do not apply the legacy partial-trigger sibling cancellation rule to an opted-in TP1 until TP1 is complete;
+- derive the trigger client ID from parent and TP1 identities, validate any existing derived child, and fail on conflict;
+- append `protection_order.created` and `trailing_stop.armed` for the derived trigger.
+
+- [ ] **Step 4: Run GREEN**
+
+Run `FakeTp1TrailingPolicyTest` and `FakeTp1TrailingTest`. Expected: policy, arming, restart, replay, race, rollback, and redaction tests pass.
+
+### Task 3: Monotone Watermark and Duplicate Price Idempotence
+
+- [ ] **Step 1: Write failing direction-specific tests**
+
+For both JSON fixture cases, assert two favorable movements ratchet the watermark and stop in one direction only. Add separate tests proving an adverse movement leaves the stop unchanged and a duplicate movement leaves both state and `trailing_stop.updated` count unchanged.
+
+- [ ] **Step 2: Run RED**
+
+Run those focused tests. Expected: stop and watermark remain at their activation values because matching does not yet ratchet trailing orders.
+
+- [ ] **Step 3: Implement the minimum ratchet**
+
+Before matching open orders, inspect active versioned trailing triggers. Use `max()` for long and `min()` for short, derive the absolute-offset stop, enforce stop monotonicity, save only favorable changes, and append exactly one `trailing_stop.updated` event per changed watermark. Reject malformed persisted trailing state explicitly.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the focused class. Expected: long/short favorable progression, no loosening, and duplicate idempotence pass.
+
+### Task 4: Gap Trigger, Cleanup, and Single-Count Ledger
+
+- [ ] **Step 1: Write failing terminal tests**
+
+Move each direction through favorable prices, then gap beyond the active stop. Assert:
+
+- fill uses the next available top-of-book price rather than the stop price;
+- only the exact `0.6` remainder closes reduce-only;
+- no position or protection remains;
+- trigger state becomes `triggered` and one `trailing_stop.triggered` event exists;
+- repeating the price/fill is a no-op;
+- entry plus TP1 plus trailing produce exactly three fills;
+- final close payload has `entry_qty=1.0`, `exit_qty=1.0`, `remaining_qty=0.0`, coherent quantity, complete costs, non-null model versions, and no duplicate PnL/fee booking.
+
+- [ ] **Step 2: Run RED**
+
+Run the terminal test filter. Expected: ordinary trigger closure may occur, but terminal trailing state/event assertions fail.
+
+- [ ] **Step 3: Implement terminal normalization**
+
+When a versioned trailing trigger fills, persist status `triggered` and execution price on that order and append one `trailing_stop.triggered` transition after the ordinary fill event. Continue to use the existing fill-cost and position-ledger paths; add no cost defaults.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the full focused trailing class. Expected: gap, cleanup, replay, quantities, fees, and PnL assertions pass for long and short.
+
+### Task 5: Golden Scenario 13
+
+- [ ] **Step 1: Promote catalog expectations before the catalog data**
+
+Change the catalog test expectation for `tp1_then_trailing` to `['executable', []]`, expect 16 runner keys, and add normalized expected facts for long and short terminal paths.
+
+- [ ] **Step 2: Run RED**
+
+Run catalog and execution tests. Expected: scenario 13 is still partial, runner keys differ, and expected facts are absent.
+
+- [ ] **Step 3: Implement fixture catalog and runner**
+
+Promote scenario 13, remove its gap, reference focused evidence, set runner `tp1_then_trailing`, add the runner key/match branch, load the versioned fixture, and return deterministic facts covering configured quantities, offsets, monotone stops, gap fills, cleanup, event counts, restart/replay evidence, and cost completeness.
+
+- [ ] **Step 4: Run GREEN**
+
+Run catalog, execution, parity, policy, and focused tests. Expected: scenario 13 executes twice identically and every golden assertion passes.
+
+### Task 6: Documentation and Final Verification
+
+- [ ] **Step 1: Document the implemented contract**
+
+Update both Fake/Paper documents with policy fields, TP1 transition, long/short formulas, lifecycle names, transaction/restart behavior, duplicate behavior, gap execution, cost lineage, safety boundary, and rollback/quarantine steps. Update golden counts and remove only scenario 13 from remaining gaps.
+
+- [ ] **Step 2: Run proportional verification in a fresh ephemeral container**
+
+Copy this worktree exactly as prescribed and run:
+
+- focused policy/trailing tests;
+- Fake adapter, fault, contract, event, runtime, golden, and TradingCore Fake suites;
+- PHPStan over every touched PHP file;
+- Symfony container lint if DI wiring changed;
+- JSON/YAML lint for touched fixtures/config;
+- MkDocs strict;
+- a repository secret/redaction scan over the diff;
+- `git diff --check`.
+
+- [ ] **Step 3: Auto-review the complete diff**
+
+Compare every requirement in the approved design and Prompt 2 against tests and code. Inspect atomic ordering, exact remainder, state validation, client-ID conflicts, long/short monotonicity, lifecycle uniqueness, restart, rollback, costs, lineage whitelist, network isolation, and unchanged `mainnet_write_enabled: false`.
+
+- [ ] **Step 4: Commit coherent changes without integration actions**
+
+Create implementation and documentation commits on `issue/196-fake-tp1-trailing-v1`. Do not push, open a PR, merge, or mark the orchestration registry done.

--- a/docs/superpowers/specs/2026-07-16-fake-tp1-trailing-v1-design.md
+++ b/docs/superpowers/specs/2026-07-16-fake-tp1-trailing-v1-design.md
@@ -1,0 +1,142 @@
+# Fake/Paper TP1 Then Trailing v1 Design
+
+## Scope
+
+This change implements issue #196 golden scenario 13, `tp1_then_trailing`, only
+inside the local Fake/Paper exchange. A fixture opts an entry into a partial
+TP1 followed by a deterministic trailing stop. No strategy, MTF rule, EntryZone,
+live profile, provider, network client, credential, demo/testnet path, or
+mainnet permission changes.
+
+The existing behavior remains unchanged when no trailing policy is requested.
+If any trailing-policy field is present, the complete capability contract must
+be valid; malformed, incomplete, disabled, or incoherent requests fail
+explicitly instead of silently falling back to a full-size take profit.
+
+## Chosen Architecture
+
+The versioned trailing state is carried by the reduce-only `TRIGGER` order. The
+existing `fake-paper-state-v1` envelope already persists orders, order metadata,
+positions, order books, events, and event sequences under one file transaction.
+Consequently, the active watermark and derived stop survive restart without a
+new database migration or a second source of truth.
+
+A focused `FakeTp1TrailingPolicy` value object owns the trusted fixture contract:
+
+- policy version `fake-tp1-trailing-v1`;
+- explicit enabled flag;
+- exact TP1 quantity;
+- fixed absolute trailing offset in quote-price units.
+
+Only these typed scalar policy fields cross the ordinary request-metadata
+boundary. Parent IDs, activation order IDs, watermark, stop, state status,
+remaining quantity, and lifecycle lineage are derived by the matching engine.
+Raw payloads, headers, credentials, and arbitrary metadata are never copied.
+
+## Entry and Protection Creation
+
+An opted-in entry must provide both an attached stop-loss price and an attached
+take-profit price. Its TP1 quantity must be positive and strictly below the
+entry quantity; its offset must be finite and positive. The normal order
+validator remains responsible for exchange context, quantity, price, leverage,
+margin, and precision.
+
+After the entry fills, attached protection is created as follows:
+
+- the initial `STOP_LOSS` is reduce-only for the complete filled exposure;
+- the `TAKE_PROFIT` is reduce-only for the fixture's exact TP1 quantity;
+- both protection orders retain the approved scalar lineage and trusted policy;
+- legacy entries without the policy keep their existing full-size SL/TP behavior.
+
+## Atomic TP1 Transition
+
+`FakeExchangeScenarioService::fillOrder()` and `movePrice()` already execute
+inside `FakeExchangeStateStore::runAtomically()`. On a complete TP1 fill that
+leaves exposure, the matching engine performs one atomic transition:
+
+1. book the normal reduce-only fill, fee, costs, and partial position update;
+2. cancel the active initial SL with reason `tp1_replaced_by_trailing`;
+3. create one reduce-only `TRIGGER` for the exact remaining position quantity;
+4. initialize the favorable watermark to the TP1 execution price;
+5. derive the first stop from the fixed offset;
+6. append `trailing_stop.armed` with versioned, redacted lineage.
+
+For a long, `stop = watermark - offset`. For a short,
+`stop = watermark + offset`. The fixture values must keep the initial trailing
+stop coherent with the scenario's initial SL; the engine never invents policy
+from a live profile.
+
+If the SL fills first, ordinary sibling cleanup cancels TP1 and a later attempt
+to fill that cancelled TP1 is a no-op. If TP1 fills first, the SL is cancelled
+before the trailing order becomes visible. The state transaction rolls the
+position, orders, ledger, and events back together if any step throws.
+
+## Watermark and Trigger Algorithm
+
+Before matching open orders after a price move, the engine updates each active
+versioned trailing order from the current deterministic mid price:
+
+- long: `new_watermark = max(old_watermark, mid)` and the stop may only rise;
+- short: `new_watermark = min(old_watermark, mid)` and the stop may only fall;
+- an adverse or duplicate price produces no state write and no lifecycle event;
+- a favorable change persists the new watermark and stop, then appends exactly
+  one `trailing_stop.updated` event.
+
+Matching then uses the ordinary `TRIGGER` crossing rule. A gap through the stop
+fills at the next available simulated top-of-book price. Before the normal fill
+event is emitted, the trailing order receives terminal state `triggered`; one
+`trailing_stop.triggered` transition identifies the execution. The normal
+reduce-only fill closes only the remaining position, and full closure cancels
+any residual protection sharing the parent lineage.
+
+## Persistence, Replay, and Idempotence
+
+The trigger order persists these state fields in its metadata:
+
+- state version;
+- state status (`active` or `triggered`);
+- activation TP1 order ID;
+- favorable watermark;
+- fixed offset;
+- parent entry lineage.
+
+The order quantity and stop price remain the canonical remaining quantity and
+derived stop. Restart reconstructs them through the existing typed order
+serialization. Replaying the entry returns the original order. Replaying a TP1
+fill, a duplicate price, an unchanged adverse price, or a filled trailing order
+does not create another order, fill, fee, PnL booking, or lifecycle event.
+
+The deterministic trailing client-order ID is derived from the parent entry and
+TP1 identities. An existing derived child is accepted only when its immutable
+intent and versioned state lineage match; a conflict fails explicitly.
+
+## Costs and PnL
+
+TP1 and trailing execution use the existing `fillOrder()` path and
+`FakeFillCostModel`. The position ledger therefore records one entry quantity,
+the configured TP1 exit quantity, and the exact trailing remainder. Final close
+evidence must report coherent entry/exit quantities, complete fill lineage, and
+the existing non-null cost model versions. Missing or invalid cost inputs remain
+exceptions; the trailing feature does not introduce a zero-cost fallback.
+
+## Fixtures and Golden Evidence
+
+`tests/fixtures/fake-paper/tp1-trailing-v1.json` contains explicit long and short
+cases. Each case fixes entry direction, total quantity, TP1 quantity, initial SL,
+TP1 price, absolute offset, favorable moves, an adverse move, and a gap price.
+The fixtures are test-only Fake/Paper inputs.
+
+Golden scenario 13 becomes `executable`, removes
+`trailing_stop_not_implemented`, and runs deterministic long and short paths.
+Focused tests cover TP1 arming, exact remainder, favorable monotonic movement,
+no loosening, gap execution, duplicate prices, restart, TP1/SL race ordering,
+cleanup, event uniqueness, lineage redaction, and single-count costs/PnL.
+
+## Rollback
+
+Rollback removes the policy and matching branches, restores scenario 13 to
+`partial` with `trailing_stop_not_implemented`, and removes the focused fixture
+and documentation. Before running a revision that does not understand the
+additive trailing metadata, archive or quarantine any Fake state file containing
+`fake-tp1-trailing-v1`; never silently reuse it. Rollback does not alter or enable
+any network, demo, testnet, or mainnet write path.

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -1157,7 +1157,7 @@ final readonly class FakeExchangeMatchingEngine
 
     private function activateTrailingStop(
         ExchangeOrderDto $tp1Order,
-        float $remainingQuantity,
+        float $positionRemainingQuantity,
         float $watermark,
     ): ExchangeOrderDto {
         $policy = FakeTp1TrailingPolicy::fromMetadata($tp1Order->metadata);
@@ -1168,8 +1168,23 @@ final readonly class FakeExchangeMatchingEngine
         if (!$tp1Order->positionSide instanceof ExchangePositionSide) {
             throw new \LogicException('fake_tp1_trailing_position_side_unavailable');
         }
+        $parentOrder = $this->stateStore->getOrder($parentOrderId);
+        if (
+            !$parentOrder instanceof ExchangeOrderDto
+            || $parentOrder->symbol !== $tp1Order->symbol
+            || $parentOrder->marketType !== $tp1Order->marketType
+            || $parentOrder->positionSide !== $tp1Order->positionSide
+        ) {
+            throw new \LogicException('fake_tp1_trailing_activation_state_invalid');
+        }
 
         try {
+            $protectedQuantityDecimalValue = BigDecimal::of(self::canonicalFloat(
+                $this->protectionQuantity($parentOrder),
+            ));
+            $quantityDecimalValue = $protectedQuantityDecimalValue
+                ->minus($this->orderFilledQuantityDecimal($tp1Order))
+                ->stripTrailingZeros();
             $watermarkDecimalValue = BigDecimal::of(self::canonicalFloat($watermark));
             $rawStopPriceDecimalValue = $tp1Order->positionSide === ExchangePositionSide::LONG
                 ? $watermarkDecimalValue->minus($policy->trailingOffset)
@@ -1182,11 +1197,18 @@ final readonly class FakeExchangeMatchingEngine
         } catch (MathException) {
             throw new \LogicException('fake_tp1_trailing_stop_invalid');
         }
-        $quantityDecimal = self::canonicalFloat($remainingQuantity);
+        $quantityDecimal = (string) $quantityDecimalValue;
+        $remainingQuantity = (float) $quantityDecimal;
         $watermarkDecimal = (string) $watermarkDecimalValue;
         $stopPriceDecimal = (string) $stopPriceDecimalValue;
         $stopPrice = (float) $stopPriceDecimal;
-        if (!\is_finite($stopPrice) || $stopPrice <= 0.0 || $remainingQuantity <= 0.00000001) {
+        if (
+            !\is_finite($stopPrice)
+            || $stopPrice <= 0.0
+            || !\is_finite($remainingQuantity)
+            || $remainingQuantity <= 0.00000001
+            || $remainingQuantity > $positionRemainingQuantity + 0.00000001
+        ) {
             throw new \LogicException('fake_tp1_trailing_stop_invalid');
         }
         $validation = $this->derivedProtectionValidation(
@@ -1252,6 +1274,10 @@ final readonly class FakeExchangeMatchingEngine
             if (
                 $initialStop->stopPrice === null
                 || !\is_finite($initialStop->stopPrice)
+                || !self::sameDecimal(
+                    $this->orderRemainingQuantityDecimal($initialStop),
+                    (string) $protectedQuantityDecimalValue,
+                )
                 || (
                     $tp1Order->positionSide === ExchangePositionSide::LONG
                     && $stopPrice < $initialStop->stopPrice

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -89,7 +89,7 @@ final readonly class FakeExchangeMatchingEngine
     ): PlaceOrderResult
     {
         $this->assertRequestContext($request);
-        $this->assertRequestIntent($request);
+        $this->assertRequestIntent($request, $trustedFallbackMetadata);
         $request = $this->withPersistedLeverageSetting($request);
 
         $existing = $this->stateStore->getOrderByClientOrderId($request->symbol, $request->clientOrderId);
@@ -565,7 +565,8 @@ final readonly class FakeExchangeMatchingEngine
             attachedStopLossPrice: $this->floatMetadata($parent->metadata, 'attached_stop_loss_price'),
             attachedTakeProfitPrice: $this->floatMetadata($parent->metadata, 'attached_take_profit_price'),
             metadata: $this->lineageMetadata($parent->metadata)
-                + $policy->toMetadata(),
+                + $policy->toMetadata()
+                + $this->tp1TrailingPolicyMetadata($parent->metadata),
             quantityDecimal: $fallbackQuantityDecimal,
             attachedStopLossPriceDecimal: $this->stringMetadata(
                 $parent->metadata,
@@ -1950,6 +1951,7 @@ final readonly class FakeExchangeMatchingEngine
 
         return $parent->status === ExchangeOrderStatus::EXPIRED
             && $terminalStatusMatches
+            && $this->tp1TrailingPolicyMatchesRequest($fallback->metadata, $parent->metadata)
             && $this->stringMetadata($parent->metadata, 'fallback_order_id') === $fallback->exchangeOrderId
             && $this->stringMetadata($parent->metadata, 'fallback_client_order_id') === $fallback->clientOrderId
             && $this->stringMetadata($parent->metadata, 'fallback_trigger')
@@ -2079,7 +2081,13 @@ final readonly class FakeExchangeMatchingEngine
         }
     }
 
-    private function assertRequestIntent(PlaceOrderRequest $request): void
+    /**
+     * @param array<string,bool|float|int|string|null> $trustedMetadata
+     */
+    private function assertRequestIntent(
+        PlaceOrderRequest $request,
+        array $trustedMetadata = [],
+    ): void
     {
         if ($request->postOnly && $request->orderType !== ExchangeOrderType::LIMIT) {
             throw new \InvalidArgumentException('postOnly is only supported for limit orders');
@@ -2124,7 +2132,11 @@ final readonly class FakeExchangeMatchingEngine
 
         try {
             $tp1Quantity = BigDecimal::of($trailingPolicy->tp1Quantity);
-            $entryQuantity = BigDecimal::of($request->exactQuantity() ?? '');
+            $logicalQuantity = $this->stringMetadata(
+                $trustedMetadata,
+                'fallback_protection_quantity_decimal',
+            ) ?? $request->exactQuantity() ?? '';
+            $entryQuantity = BigDecimal::of($logicalQuantity);
         } catch (MathException) {
             throw new \InvalidArgumentException('fake_tp1_trailing_quantity_invalid');
         }

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -710,20 +710,38 @@ final readonly class FakeExchangeMatchingEngine
                 continue;
             }
 
-            $newStopPrice = $order->positionSide === ExchangePositionSide::LONG
-                ? $midPrice - $policy->trailingOffsetFloat()
-                : $midPrice + $policy->trailingOffsetFloat();
+            try {
+                $midPriceDecimal = BigDecimal::of(self::canonicalFloat($midPrice));
+                $newStopPriceDecimal = $order->positionSide === ExchangePositionSide::LONG
+                    ? $midPriceDecimal->minus($policy->trailingOffset)
+                    : $midPriceDecimal->plus($policy->trailingOffset);
+            } catch (MathException) {
+                throw new \LogicException('fake_tp1_trailing_ratchet_invalid');
+            }
+            $newStopPrice = (float) (string) $newStopPriceDecimal;
             $monotone = $order->positionSide === ExchangePositionSide::LONG
                 ? $newStopPrice >= $order->stopPrice - 0.00000001
                 : $newStopPrice <= $order->stopPrice + 0.00000001;
             if (!\is_finite($newStopPrice) || $newStopPrice <= 0.0 || !$monotone) {
                 throw new \LogicException('fake_tp1_trailing_ratchet_invalid');
             }
+            $validation = $this->derivedProtectionValidation(
+                marketType: $order->marketType,
+                symbol: $order->symbol,
+                positionSide: $order->positionSide,
+                marginMode: 'isolated',
+                orderType: ExchangeOrderType::STOP_LOSS,
+                quantityDecimal: $this->orderRemainingQuantityDecimal($order),
+                stopPriceDecimal: (string) $newStopPriceDecimal,
+            );
+            if (!$validation->accepted) {
+                throw new \LogicException('fake_tp1_trailing_ratchet_invalid');
+            }
 
             $metadata = array_replace($order->metadata, [
                 'trailing_watermark' => $midPrice,
-                'trailing_watermark_decimal' => self::canonicalFloat($midPrice),
-                'stop_price_decimal' => self::canonicalFloat($newStopPrice),
+                'trailing_watermark_decimal' => (string) $midPriceDecimal,
+                'stop_price_decimal' => (string) $newStopPriceDecimal,
             ]);
             $updated = $this->withTrailingState($order, $newStopPrice, $metadata);
             $this->stateStore->saveOrder($updated);
@@ -1097,10 +1115,36 @@ final readonly class FakeExchangeMatchingEngine
             throw new \LogicException('fake_tp1_trailing_position_side_unavailable');
         }
 
-        $stopPrice = $tp1Order->positionSide === ExchangePositionSide::LONG
-            ? $watermark - $policy->trailingOffsetFloat()
-            : $watermark + $policy->trailingOffsetFloat();
+        try {
+            $watermarkDecimalValue = BigDecimal::of(self::canonicalFloat($watermark));
+            $stopPriceDecimalValue = $tp1Order->positionSide === ExchangePositionSide::LONG
+                ? $watermarkDecimalValue->minus($policy->trailingOffset)
+                : $watermarkDecimalValue->plus($policy->trailingOffset);
+        } catch (MathException) {
+            throw new \LogicException('fake_tp1_trailing_stop_invalid');
+        }
+        $quantityDecimal = self::canonicalFloat($remainingQuantity);
+        $watermarkDecimal = (string) $watermarkDecimalValue;
+        $stopPriceDecimal = (string) $stopPriceDecimalValue;
+        $stopPrice = (float) $stopPriceDecimal;
         if (!\is_finite($stopPrice) || $stopPrice <= 0.0 || $remainingQuantity <= 0.00000001) {
+            throw new \LogicException('fake_tp1_trailing_stop_invalid');
+        }
+        $validation = $this->derivedProtectionValidation(
+            marketType: $tp1Order->marketType,
+            symbol: $tp1Order->symbol,
+            positionSide: $tp1Order->positionSide,
+            marginMode: 'isolated',
+            orderType: ExchangeOrderType::STOP_LOSS,
+            quantityDecimal: $quantityDecimal,
+            stopPriceDecimal: $stopPriceDecimal,
+        );
+        if (!$validation->accepted) {
+            $reason = $validation->reason ?? 'order_validation_failed';
+            if (str_starts_with($reason, 'quantity_') || $reason === 'notional_below_minimum') {
+                throw new \LogicException('fake_tp1_trailing_quantity_invalid');
+            }
+
             throw new \LogicException('fake_tp1_trailing_stop_invalid');
         }
 
@@ -1109,13 +1153,32 @@ final readonly class FakeExchangeMatchingEngine
             $parentOrderId . ':' . $tp1Order->exchangeOrderId,
         ), 0, 32);
         $existing = $this->stateStore->getOrderByClientOrderId($tp1Order->symbol, $clientOrderId);
+
+        $initialStops = [];
+        foreach ($this->stateStore->getOpenOrders($tp1Order->symbol) as $candidate) {
+            if (
+                $candidate->exchangeOrderId !== $existing?->exchangeOrderId
+                &&
+                $candidate->orderType === ExchangeOrderType::STOP_LOSS
+                && $this->stringMetadata($candidate->metadata, 'parent_order_id') === $parentOrderId
+            ) {
+                $initialStops[] = $candidate;
+            }
+        }
         if ($existing instanceof ExchangeOrderDto) {
+            if ($initialStops !== []) {
+                throw new \LogicException('fake_tp1_trailing_existing_child_with_initial_stop_active');
+            }
             if (!$this->trailingChildMatchesActivation(
                 $existing,
                 $tp1Order,
                 $remainingQuantity,
                 $watermark,
                 $stopPrice,
+                $quantityDecimal,
+                $watermarkDecimal,
+                $stopPriceDecimal,
+                $policy,
             )) {
                 throw new \LogicException('fake_tp1_trailing_client_order_id_conflict');
             }
@@ -1123,25 +1186,29 @@ final readonly class FakeExchangeMatchingEngine
             return $existing;
         }
 
-        $initialStopFound = false;
-        foreach ($this->stateStore->getOpenOrders($tp1Order->symbol) as $candidate) {
-            if (
-                $candidate->orderType !== ExchangeOrderType::STOP_LOSS
-                || $this->stringMetadata($candidate->metadata, 'parent_order_id') !== $parentOrderId
-            ) {
-                continue;
-            }
-
-            $initialStopFound = true;
-            $this->cancelOpenOrder($candidate, 'tp1_replaced_by_trailing');
-        }
-        if (!$initialStopFound) {
+        if ($initialStops === []) {
             throw new \LogicException('fake_tp1_trailing_initial_stop_unavailable');
         }
+        foreach ($initialStops as $initialStop) {
+            if (
+                $initialStop->stopPrice === null
+                || !\is_finite($initialStop->stopPrice)
+                || (
+                    $tp1Order->positionSide === ExchangePositionSide::LONG
+                    && $stopPrice < $initialStop->stopPrice
+                )
+                || (
+                    $tp1Order->positionSide === ExchangePositionSide::SHORT
+                    && $stopPrice > $initialStop->stopPrice
+                )
+            ) {
+                throw new \LogicException('fake_tp1_trailing_stop_looser_than_initial_stop');
+            }
+        }
+        foreach ($initialStops as $initialStop) {
+            $this->cancelOpenOrder($initialStop, 'tp1_replaced_by_trailing');
+        }
 
-        $quantityDecimal = self::canonicalFloat($remainingQuantity);
-        $watermarkDecimal = self::canonicalFloat($watermark);
-        $stopPriceDecimal = self::canonicalFloat($stopPrice);
         $metadata = $this->lineageMetadata($tp1Order->metadata)
             + $policy->toMetadata()
             + [
@@ -1207,21 +1274,87 @@ final readonly class FakeExchangeMatchingEngine
         float $remainingQuantity,
         float $watermark,
         float $stopPrice,
+        string $quantityDecimal,
+        string $watermarkDecimal,
+        string $stopPriceDecimal,
+        FakeTp1TrailingPolicy $policy,
     ): bool {
-        return $trailing->symbol === $tp1Order->symbol
+        $parentOrderId = $this->stringMetadata($tp1Order->metadata, 'parent_order_id');
+        $parentClientOrderId = $this->stringMetadata($tp1Order->metadata, 'parent_client_order_id');
+        if ($parentOrderId === null) {
+            return false;
+        }
+        $clientOrderId = 'fake-trailing-' . substr(hash(
+            'sha256',
+            $parentOrderId . ':' . $tp1Order->exchangeOrderId,
+        ), 0, 32);
+        $expectedPolicy = $policy->toMetadata();
+
+        return $trailing->exchange === $tp1Order->exchange
+            && $trailing->symbol === $tp1Order->symbol
             && $trailing->marketType === $tp1Order->marketType
+            && $trailing->clientOrderId === $clientOrderId
             && $trailing->side === $tp1Order->side
             && $trailing->positionSide === $tp1Order->positionSide
             && $trailing->orderType === ExchangeOrderType::TRIGGER
             && $trailing->status === ExchangeOrderStatus::OPEN
             && $trailing->reduceOnly
             && !$trailing->postOnly
-            && abs($trailing->quantity - $remainingQuantity) <= 0.00000001
-            && abs(($trailing->stopPrice ?? 0.0) - $stopPrice) <= 0.00000001
+            && $trailing->timeInForce === null
+            && $trailing->quantity === $remainingQuantity
+            && $trailing->filledQuantity === 0.0
+            && $trailing->remainingQuantity === $remainingQuantity
+            && $trailing->price === null
+            && $trailing->averagePrice === null
+            && $trailing->stopPrice === $stopPrice
+            && $this->stringMetadata($trailing->metadata, 'source') === 'fake_exchange'
+            && $this->stringMetadata($trailing->metadata, 'protection_kind') === 'trailing'
+            && $this->stringMetadata($trailing->metadata, 'parent_order_id') === $parentOrderId
+            && $this->stringMetadata($trailing->metadata, 'parent_client_order_id') === $parentClientOrderId
+            && $this->lineageMetadata($trailing->metadata) === $this->lineageMetadata($tp1Order->metadata)
+            && $this->exactMetadataValuesMatch($trailing->metadata, $expectedPolicy)
             && $this->stringMetadata($trailing->metadata, 'trailing_state_version') === FakeTp1TrailingPolicy::VERSION
             && $this->stringMetadata($trailing->metadata, 'trailing_state_status') === 'active'
             && $this->stringMetadata($trailing->metadata, 'trailing_activation_order_id') === $tp1Order->exchangeOrderId
-            && abs(($this->floatMetadata($trailing->metadata, 'trailing_watermark') ?? 0.0) - $watermark) <= 0.00000001;
+            && ($trailing->metadata['trailing_watermark'] ?? null) === $watermark
+            && ($trailing->metadata['quantity_decimal'] ?? null) === $quantityDecimal
+            && ($trailing->metadata['filled_quantity_decimal'] ?? null) === '0'
+            && ($trailing->metadata['remaining_quantity_decimal'] ?? null) === $quantityDecimal
+            && ($trailing->metadata['stop_price_decimal'] ?? null) === $stopPriceDecimal
+            && ($trailing->metadata['trailing_watermark_decimal'] ?? null) === $watermarkDecimal
+            && $this->optionalExactMetadataValueMatches(
+                $trailing->metadata,
+                $tp1Order->metadata,
+                'margin_contract_size',
+            );
+    }
+
+    /**
+     * @param array<string,mixed> $actual
+     * @param array<string,bool|string> $expected
+     */
+    private function exactMetadataValuesMatch(array $actual, array $expected): bool
+    {
+        foreach ($expected as $key => $value) {
+            if (!\array_key_exists($key, $actual) || $actual[$key] !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string,mixed> $actual
+     * @param array<string,mixed> $expected
+     */
+    private function optionalExactMetadataValueMatches(array $actual, array $expected, string $key): bool
+    {
+        if (!\array_key_exists($key, $expected)) {
+            return !\array_key_exists($key, $actual);
+        }
+
+        return \array_key_exists($key, $actual) && $actual[$key] === $expected[$key];
     }
 
     private function isTp1ProtectionOrder(ExchangeOrderDto $order): bool
@@ -2137,12 +2270,105 @@ final readonly class FakeExchangeMatchingEngine
                 'fallback_protection_quantity_decimal',
             ) ?? $request->exactQuantity() ?? '';
             $entryQuantity = BigDecimal::of($logicalQuantity);
+            $tp1Price = BigDecimal::of($request->exactAttachedTakeProfitPrice() ?? '');
+            $trailingQuantity = $entryQuantity->minus($tp1Quantity);
+            $initialTrailingStop = $request->positionSide === ExchangePositionSide::LONG
+                ? $tp1Price->minus($trailingPolicy->trailingOffset)
+                : $tp1Price->plus($trailingPolicy->trailingOffset);
         } catch (MathException) {
             throw new \InvalidArgumentException('fake_tp1_trailing_quantity_invalid');
         }
         if ($tp1Quantity->isGreaterThanOrEqualTo($entryQuantity)) {
             throw new \InvalidArgumentException('fake_tp1_trailing_quantity_invalid');
         }
+
+        $this->assertDerivedProtectionValid(
+            $request,
+            ExchangeOrderType::TAKE_PROFIT,
+            (string) $tp1Quantity,
+            (string) $tp1Price,
+        );
+        $this->assertDerivedProtectionValid(
+            $request,
+            ExchangeOrderType::STOP_LOSS,
+            (string) $trailingQuantity,
+            (string) $initialTrailingStop,
+        );
+    }
+
+    private function assertDerivedProtectionValid(
+        PlaceOrderRequest $entryRequest,
+        ExchangeOrderType $orderType,
+        string $quantityDecimal,
+        string $stopPriceDecimal,
+    ): void {
+        $validation = $this->derivedProtectionValidation(
+            marketType: $entryRequest->marketType,
+            symbol: $entryRequest->symbol,
+            positionSide: $entryRequest->positionSide,
+            marginMode: $entryRequest->marginMode,
+            orderType: $orderType,
+            quantityDecimal: $quantityDecimal,
+            stopPriceDecimal: $stopPriceDecimal,
+        );
+        if ($validation->accepted) {
+            return;
+        }
+
+        $reason = $validation->reason ?? 'order_validation_failed';
+        if (
+            str_starts_with($reason, 'quantity_')
+            || $reason === 'notional_below_minimum'
+        ) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_quantity_invalid');
+        }
+
+        throw new \InvalidArgumentException('fake_tp1_trailing_stop_invalid');
+    }
+
+    private function derivedProtectionValidation(
+        MarketType $marketType,
+        string $symbol,
+        ExchangePositionSide $positionSide,
+        string $marginMode,
+        ExchangeOrderType $orderType,
+        string $quantityDecimal,
+        string $stopPriceDecimal,
+    ): FakeOrderValidationResult {
+        $quantity = (float) $quantityDecimal;
+        $stopPrice = (float) $stopPriceDecimal;
+        if (
+            !\is_finite($quantity)
+            || $quantity <= 0.0
+            || !\is_finite($stopPrice)
+            || $stopPrice <= 0.0
+        ) {
+            return FakeOrderValidationResult::rejected('stop_price_not_quantized');
+        }
+
+        $side = $positionSide === ExchangePositionSide::LONG
+            ? ExchangeOrderSide::SELL
+            : ExchangeOrderSide::BUY;
+
+        return $this->orderValidator->validate(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: $marketType,
+            symbol: $symbol,
+            side: $side,
+            positionSide: $positionSide,
+            orderType: $orderType,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: $quantity,
+            price: null,
+            stopPrice: $stopPrice,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: null,
+            marginMode: $marginMode,
+            clientOrderId: 'fake-tp1-trailing-capability-validation',
+            quantityDecimal: $quantityDecimal,
+            stopPriceDecimal: $stopPriceDecimal,
+        ), $stopPrice, 0.0);
     }
 
     private function wouldCross(PlaceOrderRequest $request): bool

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -249,6 +249,13 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         $requestedFillQuantity = min($quantity ?? $order->remainingQuantity, $order->remainingQuantity);
+        if (
+            $this->isActiveTrailingOrder($order)
+            && $requestedFillQuantity > 0.00000001
+            && $requestedFillQuantity < $order->remainingQuantity - 0.00000001
+        ) {
+            throw new \LogicException('fake_tp1_trailing_partial_fill_unsupported');
+        }
         $fillQuantity = $requestedFillQuantity;
         $cancelReduceRemainder = false;
         if ($order->reduceOnly) {

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -1189,9 +1189,17 @@ final readonly class FakeExchangeMatchingEngine
             $protectedQuantityDecimalValue = BigDecimal::of(self::canonicalFloat(
                 $this->protectionQuantity($parentOrder),
             ));
-            $quantityDecimalValue = $protectedQuantityDecimalValue
+            $protectedRemainderDecimalValue = $protectedQuantityDecimalValue
                 ->minus($this->orderFilledQuantityDecimal($tp1Order))
                 ->stripTrailingZeros();
+            $positionRemainingDecimalValue = BigDecimal::of(self::canonicalFloat(
+                $positionRemainingQuantity,
+            ));
+            $quantityDecimalValue = $protectedRemainderDecimalValue->isLessThan(
+                $positionRemainingDecimalValue,
+            )
+                ? $protectedRemainderDecimalValue
+                : $positionRemainingDecimalValue;
             $watermarkDecimalValue = BigDecimal::of(self::canonicalFloat($watermark));
             $rawStopPriceDecimalValue = $tp1Order->positionSide === ExchangePositionSide::LONG
                 ? $watermarkDecimalValue->minus($policy->trailingOffset)

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -289,6 +289,13 @@ final readonly class FakeExchangeMatchingEngine
                 'remaining_quantity_decimal' => $newRemainingDecimal,
             ],
         );
+        if ($status === ExchangeOrderStatus::FILLED && $this->isActiveTrailingOrder($order)) {
+            $metadata = array_replace($metadata, [
+                'trailing_state_status' => 'triggered',
+                'trailing_trigger_price' => $executionPrice,
+                'trailing_trigger_price_decimal' => self::canonicalFloat($executionPrice),
+            ]);
+        }
         $metadata = $cancelReduceRemainder
             ? array_replace($metadata, [
                 'reason' => 'reduce_only_position_size_capped',
@@ -350,6 +357,15 @@ final readonly class FakeExchangeMatchingEngine
                 'cost_completeness' => 'complete',
             ],
         );
+        if ($status === ExchangeOrderStatus::FILLED && $this->isActiveTrailingOrder($updated)) {
+            $this->appendEvent('trailing_stop.triggered', $updated, [
+                'state_version' => FakeTp1TrailingPolicy::VERSION,
+                'watermark' => $this->floatMetadata($updated->metadata, 'trailing_watermark'),
+                'stop_price' => $updated->stopPrice,
+                'fill_quantity' => $fillQuantity,
+                'fill_price' => $executionPrice,
+            ]);
+        }
 
         if ($cancelReduceRemainder) {
             $this->appendEvent('order.cancelled', $updated, ['reason' => 'reduce_only_position_size_capped']);
@@ -640,6 +656,8 @@ final readonly class FakeExchangeMatchingEngine
      */
     public function matchOpenOrders(string $symbol): array
     {
+        $this->ratchetTrailingStops($symbol);
+
         $filled = [];
         foreach ($this->stateStore->getOpenOrders($symbol) as $order) {
             if ($order->orderType === ExchangeOrderType::LIMIT) {
@@ -657,6 +675,65 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         return $filled;
+    }
+
+    private function ratchetTrailingStops(string $symbol): void
+    {
+        $midPrice = $this->midPrice($symbol);
+        foreach ($this->stateStore->getOpenOrders($symbol) as $order) {
+            if (!$this->isActiveTrailingOrder($order)) {
+                continue;
+            }
+
+            $policy = FakeTp1TrailingPolicy::fromMetadata($order->metadata);
+            $watermark = $this->floatMetadata($order->metadata, 'trailing_watermark');
+            if (
+                !$policy instanceof FakeTp1TrailingPolicy
+                || !$order->positionSide instanceof ExchangePositionSide
+                || $order->stopPrice === null
+                || $order->stopPrice <= 0.0
+                || $watermark === null
+                || $watermark <= 0.0
+                || $this->stringMetadata($order->metadata, 'trailing_state_version') !== FakeTp1TrailingPolicy::VERSION
+                || $this->stringMetadata($order->metadata, 'trailing_state_status') !== 'active'
+                || $this->stringMetadata($order->metadata, 'parent_order_id') === null
+                || $this->stringMetadata($order->metadata, 'trailing_activation_order_id') === null
+            ) {
+                throw new \LogicException('fake_tp1_trailing_persisted_state_invalid');
+            }
+
+            $favorable = $order->positionSide === ExchangePositionSide::LONG
+                ? $midPrice > $watermark + 0.00000001
+                : $midPrice < $watermark - 0.00000001;
+            if (!$favorable) {
+                continue;
+            }
+
+            $newStopPrice = $order->positionSide === ExchangePositionSide::LONG
+                ? $midPrice - $policy->trailingOffsetFloat()
+                : $midPrice + $policy->trailingOffsetFloat();
+            $monotone = $order->positionSide === ExchangePositionSide::LONG
+                ? $newStopPrice >= $order->stopPrice - 0.00000001
+                : $newStopPrice <= $order->stopPrice + 0.00000001;
+            if (!\is_finite($newStopPrice) || $newStopPrice <= 0.0 || !$monotone) {
+                throw new \LogicException('fake_tp1_trailing_ratchet_invalid');
+            }
+
+            $metadata = array_replace($order->metadata, [
+                'trailing_watermark' => $midPrice,
+                'trailing_watermark_decimal' => self::canonicalFloat($midPrice),
+                'stop_price_decimal' => self::canonicalFloat($newStopPrice),
+            ]);
+            $updated = $this->withTrailingState($order, $newStopPrice, $metadata);
+            $this->stateStore->saveOrder($updated);
+            $this->appendEvent('trailing_stop.updated', $updated, [
+                'state_version' => FakeTp1TrailingPolicy::VERSION,
+                'previous_watermark' => $watermark,
+                'watermark' => $midPrice,
+                'previous_stop_price' => $order->stopPrice,
+                'stop_price' => $newStopPrice,
+            ]);
+        }
     }
 
     /**
@@ -1150,6 +1227,45 @@ final readonly class FakeExchangeMatchingEngine
     {
         return $order->orderType === ExchangeOrderType::TAKE_PROFIT
             && $this->stringMetadata($order->metadata, 'protection_kind') === 'tp1';
+    }
+
+    private function isActiveTrailingOrder(ExchangeOrderDto $order): bool
+    {
+        return $order->orderType === ExchangeOrderType::TRIGGER
+            && $this->stringMetadata($order->metadata, 'protection_kind') === 'trailing';
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    private function withTrailingState(
+        ExchangeOrderDto $order,
+        float $stopPrice,
+        array $metadata,
+    ): ExchangeOrderDto {
+        return new ExchangeOrderDto(
+            exchange: $order->exchange,
+            marketType: $order->marketType,
+            symbol: $order->symbol,
+            exchangeOrderId: $order->exchangeOrderId,
+            clientOrderId: $order->clientOrderId,
+            side: $order->side,
+            positionSide: $order->positionSide,
+            orderType: $order->orderType,
+            status: $order->status,
+            quantity: $order->quantity,
+            filledQuantity: $order->filledQuantity,
+            remainingQuantity: $order->remainingQuantity,
+            price: $order->price,
+            averagePrice: $order->averagePrice,
+            stopPrice: $stopPrice,
+            reduceOnly: $order->reduceOnly,
+            postOnly: $order->postOnly,
+            timeInForce: $order->timeInForce,
+            createdAt: $order->createdAt,
+            updatedAt: $this->clock->now(),
+            metadata: $metadata,
+        );
     }
 
     /**
@@ -2221,8 +2337,29 @@ final readonly class FakeExchangeMatchingEngine
         if ($storedMarginMode !== null && $storedMarginMode !== '' && $storedMarginMode !== $request->marginMode) {
             return false;
         }
+        if (!$this->tp1TrailingPolicyMatchesRequest($order->metadata, $request->metadata)) {
+            return false;
+        }
 
         return true;
+    }
+
+    /**
+     * @param array<string,mixed> $persistedMetadata
+     * @param array<string,mixed> $requestMetadata
+     */
+    private function tp1TrailingPolicyMatchesRequest(
+        array $persistedMetadata,
+        array $requestMetadata,
+    ): bool {
+        $persisted = FakeTp1TrailingPolicy::fromMetadata($persistedMetadata);
+        $requested = FakeTp1TrailingPolicy::fromMetadata($requestMetadata);
+        if (!$persisted instanceof FakeTp1TrailingPolicy || !$requested instanceof FakeTp1TrailingPolicy) {
+            return $persisted === null && $requested === null;
+        }
+
+        return self::sameDecimal($persisted->tp1Quantity, $requested->tp1Quantity)
+            && self::sameDecimal($persisted->trailingOffset, $requested->trailingOffset);
     }
 
     /**

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -1534,6 +1534,9 @@ final readonly class FakeExchangeMatchingEngine
             || $order->filledQuantity !== 0.0
             || !\is_finite($order->remainingQuantity)
             || $order->remainingQuantity <= 0.0
+            || $order->price !== null
+            || $order->postOnly
+            || $order->timeInForce !== null
             || !\is_string($quantityDecimal)
             || !\is_string($filledQuantityDecimal)
             || !\is_string($remainingQuantityDecimal)

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -249,13 +249,6 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         $requestedFillQuantity = min($quantity ?? $order->remainingQuantity, $order->remainingQuantity);
-        if (
-            $this->isActiveTrailingOrder($order)
-            && $requestedFillQuantity > 0.00000001
-            && $requestedFillQuantity < $order->remainingQuantity - 0.00000001
-        ) {
-            throw new \LogicException('fake_tp1_trailing_partial_fill_unsupported');
-        }
         $fillQuantity = $requestedFillQuantity;
         $cancelReduceRemainder = false;
         if ($order->reduceOnly) {
@@ -268,6 +261,13 @@ final readonly class FakeExchangeMatchingEngine
 
             $fillQuantity = min($requestedFillQuantity, $position->size);
             $cancelReduceRemainder = $fillQuantity < $requestedFillQuantity - 0.00000001;
+        }
+        if (
+            $this->isActiveTrailingOrder($order)
+            && $fillQuantity > 0.00000001
+            && $fillQuantity < $order->remainingQuantity - 0.00000001
+        ) {
+            throw new \LogicException('fake_tp1_trailing_partial_fill_unsupported');
         }
 
         if ($fillQuantity <= 0.0) {

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -244,6 +244,9 @@ final readonly class FakeExchangeMatchingEngine
         if (!$order instanceof ExchangeOrderDto || !$this->isActiveStatus($order->status)) {
             return $order;
         }
+        if ($this->isPersistedTrailingOrder($order)) {
+            $this->assertPersistedActiveTrailingOrderValid($order);
+        }
 
         $requestedFillQuantity = min($quantity ?? $order->remainingQuantity, $order->remainingQuantity);
         $fillQuantity = $requestedFillQuantity;
@@ -680,8 +683,15 @@ final readonly class FakeExchangeMatchingEngine
 
     private function ratchetTrailingStops(string $symbol): void
     {
+        $openOrders = $this->stateStore->getOpenOrders($symbol);
+        foreach ($openOrders as $order) {
+            if ($this->isPersistedTrailingOrder($order)) {
+                $this->assertPersistedActiveTrailingOrderValid($order);
+            }
+        }
+
         $midPrice = $this->midPrice($symbol);
-        foreach ($this->stateStore->getOpenOrders($symbol) as $order) {
+        foreach ($openOrders as $order) {
             if (!$this->isActiveTrailingOrder($order)) {
                 continue;
             }
@@ -868,6 +878,9 @@ final readonly class FakeExchangeMatchingEngine
         if ($stopLoss === null && $takeProfit === null) {
             return $entryOrder;
         }
+        if ($trailingPolicy instanceof FakeTp1TrailingPolicy) {
+            $this->assertTp1QuantityBelowProtectedExposure($entryOrder, $trailingPolicy);
+        }
 
         $metadata = array_replace($entryOrder->metadata, ['attached_protection_processed' => true]);
 
@@ -915,6 +928,23 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         return $this->createAttachedProtectionOrders($parent);
+    }
+
+    private function assertTp1QuantityBelowProtectedExposure(
+        ExchangeOrderDto $entryOrder,
+        FakeTp1TrailingPolicy $policy,
+    ): void {
+        try {
+            $tp1Quantity = BigDecimal::of($policy->tp1Quantity);
+            $protectedExposure = BigDecimal::of(self::canonicalFloat(
+                $this->protectionQuantity($entryOrder),
+            ));
+        } catch (MathException) {
+            throw new \LogicException('fake_tp1_trailing_quantity_invalid');
+        }
+        if ($tp1Quantity->isGreaterThanOrEqualTo($protectedExposure)) {
+            throw new \LogicException('fake_tp1_trailing_quantity_invalid');
+        }
     }
 
     private function compensateRejectedProtection(ExchangeOrderDto $entryOrder): ExchangeOrderDto
@@ -1367,6 +1397,85 @@ final readonly class FakeExchangeMatchingEngine
     {
         return $order->orderType === ExchangeOrderType::TRIGGER
             && $this->stringMetadata($order->metadata, 'protection_kind') === 'trailing';
+    }
+
+    private function isPersistedTrailingOrder(ExchangeOrderDto $order): bool
+    {
+        return $this->stringMetadata($order->metadata, 'protection_kind') === 'trailing';
+    }
+
+    private function assertPersistedActiveTrailingOrderValid(ExchangeOrderDto $order): void
+    {
+        try {
+            $policy = FakeTp1TrailingPolicy::fromMetadata($order->metadata);
+        } catch (\InvalidArgumentException) {
+            throw new \LogicException('fake_tp1_trailing_persisted_state_invalid');
+        }
+
+        $positionSide = $order->positionSide;
+        $expectedSide = $positionSide === ExchangePositionSide::LONG
+            ? ExchangeOrderSide::SELL
+            : ExchangeOrderSide::BUY;
+        $quantityDecimal = $order->metadata['quantity_decimal'] ?? null;
+        $filledQuantityDecimal = $order->metadata['filled_quantity_decimal'] ?? null;
+        $remainingQuantityDecimal = $order->metadata['remaining_quantity_decimal'] ?? null;
+        $stopPriceDecimal = $order->metadata['stop_price_decimal'] ?? null;
+        $watermark = $order->metadata['trailing_watermark'] ?? null;
+        $watermarkDecimal = $order->metadata['trailing_watermark_decimal'] ?? null;
+        if (
+            !$policy instanceof FakeTp1TrailingPolicy
+            || !$positionSide instanceof ExchangePositionSide
+            || !$order->reduceOnly
+            || $order->side !== $expectedSide
+            || $order->orderType !== ExchangeOrderType::TRIGGER
+            || $order->status !== ExchangeOrderStatus::OPEN
+            || !\is_finite($order->quantity)
+            || $order->quantity <= 0.0
+            || $order->filledQuantity !== 0.0
+            || !\is_finite($order->remainingQuantity)
+            || $order->remainingQuantity <= 0.0
+            || !\is_string($quantityDecimal)
+            || !\is_string($filledQuantityDecimal)
+            || !\is_string($remainingQuantityDecimal)
+            || !\is_string($stopPriceDecimal)
+            || $order->stopPrice === null
+            || !\is_finite($order->stopPrice)
+            || $order->stopPrice <= 0.0
+            || !\is_scalar($watermark)
+            || !is_numeric($watermark)
+            || !\is_finite((float) $watermark)
+            || (float) $watermark <= 0.0
+            || !\is_string($watermarkDecimal)
+            || $this->stringMetadata($order->metadata, 'trailing_state_version') !== FakeTp1TrailingPolicy::VERSION
+            || $this->stringMetadata($order->metadata, 'trailing_state_status') !== 'active'
+            || $this->stringMetadata($order->metadata, 'parent_order_id') === null
+            || $this->stringMetadata($order->metadata, 'trailing_activation_order_id') === null
+            || !self::sameDecimal($quantityDecimal, self::canonicalFloat($order->quantity))
+            || !self::sameDecimal($filledQuantityDecimal, '0')
+            || !self::sameDecimal($remainingQuantityDecimal, self::canonicalFloat($order->remainingQuantity))
+            || !self::sameDecimal($quantityDecimal, $remainingQuantityDecimal)
+            || !self::sameDecimal(
+                self::canonicalFloat($order->quantity),
+                self::canonicalFloat($order->remainingQuantity),
+            )
+            || !self::sameDecimal($stopPriceDecimal, self::canonicalFloat($order->stopPrice))
+            || !self::sameDecimal($watermarkDecimal, self::canonicalFloat((float) $watermark))
+        ) {
+            throw new \LogicException('fake_tp1_trailing_persisted_state_invalid');
+        }
+
+        $validation = $this->derivedProtectionValidation(
+            marketType: $order->marketType,
+            symbol: $order->symbol,
+            positionSide: $positionSide,
+            marginMode: 'isolated',
+            orderType: ExchangeOrderType::STOP_LOSS,
+            quantityDecimal: $remainingQuantityDecimal,
+            stopPriceDecimal: $stopPriceDecimal,
+        );
+        if (!$validation->accepted) {
+            throw new \LogicException('fake_tp1_trailing_persisted_state_invalid');
+        }
     }
 
     /**

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -722,9 +722,14 @@ final readonly class FakeExchangeMatchingEngine
 
             try {
                 $midPriceDecimal = BigDecimal::of(self::canonicalFloat($midPrice));
-                $newStopPriceDecimal = $order->positionSide === ExchangePositionSide::LONG
+                $rawStopPriceDecimal = $order->positionSide === ExchangePositionSide::LONG
                     ? $midPriceDecimal->minus($policy->trailingOffset)
                     : $midPriceDecimal->plus($policy->trailingOffset);
+                $newStopPriceDecimal = $this->quantizeRuntimeTrailingStop(
+                    $order->symbol,
+                    $order->positionSide,
+                    $rawStopPriceDecimal,
+                );
             } catch (MathException) {
                 throw new \LogicException('fake_tp1_trailing_ratchet_invalid');
             }
@@ -1166,9 +1171,14 @@ final readonly class FakeExchangeMatchingEngine
 
         try {
             $watermarkDecimalValue = BigDecimal::of(self::canonicalFloat($watermark));
-            $stopPriceDecimalValue = $tp1Order->positionSide === ExchangePositionSide::LONG
+            $rawStopPriceDecimalValue = $tp1Order->positionSide === ExchangePositionSide::LONG
                 ? $watermarkDecimalValue->minus($policy->trailingOffset)
                 : $watermarkDecimalValue->plus($policy->trailingOffset);
+            $stopPriceDecimalValue = $this->quantizeRuntimeTrailingStop(
+                $tp1Order->symbol,
+                $tp1Order->positionSide,
+                $rawStopPriceDecimalValue,
+            );
         } catch (MathException) {
             throw new \LogicException('fake_tp1_trailing_stop_invalid');
         }
@@ -1315,6 +1325,31 @@ final readonly class FakeExchangeMatchingEngine
         ]);
 
         return $trailing;
+    }
+
+    private function quantizeRuntimeTrailingStop(
+        string $symbol,
+        ExchangePositionSide $positionSide,
+        BigDecimal $rawStopPrice,
+    ): BigDecimal {
+        $instrument = $this->instruments->find(strtoupper($symbol));
+        if (!$instrument instanceof FakeInstrument) {
+            throw new \LogicException('fake_tp1_trailing_stop_invalid');
+        }
+
+        try {
+            $tick = BigDecimal::of($instrument->priceTick);
+            $remainder = $rawStopPrice->remainder($tick);
+            if ($remainder->isZero()) {
+                return $rawStopPrice;
+            }
+
+            return $positionSide === ExchangePositionSide::LONG
+                ? $rawStopPrice->minus($remainder)
+                : $rawStopPrice->plus($tick->minus($remainder));
+        } catch (MathException) {
+            throw new \LogicException('fake_tp1_trailing_stop_invalid');
+        }
     }
 
     private function trailingChildMatchesActivation(

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -879,7 +879,26 @@ final readonly class FakeExchangeMatchingEngine
             return $entryOrder;
         }
         if ($trailingPolicy instanceof FakeTp1TrailingPolicy) {
-            $this->assertTp1QuantityBelowProtectedExposure($entryOrder, $trailingPolicy);
+            try {
+                $this->assertTp1QuantityBelowProtectedExposure($entryOrder, $trailingPolicy);
+            } catch (\LogicException $exception) {
+                if ($exception->getMessage() !== 'fake_tp1_trailing_quantity_invalid') {
+                    throw $exception;
+                }
+
+                $metadata = array_replace($entryOrder->metadata, [
+                    'attached_protection_processed' => true,
+                    'protection_status' => 'rejected',
+                    'protection_reject_reason' => 'fake_tp1_trailing_quantity_invalid',
+                ]);
+                $updated = $this->withOrderStatus($entryOrder, $entryOrder->status, $metadata);
+                $this->stateStore->saveOrder($updated);
+                $this->appendEvent('protection_order.rejected', $updated, [
+                    'reason' => 'fake_tp1_trailing_quantity_invalid',
+                ]);
+
+                return $this->compensateRejectedProtection($updated);
+            }
         }
 
         $metadata = array_replace($entryOrder->metadata, ['attached_protection_processed' => true]);
@@ -1401,7 +1420,13 @@ final readonly class FakeExchangeMatchingEngine
 
     private function isPersistedTrailingOrder(ExchangeOrderDto $order): bool
     {
-        return $this->stringMetadata($order->metadata, 'protection_kind') === 'trailing';
+        return $order->orderType === ExchangeOrderType::TRIGGER
+            || $this->stringMetadata($order->metadata, 'protection_kind') === 'trailing'
+            || \array_key_exists('trailing_state_version', $order->metadata)
+            || \array_key_exists('trailing_state_status', $order->metadata)
+            || \array_key_exists('trailing_activation_order_id', $order->metadata)
+            || \array_key_exists('trailing_watermark', $order->metadata)
+            || \array_key_exists('trailing_watermark_decimal', $order->metadata);
     }
 
     private function assertPersistedActiveTrailingOrderValid(ExchangeOrderDto $order): void
@@ -1446,6 +1471,7 @@ final readonly class FakeExchangeMatchingEngine
             || !\is_finite((float) $watermark)
             || (float) $watermark <= 0.0
             || !\is_string($watermarkDecimal)
+            || $this->stringMetadata($order->metadata, 'protection_kind') !== 'trailing'
             || $this->stringMetadata($order->metadata, 'trailing_state_version') !== FakeTp1TrailingPolicy::VERSION
             || $this->stringMetadata($order->metadata, 'trailing_state_status') !== 'active'
             || $this->stringMetadata($order->metadata, 'parent_order_id') === null

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -716,7 +716,8 @@ final readonly class FakeExchangeMatchingEngine
             'margin_contract_size' => $marginContractSize,
         ], static fn (mixed $value): bool => $value !== null)
             + $this->lineageMetadata($request->metadata)
-            + $this->fallbackPolicyMetadata($request->metadata);
+            + $this->fallbackPolicyMetadata($request->metadata)
+            + $this->tp1TrailingPolicyMetadata($request->metadata);
     }
 
     /**
@@ -767,6 +768,7 @@ final readonly class FakeExchangeMatchingEngine
 
         $stopLoss = $this->floatMetadata($entryOrder->metadata, 'attached_stop_loss_price');
         $takeProfit = $this->floatMetadata($entryOrder->metadata, 'attached_take_profit_price');
+        $trailingPolicy = FakeTp1TrailingPolicy::fromMetadata($entryOrder->metadata);
         if ($stopLoss === null && $takeProfit === null) {
             return $entryOrder;
         }
@@ -799,7 +801,8 @@ final readonly class FakeExchangeMatchingEngine
                 $entryOrder,
                 ExchangeOrderType::TAKE_PROFIT,
                 $takeProfit,
-                'tp',
+                $trailingPolicy instanceof FakeTp1TrailingPolicy ? 'tp1' : 'tp',
+                $trailingPolicy?->tp1Quantity,
             )->exchangeOrderId;
         }
 
@@ -952,20 +955,28 @@ final readonly class FakeExchangeMatchingEngine
         ExchangeOrderType $type,
         float $stopPrice,
         string $suffix,
+        ?string $quantityDecimal = null,
     ): ExchangeOrderDto {
         $side = $entryOrder->positionSide === ExchangePositionSide::SHORT
             ? ExchangeOrderSide::BUY
             : ExchangeOrderSide::SELL;
-        $metadata = $this->lineageMetadata($entryOrder->metadata) + [
-            'source' => 'fake_exchange',
-            'parent_order_id' => $entryOrder->exchangeOrderId,
-            'parent_client_order_id' => $entryOrder->clientOrderId,
-            'protection_kind' => $suffix,
-        ];
+        $metadata = $this->lineageMetadata($entryOrder->metadata)
+            + $this->tp1TrailingPolicyMetadata($entryOrder->metadata)
+            + [
+                'source' => 'fake_exchange',
+                'parent_order_id' => $entryOrder->exchangeOrderId,
+                'parent_client_order_id' => $entryOrder->clientOrderId,
+                'protection_kind' => $suffix,
+            ];
         if (\array_key_exists('margin_contract_size', $entryOrder->metadata)) {
             $metadata['margin_contract_size'] = $entryOrder->metadata['margin_contract_size'];
         }
-        $protectionQuantity = $this->protectionQuantity($entryOrder);
+        $protectionQuantity = $quantityDecimal !== null
+            ? (float) $quantityDecimal
+            : $this->protectionQuantity($entryOrder);
+        $metadata['quantity_decimal'] = $quantityDecimal ?? self::canonicalFloat($protectionQuantity);
+        $metadata['filled_quantity_decimal'] = '0';
+        $metadata['remaining_quantity_decimal'] = $metadata['quantity_decimal'];
         $order = new ExchangeOrderDto(
             exchange: Exchange::FAKE,
             marketType: MarketType::PERPETUAL,
@@ -992,6 +1003,153 @@ final readonly class FakeExchangeMatchingEngine
         $this->appendEvent('protection_order.created', $order, ['parent_order_id' => $entryOrder->exchangeOrderId]);
 
         return $order;
+    }
+
+    private function activateTrailingStop(
+        ExchangeOrderDto $tp1Order,
+        float $remainingQuantity,
+        float $watermark,
+    ): ExchangeOrderDto {
+        $policy = FakeTp1TrailingPolicy::fromMetadata($tp1Order->metadata);
+        $parentOrderId = $this->stringMetadata($tp1Order->metadata, 'parent_order_id');
+        if (!$policy instanceof FakeTp1TrailingPolicy || $parentOrderId === null) {
+            throw new \LogicException('fake_tp1_trailing_activation_state_invalid');
+        }
+        if (!$tp1Order->positionSide instanceof ExchangePositionSide) {
+            throw new \LogicException('fake_tp1_trailing_position_side_unavailable');
+        }
+
+        $stopPrice = $tp1Order->positionSide === ExchangePositionSide::LONG
+            ? $watermark - $policy->trailingOffsetFloat()
+            : $watermark + $policy->trailingOffsetFloat();
+        if (!\is_finite($stopPrice) || $stopPrice <= 0.0 || $remainingQuantity <= 0.00000001) {
+            throw new \LogicException('fake_tp1_trailing_stop_invalid');
+        }
+
+        $clientOrderId = 'fake-trailing-' . substr(hash(
+            'sha256',
+            $parentOrderId . ':' . $tp1Order->exchangeOrderId,
+        ), 0, 32);
+        $existing = $this->stateStore->getOrderByClientOrderId($tp1Order->symbol, $clientOrderId);
+        if ($existing instanceof ExchangeOrderDto) {
+            if (!$this->trailingChildMatchesActivation(
+                $existing,
+                $tp1Order,
+                $remainingQuantity,
+                $watermark,
+                $stopPrice,
+            )) {
+                throw new \LogicException('fake_tp1_trailing_client_order_id_conflict');
+            }
+
+            return $existing;
+        }
+
+        $initialStopFound = false;
+        foreach ($this->stateStore->getOpenOrders($tp1Order->symbol) as $candidate) {
+            if (
+                $candidate->orderType !== ExchangeOrderType::STOP_LOSS
+                || $this->stringMetadata($candidate->metadata, 'parent_order_id') !== $parentOrderId
+            ) {
+                continue;
+            }
+
+            $initialStopFound = true;
+            $this->cancelOpenOrder($candidate, 'tp1_replaced_by_trailing');
+        }
+        if (!$initialStopFound) {
+            throw new \LogicException('fake_tp1_trailing_initial_stop_unavailable');
+        }
+
+        $quantityDecimal = self::canonicalFloat($remainingQuantity);
+        $watermarkDecimal = self::canonicalFloat($watermark);
+        $stopPriceDecimal = self::canonicalFloat($stopPrice);
+        $metadata = $this->lineageMetadata($tp1Order->metadata)
+            + $policy->toMetadata()
+            + [
+                'source' => 'fake_exchange',
+                'parent_order_id' => $parentOrderId,
+                'parent_client_order_id' => $this->stringMetadata($tp1Order->metadata, 'parent_client_order_id'),
+                'protection_kind' => 'trailing',
+                'trailing_state_version' => FakeTp1TrailingPolicy::VERSION,
+                'trailing_state_status' => 'active',
+                'trailing_activation_order_id' => $tp1Order->exchangeOrderId,
+                'trailing_watermark' => $watermark,
+                'trailing_watermark_decimal' => $watermarkDecimal,
+                'quantity_decimal' => $quantityDecimal,
+                'filled_quantity_decimal' => '0',
+                'remaining_quantity_decimal' => $quantityDecimal,
+                'stop_price_decimal' => $stopPriceDecimal,
+            ];
+        if (\array_key_exists('margin_contract_size', $tp1Order->metadata)) {
+            $metadata['margin_contract_size'] = $tp1Order->metadata['margin_contract_size'];
+        }
+
+        $trailing = new ExchangeOrderDto(
+            exchange: Exchange::FAKE,
+            marketType: $tp1Order->marketType,
+            symbol: $tp1Order->symbol,
+            exchangeOrderId: $this->stateStore->nextOrderId(),
+            clientOrderId: $clientOrderId,
+            side: $tp1Order->side,
+            positionSide: $tp1Order->positionSide,
+            orderType: ExchangeOrderType::TRIGGER,
+            status: ExchangeOrderStatus::OPEN,
+            quantity: $remainingQuantity,
+            filledQuantity: 0.0,
+            remainingQuantity: $remainingQuantity,
+            price: null,
+            averagePrice: null,
+            stopPrice: $stopPrice,
+            reduceOnly: true,
+            postOnly: false,
+            timeInForce: null,
+            createdAt: $this->clock->now(),
+            metadata: $metadata,
+        );
+        $this->stateStore->saveOrder($trailing);
+        $this->appendEvent('protection_order.created', $trailing, [
+            'parent_order_id' => $parentOrderId,
+        ]);
+        $this->appendEvent('trailing_stop.armed', $trailing, [
+            'parent_order_id' => $parentOrderId,
+            'activation_order_id' => $tp1Order->exchangeOrderId,
+            'state_version' => FakeTp1TrailingPolicy::VERSION,
+            'watermark' => $watermark,
+            'stop_price' => $stopPrice,
+            'remaining_quantity' => $remainingQuantity,
+        ]);
+
+        return $trailing;
+    }
+
+    private function trailingChildMatchesActivation(
+        ExchangeOrderDto $trailing,
+        ExchangeOrderDto $tp1Order,
+        float $remainingQuantity,
+        float $watermark,
+        float $stopPrice,
+    ): bool {
+        return $trailing->symbol === $tp1Order->symbol
+            && $trailing->marketType === $tp1Order->marketType
+            && $trailing->side === $tp1Order->side
+            && $trailing->positionSide === $tp1Order->positionSide
+            && $trailing->orderType === ExchangeOrderType::TRIGGER
+            && $trailing->status === ExchangeOrderStatus::OPEN
+            && $trailing->reduceOnly
+            && !$trailing->postOnly
+            && abs($trailing->quantity - $remainingQuantity) <= 0.00000001
+            && abs(($trailing->stopPrice ?? 0.0) - $stopPrice) <= 0.00000001
+            && $this->stringMetadata($trailing->metadata, 'trailing_state_version') === FakeTp1TrailingPolicy::VERSION
+            && $this->stringMetadata($trailing->metadata, 'trailing_state_status') === 'active'
+            && $this->stringMetadata($trailing->metadata, 'trailing_activation_order_id') === $tp1Order->exchangeOrderId
+            && abs(($this->floatMetadata($trailing->metadata, 'trailing_watermark') ?? 0.0) - $watermark) <= 0.00000001;
+    }
+
+    private function isTp1ProtectionOrder(ExchangeOrderDto $order): bool
+    {
+        return $order->orderType === ExchangeOrderType::TAKE_PROFIT
+            && $this->stringMetadata($order->metadata, 'protection_kind') === 'tp1';
     }
 
     /**
@@ -1077,7 +1235,13 @@ final readonly class FakeExchangeMatchingEngine
                 $fillFee,
                 $fillCost,
             );
-            $remainingSize = max(0.0, $existing->size - $fillQuantity);
+            try {
+                $remainingSize = max(0.0, (float) (string) BigDecimal::of(self::canonicalFloat($existing->size))
+                    ->minus(self::canonicalFloat($fillQuantity))
+                    ->stripTrailingZeros());
+            } catch (MathException) {
+                throw new \LogicException('fake_position_remaining_quantity_invalid');
+            }
             if ($remainingSize <= 0.00000001) {
                 $this->stateStore->removePosition($order->symbol, $order->positionSide);
                 $this->stateStore->appendEvent(new FakeExchangeEvent(
@@ -1098,7 +1262,11 @@ final readonly class FakeExchangeMatchingEngine
                 $this->clock->now(),
                 ['order_id' => $order->exchangeOrderId, 'size' => $remainingSize],
             ));
-            if ($this->isTriggerOrder($order)) {
+            if ($this->isTp1ProtectionOrder($order)) {
+                if ($order->status === ExchangeOrderStatus::FILLED) {
+                    $this->activateTrailingStop($order, $remainingSize, $executionPrice);
+                }
+            } elseif ($this->isTriggerOrder($order)) {
                 $this->cancelSiblingProtectionOrders($order);
             }
 
@@ -1373,6 +1541,27 @@ final readonly class FakeExchangeMatchingEngine
         }
 
         return $fallback;
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     * @return array<string,mixed>
+     */
+    private function tp1TrailingPolicyMetadata(array $metadata): array
+    {
+        $policy = [];
+        foreach (FakeTp1TrailingPolicy::METADATA_KEYS as $key) {
+            if (!\array_key_exists($key, $metadata)) {
+                continue;
+            }
+
+            $value = $metadata[$key];
+            if ($value === null || \is_scalar($value)) {
+                $policy[$key] = $value;
+            }
+        }
+
+        return $policy;
     }
 
     private function protectionQuantity(ExchangeOrderDto $entryOrder): float
@@ -1803,6 +1992,28 @@ final readonly class FakeExchangeMatchingEngine
                 $reduceIntent ? 'reduce-only' : 'entry',
                 $request->positionSide->value,
             ));
+        }
+
+        $trailingPolicy = FakeTp1TrailingPolicy::fromMetadata($request->metadata);
+        if (!$trailingPolicy instanceof FakeTp1TrailingPolicy) {
+            return;
+        }
+        if (
+            $reduceIntent
+            || $request->attachedStopLossPrice === null
+            || $request->attachedTakeProfitPrice === null
+        ) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_protection_required');
+        }
+
+        try {
+            $tp1Quantity = BigDecimal::of($trailingPolicy->tp1Quantity);
+            $entryQuantity = BigDecimal::of($request->exactQuantity() ?? '');
+        } catch (MathException) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_quantity_invalid');
+        }
+        if ($tp1Quantity->isGreaterThanOrEqualTo($entryQuantity)) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_quantity_invalid');
         }
     }
 

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -1420,8 +1420,7 @@ final readonly class FakeExchangeMatchingEngine
 
     private function isPersistedTrailingOrder(ExchangeOrderDto $order): bool
     {
-        return $order->orderType === ExchangeOrderType::TRIGGER
-            || $this->stringMetadata($order->metadata, 'protection_kind') === 'trailing'
+        return $this->stringMetadata($order->metadata, 'protection_kind') === 'trailing'
             || \array_key_exists('trailing_state_version', $order->metadata)
             || \array_key_exists('trailing_state_status', $order->metadata)
             || \array_key_exists('trailing_activation_order_id', $order->metadata)

--- a/trading-app/src/Exchange/Fake/FakeTp1TrailingPolicy.php
+++ b/trading-app/src/Exchange/Fake/FakeTp1TrailingPolicy.php
@@ -61,10 +61,11 @@ final readonly class FakeTp1TrailingPolicy
         if (($metadata[self::VERSION_KEY] ?? null) !== self::VERSION) {
             throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
         }
-        if (($metadata[self::ENABLED_KEY] ?? null) === false) {
+        $enabled = $metadata[self::ENABLED_KEY] ?? null;
+        if ($enabled === false) {
             throw new \InvalidArgumentException('fake_tp1_trailing_policy_disabled');
         }
-        if (($metadata[self::ENABLED_KEY] ?? null) !== true) {
+        if ($enabled !== true) {
             throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
         }
 

--- a/trading-app/src/Exchange/Fake/FakeTp1TrailingPolicy.php
+++ b/trading-app/src/Exchange/Fake/FakeTp1TrailingPolicy.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+use Brick\Math\BigDecimal;
+use Brick\Math\Exception\MathException;
+
+final readonly class FakeTp1TrailingPolicy
+{
+    public const VERSION = 'fake-tp1-trailing-v1';
+    public const VERSION_KEY = 'fake_tp1_trailing_version';
+    public const ENABLED_KEY = 'fake_tp1_trailing_enabled';
+    public const TP1_QUANTITY_KEY = 'fake_tp1_quantity';
+    public const TRAILING_OFFSET_KEY = 'fake_trailing_offset';
+
+    /** @var list<string> */
+    public const METADATA_KEYS = [
+        self::VERSION_KEY,
+        self::ENABLED_KEY,
+        self::TP1_QUANTITY_KEY,
+        self::TRAILING_OFFSET_KEY,
+    ];
+
+    public function __construct(
+        public string $tp1Quantity,
+        public string $trailingOffset,
+    ) {
+        self::assertPositiveDecimal($tp1Quantity);
+        self::assertPositiveDecimal($trailingOffset);
+    }
+
+    /** @return array<string,bool|string> */
+    public function toMetadata(): array
+    {
+        return [
+            self::VERSION_KEY => self::VERSION,
+            self::ENABLED_KEY => true,
+            self::TP1_QUANTITY_KEY => $this->tp1Quantity,
+            self::TRAILING_OFFSET_KEY => $this->trailingOffset,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public static function fromMetadata(array $metadata): ?self
+    {
+        $requested = false;
+        foreach (self::METADATA_KEYS as $key) {
+            if (\array_key_exists($key, $metadata)) {
+                $requested = true;
+                break;
+            }
+        }
+        if (!$requested) {
+            return null;
+        }
+
+        if (($metadata[self::VERSION_KEY] ?? null) !== self::VERSION) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
+        }
+        if (($metadata[self::ENABLED_KEY] ?? null) === false) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_policy_disabled');
+        }
+        if (($metadata[self::ENABLED_KEY] ?? null) !== true) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
+        }
+
+        $tp1Quantity = $metadata[self::TP1_QUANTITY_KEY] ?? null;
+        $trailingOffset = $metadata[self::TRAILING_OFFSET_KEY] ?? null;
+        if (!\is_string($tp1Quantity) || !\is_string($trailingOffset)) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
+        }
+
+        return new self($tp1Quantity, $trailingOffset);
+    }
+
+    public function tp1QuantityFloat(): float
+    {
+        return (float) $this->tp1Quantity;
+    }
+
+    public function trailingOffsetFloat(): float
+    {
+        return (float) $this->trailingOffset;
+    }
+
+    private static function assertPositiveDecimal(string $value): void
+    {
+        if (preg_match('/^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/D', $value) !== 1) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
+        }
+
+        try {
+            $decimal = BigDecimal::of($value);
+        } catch (MathException) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
+        }
+        if ($decimal->isLessThanOrEqualTo(BigDecimal::zero()) || !\is_finite((float) $value)) {
+            throw new \InvalidArgumentException('fake_tp1_trailing_policy_invalid');
+        }
+    }
+}

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -9,6 +9,7 @@ Supported scenarios:
 - partially fill and then complete an order with `fillOrder()`;
 - convert the exact remainder of an end-of-zone maker order to a deterministic
   market fallback with `fallbackTaker()`;
+- reduce an opted-in position at TP1 and trail the exact Fake/Paper remainder;
 - create local positions after entry fills;
 - create or reject attached SL/TP protection orders;
 - close a fully filled entry with an immediate reduce-only market order when
@@ -73,6 +74,74 @@ protection-rejection fixtures use the same persisted-state transaction boundary,
 so stale scenario instances reload before mutation. No network client,
 credential, or exchange adapter write path is involved.
 
+## Deterministic TP1 then trailing stop
+
+Fake/Paper entries can opt into `fake-tp1-trailing-v1` through
+`FakeTp1TrailingPolicy::toMetadata()`. The policy is a fixture contract, not a
+strategy profile. It contains an explicit enabled flag, an exact TP1 quantity,
+and a fixed absolute trailing offset in quote-price units. An entry requesting
+the capability must also provide attached SL and TP prices, and its TP1 quantity
+must be strictly smaller than its total quantity. A missing field, unsupported
+version, disabled capability, non-decimal quantity, non-positive offset, or
+incoherent protection request fails explicitly. When none of the policy keys is
+present, existing full-size attached-protection behavior is unchanged.
+
+Only the four typed policy fields and the existing scalar lineage whitelist are
+persisted from request metadata. Watermark, derived stop, parent IDs, activation
+ID, state status, and deterministic trailing client ID are engine-derived.
+Arbitrary metadata, credentials, and raw payloads are not copied.
+
+The attached SL initially covers the complete filled exposure. The attached TP1
+covers exactly the configured partial quantity. A partial execution of the TP1
+order leaves the initial SL active. Once TP1 is completely executed and exposure
+remains, one existing Fake state transaction:
+
+1. books the reduce-only TP1 fill and costs;
+2. updates the position to the exact decimal remainder;
+3. cancels the initial SL with `tp1_replaced_by_trailing`;
+4. creates one reduce-only `TRIGGER` for that remainder;
+5. initializes its watermark from the TP1 execution price;
+6. appends `trailing_stop.armed`.
+
+For a long, the active stop is `watermark - absolute_offset`; only a higher mid
+price can advance the watermark and stop. For a short, it is
+`watermark + absolute_offset`; only a lower mid price can advance them. Each
+favorable change is persisted on the `TRIGGER` order and emits one
+`trailing_stop.updated`. An adverse or duplicate price is a no-op and can never
+loosen the stop.
+
+A gap through the stop uses ordinary trigger matching and the ordinary fill
+path, so the next available simulated bid/ask is the execution price rather than
+the stop price. The order becomes `triggered`, emits one
+`trailing_stop.triggered`, and closes only its reduce-only remainder. Full
+closure cancels remaining sibling protection. TP1 and trailing fills retain the
+ordinary fee, spread/slippage, quantity, PnL, and cost-model ledger; no missing
+cost is converted to zero by this capability.
+
+The active `TRIGGER` order is the versioned persistent state. Its metadata stores
+the current watermark, fixed offset, derived stop decimal, activation lineage,
+and `active`/`triggered` status inside the existing `fake-paper-state-v1`
+envelope. Restart therefore resumes the same watermark and event sequence without
+a migration. Exact entry replay returns the existing order; a different policy
+on the same client ID is an intent mismatch. Replayed TP1 fills, prices, gaps,
+and terminal fills create no duplicate order, lifecycle, fee, or PnL booking.
+
+The SL/TP race is deterministic under the state lock. SL-first closes the
+position and cancels TP1, making a later TP1 fill a no-op. TP1-first atomically
+replaces SL with the trailing trigger, making the stale SL a no-op. Any exception
+during replacement restores position, orders, events, and ledgers together.
+
+The versioned long and short inputs live in
+`tests/fixtures/fake-paper/tp1-trailing-v1.json`; golden scenario 13 executes
+both. This path uses no network client, credential, demo/testnet adapter, or live
+write permission.
+
+Rollback removes the policy and matching branches and restores scenario 13 to
+`partial` with `trailing_stop_not_implemented`. Archive or quarantine every Fake
+state file containing `fake-tp1-trailing-v1` before running a revision that does
+not understand the additive order metadata. Never silently reuse such a file or
+turn rollback into an exchange write activation.
+
 ## Attached-protection fail-safe
 
 When the one-shot scenario fixture rejects attached protection after an entry
@@ -117,7 +186,7 @@ sends an exchange order.
 
 The file-backed store writes a versioned `fake-paper-state-v1` envelope containing the engine version, a deterministic scenario configuration hash, a payload checksum, and the next event sequence. Writes use a temporary file followed by an atomic replacement.
 
-On restart, orders, the `client_order_id` index, positions, balances, order books, protection orders, events, and the pending protection-failure fixture are restored together. A legacy unversioned state file is accepted and upgraded on the next write. A present but unreadable, unsupported, or checksum-invalid file raises `FakeExchangeStateCorruptedException`; it is never silently replaced with an empty state.
+On restart, orders, the `client_order_id` index, positions, balances, order books, protection orders, versioned trailing-order metadata, events, and the pending protection-failure fixture are restored together. A legacy unversioned state file is accepted and upgraded on the next write. A present but unreadable, unsupported, or checksum-invalid file raises `FakeExchangeStateCorruptedException`; it is never silently replaced with an empty state.
 
 `FakeExchangeStateStore::recoveryMetadata()` exposes the effective format, engine/config identity, whether the instance restored persisted state, whether that state used the legacy format, and the next event sequence. This is local Paper evidence only and does not certify exchange reconciliation or enable any demo/live write path.
 

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -65,7 +65,10 @@ bypassed. Maker and taker costs therefore stay separate.
 Attached SL/TP metadata and lineage are copied to the child. Protection uses the
 logical entry quantity, equal to the maker fill plus the fallback remainder, so
 a partial maker fill followed by a fallback is protected for the complete
-position. If protection is rejected, the deterministic reduce-only fail-safe
+position. When the parent also carries `fake-tp1-trailing-v1`, that policy is
+copied to the child and its TP1 quantity is validated against the logical total
+exposure rather than only the fallback remainder. If protection is rejected,
+the deterministic reduce-only fail-safe
 also closes that complete logical quantity. If a zone/slippage/margin/validation
 rejection or prior cancellation leaves only a partial maker fill, that exact
 maker exposure is protected; a rejected protection compensates that partial

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
@@ -23,7 +23,7 @@ final class FakePaperGoldenScenarioCatalogTest extends TestCase
         'timeout_after_acceptance' => ['executable', []],
         'stop_loss_attach_success' => ['executable', []],
         'stop_loss_attach_failure' => ['executable', []],
-        'tp1_then_trailing' => ['partial', ['trailing_stop_not_implemented']],
+        'tp1_then_trailing' => ['executable', []],
         'gap_at_stop_loss' => ['executable', []],
         'websocket_disconnect_resync' => ['executable', []],
         'duplicate_out_of_order_event' => ['partial', ['out_of_order_event_injection_not_implemented']],

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
@@ -158,6 +158,53 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             'position_closed_count' => 1,
             'protection_status' => 'rejected',
         ],
+        'tp1_then_trailing' => [
+            'fixture_version' => 'fake-tp1-trailing-fixtures-v1',
+            'long' => [
+                'activation_stop' => 25100.0,
+                'armed_event_count' => 1,
+                'cost_completeness' => 'complete',
+                'duplicate_price_idempotent' => true,
+                'entry_quantity' => 1.0,
+                'fill_count' => 3,
+                'gap_fill_price' => 25250.0,
+                'metadata_redacted' => true,
+                'open_order_count' => 0,
+                'open_position_count' => 0,
+                'quantity_coherent' => true,
+                'restart_restored' => true,
+                'stop_monotone' => true,
+                'terminal_replay_idempotent' => true,
+                'tp1_quantity' => 0.4,
+                'trailing_offset' => 100.0,
+                'trailing_quantity' => 0.6,
+                'triggered_event_count' => 1,
+                'updated_event_count' => 2,
+                'watermark_after_restart' => 25300.0,
+            ],
+            'short' => [
+                'activation_stop' => 24900.0,
+                'armed_event_count' => 1,
+                'cost_completeness' => 'complete',
+                'duplicate_price_idempotent' => true,
+                'entry_quantity' => 1.0,
+                'fill_count' => 3,
+                'gap_fill_price' => 24750.0,
+                'metadata_redacted' => true,
+                'open_order_count' => 0,
+                'open_position_count' => 0,
+                'quantity_coherent' => true,
+                'restart_restored' => true,
+                'stop_monotone' => true,
+                'terminal_replay_idempotent' => true,
+                'tp1_quantity' => 0.4,
+                'trailing_offset' => 100.0,
+                'trailing_quantity' => 0.6,
+                'triggered_event_count' => 1,
+                'updated_event_count' => 2,
+                'watermark_after_restart' => 24700.0,
+            ],
+        ],
         'gap_at_stop_loss' => [
             'fill_price' => 24790.0,
             'open_position_count' => 0,
@@ -196,7 +243,7 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             ),
         ));
 
-        self::assertCount(15, $catalogKeys);
+        self::assertCount(16, $catalogKeys);
         self::assertSame($catalogKeys, FakePaperGoldenScenarioRunner::keys());
     }
 

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
@@ -8,6 +8,7 @@ use App\Common\Enum\Exchange;
 use App\Common\Enum\MarketType;
 use App\Exchange\Adapter\FakeExchangeAdapter;
 use App\Exchange\Dto\CancelOrderRequest;
+use App\Exchange\Dto\ExchangeOrderDto;
 use App\Exchange\Dto\PlaceOrderRequest;
 use App\Exchange\Dto\PlaceOrderResult;
 use App\Exchange\Enum\ExchangeOrderSide;
@@ -28,6 +29,7 @@ use App\Exchange\Fake\FakeExchangeWsClient;
 use App\Exchange\Fake\FakeFallbackTakerPolicy;
 use App\Exchange\Fake\FakePrivateWsException;
 use App\Exchange\Fake\FakeInstrumentCatalog;
+use App\Exchange\Fake\FakeTp1TrailingPolicy;
 use Psr\Clock\ClockInterface;
 
 final class FakePaperGoldenScenarioRunner
@@ -45,6 +47,7 @@ final class FakePaperGoldenScenarioRunner
         'timeout_after_acceptance',
         'stop_loss_attach_success',
         'stop_loss_attach_failure',
+        'tp1_then_trailing',
         'gap_at_stop_loss',
         'websocket_disconnect_resync',
         'restart_with_open_position',
@@ -78,6 +81,7 @@ final class FakePaperGoldenScenarioRunner
             'timeout_after_acceptance' => $this->timeoutAfterAcceptance(),
             'stop_loss_attach_success' => $this->stopLossAttachSuccess(),
             'stop_loss_attach_failure' => $this->stopLossAttachFailure(),
+            'tp1_then_trailing' => $this->tp1ThenTrailing(),
             'gap_at_stop_loss' => $this->gapAtStopLoss(),
             'websocket_disconnect_resync' => $this->websocketDisconnectResync(),
             'restart_with_open_position' => $this->restartWithOpenPosition(),
@@ -478,6 +482,211 @@ final class FakePaperGoldenScenarioRunner
             'position_closed_count' => \count($scenario->events('position.closed')),
             'protection_status' => $entry->order?->metadata['protection_status'] ?? null,
         ];
+    }
+
+    /** @return array<string,mixed> */
+    private function tp1ThenTrailing(): array
+    {
+        $fixtures = $this->tp1TrailingFixtures();
+        $facts = ['fixture_version' => $fixtures['schema_version']];
+        foreach ($fixtures['cases'] as $fixture) {
+            $name = $fixture['name'] ?? null;
+            if (!\is_string($name) || !\in_array($name, ['long', 'short'], true)) {
+                throw new \LogicException('The TP1 trailing fixture direction is invalid.');
+            }
+
+            $facts[$name] = $this->tp1TrailingDirectionFacts($fixture);
+        }
+
+        return $facts;
+    }
+
+    /**
+     * @param array<string,mixed> $fixture
+     * @return array<string,mixed>
+     */
+    private function tp1TrailingDirectionFacts(array $fixture): array
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_paper_golden_tp1_trailing_');
+        if ($stateFile === false) {
+            throw new \RuntimeException('Unable to allocate the TP1 trailing golden state file.');
+        }
+        @unlink($stateFile);
+
+        try {
+            [$state, $adapter, $scenario] = $this->exchange($stateFile);
+            $adapter->placeOrder($this->tp1TrailingRequest($fixture));
+            $tp1 = $this->goldenOrderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+            $scenario->fillOrder(
+                $tp1->exchangeOrderId,
+                null,
+                (float) $fixture['tp1_price'],
+            );
+            $trailing = $this->goldenOrderByType($adapter, ExchangeOrderType::TRIGGER);
+            $activationStop = $trailing->stopPrice;
+            $firstFavorable = (float) $fixture['favorable_prices'][0];
+            $scenario->movePrice((string) $fixture['symbol'], $firstFavorable, 0.0);
+            $firstRatcheted = $adapter->getOrder((string) $fixture['symbol'], $trailing->exchangeOrderId);
+            $eventsBeforeRestart = \count($state->events());
+
+            $restoredState = new FakeExchangeStateStore($stateFile);
+            [, $restoredAdapter, $restoredScenario] = $this->exchangeForState($restoredState);
+            $restoredTrailing = $restoredAdapter->getOrder(
+                (string) $fixture['symbol'],
+                $trailing->exchangeOrderId,
+            );
+            $watermarkAfterRestart = $restoredTrailing?->metadata['trailing_watermark'] ?? null;
+            $restartRestored = $restoredState->recoveryMetadata()['restored']
+                && $watermarkAfterRestart === $firstFavorable
+                && \count($restoredState->events()) === $eventsBeforeRestart;
+
+            $eventsBeforeDuplicate = \count($restoredState->events());
+            $restoredScenario->movePrice((string) $fixture['symbol'], $firstFavorable, 0.0);
+            $duplicatePriceIdempotent = \count($restoredState->events()) === $eventsBeforeDuplicate;
+
+            $secondFavorable = (float) $fixture['favorable_prices'][1];
+            $restoredScenario->movePrice((string) $fixture['symbol'], $secondFavorable, 0.0);
+            $finalTrailing = $restoredAdapter->getOrder(
+                (string) $fixture['symbol'],
+                $trailing->exchangeOrderId,
+            );
+            $gap = $restoredScenario->movePrice(
+                (string) $fixture['symbol'],
+                (float) $fixture['gap_price'],
+                0.0,
+            );
+            $gapFill = $gap['matched_orders'][0] ?? null;
+            if (!$gapFill instanceof ExchangeOrderDto) {
+                throw new \LogicException('The TP1 trailing golden gap did not fill.');
+            }
+
+            $ordersBeforeReplay = \count($restoredState->getOrders((string) $fixture['symbol']));
+            $eventsBeforeReplay = \count($restoredState->events());
+            $restoredScenario->movePrice(
+                (string) $fixture['symbol'],
+                (float) $fixture['gap_price'],
+                0.0,
+            );
+            $restoredScenario->fillOrder($trailing->exchangeOrderId);
+            $terminalReplayIdempotent = $ordersBeforeReplay
+                    === \count($restoredState->getOrders((string) $fixture['symbol']))
+                && $eventsBeforeReplay === \count($restoredState->events());
+
+            $closed = $restoredState->events('position.closed')[0] ?? null;
+            if (!$closed instanceof FakeExchangeEvent) {
+                throw new \LogicException('The TP1 trailing golden fixture did not close its position.');
+            }
+            $serialized = (string) file_get_contents($stateFile);
+            $positionSide = ExchangePositionSide::from((string) $fixture['position_side']);
+            $firstStop = $firstRatcheted?->stopPrice;
+            $finalStop = $finalTrailing?->stopPrice;
+            $stopMonotone = $activationStop !== null && $firstStop !== null && $finalStop !== null
+                && ($positionSide === ExchangePositionSide::LONG
+                    ? $activationStop <= $firstStop && $firstStop <= $finalStop
+                    : $activationStop >= $firstStop && $firstStop >= $finalStop);
+
+            return [
+                'activation_stop' => $activationStop,
+                'armed_event_count' => \count($restoredState->events('trailing_stop.armed')),
+                'cost_completeness' => $closed->payload['cost_completeness'] ?? null,
+                'duplicate_price_idempotent' => $duplicatePriceIdempotent,
+                'entry_quantity' => (float) $fixture['quantity'],
+                'fill_count' => \count($restoredAdapter->getFillsSnapshot((string) $fixture['symbol'])),
+                'gap_fill_price' => round((float) $gapFill->averagePrice, 6),
+                'metadata_redacted' => !str_contains($serialized, 'TOP-SECRET')
+                    && !str_contains($serialized, 'Bearer SECRET')
+                    && !str_contains($serialized, 'api_key')
+                    && !str_contains($serialized, 'raw_payload'),
+                'open_order_count' => \count($restoredAdapter->getOpenOrders((string) $fixture['symbol'])),
+                'open_position_count' => \count($restoredAdapter->getOpenPositions((string) $fixture['symbol'])),
+                'quantity_coherent' => $closed->payload['quantity_coherent'] ?? null,
+                'restart_restored' => $restartRestored,
+                'stop_monotone' => $stopMonotone,
+                'terminal_replay_idempotent' => $terminalReplayIdempotent,
+                'tp1_quantity' => $tp1->quantity,
+                'trailing_offset' => (float) $fixture['trailing_offset'],
+                'trailing_quantity' => $trailing->quantity,
+                'triggered_event_count' => \count($restoredState->events('trailing_stop.triggered')),
+                'updated_event_count' => \count($restoredState->events('trailing_stop.updated')),
+                'watermark_after_restart' => $watermarkAfterRestart,
+            ];
+        } finally {
+            @unlink($stateFile);
+            @unlink($stateFile . '.lock');
+            foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+                @unlink($temporaryFile);
+            }
+        }
+    }
+
+    /**
+     * @return array{schema_version:string,cases:list<array<string,mixed>>}
+     */
+    private function tp1TrailingFixtures(): array
+    {
+        $path = dirname(__DIR__, 2) . '/fixtures/fake-paper/tp1-trailing-v1.json';
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw new \LogicException('The TP1 trailing golden fixture is unavailable.');
+        }
+
+        /** @var array{schema_version:string,cases:list<array<string,mixed>>} $fixtures */
+        $fixtures = json_decode($raw, true, 32, JSON_THROW_ON_ERROR);
+        if ($fixtures['schema_version'] !== 'fake-tp1-trailing-fixtures-v1') {
+            throw new \LogicException('The TP1 trailing golden fixture version is unsupported.');
+        }
+
+        return $fixtures;
+    }
+
+    /** @param array<string,mixed> $fixture */
+    private function tp1TrailingRequest(array $fixture): PlaceOrderRequest
+    {
+        $policy = new FakeTp1TrailingPolicy(
+            (string) $fixture['tp1_quantity'],
+            (string) $fixture['trailing_offset'],
+        );
+
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: (string) $fixture['symbol'],
+            side: ExchangeOrderSide::from((string) $fixture['entry_side']),
+            positionSide: ExchangePositionSide::from((string) $fixture['position_side']),
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: (float) $fixture['quantity'],
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'golden-tp1-trailing-' . $fixture['name'],
+            attachedStopLossPrice: (float) $fixture['initial_stop'],
+            attachedTakeProfitPrice: (float) $fixture['tp1_price'],
+            metadata: $policy->toMetadata() + [
+                'internal_trade_id' => 'golden-tp1-trailing-' . $fixture['name'],
+                'api_key' => 'TOP-SECRET',
+                'raw_payload' => ['authorization' => 'Bearer SECRET'],
+            ],
+            quantityDecimal: (string) $fixture['quantity'],
+            attachedStopLossPriceDecimal: (string) $fixture['initial_stop'],
+            attachedTakeProfitPriceDecimal: (string) $fixture['tp1_price'],
+        );
+    }
+
+    private function goldenOrderByType(
+        FakeExchangeAdapter $adapter,
+        ExchangeOrderType $type,
+    ): ExchangeOrderDto {
+        foreach ($adapter->getOrdersSnapshot('BTCUSDT') as $order) {
+            if ($order->orderType === $type) {
+                return $order;
+            }
+        }
+
+        throw new \LogicException(sprintf('Missing golden %s order.', $type->value));
     }
 
     /** @return array<string,mixed> */

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingPolicyTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingPolicyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Fake;
+
+use App\Exchange\Fake\FakeTp1TrailingPolicy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FakeTp1TrailingPolicy::class)]
+final class FakeTp1TrailingPolicyTest extends TestCase
+{
+    public function testPolicyContractExists(): void
+    {
+        self::assertTrue(class_exists(FakeTp1TrailingPolicy::class));
+    }
+
+    public function testRoundTripsVersionedFixtureMetadata(): void
+    {
+        $policy = new FakeTp1TrailingPolicy('0.4', '100.0');
+
+        self::assertEquals($policy, FakeTp1TrailingPolicy::fromMetadata($policy->toMetadata()));
+        self::assertSame(0.4, $policy->tp1QuantityFloat());
+        self::assertSame(100.0, $policy->trailingOffsetFloat());
+        self::assertSame([
+            FakeTp1TrailingPolicy::VERSION_KEY => FakeTp1TrailingPolicy::VERSION,
+            FakeTp1TrailingPolicy::ENABLED_KEY => true,
+            FakeTp1TrailingPolicy::TP1_QUANTITY_KEY => '0.4',
+            FakeTp1TrailingPolicy::TRAILING_OFFSET_KEY => '100.0',
+        ], $policy->toMetadata());
+    }
+
+    public function testReturnsNullOnlyWhenNoPolicyCapabilityWasRequested(): void
+    {
+        self::assertNull(FakeTp1TrailingPolicy::fromMetadata([
+            'internal_trade_id' => 'trade-without-trailing',
+        ]));
+    }
+
+    /** @param array<string,mixed> $metadata */
+    #[DataProvider('invalidMetadataProvider')]
+    public function testFailsExplicitlyForInvalidOrDisabledRequestedCapability(
+        array $metadata,
+        string $expectedMessage,
+    ): void {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        FakeTp1TrailingPolicy::fromMetadata($metadata);
+    }
+
+    /** @return iterable<string,array{array<string,mixed>,string}> */
+    public static function invalidMetadataProvider(): iterable
+    {
+        yield 'missing fields' => [[
+            'fake_tp1_trailing_version' => 'fake-tp1-trailing-v1',
+        ], 'fake_tp1_trailing_policy_invalid'];
+
+        yield 'unsupported version' => [[
+            'fake_tp1_trailing_version' => 'fake-tp1-trailing-v0',
+            'fake_tp1_trailing_enabled' => true,
+            'fake_tp1_quantity' => '0.4',
+            'fake_trailing_offset' => '100.0',
+        ], 'fake_tp1_trailing_policy_invalid'];
+
+        yield 'disabled capability' => [[
+            'fake_tp1_trailing_version' => 'fake-tp1-trailing-v1',
+            'fake_tp1_trailing_enabled' => false,
+            'fake_tp1_quantity' => '0.4',
+            'fake_trailing_offset' => '100.0',
+        ], 'fake_tp1_trailing_policy_disabled'];
+
+        yield 'non decimal quantity' => [[
+            'fake_tp1_trailing_version' => 'fake-tp1-trailing-v1',
+            'fake_tp1_trailing_enabled' => true,
+            'fake_tp1_quantity' => 'four tenths',
+            'fake_trailing_offset' => '100.0',
+        ], 'fake_tp1_trailing_policy_invalid'];
+
+        yield 'zero offset' => [[
+            'fake_tp1_trailing_version' => 'fake-tp1-trailing-v1',
+            'fake_tp1_trailing_enabled' => true,
+            'fake_tp1_quantity' => '0.4',
+            'fake_trailing_offset' => '0',
+        ], 'fake_tp1_trailing_policy_invalid'];
+    }
+}

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -459,7 +459,7 @@ final class FakeTp1TrailingTest extends TestCase
     }
 
     #[DataProvider('fallbackProtectionFailureProvider')]
-    public function testFallbackProtectionRejectsTp1ThatWouldConsumePartialExposureWithoutMutation(
+    public function testFallbackProtectionCompensatesWhenTp1WouldConsumePartialExposure(
         bool $rejectFallbackOrder,
     ): void {
         $state = new class extends FakeExchangeStateStore {
@@ -506,24 +506,25 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertNotNull($parent->exchangeOrderId);
         $scenario->fillOrder($parent->exchangeOrderId, 0.2, 24950.0);
         $state->rejectEntryOrder = $rejectFallbackOrder;
-        $ordersBefore = $state->getOrders('BTCUSDT');
-        $positionsBefore = $state->getOpenPositions('BTCUSDT');
-        $eventsBefore = $state->events();
-        $bookBefore = $state->getOrderBookTop('BTCUSDT');
+        $result = $scenario->fallbackTaker($parent->exchangeOrderId);
 
-        try {
-            $scenario->fallbackTaker($parent->exchangeOrderId);
-            self::fail('Expected TP1 equal to or above partial protected exposure to fail.');
-        } catch (\LogicException $exception) {
-            self::assertSame('fake_tp1_trailing_quantity_invalid', $exception->getMessage());
-        }
-
-        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
-        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
-        self::assertEquals($eventsBefore, $state->events());
-        self::assertSame($bookBefore, $state->getOrderBookTop('BTCUSDT'));
-        self::assertSame(0.2, $adapter->getOpenPositions('BTCUSDT')[0]->size);
-        self::assertCount(1, $state->getOrders('BTCUSDT'));
+        self::assertFalse($result->executed);
+        self::assertCount(0, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertSame(
+            'reduce_only_market_close',
+            $result->parentOrder?->metadata['fail_safe_action'] ?? null,
+        );
+        self::assertSame(
+            'fake_tp1_trailing_quantity_invalid',
+            $result->parentOrder?->metadata['protection_reject_reason'] ?? null,
+        );
+        self::assertTrue($result->parentOrder?->metadata['position_flat_after_compensation'] ?? false);
+        self::assertCount(1, array_filter(
+            $state->getOrders('BTCUSDT'),
+            static fn (ExchangeOrderDto $order): bool => $order->reduceOnly
+                && $order->orderType === ExchangeOrderType::MARKET
+                && $order->status === ExchangeOrderStatus::FILLED,
+        ));
         self::assertCount(0, array_filter(
             $adapter->getOpenOrders('BTCUSDT'),
             static fn (ExchangeOrderDto $order): bool => \in_array(
@@ -895,6 +896,8 @@ final class FakeTp1TrailingTest extends TestCase
             'watermark',
             'watermark_decimal',
             'watermark_decimal_missing',
+            'protection_kind',
+            'protection_kind_missing',
         ] as $conflict) {
             yield $conflict => [$conflict];
         }
@@ -1135,11 +1138,13 @@ final class FakeTp1TrailingTest extends TestCase
             'quantity_decimal_missing',
             'stop_price_decimal_missing',
             'watermark_decimal_missing',
+            'protection_kind_missing',
         ], true)) {
             unset($metadata[match ($conflict) {
                 'quantity_decimal_missing' => 'quantity_decimal',
                 'stop_price_decimal_missing' => 'stop_price_decimal',
                 'watermark_decimal_missing' => 'trailing_watermark_decimal',
+                'protection_kind_missing' => 'protection_kind',
             }]);
         } else {
             match ($conflict) {
@@ -1158,6 +1163,7 @@ final class FakeTp1TrailingTest extends TestCase
                 'stop_price_decimal' => $metadata['stop_price_decimal'] = '25100.1',
                 'watermark' => $metadata['trailing_watermark'] = 25200.1,
                 'watermark_decimal' => $metadata['trailing_watermark_decimal'] = '25200.1',
+                'protection_kind' => $metadata['protection_kind'] = 'sl',
                 default => throw new \LogicException('Unknown persisted trailing conflict ' . $conflict),
             };
         }

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -879,6 +879,55 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertCount(1, $state->events('trailing_stop.triggered'));
     }
 
+    #[DataProvider('directionProvider')]
+    public function testReduceOnlyCapCannotPartiallyFillActiveTrailingOrder(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $trailing = $this->armFixture($adapter, $scenario, $this->fixture($direction));
+        $manualExit = $adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: $trailing->side,
+            positionSide: $trailing->positionSide,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.2,
+            price: null,
+            stopPrice: null,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'manual-reduce-before-trailing-' . $direction,
+            quantityDecimal: '0.2',
+        ));
+        self::assertTrue($manualExit->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $manualExit->status);
+        self::assertSame(0.4, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(
+            ExchangeOrderStatus::OPEN,
+            $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId)?->status,
+        );
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+        $fillsBefore = $adapter->getFillsSnapshot('BTCUSDT');
+
+        try {
+            $scenario->fillOrder($trailing->exchangeOrderId);
+            self::fail('Expected a reduce-only capped trailing fill to be rejected.');
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_partial_fill_unsupported', $exception->getMessage());
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertEquals($fillsBefore, $adapter->getFillsSnapshot('BTCUSDT'));
+        self::assertCount(0, $state->events('trailing_stop.triggered'));
+    }
+
     public function testOrdinaryPersistedTriggerWithoutTrailingStateRemainsExecutable(): void
     {
         [$state, $adapter, $scenario] = $this->exchange();

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Fake;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Dto\PlaceOrderResult;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Fake\FakeExchangeEvent;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeScenarioService;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Fake\FakeTp1TrailingPolicy;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversClass(FakeExchangeMatchingEngine::class)]
+#[CoversClass(FakeTp1TrailingPolicy::class)]
+final class FakeTp1TrailingTest extends TestCase
+{
+    public function testTp1UsesConfiguredQuantityAndAtomicallyArmsTrailingForRemainder(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture);
+        $initialStop = $this->orderByType($adapter, ExchangeOrderType::STOP_LOSS);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+
+        self::assertSame(1.0, $initialStop->quantity);
+        self::assertSame(0.4, $tp1->quantity);
+
+        $scenario->fillOrder($tp1->exchangeOrderId, null, (float) $fixture['tp1_price']);
+
+        $position = $adapter->getOpenPositions('BTCUSDT')[0] ?? null;
+        $trailing = $this->orderByType($adapter, ExchangeOrderType::TRIGGER);
+        $persistedStop = $adapter->getOrder('BTCUSDT', $initialStop->exchangeOrderId);
+        self::assertNotNull($position);
+        self::assertSame(0.6, $position->size);
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $persistedStop?->status);
+        self::assertSame('tp1_replaced_by_trailing', $persistedStop?->metadata['reason'] ?? null);
+        self::assertTrue($trailing->reduceOnly);
+        self::assertSame(0.6, $trailing->quantity);
+        self::assertSame(25100.0, $trailing->stopPrice);
+        self::assertSame(FakeTp1TrailingPolicy::VERSION, $trailing->metadata['trailing_state_version'] ?? null);
+        self::assertSame('active', $trailing->metadata['trailing_state_status'] ?? null);
+        self::assertSame(25200.0, $trailing->metadata['trailing_watermark'] ?? null);
+        self::assertSame('100.0', $trailing->metadata[FakeTp1TrailingPolicy::TRAILING_OFFSET_KEY] ?? null);
+        self::assertSame($tp1->exchangeOrderId, $trailing->metadata['trailing_activation_order_id'] ?? null);
+        self::assertCount(1, $state->events('trailing_stop.armed'));
+    }
+
+    public function testPartialTp1FillKeepsInitialStopUntilConfiguredQuantityCompletes(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+
+        $partial = $scenario->fillOrder($tp1->exchangeOrderId, 0.2, 25200.0);
+
+        self::assertSame(ExchangeOrderStatus::PARTIALLY_FILLED, $partial?->status);
+        self::assertSame(0.8, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertCount(1, array_filter(
+            $adapter->getOpenOrders('BTCUSDT'),
+            static fn (ExchangeOrderDto $order): bool => $order->orderType === ExchangeOrderType::STOP_LOSS,
+        ));
+        self::assertCount(0, $state->events('trailing_stop.armed'));
+
+        $scenario->fillOrder($tp1->exchangeOrderId, 0.2, 25200.0);
+
+        self::assertSame(0.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(0.6, $this->orderByType($adapter, ExchangeOrderType::TRIGGER)->quantity);
+        self::assertCount(1, $state->events('trailing_stop.armed'));
+    }
+
+    public function testIncompleteRequestedCapabilityFailsBeforeMutation(): void
+    {
+        [$state, $adapter] = $this->exchange();
+        $fixture = $this->fixture('long');
+
+        try {
+            $this->placeFixtureEntry($adapter, $fixture, [
+                FakeTp1TrailingPolicy::VERSION_KEY => FakeTp1TrailingPolicy::VERSION,
+            ], false);
+            self::fail('Expected the incomplete trailing capability to fail.');
+        } catch (\InvalidArgumentException $exception) {
+            self::assertSame('fake_tp1_trailing_policy_invalid', $exception->getMessage());
+        }
+
+        self::assertCount(0, $state->getOrders());
+        self::assertCount(0, $state->getOpenPositions());
+        self::assertCount(0, $state->events());
+    }
+
+    public function testTp1ReplayDoesNotDuplicateTrailingOrderOrLifecycle(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
+        $orderCount = \count($state->getOrders('BTCUSDT'));
+        $eventCount = \count($state->events());
+        $trailingId = $this->orderByType($adapter, ExchangeOrderType::TRIGGER)->exchangeOrderId;
+
+        $replay = $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
+
+        self::assertSame(ExchangeOrderStatus::FILLED, $replay?->status);
+        self::assertCount($orderCount, $state->getOrders('BTCUSDT'));
+        self::assertCount($eventCount, $state->events());
+        self::assertSame($trailingId, $this->orderByType($adapter, ExchangeOrderType::TRIGGER)->exchangeOrderId);
+        self::assertCount(1, $state->events('trailing_stop.armed'));
+    }
+
+    public function testRestartRestoresActiveTrailingStateAndRedactsUntrustedMetadata(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_tp1_trailing_restart_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            [$state, $adapter, $scenario] = $this->exchange($stateFile);
+            $fixture = $this->fixture('long');
+            $this->placeFixtureEntry($adapter, $fixture, [
+                'internal_trade_id' => 'tp1-restart-trade',
+                'api_key' => 'TOP-SECRET',
+                'raw_payload' => ['authorization' => 'Bearer SECRET'],
+            ]);
+            $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+            $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
+            $sequencesBefore = $this->eventSequences($state->events());
+
+            $restoredState = new FakeExchangeStateStore($stateFile);
+            [, $restoredAdapter] = $this->exchangeForState($restoredState);
+            $trailing = $this->orderByType($restoredAdapter, ExchangeOrderType::TRIGGER);
+            $serialized = (string) file_get_contents($stateFile);
+
+            self::assertTrue($restoredState->recoveryMetadata()['restored']);
+            self::assertSame(25200.0, $trailing->metadata['trailing_watermark'] ?? null);
+            self::assertSame('active', $trailing->metadata['trailing_state_status'] ?? null);
+            self::assertSame('tp1-restart-trade', $trailing->metadata['internal_trade_id'] ?? null);
+            self::assertSame($sequencesBefore, $this->eventSequences($restoredState->events()));
+            self::assertStringNotContainsString('TOP-SECRET', $serialized);
+            self::assertStringNotContainsString('Bearer SECRET', $serialized);
+            self::assertStringNotContainsString('api_key', $serialized);
+            self::assertStringNotContainsString('raw_payload', $serialized);
+        } finally {
+            @unlink($stateFile);
+            @unlink($stateFile . '.lock');
+            foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+                @unlink($temporaryFile);
+            }
+        }
+    }
+
+    public function testStopLossWinningRacePreventsTp1Activation(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture);
+        $stop = $this->orderByType($adapter, ExchangeOrderType::STOP_LOSS);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+
+        $scenario->fillOrder($stop->exchangeOrderId, null, 24800.0);
+        $tp1AfterRace = $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
+
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $tp1AfterRace?->status);
+        self::assertCount(0, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(0, $adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(0, $state->events('trailing_stop.armed'));
+    }
+
+    public function testTp1WinningRaceMakesStaleInitialStopANoOp(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture);
+        $stop = $this->orderByType($adapter, ExchangeOrderType::STOP_LOSS);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+
+        $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
+        $staleStop = $scenario->fillOrder($stop->exchangeOrderId, null, 24800.0);
+
+        self::assertSame(ExchangeOrderStatus::CANCELLED, $staleStop?->status);
+        self::assertSame(0.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(ExchangeOrderType::TRIGGER, $adapter->getOpenOrders('BTCUSDT')[0]->orderType);
+        self::assertCount(1, $state->events('trailing_stop.armed'));
+    }
+
+    public function testTrailingCreationFailureRollsBackTp1PositionProtectionAndEvents(): void
+    {
+        $state = new class extends FakeExchangeStateStore {
+            public bool $rejectTrailingSave = false;
+
+            public function saveOrder(ExchangeOrderDto $order): void
+            {
+                if (
+                    $this->rejectTrailingSave
+                    && $order->orderType === ExchangeOrderType::TRIGGER
+                    && $order->status === ExchangeOrderStatus::OPEN
+                ) {
+                    throw new \RuntimeException('forced_trailing_save_failure');
+                }
+
+                parent::saveOrder($order);
+            }
+        };
+        [$state, $adapter, $scenario] = $this->exchangeForState($state);
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture);
+        $stop = $this->orderByType($adapter, ExchangeOrderType::STOP_LOSS);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $eventsBefore = \count($state->events());
+        $state->rejectTrailingSave = true;
+
+        try {
+            $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
+            self::fail('Expected forced trailing save failure.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('forced_trailing_save_failure', $exception->getMessage());
+        }
+
+        self::assertSame(1.0, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(ExchangeOrderStatus::OPEN, $adapter->getOrder('BTCUSDT', $stop->exchangeOrderId)?->status);
+        self::assertSame(ExchangeOrderStatus::OPEN, $adapter->getOrder('BTCUSDT', $tp1->exchangeOrderId)?->status);
+        self::assertCount(2, $adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount($eventsBefore, $state->events());
+        self::assertCount(0, $state->events('trailing_stop.armed'));
+    }
+
+    /**
+     * @param array<string,mixed> $fixture
+     * @param array<string,mixed> $extraMetadata
+     */
+    private function placeFixtureEntry(
+        FakeExchangeAdapter $adapter,
+        array $fixture,
+        array $extraMetadata = [],
+        bool $includePolicy = true,
+    ): PlaceOrderResult {
+        $policy = new FakeTp1TrailingPolicy(
+            (string) $fixture['tp1_quantity'],
+            (string) $fixture['trailing_offset'],
+        );
+        $metadata = $includePolicy ? $policy->toMetadata() + $extraMetadata : $extraMetadata;
+
+        return $adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: (string) $fixture['symbol'],
+            side: ExchangeOrderSide::from((string) $fixture['entry_side']),
+            positionSide: ExchangePositionSide::from((string) $fixture['position_side']),
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: (float) $fixture['quantity'],
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'tp1-trailing-' . $fixture['name'],
+            attachedStopLossPrice: (float) $fixture['initial_stop'],
+            attachedTakeProfitPrice: (float) $fixture['tp1_price'],
+            metadata: $metadata,
+            quantityDecimal: (string) $fixture['quantity'],
+            attachedStopLossPriceDecimal: (string) $fixture['initial_stop'],
+            attachedTakeProfitPriceDecimal: (string) $fixture['tp1_price'],
+        ));
+    }
+
+    private function orderByType(
+        FakeExchangeAdapter $adapter,
+        ExchangeOrderType $type,
+    ): ExchangeOrderDto {
+        $order = array_values(array_filter(
+            $adapter->getOrdersSnapshot('BTCUSDT'),
+            static fn (ExchangeOrderDto $candidate): bool => $candidate->orderType === $type,
+        ))[0] ?? null;
+        self::assertInstanceOf(ExchangeOrderDto::class, $order);
+
+        return $order;
+    }
+
+    /** @return array<string,mixed> */
+    private function fixture(string $name): array
+    {
+        $path = dirname(__DIR__, 2) . '/fixtures/fake-paper/tp1-trailing-v1.json';
+        $raw = file_get_contents($path);
+        self::assertIsString($raw);
+        /** @var array{schema_version:string,cases:list<array<string,mixed>>} $catalog */
+        $catalog = json_decode($raw, true, 32, JSON_THROW_ON_ERROR);
+        self::assertSame('fake-tp1-trailing-fixtures-v1', $catalog['schema_version']);
+
+        foreach ($catalog['cases'] as $fixture) {
+            if (($fixture['name'] ?? null) === $name) {
+                return $fixture;
+            }
+        }
+
+        throw new \LogicException('Unknown TP1 trailing fixture ' . $name);
+    }
+
+    /**
+     * @return array{FakeExchangeStateStore,FakeExchangeAdapter,FakeExchangeScenarioService}
+     */
+    private function exchange(?string $stateFile = null): array
+    {
+        return $this->exchangeForState(new FakeExchangeStateStore($stateFile));
+    }
+
+    /**
+     * @return array{FakeExchangeStateStore,FakeExchangeAdapter,FakeExchangeScenarioService}
+     */
+    private function exchangeForState(FakeExchangeStateStore $state): array
+    {
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->clock());
+
+        return [
+            $state,
+            new FakeExchangeAdapter($state, $book, $engine, $this->clock()),
+            new FakeExchangeScenarioService($state, $book, $engine),
+        ];
+    }
+
+    /** @param FakeExchangeEvent[] $events
+     * @return list<int>
+     */
+    private function eventSequences(array $events): array
+    {
+        return array_map(
+            static fn (FakeExchangeEvent $event): int => (int) ($event->payload['event_sequence'] ?? 0),
+            $events,
+        );
+    }
+
+    private function clock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -20,6 +20,7 @@ use App\Exchange\Fake\FakeExchangeMatchingEngine;
 use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeScenarioService;
 use App\Exchange\Fake\FakeExchangeStateStore;
+use App\Exchange\Fake\FakeFallbackTakerPolicy;
 use App\Exchange\Fake\FakeTp1TrailingPolicy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -344,6 +345,61 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertFalse($replay->metadata['idempotent_replay'] ?? true);
         self::assertCount($orderCount, $state->getOrders('BTCUSDT'));
         self::assertCount($eventCount, $state->events());
+    }
+
+    public function testFallbackEntryPreservesTp1TrailingPolicyForLogicalTotalExposure(): void
+    {
+        [, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $trailingPolicy = new FakeTp1TrailingPolicy('0.4', '100.0');
+        $fallbackPolicy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: 25100.0,
+            maxSlippageBps: 30.0,
+        );
+        $parent = $adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::LIMIT,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: 24950.0,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'tp1-trailing-fallback',
+            attachedStopLossPrice: (float) $fixture['initial_stop'],
+            attachedTakeProfitPrice: (float) $fixture['tp1_price'],
+            metadata: $trailingPolicy->toMetadata() + $fallbackPolicy->toMetadata(),
+            quantityDecimal: '1.0',
+            priceDecimal: '24950.0',
+            attachedStopLossPriceDecimal: (string) $fixture['initial_stop'],
+            attachedTakeProfitPriceDecimal: (string) $fixture['tp1_price'],
+        ));
+        self::assertNotNull($parent->exchangeOrderId);
+        $scenario->fillOrder($parent->exchangeOrderId, 0.8, 24950.0);
+
+        $fallback = $scenario->fallbackTaker($parent->exchangeOrderId);
+
+        self::assertTrue($fallback->executed);
+        self::assertSame(0.2, $fallback->fallbackOrder?->quantity);
+        self::assertSame(
+            FakeTp1TrailingPolicy::VERSION,
+            $fallback->fallbackOrder?->metadata[FakeTp1TrailingPolicy::VERSION_KEY] ?? null,
+        );
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        self::assertSame(0.4, $tp1->quantity);
+
+        $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
+
+        self::assertSame(0.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(0.6, $this->orderByType($adapter, ExchangeOrderType::TRIGGER)->quantity);
     }
 
     public function testRestartRestoresActiveTrailingStateAndRedactsUntrustedMetadata(): void

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -233,6 +233,28 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertCount($updateCount, $state->events('trailing_stop.updated'));
     }
 
+    public function testRatchetDerivedStopMustObeyInstrumentTickAndRollsBackPriceMove(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $trailing = $this->armFixture($adapter, $scenario, $fixture);
+        $orderBefore = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+        $bookBefore = $state->getOrderBookTop('BTCUSDT');
+        $eventsBefore = $state->events();
+
+        try {
+            $scenario->movePrice('BTCUSDT', 25300.03, 0.0);
+            self::fail('Expected the non-quantized ratcheted stop to fail.');
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_ratchet_invalid', $exception->getMessage());
+        }
+
+        self::assertEquals($orderBefore, $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId));
+        self::assertSame($bookBefore, $state->getOrderBookTop('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertCount(0, $state->events('trailing_stop.updated'));
+    }
+
     public function testTp1UsesConfiguredQuantityAndAtomicallyArmsTrailingForRemainder(): void
     {
         [$state, $adapter, $scenario] = $this->exchange();
@@ -300,6 +322,40 @@ final class FakeTp1TrailingTest extends TestCase
             self::fail('Expected the incomplete trailing capability to fail.');
         } catch (\InvalidArgumentException $exception) {
             self::assertSame('fake_tp1_trailing_policy_invalid', $exception->getMessage());
+        }
+
+        self::assertCount(0, $state->getOrders());
+        self::assertCount(0, $state->getOpenPositions());
+        self::assertCount(0, $state->events());
+    }
+
+    public function testTp1QuantityMustObeyInstrumentQuantityRulesBeforeMutation(): void
+    {
+        [$state, $adapter] = $this->exchange();
+        $fixture = array_replace($this->fixture('long'), ['tp1_quantity' => '0.0005']);
+
+        try {
+            $this->placeFixtureEntry($adapter, $fixture);
+            self::fail('Expected the non-quantized TP1 quantity to fail.');
+        } catch (\InvalidArgumentException $exception) {
+            self::assertSame('fake_tp1_trailing_quantity_invalid', $exception->getMessage());
+        }
+
+        self::assertCount(0, $state->getOrders());
+        self::assertCount(0, $state->getOpenPositions());
+        self::assertCount(0, $state->events());
+    }
+
+    public function testDerivedInitialTrailingStopMustObeyInstrumentTickBeforeMutation(): void
+    {
+        [$state, $adapter] = $this->exchange();
+        $fixture = array_replace($this->fixture('long'), ['trailing_offset' => '100.03']);
+
+        try {
+            $this->placeFixtureEntry($adapter, $fixture);
+            self::fail('Expected the non-quantized derived trailing stop to fail.');
+        } catch (\InvalidArgumentException $exception) {
+            self::assertSame('fake_tp1_trailing_stop_invalid', $exception->getMessage());
         }
 
         self::assertCount(0, $state->getOrders());
@@ -477,6 +533,92 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertCount(1, $state->events('trailing_stop.armed'));
     }
 
+    #[DataProvider('directionProvider')]
+    public function testTp1ActivationRejectsLooserStopAndRollsBackForBothSides(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = array_replace($this->fixture($direction), ['trailing_offset' => '500.0']);
+        $this->placeFixtureEntry($adapter, $fixture);
+        $initialStop = $this->orderByType($adapter, ExchangeOrderType::STOP_LOSS);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+
+        try {
+            $scenario->fillOrder($tp1->exchangeOrderId, null, (float) $fixture['tp1_price']);
+            self::fail('Expected a looser derived trailing stop to fail activation.');
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_stop_looser_than_initial_stop', $exception->getMessage());
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertSame(ExchangeOrderStatus::OPEN, $adapter->getOrder('BTCUSDT', $initialStop->exchangeOrderId)?->status);
+        self::assertSame(ExchangeOrderStatus::OPEN, $adapter->getOrder('BTCUSDT', $tp1->exchangeOrderId)?->status);
+        self::assertCount(0, $state->events('trailing_stop.armed'));
+    }
+
+    public function testExistingTrailingChildWithActiveInitialStopFailsExplicitlyAndRollsBack(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture, ['internal_trade_id' => 'immutable-trade']);
+        $entry = $this->orderByType($adapter, ExchangeOrderType::MARKET);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $state->saveOrder($this->expectedTrailingChild($entry, $tp1, $fixture));
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+
+        try {
+            $scenario->fillOrder($tp1->exchangeOrderId, null, (float) $fixture['tp1_price']);
+            self::fail('Expected the active initial stop to conflict with the existing trailing child.');
+        } catch (\LogicException $exception) {
+            self::assertSame(
+                'fake_tp1_trailing_existing_child_with_initial_stop_active',
+                $exception->getMessage(),
+            );
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertCount(0, $state->events('trailing_stop.armed'));
+    }
+
+    #[DataProvider('trailingChildConflictProvider')]
+    public function testExistingTrailingChildImmutableIntentConflictsRollBack(string $conflict): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture, ['internal_trade_id' => 'immutable-trade']);
+        $entry = $this->orderByType($adapter, ExchangeOrderType::MARKET);
+        $initialStop = $this->orderByType($adapter, ExchangeOrderType::STOP_LOSS);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $state->saveOrder($this->withStatus($initialStop, ExchangeOrderStatus::CANCELLED));
+        $state->saveOrder($this->conflictingTrailingChild(
+            $this->expectedTrailingChild($entry, $tp1, $fixture),
+            $conflict,
+        ));
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+
+        try {
+            $scenario->fillOrder($tp1->exchangeOrderId, null, (float) $fixture['tp1_price']);
+            self::fail(sprintf('Expected trailing child conflict "%s" to fail.', $conflict));
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_client_order_id_conflict', $exception->getMessage());
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertCount(0, $state->events('trailing_stop.armed'));
+    }
+
     public function testTrailingCreationFailureRollsBackTp1PositionProtectionAndEvents(): void
     {
         $faultState = new class extends FakeExchangeStateStore {
@@ -596,6 +738,249 @@ final class FakeTp1TrailingTest extends TestCase
     {
         yield 'long' => ['long'];
         yield 'short' => ['short'];
+    }
+
+    /** @return iterable<string,array{string}> */
+    public static function trailingChildConflictProvider(): iterable
+    {
+        foreach ([
+            'exchange',
+            'market_type',
+            'side',
+            'position_side',
+            'order_type',
+            'status',
+            'quantity',
+            'filled_quantity',
+            'remaining_quantity',
+            'price',
+            'average_price',
+            'stop_price',
+            'reduce_only',
+            'post_only',
+            'time_in_force',
+            'source',
+            'protection_kind',
+            'parent_order_id',
+            'parent_client_order_id',
+            'lineage',
+            'policy_version',
+            'policy_enabled',
+            'policy_tp1_quantity_decimal',
+            'policy_offset_decimal',
+            'state_version',
+            'state_status',
+            'activation_order_id',
+            'watermark',
+            'quantity_decimal',
+            'filled_quantity_decimal',
+            'remaining_quantity_decimal',
+            'stop_price_decimal',
+            'watermark_decimal',
+            'margin_contract_size',
+        ] as $conflict) {
+            yield $conflict => [$conflict];
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $fixture
+     */
+    private function expectedTrailingChild(
+        ExchangeOrderDto $entry,
+        ExchangeOrderDto $tp1,
+        array $fixture,
+    ): ExchangeOrderDto {
+        $parentOrderId = (string) ($tp1->metadata['parent_order_id'] ?? '');
+        $clientOrderId = 'fake-trailing-' . substr(hash(
+            'sha256',
+            $parentOrderId . ':' . $tp1->exchangeOrderId,
+        ), 0, 32);
+        $quantity = (float) $fixture['quantity'] - (float) $fixture['tp1_quantity'];
+        $watermark = (float) $fixture['tp1_price'];
+        $stopPrice = $tp1->positionSide === ExchangePositionSide::LONG
+            ? $watermark - (float) $fixture['trailing_offset']
+            : $watermark + (float) $fixture['trailing_offset'];
+        $lineageKeys = [
+            'internal_trade_id',
+            'trade_id',
+            'internal_position_id',
+            'position_id',
+            'exchange_position_id',
+            'order_intent_id',
+            'client_order_id',
+            'run_id',
+            'correlation_run_id',
+            'orchestration_run_id',
+            'orchestration_set_id',
+            'orchestration_dashboard_id',
+            'mtf_profile',
+            'origin',
+            'attempt_number',
+            'decision_key',
+        ];
+        $metadata = array_intersect_key($tp1->metadata, array_flip($lineageKeys))
+            + (new FakeTp1TrailingPolicy(
+                (string) $fixture['tp1_quantity'],
+                (string) $fixture['trailing_offset'],
+            ))->toMetadata()
+            + [
+                'source' => 'fake_exchange',
+                'parent_order_id' => $parentOrderId,
+                'parent_client_order_id' => $tp1->metadata['parent_client_order_id'] ?? null,
+                'protection_kind' => 'trailing',
+                'trailing_state_version' => FakeTp1TrailingPolicy::VERSION,
+                'trailing_state_status' => 'active',
+                'trailing_activation_order_id' => $tp1->exchangeOrderId,
+                'trailing_watermark' => $watermark,
+                'trailing_watermark_decimal' => (string) $fixture['tp1_price'],
+                'quantity_decimal' => json_encode(
+                    $quantity,
+                    JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR,
+                ),
+                'filled_quantity_decimal' => '0',
+                'remaining_quantity_decimal' => json_encode(
+                    $quantity,
+                    JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR,
+                ),
+                'stop_price_decimal' => json_encode(
+                    $stopPrice,
+                    JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR,
+                ),
+                'margin_contract_size' => $tp1->metadata['margin_contract_size'] ?? null,
+            ];
+
+        return new ExchangeOrderDto(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: (string) $fixture['symbol'],
+            exchangeOrderId: 'fake-existing-trailing',
+            clientOrderId: $clientOrderId,
+            side: $tp1->side,
+            positionSide: $tp1->positionSide,
+            orderType: ExchangeOrderType::TRIGGER,
+            status: ExchangeOrderStatus::OPEN,
+            quantity: $quantity,
+            filledQuantity: 0.0,
+            remainingQuantity: $quantity,
+            price: null,
+            averagePrice: null,
+            stopPrice: $stopPrice,
+            reduceOnly: true,
+            postOnly: false,
+            timeInForce: null,
+            createdAt: $entry->createdAt,
+            metadata: $metadata,
+        );
+    }
+
+    private function conflictingTrailingChild(ExchangeOrderDto $order, string $conflict): ExchangeOrderDto
+    {
+        $exchange = $order->exchange;
+        $marketType = $order->marketType;
+        $side = $order->side;
+        $positionSide = $order->positionSide;
+        $orderType = $order->orderType;
+        $status = $order->status;
+        $quantity = $order->quantity;
+        $filledQuantity = $order->filledQuantity;
+        $remainingQuantity = $order->remainingQuantity;
+        $price = $order->price;
+        $averagePrice = $order->averagePrice;
+        $stopPrice = $order->stopPrice;
+        $reduceOnly = $order->reduceOnly;
+        $postOnly = $order->postOnly;
+        $timeInForce = $order->timeInForce;
+        $metadata = $order->metadata;
+
+        match ($conflict) {
+            'exchange' => $exchange = Exchange::OKX,
+            'market_type' => $marketType = MarketType::SPOT,
+            'side' => $side = ExchangeOrderSide::BUY,
+            'position_side' => $positionSide = ExchangePositionSide::SHORT,
+            'order_type' => $orderType = ExchangeOrderType::STOP_LOSS,
+            'status' => $status = ExchangeOrderStatus::FILLED,
+            'quantity' => $quantity = 0.7,
+            'filled_quantity' => $filledQuantity = 0.1,
+            'remaining_quantity' => $remainingQuantity = 0.5,
+            'price' => $price = 25100.0,
+            'average_price' => $averagePrice = 25100.0,
+            'stop_price' => $stopPrice = 25100.1,
+            'reduce_only' => $reduceOnly = false,
+            'post_only' => $postOnly = true,
+            'time_in_force' => $timeInForce = ExchangeTimeInForce::GTC,
+            'source' => $metadata['source'] = 'other',
+            'protection_kind' => $metadata['protection_kind'] = 'sl',
+            'parent_order_id' => $metadata['parent_order_id'] = 'other-parent',
+            'parent_client_order_id' => $metadata['parent_client_order_id'] = 'other-client',
+            'lineage' => $metadata['internal_trade_id'] = 'other-trade',
+            'policy_version' => $metadata[FakeTp1TrailingPolicy::VERSION_KEY] = 'fake-tp1-trailing-v2',
+            'policy_enabled' => $metadata[FakeTp1TrailingPolicy::ENABLED_KEY] = false,
+            'policy_tp1_quantity_decimal' => $metadata[FakeTp1TrailingPolicy::TP1_QUANTITY_KEY] = '0.40',
+            'policy_offset_decimal' => $metadata[FakeTp1TrailingPolicy::TRAILING_OFFSET_KEY] = '100.00',
+            'state_version' => $metadata['trailing_state_version'] = 'fake-tp1-trailing-v2',
+            'state_status' => $metadata['trailing_state_status'] = 'triggered',
+            'activation_order_id' => $metadata['trailing_activation_order_id'] = 'other-activation',
+            'watermark' => $metadata['trailing_watermark'] = 25200.1,
+            'quantity_decimal' => $metadata['quantity_decimal'] = '0.60',
+            'filled_quantity_decimal' => $metadata['filled_quantity_decimal'] = '0.0',
+            'remaining_quantity_decimal' => $metadata['remaining_quantity_decimal'] = '0.60',
+            'stop_price_decimal' => $metadata['stop_price_decimal'] = '25100.00',
+            'watermark_decimal' => $metadata['trailing_watermark_decimal'] = '25200.00',
+            'margin_contract_size' => $metadata['margin_contract_size'] = '2',
+            default => throw new \LogicException('Unknown trailing child conflict ' . $conflict),
+        };
+
+        return new ExchangeOrderDto(
+            exchange: $exchange,
+            marketType: $marketType,
+            symbol: $order->symbol,
+            exchangeOrderId: $order->exchangeOrderId,
+            clientOrderId: $order->clientOrderId,
+            side: $side,
+            positionSide: $positionSide,
+            orderType: $orderType,
+            status: $status,
+            quantity: $quantity,
+            filledQuantity: $filledQuantity,
+            remainingQuantity: $remainingQuantity,
+            price: $price,
+            averagePrice: $averagePrice,
+            stopPrice: $stopPrice,
+            reduceOnly: $reduceOnly,
+            postOnly: $postOnly,
+            timeInForce: $timeInForce,
+            createdAt: $order->createdAt,
+            updatedAt: $order->updatedAt,
+            metadata: $metadata,
+        );
+    }
+
+    private function withStatus(ExchangeOrderDto $order, ExchangeOrderStatus $status): ExchangeOrderDto
+    {
+        return new ExchangeOrderDto(
+            exchange: $order->exchange,
+            marketType: $order->marketType,
+            symbol: $order->symbol,
+            exchangeOrderId: $order->exchangeOrderId,
+            clientOrderId: $order->clientOrderId,
+            side: $order->side,
+            positionSide: $order->positionSide,
+            orderType: $order->orderType,
+            status: $status,
+            quantity: $order->quantity,
+            filledQuantity: $order->filledQuantity,
+            remainingQuantity: $order->remainingQuantity,
+            price: $order->price,
+            averagePrice: $order->averagePrice,
+            stopPrice: $order->stopPrice,
+            reduceOnly: $order->reduceOnly,
+            postOnly: $order->postOnly,
+            timeInForce: $order->timeInForce,
+            createdAt: $order->createdAt,
+            updatedAt: $order->updatedAt,
+            metadata: $order->metadata,
+        );
     }
 
     /** @return array<string,mixed> */

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -458,6 +458,82 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertSame(0.6, $this->orderByType($adapter, ExchangeOrderType::TRIGGER)->quantity);
     }
 
+    #[DataProvider('fallbackProtectionFailureProvider')]
+    public function testFallbackProtectionRejectsTp1ThatWouldConsumePartialExposureWithoutMutation(
+        bool $rejectFallbackOrder,
+    ): void {
+        $state = new class extends FakeExchangeStateStore {
+            public bool $rejectEntryOrder = false;
+
+            public function availableMarginUsdt(): float
+            {
+                return $this->rejectEntryOrder ? 0.0 : parent::availableMarginUsdt();
+            }
+        };
+        [, $adapter, $scenario] = $this->exchangeForState($state);
+        $fixture = $this->fixture('long');
+        $trailingPolicy = new FakeTp1TrailingPolicy('0.4', '100.0');
+        $fallbackPolicy = new FakeFallbackTakerPolicy(
+            enabled: true,
+            zoneMin: 24900.0,
+            zoneMax: $rejectFallbackOrder ? 25100.0 : 24999.0,
+            maxSlippageBps: 30.0,
+        );
+        $parent = $adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::LIMIT,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: 24950.0,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'tp1-trailing-partial-fallback-' . ($rejectFallbackOrder ? 'order' : 'price'),
+            attachedStopLossPrice: (float) $fixture['initial_stop'],
+            attachedTakeProfitPrice: (float) $fixture['tp1_price'],
+            metadata: $trailingPolicy->toMetadata() + $fallbackPolicy->toMetadata(),
+            quantityDecimal: '1.0',
+            priceDecimal: '24950.0',
+            attachedStopLossPriceDecimal: (string) $fixture['initial_stop'],
+            attachedTakeProfitPriceDecimal: (string) $fixture['tp1_price'],
+        ));
+        self::assertNotNull($parent->exchangeOrderId);
+        $scenario->fillOrder($parent->exchangeOrderId, 0.2, 24950.0);
+        $state->rejectEntryOrder = $rejectFallbackOrder;
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+        $bookBefore = $state->getOrderBookTop('BTCUSDT');
+
+        try {
+            $scenario->fallbackTaker($parent->exchangeOrderId);
+            self::fail('Expected TP1 equal to or above partial protected exposure to fail.');
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_quantity_invalid', $exception->getMessage());
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertSame($bookBefore, $state->getOrderBookTop('BTCUSDT'));
+        self::assertSame(0.2, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertCount(1, $state->getOrders('BTCUSDT'));
+        self::assertCount(0, array_filter(
+            $adapter->getOpenOrders('BTCUSDT'),
+            static fn (ExchangeOrderDto $order): bool => \in_array(
+                $order->orderType,
+                [ExchangeOrderType::STOP_LOSS, ExchangeOrderType::TAKE_PROFIT],
+                true,
+            ),
+        ));
+    }
+
     public function testRestartRestoresActiveTrailingStateAndRedactsUntrustedMetadata(): void
     {
         $stateFile = tempnam(sys_get_temp_dir(), 'fake_tp1_trailing_restart_');
@@ -660,6 +736,56 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertCount(0, $faultState->events('trailing_stop.armed'));
     }
 
+    #[DataProvider('malformedPersistedTrailingStateProvider')]
+    public function testMalformedPersistedActiveTrailingStateFailsAtomicallyBeforeRatchetOrTrigger(
+        string $conflict,
+    ): void {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $trailing = $this->armFixture($adapter, $scenario, $fixture);
+        $state->saveOrder($this->malformedPersistedTrailingOrder($trailing, $conflict));
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+        $bookBefore = $state->getOrderBookTop('BTCUSDT');
+
+        try {
+            $scenario->movePrice('BTCUSDT', 25000.0, 0.0);
+            self::fail(sprintf('Expected malformed trailing state "%s" to fail.', $conflict));
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_persisted_state_invalid', $exception->getMessage());
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertSame($bookBefore, $state->getOrderBookTop('BTCUSDT'));
+        self::assertSame(0.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertCount(1, $adapter->getOpenPositions('BTCUSDT'));
+    }
+
+    public function testMalformedPersistedTrailingStateFailsBeforeDirectTriggerFill(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $trailing = $this->armFixture($adapter, $scenario, $this->fixture('long'));
+        $state->saveOrder($this->malformedPersistedTrailingOrder($trailing, 'reduce_only'));
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+
+        try {
+            $scenario->fillOrder($trailing->exchangeOrderId);
+            self::fail('Expected malformed trailing state to fail before a direct trigger fill.');
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_persisted_state_invalid', $exception->getMessage());
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertSame(0.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+    }
+
     /**
      * @param array<string,mixed> $fixture
      * @param array<string,mixed> $extraMetadata
@@ -738,6 +864,40 @@ final class FakeTp1TrailingTest extends TestCase
     {
         yield 'long' => ['long'];
         yield 'short' => ['short'];
+    }
+
+    /** @return iterable<string,array{bool}> */
+    public static function fallbackProtectionFailureProvider(): iterable
+    {
+        yield 'fallback price rejected' => [false];
+        yield 'fallback order rejected' => [true];
+    }
+
+    /** @return iterable<string,array{string}> */
+    public static function malformedPersistedTrailingStateProvider(): iterable
+    {
+        foreach ([
+            'reduce_only',
+            'side',
+            'position_side',
+            'order_type',
+            'active_status',
+            'filled_quantity',
+            'quantity',
+            'remaining_quantity',
+            'quantity_decimal',
+            'quantity_decimal_missing',
+            'filled_quantity_decimal',
+            'remaining_quantity_decimal',
+            'stop_price',
+            'stop_price_decimal',
+            'stop_price_decimal_missing',
+            'watermark',
+            'watermark_decimal',
+            'watermark_decimal_missing',
+        ] as $conflict) {
+            yield $conflict => [$conflict];
+        }
     }
 
     /** @return iterable<string,array{string}> */
@@ -950,6 +1110,77 @@ final class FakeTp1TrailingTest extends TestCase
             reduceOnly: $reduceOnly,
             postOnly: $postOnly,
             timeInForce: $timeInForce,
+            createdAt: $order->createdAt,
+            updatedAt: $order->updatedAt,
+            metadata: $metadata,
+        );
+    }
+
+    private function malformedPersistedTrailingOrder(
+        ExchangeOrderDto $order,
+        string $conflict,
+    ): ExchangeOrderDto {
+        $side = $order->side;
+        $positionSide = $order->positionSide;
+        $orderType = $order->orderType;
+        $status = $order->status;
+        $quantity = $order->quantity;
+        $filledQuantity = $order->filledQuantity;
+        $remainingQuantity = $order->remainingQuantity;
+        $stopPrice = $order->stopPrice;
+        $reduceOnly = $order->reduceOnly;
+        $metadata = $order->metadata;
+
+        if (\in_array($conflict, [
+            'quantity_decimal_missing',
+            'stop_price_decimal_missing',
+            'watermark_decimal_missing',
+        ], true)) {
+            unset($metadata[match ($conflict) {
+                'quantity_decimal_missing' => 'quantity_decimal',
+                'stop_price_decimal_missing' => 'stop_price_decimal',
+                'watermark_decimal_missing' => 'trailing_watermark_decimal',
+            }]);
+        } else {
+            match ($conflict) {
+                'reduce_only' => $reduceOnly = false,
+                'side' => $side = ExchangeOrderSide::BUY,
+                'position_side' => $positionSide = ExchangePositionSide::SHORT,
+                'order_type' => $orderType = ExchangeOrderType::STOP_LOSS,
+                'active_status' => $status = ExchangeOrderStatus::PENDING,
+                'filled_quantity' => $filledQuantity = 0.1,
+                'quantity' => $quantity = 0.0,
+                'remaining_quantity' => $remainingQuantity = 0.5,
+                'quantity_decimal' => $metadata['quantity_decimal'] = '0.7',
+                'filled_quantity_decimal' => $metadata['filled_quantity_decimal'] = '0.1',
+                'remaining_quantity_decimal' => $metadata['remaining_quantity_decimal'] = '0.5',
+                'stop_price' => $stopPrice = 25100.03,
+                'stop_price_decimal' => $metadata['stop_price_decimal'] = '25100.1',
+                'watermark' => $metadata['trailing_watermark'] = 25200.1,
+                'watermark_decimal' => $metadata['trailing_watermark_decimal'] = '25200.1',
+                default => throw new \LogicException('Unknown persisted trailing conflict ' . $conflict),
+            };
+        }
+
+        return new ExchangeOrderDto(
+            exchange: $order->exchange,
+            marketType: $order->marketType,
+            symbol: $order->symbol,
+            exchangeOrderId: $order->exchangeOrderId,
+            clientOrderId: $order->clientOrderId,
+            side: $side,
+            positionSide: $positionSide,
+            orderType: $orderType,
+            status: $status,
+            quantity: $quantity,
+            filledQuantity: $filledQuantity,
+            remainingQuantity: $remainingQuantity,
+            price: $order->price,
+            averagePrice: $order->averagePrice,
+            stopPrice: $stopPrice,
+            reduceOnly: $reduceOnly,
+            postOnly: $order->postOnly,
+            timeInForce: $order->timeInForce,
             createdAt: $order->createdAt,
             updatedAt: $order->updatedAt,
             metadata: $metadata,

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -281,6 +281,44 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertCount(1, $state->events('trailing_stop.armed'));
     }
 
+    public function testTrailingProtectsOnlyNewEntryRemainderWhenSameSideExposureAlreadyExists(): void
+    {
+        [, $adapter, $scenario] = $this->exchange();
+        $adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::BUY,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'pre-existing-long',
+            quantityDecimal: '1.0',
+        ));
+        $fixture = $this->fixture('long');
+        $this->placeFixtureEntry($adapter, $fixture);
+        self::assertSame(2.0, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $scenario->fillOrder($tp1->exchangeOrderId, null, (float) $fixture['tp1_price']);
+
+        $trailing = $this->orderByType($adapter, ExchangeOrderType::TRIGGER);
+        self::assertSame(1.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(0.6, $trailing->quantity);
+        self::assertSame('0.6', $trailing->metadata['quantity_decimal'] ?? null);
+
+        $scenario->fillOrder($trailing->exchangeOrderId);
+
+        self::assertSame(1.0, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+    }
+
     #[DataProvider('directionProvider')]
     public function testDefaultSpreadActivationAndNonTickRatchetQuantizeRuntimeStop(string $direction): void
     {

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -305,18 +305,83 @@ final class FakeTp1TrailingTest extends TestCase
         $fixture = $this->fixture('long');
         $this->placeFixtureEntry($adapter, $fixture);
         self::assertSame(2.0, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        $manualExit = $adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::SELL,
+            positionSide: ExchangePositionSide::LONG,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.1,
+            price: null,
+            stopPrice: null,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'pre-existing-long-manual-reduce',
+            quantityDecimal: '0.1',
+        ));
+        self::assertSame(ExchangeOrderStatus::FILLED, $manualExit->status);
+        self::assertSame(1.9, $adapter->getOpenPositions('BTCUSDT')[0]->size);
 
         $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
         $scenario->fillOrder($tp1->exchangeOrderId, null, (float) $fixture['tp1_price']);
 
         $trailing = $this->orderByType($adapter, ExchangeOrderType::TRIGGER);
-        self::assertSame(1.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(1.5, $adapter->getOpenPositions('BTCUSDT')[0]->size);
         self::assertSame(0.6, $trailing->quantity);
         self::assertSame('0.6', $trailing->metadata['quantity_decimal'] ?? null);
 
         $scenario->fillOrder($trailing->exchangeOrderId);
 
-        self::assertSame(1.0, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(0.9, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testManualReductionBeforeTp1CapsTrailingToActualPostTp1Exposure(string $direction): void
+    {
+        [, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture($direction);
+        $this->placeFixtureEntry($adapter, $fixture);
+        $manualExit = $adapter->placeOrder(new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: ExchangeOrderSide::from((string) $fixture['exit_side']),
+            positionSide: ExchangePositionSide::from((string) $fixture['position_side']),
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 0.1,
+            price: null,
+            stopPrice: null,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: 'manual-reduce-before-tp1-' . $direction,
+            quantityDecimal: '0.1',
+        ));
+        self::assertSame(ExchangeOrderStatus::FILLED, $manualExit->status);
+        self::assertSame(0.9, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+
+        $filledTp1 = $scenario->fillOrder(
+            $tp1->exchangeOrderId,
+            null,
+            (float) $fixture['tp1_price'],
+        );
+
+        $trailing = $this->orderByType($adapter, ExchangeOrderType::TRIGGER);
+        self::assertSame(ExchangeOrderStatus::FILLED, $filledTp1?->status);
+        self::assertSame(0.5, $adapter->getOpenPositions('BTCUSDT')[0]->size);
+        self::assertSame(0.5, $trailing->quantity);
+        self::assertSame('0.5', $trailing->metadata['quantity_decimal'] ?? null);
+
+        $scenario->fillOrder($trailing->exchangeOrderId);
+
+        self::assertCount(0, $adapter->getOpenPositions('BTCUSDT'));
     }
 
     #[DataProvider('directionProvider')]

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -1138,6 +1138,9 @@ final class FakeTp1TrailingTest extends TestCase
             'filled_quantity',
             'quantity',
             'remaining_quantity',
+            'price',
+            'post_only',
+            'time_in_force',
             'quantity_decimal',
             'quantity_decimal_missing',
             'filled_quantity_decimal',
@@ -1382,8 +1385,11 @@ final class FakeTp1TrailingTest extends TestCase
         $quantity = $order->quantity;
         $filledQuantity = $order->filledQuantity;
         $remainingQuantity = $order->remainingQuantity;
+        $price = $order->price;
         $stopPrice = $order->stopPrice;
         $reduceOnly = $order->reduceOnly;
+        $postOnly = $order->postOnly;
+        $timeInForce = $order->timeInForce;
         $metadata = $order->metadata;
 
         if (\in_array($conflict, [
@@ -1408,6 +1414,9 @@ final class FakeTp1TrailingTest extends TestCase
                 'filled_quantity' => $filledQuantity = 0.1,
                 'quantity' => $quantity = 0.0,
                 'remaining_quantity' => $remainingQuantity = 0.5,
+                'price' => $price = 25100.0,
+                'post_only' => $postOnly = true,
+                'time_in_force' => $timeInForce = ExchangeTimeInForce::GTC,
                 'quantity_decimal' => $metadata['quantity_decimal'] = '0.7',
                 'filled_quantity_decimal' => $metadata['filled_quantity_decimal'] = '0.1',
                 'remaining_quantity_decimal' => $metadata['remaining_quantity_decimal'] = '0.5',
@@ -1433,12 +1442,12 @@ final class FakeTp1TrailingTest extends TestCase
             quantity: $quantity,
             filledQuantity: $filledQuantity,
             remainingQuantity: $remainingQuantity,
-            price: $order->price,
+            price: $price,
             averagePrice: $order->averagePrice,
             stopPrice: $stopPrice,
             reduceOnly: $reduceOnly,
-            postOnly: $order->postOnly,
-            timeInForce: $order->timeInForce,
+            postOnly: $postOnly,
+            timeInForce: $timeInForce,
             createdAt: $order->createdAt,
             updatedAt: $order->updatedAt,
             metadata: $metadata,

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -22,6 +22,7 @@ use App\Exchange\Fake\FakeExchangeScenarioService;
 use App\Exchange\Fake\FakeExchangeStateStore;
 use App\Exchange\Fake\FakeTp1TrailingPolicy;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Clock\ClockInterface;
 
@@ -29,6 +30,208 @@ use Psr\Clock\ClockInterface;
 #[CoversClass(FakeTp1TrailingPolicy::class)]
 final class FakeTp1TrailingTest extends TestCase
 {
+    #[DataProvider('directionProvider')]
+    public function testGapThroughTrailingClosesOnlyRemainderAndCleansProtections(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture($direction);
+        $trailing = $this->armFixture($adapter, $scenario, $fixture);
+        foreach ($fixture['favorable_prices'] as $favorablePrice) {
+            $scenario->movePrice((string) $fixture['symbol'], (float) $favorablePrice, 0.0);
+        }
+
+        $move = $scenario->movePrice(
+            (string) $fixture['symbol'],
+            (float) $fixture['gap_price'],
+            0.0,
+        );
+        $filled = $move['matched_orders'][0] ?? null;
+        $persisted = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+
+        self::assertInstanceOf(ExchangeOrderDto::class, $filled);
+        self::assertSame($trailing->exchangeOrderId, $filled->exchangeOrderId);
+        self::assertSame(ExchangeOrderStatus::FILLED, $filled->status);
+        self::assertTrue($filled->reduceOnly);
+        self::assertSame(0.6, $filled->filledQuantity);
+        self::assertSame((float) $fixture['gap_price'], round((float) $filled->averagePrice, 6));
+        self::assertSame('triggered', $persisted?->metadata['trailing_state_status'] ?? null);
+        self::assertSame($filled->averagePrice, $persisted?->metadata['trailing_trigger_price'] ?? null);
+        self::assertCount(0, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(0, $adapter->getOpenOrders('BTCUSDT'));
+        self::assertCount(1, $state->events('trailing_stop.triggered'));
+
+        $orderCount = \count($state->getOrders('BTCUSDT'));
+        $eventCount = \count($state->events());
+        $scenario->movePrice((string) $fixture['symbol'], (float) $fixture['gap_price'], 0.0);
+        $scenario->fillOrder($trailing->exchangeOrderId);
+        self::assertCount($orderCount, $state->getOrders('BTCUSDT'));
+        self::assertCount($eventCount, $state->events());
+        self::assertCount(1, $state->events('trailing_stop.triggered'));
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testTp1AndTrailingCostsAndPnlAreBookedExactlyOnce(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture($direction);
+        $trailing = $this->armFixture($adapter, $scenario, $fixture);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        foreach ($fixture['favorable_prices'] as $favorablePrice) {
+            $scenario->movePrice((string) $fixture['symbol'], (float) $favorablePrice, 0.0);
+        }
+        $scenario->movePrice((string) $fixture['symbol'], (float) $fixture['gap_price'], 0.0);
+
+        $fills = $adapter->getFillsSnapshot('BTCUSDT');
+        $closed = $state->events('position.closed')[0] ?? null;
+        self::assertInstanceOf(FakeExchangeEvent::class, $closed);
+        self::assertCount(3, $fills);
+        self::assertSame([1.0, 0.4, 0.6], array_map(
+            static fn ($fill): float => $fill->quantity,
+            $fills,
+        ));
+        self::assertSame(1.0, $closed->payload['entry_qty'] ?? null);
+        self::assertSame(1.0, $closed->payload['exit_qty'] ?? null);
+        self::assertSame(0.0, $closed->payload['remaining_qty'] ?? null);
+        self::assertTrue($closed->payload['quantity_coherent'] ?? false);
+        self::assertTrue($closed->payload['position_fully_closed'] ?? false);
+        self::assertTrue($closed->payload['fills_complete'] ?? false);
+        self::assertSame('complete', $closed->payload['cost_completeness'] ?? null);
+        self::assertSame('fake_paper_fill_ledger_v1', $closed->payload['pnl_source'] ?? null);
+        self::assertSame('fixed_adverse_slippage_bps_v1', $closed->payload['cost_model_version'] ?? null);
+        self::assertSame('top_of_book_embedded_spread_v1', $closed->payload['spread_model_version'] ?? null);
+        self::assertGreaterThan(0.0, $closed->payload['entry_fee_usdt'] ?? 0.0);
+        self::assertGreaterThan(0.0, $closed->payload['exit_fee_usdt'] ?? 0.0);
+
+        $reduceFillEvents = array_values(array_filter(
+            $state->events('order.filled'),
+            static fn (FakeExchangeEvent $event): bool => \in_array(
+                $event->payload['order_id'] ?? null,
+                [$tp1->exchangeOrderId, $trailing->exchangeOrderId],
+                true,
+            ),
+        ));
+        $exitFeeFromFills = array_sum(array_map(
+            static fn (FakeExchangeEvent $event): float => (float) ($event->payload['fill_fee'] ?? 0.0),
+            $reduceFillEvents,
+        ));
+        self::assertCount(2, $reduceFillEvents);
+        self::assertSame(round($exitFeeFromFills, 12), $closed->payload['exit_fee_usdt'] ?? null);
+
+        $eventsBeforeReplay = \count($state->events());
+        $recordedPnl = $closed->payload['recorded_pnl_usdt'] ?? null;
+        $scenario->fillOrder($trailing->exchangeOrderId);
+        self::assertCount($eventsBeforeReplay, $state->events());
+        self::assertSame($recordedPnl, $state->events('position.closed')[0]->payload['recorded_pnl_usdt'] ?? null);
+    }
+
+    public function testRestartPreservesRatchetWatermarkAndContinuesWithoutDuplicateUpdate(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_tp1_trailing_ratchet_');
+        self::assertIsString($stateFile);
+        @unlink($stateFile);
+
+        try {
+            [$state, $adapter, $scenario] = $this->exchange($stateFile);
+            $fixture = $this->fixture('long');
+            $trailing = $this->armFixture($adapter, $scenario, $fixture);
+            $scenario->movePrice('BTCUSDT', 25300.0, 0.0);
+            self::assertCount(1, $state->events('trailing_stop.updated'));
+
+            $restoredState = new FakeExchangeStateStore($stateFile);
+            [, $restoredAdapter, $restoredScenario] = $this->exchangeForState($restoredState);
+            $restored = $restoredAdapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+            self::assertSame(25300.0, $restored?->metadata['trailing_watermark'] ?? null);
+            self::assertSame(25200.0, $restored?->stopPrice);
+
+            $eventCount = \count($restoredState->events());
+            $restoredScenario->movePrice('BTCUSDT', 25300.0, 0.0);
+            self::assertCount($eventCount, $restoredState->events());
+            self::assertCount(1, $restoredState->events('trailing_stop.updated'));
+
+            $restoredScenario->movePrice('BTCUSDT', 25400.0, 0.0);
+            $advanced = $restoredAdapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+            self::assertSame(25400.0, $advanced?->metadata['trailing_watermark'] ?? null);
+            self::assertSame(25300.0, $advanced?->stopPrice);
+            self::assertCount(2, $restoredState->events('trailing_stop.updated'));
+        } finally {
+            @unlink($stateFile);
+            @unlink($stateFile . '.lock');
+            foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+                @unlink($temporaryFile);
+            }
+        }
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testFavorableMovementRatchetsWatermarkAndStopForBothSides(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture($direction);
+        $trailing = $this->armFixture($adapter, $scenario, $fixture);
+
+        foreach ($fixture['favorable_prices'] as $index => $favorablePrice) {
+            $scenario->movePrice((string) $fixture['symbol'], (float) $favorablePrice, 0.0);
+            $persisted = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+
+            self::assertSame((float) $favorablePrice, $persisted?->metadata['trailing_watermark'] ?? null);
+            self::assertSame(
+                (float) $fixture['expected_favorable_stops'][$index],
+                $persisted?->stopPrice,
+            );
+        }
+
+        self::assertCount(2, $state->events('trailing_stop.updated'));
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testAdverseMovementNeverLoosensTrailingStop(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture($direction);
+        $trailing = $this->armFixture($adapter, $scenario, $fixture);
+        foreach ($fixture['favorable_prices'] as $favorablePrice) {
+            $scenario->movePrice((string) $fixture['symbol'], (float) $favorablePrice, 0.0);
+        }
+        $beforeAdverse = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+        $updateCount = \count($state->events('trailing_stop.updated'));
+
+        $scenario->movePrice((string) $fixture['symbol'], (float) $fixture['adverse_price'], 0.0);
+        $afterAdverse = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+        $lastFavorableIndex = array_key_last($fixture['favorable_prices']);
+        $lastStopIndex = array_key_last($fixture['expected_favorable_stops']);
+
+        self::assertInstanceOf(ExchangeOrderDto::class, $beforeAdverse);
+        self::assertInstanceOf(ExchangeOrderDto::class, $afterAdverse);
+        self::assertIsInt($lastFavorableIndex);
+        self::assertIsInt($lastStopIndex);
+        self::assertSame((float) $fixture['favorable_prices'][$lastFavorableIndex], $beforeAdverse->metadata['trailing_watermark'] ?? null);
+        self::assertSame((float) $fixture['expected_favorable_stops'][$lastStopIndex], $beforeAdverse->stopPrice);
+        self::assertSame($beforeAdverse->metadata['trailing_watermark'], $afterAdverse->metadata['trailing_watermark'] ?? null);
+        self::assertSame($beforeAdverse->stopPrice, $afterAdverse->stopPrice);
+        self::assertCount($updateCount, $state->events('trailing_stop.updated'));
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testDuplicatePriceEventDoesNotRewriteStateOrDuplicateLifecycle(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture($direction);
+        $trailing = $this->armFixture($adapter, $scenario, $fixture);
+        $favorablePrice = (float) $fixture['favorable_prices'][0];
+        $scenario->movePrice((string) $fixture['symbol'], $favorablePrice, 0.0);
+        $afterFirst = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+        $eventCount = \count($state->events());
+        $updateCount = \count($state->events('trailing_stop.updated'));
+
+        $scenario->movePrice((string) $fixture['symbol'], $favorablePrice, 0.0);
+        $afterDuplicate = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+
+        self::assertSame((float) $fixture['expected_favorable_stops'][0], $afterFirst?->stopPrice);
+        self::assertEquals($afterFirst, $afterDuplicate);
+        self::assertCount($eventCount, $state->events());
+        self::assertCount($updateCount, $state->events('trailing_stop.updated'));
+    }
+
     public function testTp1UsesConfiguredQuantityAndAtomicallyArmsTrailingForRemainder(): void
     {
         [$state, $adapter, $scenario] = $this->exchange();
@@ -123,6 +326,26 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertCount(1, $state->events('trailing_stop.armed'));
     }
 
+    public function testEntryReplayWithDifferentTrailingPolicyIsRejectedAsIntentMismatch(): void
+    {
+        [$state, $adapter] = $this->exchange();
+        $fixture = $this->fixture('long');
+        $first = $this->placeFixtureEntry($adapter, $fixture);
+        $orderCount = \count($state->getOrders('BTCUSDT'));
+        $eventCount = \count($state->events());
+        $conflictingFixture = array_replace($fixture, ['trailing_offset' => '120.0']);
+
+        $replay = $this->placeFixtureEntry($adapter, $conflictingFixture);
+
+        self::assertTrue($first->accepted);
+        self::assertFalse($replay->accepted);
+        self::assertSame($first->exchangeOrderId, $replay->exchangeOrderId);
+        self::assertSame('duplicate_client_order_id_intent_mismatch', $replay->metadata['reason'] ?? null);
+        self::assertFalse($replay->metadata['idempotent_replay'] ?? true);
+        self::assertCount($orderCount, $state->getOrders('BTCUSDT'));
+        self::assertCount($eventCount, $state->events());
+    }
+
     public function testRestartRestoresActiveTrailingStateAndRedactsUntrustedMetadata(): void
     {
         $stateFile = tempnam(sys_get_temp_dir(), 'fake_tp1_trailing_restart_');
@@ -200,7 +423,7 @@ final class FakeTp1TrailingTest extends TestCase
 
     public function testTrailingCreationFailureRollsBackTp1PositionProtectionAndEvents(): void
     {
-        $state = new class extends FakeExchangeStateStore {
+        $faultState = new class extends FakeExchangeStateStore {
             public bool $rejectTrailingSave = false;
 
             public function saveOrder(ExchangeOrderDto $order): void
@@ -216,13 +439,13 @@ final class FakeTp1TrailingTest extends TestCase
                 parent::saveOrder($order);
             }
         };
-        [$state, $adapter, $scenario] = $this->exchangeForState($state);
+        [, $adapter, $scenario] = $this->exchangeForState($faultState);
         $fixture = $this->fixture('long');
         $this->placeFixtureEntry($adapter, $fixture);
         $stop = $this->orderByType($adapter, ExchangeOrderType::STOP_LOSS);
         $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
-        $eventsBefore = \count($state->events());
-        $state->rejectTrailingSave = true;
+        $eventsBefore = \count($faultState->events());
+        $faultState->rejectTrailingSave = true;
 
         try {
             $scenario->fillOrder($tp1->exchangeOrderId, null, 25200.0);
@@ -235,8 +458,8 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertSame(ExchangeOrderStatus::OPEN, $adapter->getOrder('BTCUSDT', $stop->exchangeOrderId)?->status);
         self::assertSame(ExchangeOrderStatus::OPEN, $adapter->getOrder('BTCUSDT', $tp1->exchangeOrderId)?->status);
         self::assertCount(2, $adapter->getOpenOrders('BTCUSDT'));
-        self::assertCount($eventsBefore, $state->events());
-        self::assertCount(0, $state->events('trailing_stop.armed'));
+        self::assertCount($eventsBefore, $faultState->events());
+        self::assertCount(0, $faultState->events('trailing_stop.armed'));
     }
 
     /**
@@ -291,6 +514,32 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertInstanceOf(ExchangeOrderDto::class, $order);
 
         return $order;
+    }
+
+    /**
+     * @param array<string,mixed> $fixture
+     */
+    private function armFixture(
+        FakeExchangeAdapter $adapter,
+        FakeExchangeScenarioService $scenario,
+        array $fixture,
+    ): ExchangeOrderDto {
+        $this->placeFixtureEntry($adapter, $fixture);
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $scenario->fillOrder(
+            $tp1->exchangeOrderId,
+            null,
+            (float) $fixture['tp1_price'],
+        );
+
+        return $this->orderByType($adapter, ExchangeOrderType::TRIGGER);
+    }
+
+    /** @return iterable<string,array{string}> */
+    public static function directionProvider(): iterable
+    {
+        yield 'long' => ['long'];
+        yield 'short' => ['short'];
     }
 
     /** @return array<string,mixed> */

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -787,6 +787,52 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertSame(0.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
     }
 
+    public function testOrdinaryPersistedTriggerWithoutTrailingStateRemainsExecutable(): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $trailing = $this->armFixture($adapter, $scenario, $this->fixture('long'));
+        $metadata = $trailing->metadata;
+        foreach ([
+            'protection_kind',
+            'trailing_state_version',
+            'trailing_state_status',
+            'trailing_activation_order_id',
+            'trailing_watermark',
+            'trailing_watermark_decimal',
+        ] as $key) {
+            unset($metadata[$key]);
+        }
+        $ordinaryTrigger = new ExchangeOrderDto(
+            exchange: $trailing->exchange,
+            marketType: $trailing->marketType,
+            symbol: $trailing->symbol,
+            exchangeOrderId: $trailing->exchangeOrderId,
+            clientOrderId: $trailing->clientOrderId,
+            side: $trailing->side,
+            positionSide: $trailing->positionSide,
+            orderType: $trailing->orderType,
+            status: $trailing->status,
+            quantity: $trailing->quantity,
+            filledQuantity: $trailing->filledQuantity,
+            remainingQuantity: $trailing->remainingQuantity,
+            price: $trailing->price,
+            averagePrice: $trailing->averagePrice,
+            stopPrice: $trailing->stopPrice,
+            reduceOnly: $trailing->reduceOnly,
+            postOnly: $trailing->postOnly,
+            timeInForce: $trailing->timeInForce,
+            createdAt: $trailing->createdAt,
+            updatedAt: $trailing->updatedAt,
+            metadata: $metadata,
+        );
+        $state->saveOrder($ordinaryTrigger);
+
+        $filled = $scenario->fillOrder($ordinaryTrigger->exchangeOrderId);
+
+        self::assertSame(ExchangeOrderStatus::FILLED, $filled?->status);
+        self::assertCount(0, $adapter->getOpenPositions('BTCUSDT'));
+    }
+
     /**
      * @param array<string,mixed> $fixture
      * @param array<string,mixed> $extraMetadata

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -849,6 +849,36 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertSame(0.6, $adapter->getOpenPositions('BTCUSDT')[0]->size);
     }
 
+    #[DataProvider('directionProvider')]
+    public function testPartialTrailingFillIsRejectedAtomicallyAndFullFillRemainsUsable(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $trailing = $this->armFixture($adapter, $scenario, $this->fixture($direction));
+        $ordersBefore = $state->getOrders('BTCUSDT');
+        $positionsBefore = $state->getOpenPositions('BTCUSDT');
+        $eventsBefore = $state->events();
+        $fillsBefore = $adapter->getFillsSnapshot('BTCUSDT');
+
+        try {
+            $scenario->fillOrder($trailing->exchangeOrderId, 0.2);
+            self::fail('Expected a partial trailing fill to be rejected.');
+        } catch (\LogicException $exception) {
+            self::assertSame('fake_tp1_trailing_partial_fill_unsupported', $exception->getMessage());
+        }
+
+        self::assertEquals($ordersBefore, $state->getOrders('BTCUSDT'));
+        self::assertEquals($positionsBefore, $state->getOpenPositions('BTCUSDT'));
+        self::assertEquals($eventsBefore, $state->events());
+        self::assertEquals($fillsBefore, $adapter->getFillsSnapshot('BTCUSDT'));
+
+        $filled = $scenario->fillOrder($trailing->exchangeOrderId);
+
+        self::assertSame(ExchangeOrderStatus::FILLED, $filled->status);
+        self::assertSame(0.6, $filled->filledQuantity);
+        self::assertCount(0, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(1, $state->events('trailing_stop.triggered'));
+    }
+
     public function testOrdinaryPersistedTriggerWithoutTrailingStateRemainsExecutable(): void
     {
         [$state, $adapter, $scenario] = $this->exchange();

--- a/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeTp1TrailingTest.php
@@ -21,6 +21,7 @@ use App\Exchange\Fake\FakeExchangeOrderBook;
 use App\Exchange\Fake\FakeExchangeScenarioService;
 use App\Exchange\Fake\FakeExchangeStateStore;
 use App\Exchange\Fake\FakeFallbackTakerPolicy;
+use App\Exchange\Fake\FakeInstrumentCatalog;
 use App\Exchange\Fake\FakeTp1TrailingPolicy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -233,26 +234,20 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertCount($updateCount, $state->events('trailing_stop.updated'));
     }
 
-    public function testRatchetDerivedStopMustObeyInstrumentTickAndRollsBackPriceMove(): void
+    public function testRatchetDerivedStopQuantizesToInstrumentTick(): void
     {
         [$state, $adapter, $scenario] = $this->exchange();
         $fixture = $this->fixture('long');
         $trailing = $this->armFixture($adapter, $scenario, $fixture);
-        $orderBefore = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
-        $bookBefore = $state->getOrderBookTop('BTCUSDT');
-        $eventsBefore = $state->events();
 
-        try {
-            $scenario->movePrice('BTCUSDT', 25300.03, 0.0);
-            self::fail('Expected the non-quantized ratcheted stop to fail.');
-        } catch (\LogicException $exception) {
-            self::assertSame('fake_tp1_trailing_ratchet_invalid', $exception->getMessage());
-        }
+        $scenario->movePrice('BTCUSDT', 25300.03, 0.0);
 
-        self::assertEquals($orderBefore, $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId));
-        self::assertSame($bookBefore, $state->getOrderBookTop('BTCUSDT'));
-        self::assertEquals($eventsBefore, $state->events());
-        self::assertCount(0, $state->events('trailing_stop.updated'));
+        $updated = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+        self::assertSame(25200.0, $updated?->stopPrice);
+        $stopPriceDecimal = $updated?->metadata['stop_price_decimal'] ?? null;
+        self::assertIsString($stopPriceDecimal);
+        self::assertTrue((new FakeInstrumentCatalog())->find('BTCUSDT')?->isPriceQuantized($stopPriceDecimal));
+        self::assertCount(1, $state->events('trailing_stop.updated'));
     }
 
     public function testTp1UsesConfiguredQuantityAndAtomicallyArmsTrailingForRemainder(): void
@@ -284,6 +279,35 @@ final class FakeTp1TrailingTest extends TestCase
         self::assertSame('100.0', $trailing->metadata[FakeTp1TrailingPolicy::TRAILING_OFFSET_KEY] ?? null);
         self::assertSame($tp1->exchangeOrderId, $trailing->metadata['trailing_activation_order_id'] ?? null);
         self::assertCount(1, $state->events('trailing_stop.armed'));
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testDefaultSpreadActivationAndNonTickRatchetQuantizeRuntimeStop(string $direction): void
+    {
+        [$state, $adapter, $scenario] = $this->exchange();
+        $fixture = $this->fixture($direction);
+        $this->placeFixtureEntry($adapter, $fixture);
+
+        $scenario->movePrice('BTCUSDT', (float) $fixture['tp1_price']);
+
+        $tp1 = $this->orderByType($adapter, ExchangeOrderType::TAKE_PROFIT);
+        $trailing = $this->orderByType($adapter, ExchangeOrderType::TRIGGER);
+        $instrument = (new FakeInstrumentCatalog())->find('BTCUSDT');
+        self::assertNotNull($instrument);
+        self::assertSame(ExchangeOrderStatus::FILLED, $tp1->status);
+        self::assertSame(ExchangeOrderStatus::OPEN, $trailing->status);
+        self::assertIsString($trailing->metadata['stop_price_decimal'] ?? null);
+        self::assertTrue($instrument->isPriceQuantized($trailing->metadata['stop_price_decimal']));
+        self::assertCount(1, $state->events('trailing_stop.armed'));
+
+        $favorableMid = $direction === 'long' ? 25300.03 : 24699.97;
+        $scenario->movePrice('BTCUSDT', $favorableMid);
+
+        $ratcheted = $adapter->getOrder('BTCUSDT', $trailing->exchangeOrderId);
+        self::assertNotNull($ratcheted);
+        self::assertIsString($ratcheted->metadata['stop_price_decimal'] ?? null);
+        self::assertTrue($instrument->isPriceQuantized($ratcheted->metadata['stop_price_decimal']));
+        self::assertCount(1, $state->events('trailing_stop.updated'));
     }
 
     public function testPartialTp1FillKeepsInitialStopUntilConfiguredQuantityCompletes(): void

--- a/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
+++ b/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
@@ -114,13 +114,17 @@
       "status": "executable"
     },
     {
-      "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testMovePriceTriggersAttachedTakeProfitAndClosesPosition"],
-      "gap_codes": ["trailing_stop_not_implemented"],
+      "evidence": [
+        "tests/Exchange/Fake/FakeTp1TrailingTest.php::testTp1UsesConfiguredQuantityAndAtomicallyArmsTrailingForRemainder",
+        "tests/Exchange/Fake/FakeTp1TrailingTest.php::testGapThroughTrailingClosesOnlyRemainderAndCleansProtections",
+        "tests/Exchange/Fake/FakeTp1TrailingTest.php::testRestartPreservesRatchetWatermarkAndContinuesWithoutDuplicateUpdate"
+      ],
+      "gap_codes": [],
       "id": 13,
       "name": "tp1_then_trailing",
       "requirement": "A partial TP1 fill arms a trailing stop for the remaining position.",
-      "runner": null,
-      "status": "partial"
+      "runner": "tp1_then_trailing",
+      "status": "executable"
     },
     {
       "evidence": ["tests/Exchange/Adapter/FakeExchangeAdapterTest.php::testMovePriceTriggersAttachedStopLossAndClosesPosition"],

--- a/trading-app/tests/fixtures/fake-paper/tp1-trailing-v1.json
+++ b/trading-app/tests/fixtures/fake-paper/tp1-trailing-v1.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "fake-tp1-trailing-fixtures-v1",
+  "cases": [
+    {
+      "name": "long",
+      "symbol": "BTCUSDT",
+      "position_side": "long",
+      "entry_side": "buy",
+      "exit_side": "sell",
+      "quantity": "1.0",
+      "initial_stop": "24800.0",
+      "tp1_price": "25200.0",
+      "tp1_quantity": "0.4",
+      "trailing_offset": "100.0",
+      "activation_stop": "25100.0",
+      "favorable_prices": ["25300.0", "25400.0"],
+      "expected_favorable_stops": ["25200.0", "25300.0"],
+      "adverse_price": "25350.0",
+      "gap_price": "25250.0"
+    },
+    {
+      "name": "short",
+      "symbol": "BTCUSDT",
+      "position_side": "short",
+      "entry_side": "sell",
+      "exit_side": "buy",
+      "quantity": "1.0",
+      "initial_stop": "25200.0",
+      "tp1_price": "24800.0",
+      "tp1_quantity": "0.4",
+      "trailing_offset": "100.0",
+      "activation_stop": "24900.0",
+      "favorable_prices": ["24700.0", "24600.0"],
+      "expected_favorable_stops": ["24800.0", "24700.0"],
+      "adverse_price": "24650.0",
+      "gap_price": "24750.0"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add an opt-in Fake/Paper TP1 policy with exact partial quantity and persistent trailing remainder
- replace the initial SL atomically after TP1, then ratchet/trigger deterministically across replay and restart
- fail closed on invalid instrument precision, looser stops, conflicting lineage, malformed persisted state, and unsafe partial-fallback exposure
- promote golden scenario 13 and document the lifecycle/rollback boundary

## Verification
- `115 tests, 1322 assertions` for focused TP1/policy/golden/parity suites
- `1699 tests, 7725 assertions, 30 expected skips` for Exchange/Fake/TradingCore/TradeEntry regression scope
- PHPStan targeted changed PHP files: green
- MkDocs strict: green
- JSON fixtures, secret/mainnet scan, and `git diff --check`: green
- independent final safety review: no findings on `b3a0052d`

## Safety
- Fake/Paper only; no demo, testnet, or mainnet exchange write path changed
- `mainnet_write_enabled` remains false
- rollback is a revert of this atomic PR plus quarantine of incompatible Fake state files

Part of #196