### PR TITLE
feat(fake): enforce One-Way position conflicts

### DIFF
--- a/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
+++ b/TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md
@@ -12,8 +12,8 @@
 | 1 | #196 — Fallback taker de fin de zone | done | issue/196-fake-fallback-taker-v1 | #282 | 4186abf243a035af16f7672bc493c225d31112d3 | worker_critical → review_fix | verte | favorable sur 4186abf243 | 2026-07-16T14:18:05Z |
 | 2 | #196 — TP1 puis trailing stop | done | issue/196-fake-tp1-trailing-v1 | #283 | 806f92dc1a162b50515a44e42a825f976f0610cb | worker_critical → review_fix → review_escalated | verte | favorable sur 806f92dc1a | 2026-07-16T19:32:05Z |
 | 3 | #196 — Injection out-of-order | done | issue/196-fake-out-of-order-v1 | #284 | 71834044b4515ee4d5ce7682baabb06cc1769f36 | worker_complex → review_fix → review_escalated | verte | favorable sur 71834044b4 | 2026-07-18T10:23:57Z |
-| 4 | #196 — Funding positif/négatif | in_progress | issue/196-funding-v1 | — | — | worker_complex | — | — | — |
-| 5 | #196 — Garde One-Way | pending | — | — | — | — | — | — | — |
+| 4 | #196 — Funding positif/négatif | done | issue/196-funding-v1 | #285 | 6b5aa4654a230eafdbfc356ee726fe5e76fe1293 | worker_complex → review_fix | verte | favorable sur 6b5aa4654a | 2026-07-18T11:29:44Z |
+| 5 | #196 — Garde One-Way | in_progress | issue/196-one-way-conflict-v1 | — | — | worker_complex | — | — | — |
 | 6 | #196 — Recette Fake multi-profils | pending | — | — | — | — | — | — | — |
 | 7 | #196 — Daily loss cap | pending | — | — | — | — | — | — | — |
 | 8 | #196 — Liquidation guard/model | pending | — | — | — | — | — | — | — |

--- a/docs/handbook/technical/fake-paper-gateway.md
+++ b/docs/handbook/technical/fake-paper-gateway.md
@@ -468,6 +468,49 @@ appel reseau exchange, aucune permission demo/testnet/mainnet et aucun
 changement de strategie, MTF, EntryZone, sizing, levier, SL/TP, frais ou
 slippage.
 
+## Mode One-Way Fake/Paper
+
+Le runtime supporte uniquement le mode One-Way pour l'adapter local
+`fake/perpetual`. La cle d'exposition est exacte et deterministe :
+
+```text
+exchange + market_type + uppercase(symbol)
+```
+
+`positionSide` est obligatoire et n'est jamais deduit de BUY/SELL. Une entree
+LONG utilise BUY, une entree SHORT utilise SELL, une sortie reduce-only LONG
+utilise SELL et une sortie reduce-only SHORT utilise BUY. Aucun mode hedge,
+netting arbitraire ou fallback Bitmart/autre exchange n'est disponible.
+
+Pour toute nouvelle entree non reduce-only, `FakeOneWayConflictGuard` inspecte
+les positions ouvertes et les ordres actifs non reduce-only du scope exact. Une
+position ou entree active opposee produit `one_way_position_conflict`. Un ordre
+actif legacy sans `positionSide` echoue ferme avec la meme raison et une source
+`ambiguous_active_order`. Les sorties/protections reduce-only, les augmentations
+du meme cote et les symboles differents restent independants. Apres cloture et
+absence d'ordre d'entree incompatible, le cote oppose est autorise.
+
+La garde s'execute apres le replay exact du `clientOrderId`, mais avant lecture
+du carnet, calcul/reservation de marge, validation de marge et creation d'un
+ordre actif. Le rejet seul est persiste comme ordre `rejected`, accompagne d'un
+unique evenement `order.rejected`; il ne change ni exposition ni marge. Son
+contexte contient uniquement version du mode, scope, cote demande, source et
+cote conflictuel connu. Aucun payload brut, credential, header ou URL n'est
+copie. Un replay identique renvoie le meme rejet avec
+`idempotent_replay=true`. Le fichier checksume `fake-paper-state-v1` conserve
+positions, ordres, rejet et sequence au restart sans migration.
+
+Le scenario golden 19 `one_way_conflict` execute position LONG contre SHORT,
+position SHORT contre LONG, sortie reduce-only, entree opposee apres cloture,
+ordre actif sans position, replay, restart et symboles independants. Tout reste
+local, sans credential, reseau exchange ou permission mutative
+demo/testnet/mainnet.
+
+Le rollback retire la garde, remet le scenario 19 a `unsupported` avec
+`one_way_conflict_guard_not_implemented` et restaure la presente section. Aucun
+schema ni format d'etat n'est a supprimer ; les rejets historiques restent des
+preuves v1 ordinaires.
+
 ## Golden suite Fake/Paper v1
 
 Le catalogue versionne des 20 scenarios obligatoires de #196 est disponible dans :
@@ -489,21 +532,21 @@ Une ligne presente dans le catalogue n est pas un PASS. Seul le statut `executab
 avec un test vert constitue une preuve. Les lignes `partial` et `unsupported` ne
 peuvent ni rendre le runtime-check ready, ni autoriser une mutation demo/testnet.
 
-Les dix-huit scenarios executes dans cette version sont : maker limit rempli, limit
+Les dix-neuf scenarios executes dans cette version sont : maker limit rempli, limit
 IOC expire sans fill, partial fill puis cancel, fallback taker de fin de zone sur
 le reliquat exact, market avec slippage 5 bps, insufficient balance, precision
 reject, leverage cap reject, replay du `client_order_id`, timeout apres
 acceptation, attachement SL reussi, echec d attachement SL compense par fermeture
 market reduce-only, TP1 partiel puis trailing persistant long/short, gap au SL au
 prochain prix disponible, deconnexion/reprise private WS, duplicate/out-of-order
-private WS avec snapshot resync, restart avec position protegee ouverte, et
-funding perpetuel deterministe/persistant.
+private WS avec snapshot resync, restart avec position protegee ouverte,
+funding perpetuel deterministe/persistant, et conflit One-Way position/ordre
+actif avec replay et restart.
 
 Les ecarts encore explicites sont :
 
 | Scenario | Statut | Gap stable |
 | --- | --- | --- |
-| One-Way conflict | `unsupported` | `one_way_conflict_guard_not_implemented` |
 | dry-run multi-profils meme symbole | `partial` | `multi_profile_fake_recipe_not_consolidated` |
 
 Commande consolidee :

--- a/docs/superpowers/plans/2026-07-18-fake-paper-one-way-conflict-v1.md
+++ b/docs/superpowers/plans/2026-07-18-fake-paper-one-way-conflict-v1.md
@@ -1,0 +1,145 @@
+# Fake/Paper One-Way Conflict Guard v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce deterministic Fake/Paper One-Way entry conflicts before margin/order creation and make golden scenario 19 executable.
+
+**Architecture:** A focused guard reads persisted Fake state at the central matching-engine boundary and evaluates the exact `exchange + market_type + symbol` scope using explicit `positionSide`. Existing rejected-order/event persistence supplies redacted audit, restart, and idempotent replay without adding a schema or state format.
+
+**Tech Stack:** PHP 8.4, Symfony 7.1, PHPUnit 11, existing Fake/Paper matching engine, checksummed state store, golden scenario runner, MkDocs.
+
+---
+
+### Task 1: Observe the Missing One-Way Guard
+
+**Files:**
+- Create: `trading-app/tests/Exchange/Fake/FakeOneWayConflictGuardTest.php`
+
+- [ ] **Step 1: Write focused failing behavior tests**
+
+  Build real matching engines and assert LONG blocks SHORT, SHORT blocks LONG,
+  reduce-only exits remain accepted, flat permits the opposite side, an active
+  opposite entry blocks without a position, exact rejection replay is
+  idempotent, restart preserves enforcement/evidence, and BTC/ETH are
+  independent. Assert `one_way_position_conflict`, unchanged exposure/margin,
+  no active rejected order, one persistent event, and no secret/raw metadata.
+
+- [ ] **Step 2: Run RED**
+
+  Run:
+
+  ```bash
+  vendor/bin/phpunit tests/Exchange/Fake/FakeOneWayConflictGuardTest.php
+  ```
+
+  Expected: FAIL because opposite entries are currently accepted/opened.
+
+### Task 2: Add the Minimal Central Guard
+
+**Files:**
+- Create: `trading-app/src/Exchange/Fake/FakeOneWayConflictGuard.php`
+- Modify: `trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php`
+
+- [ ] **Step 1: Implement exact-scope conflict evaluation**
+
+  `FakeOneWayConflictGuard::conflictMetadata()` returns `null` for reduce-only
+  intent. Otherwise it filters open positions and active orders by exact
+  exchange, market type and normalized symbol; opposite positions and
+  non-reduce-only opposite entries return derived redacted metadata. An
+  ambiguous active non-reduce-only order fails closed.
+
+- [ ] **Step 2: Insert the guard before order-book and margin work**
+
+  Preserve request-context/intent checks and exact replay first. For a new
+  conflicting intent call the existing `rejectOrder()` with reason
+  `one_way_position_conflict`; do not create an active order or reserve/read
+  margin before this branch.
+
+- [ ] **Step 3: Run GREEN**
+
+  Run the focused test file and existing adapter/state tests. Require all
+  assertions to pass without warnings or risky tests.
+
+### Task 3: Make Golden Scenario 19 Executable
+
+**Files:**
+- Modify: `trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json`
+- Modify: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php`
+- Modify: `trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php`
+
+- [ ] **Step 1: Write the failing catalogue/golden expectation**
+
+  Change scenario 19 to `executable`, clear its gap, add runner key
+  `one_way_conflict`, increment the executable count to 19, and declare exact
+  expected facts for rejection, replay, restart, closure, active order, margin,
+  redaction and symbol independence.
+
+- [ ] **Step 2: Run RED**
+
+  Run the golden catalogue/execution tests. Expected: FAIL because the runner
+  implementation and facts do not yet exist.
+
+- [ ] **Step 3: Implement the controlled scenario runner**
+
+  Exercise real Fake adapter/engine/state objects, persist/reload a temporary
+  Paper state file, and return deterministic scalar/list facts only. Use no
+  credential or network client.
+
+- [ ] **Step 4: Run GREEN**
+
+  Run focused guard plus golden catalogue/execution tests twice through the
+  existing deterministic data provider.
+
+### Task 4: Document Supported One-Way Mode
+
+**Files:**
+- Modify: `trading-app/src/Exchange/Fake/README.md`
+- Modify: `docs/handbook/technical/fake-paper-gateway.md`
+
+- [ ] **Step 1: Document the contract and audit**
+
+  State the supported `fake/perpetual` One-Way-only scope, exact key,
+  position-side mapping, conflict sources, reduce-only exception, rejection
+  ordering, stable reason, persistence/replay/restart behavior, absence of
+  netting/hedge fallback, redaction, local-only safety, and rollback.
+
+- [ ] **Step 2: Update golden inventory**
+
+  List 19 executable scenarios and leave only scenario 20 partial. Do not claim
+  issue #196 complete.
+
+### Task 5: Proportional Validation and Delivery
+
+**Files:**
+- Preserve: `TradingV3_OKX_Hyperliquid_demo_testnet_prompts_canoniques_UNIQUE.md`
+- Add all Task 1-4 files to the atomic PR.
+
+- [ ] **Step 1: Run verification**
+
+  Run focused and broader Fake/Exchange PHPUnit, PHPStan on touched PHP,
+  `php bin/console lint:container --no-debug`, `php bin/console lint:yaml config`,
+  `python3 -m mkdocs build --strict`, `git diff --check`, and a targeted secret
+  scan. No exchange write command is permitted.
+
+- [ ] **Step 2: Review requirements and diff**
+
+  Confirm every Prompt 5 minimum test, no strategy/MTF/EntryZone/frequency
+  change, no netting/hedge fallback, no schema migration, no secret, and the
+  pre-existing Prompt 4/5 registry edit remains unchanged.
+
+- [ ] **Step 3: Commit and inspect quota**
+
+  Commit atomically, then launch Codex in TTY with profile `worker_complex` and
+  verify the displayed five-hour quota is neither exhausted nor within the 3%
+  stop gate.
+
+- [ ] **Step 4: Push and open the requested PR**
+
+  Push `issue/196-one-way-conflict-v1`, open a PR against `main` whose body says
+  `Part of #196`, keep #196 open, wait about 90 seconds, and comment
+  `@codex review` on the pushed HEAD.
+
+- [ ] **Step 5: Observe only**
+
+  Report commit, PR, files, tests, CI and review state. Do not merge and do not
+  resolve any review thread.

--- a/docs/superpowers/specs/2026-07-18-fake-paper-one-way-conflict-v1-design.md
+++ b/docs/superpowers/specs/2026-07-18-fake-paper-one-way-conflict-v1-design.md
@@ -1,0 +1,131 @@
+# Fake/Paper One-Way Conflict Guard v1 Design
+
+## Scope
+
+This lot implements Prompt 5 of issue #196: deterministic One-Way enforcement
+for Fake/Paper and executable golden scenario 19. It does not change strategy,
+MTF, EntryZone, frequency, sizing, leverage, fees, funding, liquidation, or any
+demo/testnet/mainnet write gate.
+
+The only supported runtime scope remains `fake + perpetual`. Within that
+runtime, One-Way identity is the exact tuple:
+
+```text
+exchange + market_type + uppercase(symbol)
+```
+
+There is no hedge mode, implicit netting, exchange fallback, or inferred
+`positionSide`.
+
+## Audited Existing Flow and Root Cause
+
+`FakeExchangeMatchingEngine::submit()` currently validates request context and
+the explicit `positionSide`, resolves an idempotent `clientOrderId` replay,
+reads the order book and available margin, validates the order, then persists
+and fills it. `FakeExchangeStateStore` persists positions under
+`symbol + positionSide`, so both LONG and SHORT records can coexist. No step
+compares a non-reduce-only entry with the opposite position or active entry
+order.
+
+`PlaceOrderRequest::positionSide` is non-null. `assertRequestIntent()` already
+requires BUY for LONG entry, SELL for SHORT entry, SELL to reduce LONG, and BUY
+to reduce SHORT. The new guard therefore consumes this explicit enum and never
+derives position side from BUY/SELL.
+
+Orders and positions themselves carry exchange and market type. The guard will
+filter those fields as well as the normalized symbol, rather than relying on
+the state store's legacy in-memory index shape. This preserves restart
+compatibility with the existing `fake-paper-state-v1` envelope while enforcing
+the full canonical One-Way scope.
+
+## Considered Approaches
+
+### Guard in providers or the exchange adapter
+
+This would reject normal API calls but leave direct matching-engine paths,
+scenario services, fallback children, and tests able to bypass the policy.
+Rejected because the guard would not be central.
+
+### Add mutable state to `FakeOrderValidator`
+
+This would place the check near validation, but the validator is currently a
+pure instrument/margin validator. It would also run only after available margin
+has been calculated. Rejected because it mixes responsibilities and violates
+the required ordering.
+
+### Guard in the matching engine before margin validation
+
+Selected. A focused `FakeOneWayConflictGuard` evaluates current persisted state
+after exact replay resolution and before order-book/margin work. Every Fake
+order path ultimately uses the matching engine, so the policy has one
+enforcement point and remains inside the adapter's existing atomic state
+transaction.
+
+## Conflict Contract
+
+For a non-reduce-only entry, the guard checks only records matching the exact
+exchange, market type, and uppercase symbol:
+
+1. an open position with the opposite `positionSide` conflicts;
+2. an active, non-reduce-only entry order with the opposite `positionSide`
+   conflicts;
+3. a persisted active non-reduce-only order without `positionSide` fails
+   closed as ambiguous instead of enabling hedge fallback;
+4. same-side positions and entry orders may be increased;
+5. other symbols and other exact scopes are independent.
+
+Reduce-only exits and standalone reduce-only protection orders bypass the
+entry-conflict check. They still follow the existing validation and fill rules,
+including exact target `positionSide`. Once the prior position is closed and
+incompatible active entries are absent, an opposite entry is accepted.
+
+The stable rejection reason is:
+
+```text
+one_way_position_conflict
+```
+
+Derived rejection metadata contains only the mode version, canonical scope,
+requested position side, conflict source (`open_position`, `active_order`, or
+`ambiguous_active_order`), and conflicting side when known. It contains no raw
+request, client payload, credential, header, URL, or secret.
+
+## Ordering, Persistence, Replay, and Restart
+
+Exact `clientOrderId` replay remains first. A prior rejection returns the same
+rejected order with `idempotent_replay=true` and creates no new order or event;
+a mismatched intent keeps the existing stable duplicate-intent rejection.
+
+For a new intent, One-Way evaluation precedes order-book lookup, available
+margin calculation, margin validation, accepted-order persistence, and fill.
+A conflict creates only the existing rejected-order audit record plus one
+`order.rejected` event. It creates no active order, reserves no margin, and
+changes no exposure. Those records are already persisted in the checksummed
+Fake/Paper state envelope, so restart retains both the conflict evidence and
+the position/order state that caused it.
+
+## Tests and Golden Scenario 19
+
+Focused engine tests cover LONG then SHORT rejection, SHORT then LONG
+rejection, reduce-only exit, opposite entry after closure, active opposing
+entry without a position, exact rejection replay, restart/replay, and symbol
+independence. Assertions include unchanged exposure and available margin, one
+rejected record/event, stable reason, redacted metadata, and no active
+conflicting order.
+
+Golden scenario 19 runs the representative long-position conflict, replay,
+restart, reduce-only closure, opposite entry after flat, active-order conflict,
+and independent-symbol cases twice from fresh controlled state. Its catalogue
+row changes from `unsupported` to `executable`; no gap is reported as complete
+without the runner passing.
+
+## Safety and Rollback
+
+The change is local Fake/Paper logic and documentation only. It reads no
+credential, contacts no exchange endpoint, sends no demo/testnet/live order,
+and leaves `mainnet_write_enabled=false`.
+
+Rollback removes the guard call/class/tests, restores scenario 19 to
+`unsupported` with `one_way_conflict_guard_not_implemented`, and reverts the
+documentation. No schema or state-envelope migration is required; rejected
+orders and events remain ordinary auditable v1 records.

--- a/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
+++ b/trading-app/src/Exchange/Fake/FakeExchangeMatchingEngine.php
@@ -62,6 +62,8 @@ final readonly class FakeExchangeMatchingEngine
 
     private FakeFillCostModel $fillCostModel;
 
+    private FakeOneWayConflictGuard $oneWayConflictGuard;
+
     public function __construct(
         private FakeExchangeStateStore $stateStore,
         private FakeExchangeOrderBook $orderBook,
@@ -69,10 +71,12 @@ final readonly class FakeExchangeMatchingEngine
         ?FakeOrderValidator $orderValidator = null,
         ?FakeInstrumentProviderInterface $instruments = null,
         ?FakeFillCostModel $fillCostModel = null,
+        ?FakeOneWayConflictGuard $oneWayConflictGuard = null,
     ) {
         $this->instruments = $instruments ?? new FakeInstrumentCatalog();
         $this->orderValidator = $orderValidator ?? new FakeOrderValidator($this->instruments);
         $this->fillCostModel = $fillCostModel ?? new FakeFillCostModel();
+        $this->oneWayConflictGuard = $oneWayConflictGuard ?? new FakeOneWayConflictGuard($this->stateStore);
     }
 
     public function submit(PlaceOrderRequest $request): PlaceOrderResult
@@ -107,6 +111,19 @@ final readonly class FakeExchangeMatchingEngine
                 submittedAt: $this->clock->now(),
                 order: $existing,
                 metadata: array_replace($existing->metadata, ['idempotent_replay' => true]),
+            );
+        }
+
+        $conflictMetadata = $this->oneWayConflictGuard->conflictMetadata(
+            $request,
+            $request->reduceOnly || $this->isStandaloneProtection($request),
+        );
+        if ($conflictMetadata !== null) {
+            return $this->rejectOrder(
+                $request,
+                FakeOneWayConflictGuard::REJECTION_REASON,
+                $trustedFallbackMetadata,
+                $conflictMetadata,
             );
         }
 

--- a/trading-app/src/Exchange/Fake/FakeOneWayConflictGuard.php
+++ b/trading-app/src/Exchange/Fake/FakeOneWayConflictGuard.php
@@ -32,7 +32,7 @@ final readonly class FakeOneWayConflictGuard
             ExchangePositionSide::SHORT => ExchangePositionSide::LONG,
         };
 
-        foreach ($this->stateStore->getOpenPositions($request->symbol) as $position) {
+        foreach ($this->stateStore->getOpenPositions() as $position) {
             if (!$this->positionMatchesScope($position, $request) || $position->side !== $oppositeSide) {
                 continue;
             }
@@ -40,7 +40,7 @@ final readonly class FakeOneWayConflictGuard
             return $this->metadata($request, 'open_position', $position->side);
         }
 
-        foreach ($this->stateStore->getOpenOrders($request->symbol) as $order) {
+        foreach ($this->stateStore->getOpenOrders() as $order) {
             if (!$this->orderMatchesScope($order, $request) || $order->reduceOnly) {
                 continue;
             }

--- a/trading-app/src/Exchange/Fake/FakeOneWayConflictGuard.php
+++ b/trading-app/src/Exchange/Fake/FakeOneWayConflictGuard.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exchange\Fake;
+
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangePositionSide;
+
+final readonly class FakeOneWayConflictGuard
+{
+    public const REJECTION_REASON = 'one_way_position_conflict';
+    public const VERSION = 'fake-one-way-v1';
+
+    public function __construct(private FakeExchangeStateStore $stateStore)
+    {
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    public function conflictMetadata(PlaceOrderRequest $request, bool $reduceIntent): ?array
+    {
+        if ($reduceIntent) {
+            return null;
+        }
+
+        $oppositeSide = match ($request->positionSide) {
+            ExchangePositionSide::LONG => ExchangePositionSide::SHORT,
+            ExchangePositionSide::SHORT => ExchangePositionSide::LONG,
+        };
+
+        foreach ($this->stateStore->getOpenPositions($request->symbol) as $position) {
+            if (!$this->positionMatchesScope($position, $request) || $position->side !== $oppositeSide) {
+                continue;
+            }
+
+            return $this->metadata($request, 'open_position', $position->side);
+        }
+
+        foreach ($this->stateStore->getOpenOrders($request->symbol) as $order) {
+            if (!$this->orderMatchesScope($order, $request) || $order->reduceOnly) {
+                continue;
+            }
+            if ($order->positionSide === null) {
+                return $this->metadata($request, 'ambiguous_active_order');
+            }
+            if ($order->positionSide === $oppositeSide) {
+                return $this->metadata($request, 'active_order', $order->positionSide);
+            }
+        }
+
+        return null;
+    }
+
+    private function positionMatchesScope(ExchangePositionDto $position, PlaceOrderRequest $request): bool
+    {
+        return $position->exchange === $request->exchange
+            && $position->marketType === $request->marketType
+            && strtoupper($position->symbol) === strtoupper($request->symbol);
+    }
+
+    private function orderMatchesScope(ExchangeOrderDto $order, PlaceOrderRequest $request): bool
+    {
+        return $order->exchange === $request->exchange
+            && $order->marketType === $request->marketType
+            && strtoupper($order->symbol) === strtoupper($request->symbol);
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function metadata(
+        PlaceOrderRequest $request,
+        string $source,
+        ?ExchangePositionSide $conflictingSide = null,
+    ): array {
+        return array_filter([
+            'position_mode' => 'one_way',
+            'position_mode_version' => self::VERSION,
+            'position_scope' => implode('::', [
+                $request->exchange->value,
+                $request->marketType->value,
+                strtoupper($request->symbol),
+            ]),
+            'requested_position_side' => $request->positionSide->value,
+            'conflict_source' => $source,
+            'conflicting_position_side' => $conflictingSide?->value,
+        ], static fn (?string $value): bool => $value !== null);
+    }
+}

--- a/trading-app/src/Exchange/Fake/README.md
+++ b/trading-app/src/Exchange/Fake/README.md
@@ -16,6 +16,7 @@ Supported scenarios:
   attached protection is rejected;
 - cancel by exchange order id or client order id;
 - replay the same active `clientOrderId` without creating a second active order;
+- enforce One-Way entry conflicts for the exact `fake/perpetual/symbol` scope;
 - inspect simulated events such as `order.created`, `order.filled`, `position.opened`, `protection_order.created`, and `protection_order.rejected`.
 
 Useful local endpoints:
@@ -166,6 +167,39 @@ position, only the failed increase is removed and the residual position must
 still have full active stop coverage. A wrong close quantity or unprotected
 residual raises an exception and restores the whole local operation. No
 credential, raw request payload, or external exchange mutation is involved.
+
+## Deterministic One-Way position mode
+
+Fake/Paper supports one position mode only: One-Way on `fake/perpetual`. Its
+canonical scope key is `exchange + market_type + uppercase(symbol)`. There is
+no hedge mode, implicit netting, or fallback to another exchange. Every
+`PlaceOrderRequest` must carry an explicit `positionSide`; the engine never
+infers it from BUY/SELL. A LONG entry is BUY, a SHORT entry is SELL, a
+reduce-only LONG exit is SELL, and a reduce-only SHORT exit is BUY.
+
+Before reading available margin or creating an active order, the matching
+engine checks the exact scope for an opposite open position and for an active
+opposite non-reduce-only entry. Either condition is persisted as a rejected
+order and one `order.rejected` event with stable reason
+`one_way_position_conflict`. An active entry whose persisted `positionSide` is
+missing fails closed as ambiguous. Same-side increases remain possible, other
+symbols remain independent, and reduce-only exits/protections stay allowed.
+Once the existing exposure is flat and no incompatible entry remains active,
+the opposite side can open normally.
+
+Rejection metadata is derived only: mode/version, canonical scope, requested
+side, conflict source, and conflicting side when known. Raw request metadata,
+credentials, headers, URLs, and payloads are not copied. Exact
+`clientOrderId` replay returns the same rejected order with
+`idempotent_replay=true` and no duplicate event. The ordinary checksummed
+`fake-paper-state-v1` envelope persists positions, active orders, rejection,
+and event sequence, so restart enforces the same policy without migration.
+
+This path is local and performs no exchange network request or
+demo/testnet/mainnet write. Rollback removes `FakeOneWayConflictGuard`, restores
+golden scenario 19 to `unsupported` with
+`one_way_conflict_guard_not_implemented`, and archives no new state format;
+existing rejected orders/events remain valid v1 audit records.
 
 ## Private WS disconnect/resync fixture
 

--- a/trading-app/tests/Exchange/Fake/FakeOneWayConflictGuardTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeOneWayConflictGuardTest.php
@@ -199,6 +199,98 @@ final class FakeOneWayConflictGuardTest extends TestCase
         }
     }
 
+    public function testRestoredMixedCasePositionRejectsOppositeEntry(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_one_way_mixed_position_');
+        self::assertNotFalse($stateFile);
+        unlink($stateFile);
+
+        try {
+            $seeded = new FakeExchangeStateStore($stateFile);
+            $seeded->savePosition(new ExchangePositionDto(
+                exchange: Exchange::FAKE,
+                marketType: MarketType::PERPETUAL,
+                symbol: 'bTcUsDt',
+                side: ExchangePositionSide::LONG,
+                size: 1.0,
+                entryPrice: 25000.0,
+                markPrice: 25000.0,
+                unrealizedPnl: 0.0,
+                realizedPnl: 0.0,
+                margin: 8333.33,
+                leverage: 3.0,
+                openedAt: $this->clock()->now(),
+                updatedAt: $this->clock()->now(),
+            ));
+
+            [$restored] = $this->exchangeForState(new FakeExchangeStateStore($stateFile));
+            $rejected = $restored->placeOrder($this->entryRequest(
+                ExchangePositionSide::SHORT,
+                'one-way-mixed-position-conflict',
+            ));
+
+            self::assertFalse($rejected->accepted);
+            self::assertSame('one_way_position_conflict', $rejected->metadata['reason'] ?? null);
+            self::assertSame('open_position', $rejected->metadata['conflict_source'] ?? null);
+            self::assertSame('long', $rejected->metadata['conflicting_position_side'] ?? null);
+            self::assertSame('fake::perpetual::BTCUSDT', $rejected->metadata['position_scope'] ?? null);
+        } finally {
+            $this->removeStateFiles($stateFile);
+        }
+    }
+
+    public function testRestoredMixedCaseActiveOrderRejectsOppositeEntry(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_one_way_mixed_order_');
+        self::assertNotFalse($stateFile);
+        unlink($stateFile);
+
+        try {
+            $seeded = new FakeExchangeStateStore($stateFile);
+            $seeded->saveOrder(new ExchangeOrderDto(
+                exchange: Exchange::FAKE,
+                marketType: MarketType::PERPETUAL,
+                symbol: 'bTcUsDt',
+                exchangeOrderId: 'fake-mixed-active-long',
+                clientOrderId: 'mixed-active-long',
+                side: ExchangeOrderSide::BUY,
+                positionSide: ExchangePositionSide::LONG,
+                orderType: ExchangeOrderType::LIMIT,
+                status: ExchangeOrderStatus::OPEN,
+                quantity: 1.0,
+                filledQuantity: 0.0,
+                remainingQuantity: 1.0,
+                price: 24950.0,
+                averagePrice: null,
+                stopPrice: null,
+                reduceOnly: false,
+                postOnly: true,
+                timeInForce: ExchangeTimeInForce::GTC,
+                createdAt: $this->clock()->now(),
+                metadata: [
+                    'margin_reference_price' => 24950.0,
+                    'margin_reference_source' => 'top_of_book',
+                    'margin_contract_size' => '1',
+                    'leverage' => 3,
+                ],
+            ));
+
+            [$restored] = $this->exchangeForState(new FakeExchangeStateStore($stateFile));
+            $rejected = $restored->placeOrder($this->entryRequest(
+                ExchangePositionSide::SHORT,
+                'one-way-mixed-order-conflict',
+            ));
+
+            self::assertFalse($rejected->accepted);
+            self::assertSame('one_way_position_conflict', $rejected->metadata['reason'] ?? null);
+            self::assertSame('active_order', $rejected->metadata['conflict_source'] ?? null);
+            self::assertSame('long', $rejected->metadata['conflicting_position_side'] ?? null);
+            self::assertSame('fake::perpetual::BTCUSDT', $rejected->metadata['position_scope'] ?? null);
+        } finally {
+            $this->removeStateFiles($stateFile);
+        }
+    }
+
     public function testDifferentSymbolsRemainIndependent(): void
     {
         [$adapter] = $this->exchangeForState(new FakeExchangeStateStore());
@@ -371,6 +463,19 @@ final class FakeOneWayConflictGuardTest extends TestCase
                 return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
             }
         };
+    }
+
+    private function removeStateFiles(string $stateFile): void
+    {
+        if (is_file($stateFile)) {
+            unlink($stateFile);
+        }
+        if (is_file($stateFile . '.lock')) {
+            unlink($stateFile . '.lock');
+        }
+        foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+            unlink($temporaryFile);
+        }
     }
 }
 

--- a/trading-app/tests/Exchange/Fake/FakeOneWayConflictGuardTest.php
+++ b/trading-app/tests/Exchange/Fake/FakeOneWayConflictGuardTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Exchange\Fake;
+
+use App\Common\Enum\Exchange;
+use App\Common\Enum\MarketType;
+use App\Exchange\Adapter\FakeExchangeAdapter;
+use App\Exchange\Dto\ExchangeOrderDto;
+use App\Exchange\Dto\ExchangePositionDto;
+use App\Exchange\Dto\PlaceOrderRequest;
+use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
+use App\Exchange\Enum\ExchangeOrderType;
+use App\Exchange\Enum\ExchangePositionSide;
+use App\Exchange\Enum\ExchangeTimeInForce;
+use App\Exchange\Fake\FakeExchangeMatchingEngine;
+use App\Exchange\Fake\FakeOneWayConflictGuard;
+use App\Exchange\Fake\FakeExchangeOrderBook;
+use App\Exchange\Fake\FakeExchangeScenarioService;
+use App\Exchange\Fake\FakeExchangeStateStore;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+
+#[CoversNothing]
+final class FakeOneWayConflictGuardTest extends TestCase
+{
+    public function testLongPositionRejectsShortBeforeMarginAndPersistsRedactedIdempotentRejection(): void
+    {
+        $state = new MarginReadFailingFakeExchangeStateStore();
+        [$adapter, $scenario] = $this->exchangeForState($state);
+        $long = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::LONG,
+            'one-way-long-open',
+            metadata: ['internal_trade_id' => 'trade-long'],
+        ));
+        $availableMarginBefore = $state->availableMarginUsdt();
+
+        $state->failOnMarginRead = true;
+        $shortRequest = $this->entryRequest(
+            ExchangePositionSide::SHORT,
+            'one-way-short-conflict',
+            metadata: [
+                'internal_trade_id' => 'trade-short',
+                'api_key' => 'TOP-SECRET',
+                'raw_payload' => ['authorization' => 'Bearer SECRET'],
+            ],
+        );
+        $rejected = $adapter->placeOrder($shortRequest);
+        $replayed = $adapter->placeOrder($shortRequest);
+        $state->failOnMarginRead = false;
+
+        self::assertTrue($long->accepted);
+        self::assertFalse($rejected->accepted);
+        self::assertSame(ExchangeOrderStatus::REJECTED, $rejected->status);
+        self::assertSame('one_way_position_conflict', $rejected->metadata['reason'] ?? null);
+        self::assertSame('fake-one-way-v1', $rejected->metadata['position_mode_version'] ?? null);
+        self::assertSame('fake::perpetual::BTCUSDT', $rejected->metadata['position_scope'] ?? null);
+        self::assertSame('short', $rejected->metadata['requested_position_side'] ?? null);
+        self::assertSame('long', $rejected->metadata['conflicting_position_side'] ?? null);
+        self::assertSame('open_position', $rejected->metadata['conflict_source'] ?? null);
+        self::assertSame($rejected->exchangeOrderId, $replayed->exchangeOrderId);
+        self::assertTrue($replayed->metadata['idempotent_replay'] ?? false);
+        self::assertSame($availableMarginBefore, $state->availableMarginUsdt());
+        self::assertCount(1, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertSame(ExchangePositionSide::LONG, $adapter->getOpenPositions('BTCUSDT')[0]->side);
+        self::assertCount(1, $adapter->getOpenOrders('BTCUSDT'));
+        self::assertTrue($adapter->getOpenOrders('BTCUSDT')[0]->reduceOnly);
+        self::assertCount(1, $scenario->events('order.rejected'));
+
+        $serialized = json_encode([
+            $rejected->metadata,
+            array_map(static fn ($event): array => $event->toArray(), $scenario->events('order.rejected')),
+        ], JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('TOP-SECRET', $serialized);
+        self::assertStringNotContainsString('Bearer SECRET', $serialized);
+        self::assertStringNotContainsString('api_key', $serialized);
+        self::assertStringNotContainsString('raw_payload', $serialized);
+    }
+
+    public function testShortPositionRejectsLongEntry(): void
+    {
+        [$adapter] = $this->exchangeForState(new FakeExchangeStateStore());
+        $short = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::SHORT,
+            'one-way-short-open',
+        ));
+
+        $long = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::LONG,
+            'one-way-long-conflict',
+        ));
+
+        self::assertTrue($short->accepted);
+        self::assertFalse($long->accepted);
+        self::assertSame('one_way_position_conflict', $long->metadata['reason'] ?? null);
+        self::assertSame('short', $long->metadata['conflicting_position_side'] ?? null);
+        self::assertCount(1, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertSame(ExchangePositionSide::SHORT, $adapter->getOpenPositions('BTCUSDT')[0]->side);
+    }
+
+    public function testReduceOnlyExitIsAllowedAndFlatPositionAllowsOppositeEntry(): void
+    {
+        [$adapter] = $this->exchangeForState(new FakeExchangeStateStore());
+        $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::LONG,
+            'one-way-long-before-close',
+        ));
+
+        $exit = $adapter->placeOrder($this->reduceOnlyRequest(
+            ExchangePositionSide::LONG,
+            'one-way-long-exit',
+        ));
+        $opposite = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::SHORT,
+            'one-way-short-after-flat',
+        ));
+
+        self::assertTrue($exit->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $exit->status);
+        self::assertTrue($exit->order?->reduceOnly);
+        self::assertTrue($opposite->accepted);
+        self::assertSame(ExchangeOrderStatus::FILLED, $opposite->status);
+        self::assertCount(1, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertSame(ExchangePositionSide::SHORT, $adapter->getOpenPositions('BTCUSDT')[0]->side);
+    }
+
+    public function testActiveOppositeEntryConflictsWithoutAnOpenPosition(): void
+    {
+        [$adapter] = $this->exchangeForState(new FakeExchangeStateStore());
+        $active = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::LONG,
+            'one-way-active-long',
+            orderType: ExchangeOrderType::LIMIT,
+            price: 24950.0,
+            postOnly: true,
+            withProtection: false,
+        ));
+
+        $rejected = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::SHORT,
+            'one-way-short-against-active',
+        ));
+
+        self::assertTrue($active->accepted);
+        self::assertSame(ExchangeOrderStatus::OPEN, $active->status);
+        self::assertFalse($rejected->accepted);
+        self::assertSame('one_way_position_conflict', $rejected->metadata['reason'] ?? null);
+        self::assertSame('active_order', $rejected->metadata['conflict_source'] ?? null);
+        self::assertSame('long', $rejected->metadata['conflicting_position_side'] ?? null);
+        self::assertCount(0, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(1, $adapter->getOpenOrders('BTCUSDT'));
+        self::assertSame($active->exchangeOrderId, $adapter->getOpenOrders('BTCUSDT')[0]->exchangeOrderId);
+    }
+
+    public function testRestartPreservesConflictAndRejectedReplay(): void
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_one_way_restart_');
+        self::assertNotFalse($stateFile);
+        unlink($stateFile);
+
+        try {
+            [$adapter] = $this->exchangeForState(new FakeExchangeStateStore($stateFile));
+            $adapter->placeOrder($this->entryRequest(
+                ExchangePositionSide::LONG,
+                'one-way-restart-long',
+            ));
+
+            [$restarted, $scenario] = $this->exchangeForState(new FakeExchangeStateStore($stateFile));
+            $request = $this->entryRequest(
+                ExchangePositionSide::SHORT,
+                'one-way-restart-short-conflict',
+            );
+            $rejected = $restarted->placeOrder($request);
+
+            [$restartedAgain, $scenarioAgain] = $this->exchangeForState(new FakeExchangeStateStore($stateFile));
+            $replayed = $restartedAgain->placeOrder($request);
+
+            self::assertFalse($rejected->accepted);
+            self::assertSame('one_way_position_conflict', $rejected->metadata['reason'] ?? null);
+            self::assertSame($rejected->exchangeOrderId, $replayed->exchangeOrderId);
+            self::assertTrue($replayed->metadata['idempotent_replay'] ?? false);
+            self::assertCount(1, $scenario->events('order.rejected'));
+            self::assertCount(1, $scenarioAgain->events('order.rejected'));
+            self::assertCount(1, $restartedAgain->getOpenPositions('BTCUSDT'));
+            self::assertSame(ExchangePositionSide::LONG, $restartedAgain->getOpenPositions('BTCUSDT')[0]->side);
+        } finally {
+            if (is_file($stateFile)) {
+                unlink($stateFile);
+            }
+            if (is_file($stateFile . '.lock')) {
+                unlink($stateFile . '.lock');
+            }
+            foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+                unlink($temporaryFile);
+            }
+        }
+    }
+
+    public function testDifferentSymbolsRemainIndependent(): void
+    {
+        [$adapter] = $this->exchangeForState(new FakeExchangeStateStore());
+        $btcLong = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::LONG,
+            'one-way-btc-long',
+        ));
+        $ethShort = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::SHORT,
+            'one-way-eth-short',
+            symbol: 'ETHUSDT',
+        ));
+
+        self::assertTrue($btcLong->accepted);
+        self::assertTrue($ethShort->accepted);
+        self::assertCount(1, $adapter->getOpenPositions('BTCUSDT'));
+        self::assertCount(1, $adapter->getOpenPositions('ETHUSDT'));
+        self::assertSame(ExchangePositionSide::LONG, $adapter->getOpenPositions('BTCUSDT')[0]->side);
+        self::assertSame(ExchangePositionSide::SHORT, $adapter->getOpenPositions('ETHUSDT')[0]->side);
+    }
+
+    public function testAmbiguousActiveEntryFailsClosedInsteadOfFallingBackToHedge(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $state->saveOrder(new ExchangeOrderDto(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            exchangeOrderId: 'fake-legacy-ambiguous',
+            clientOrderId: 'legacy-ambiguous-entry',
+            side: ExchangeOrderSide::BUY,
+            positionSide: null,
+            orderType: ExchangeOrderType::LIMIT,
+            status: ExchangeOrderStatus::OPEN,
+            quantity: 1.0,
+            filledQuantity: 0.0,
+            remainingQuantity: 1.0,
+            price: 24950.0,
+            averagePrice: null,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: true,
+            timeInForce: ExchangeTimeInForce::GTC,
+            createdAt: $this->clock()->now(),
+            metadata: [
+                'margin_reference_price' => 24950.0,
+                'margin_reference_source' => 'top_of_book',
+                'margin_contract_size' => '1',
+                'leverage' => 3,
+            ],
+        ));
+        [$adapter] = $this->exchangeForState($state);
+
+        $rejected = $adapter->placeOrder($this->entryRequest(
+            ExchangePositionSide::LONG,
+            'one-way-ambiguous-active-conflict',
+        ));
+
+        self::assertFalse($rejected->accepted);
+        self::assertSame('one_way_position_conflict', $rejected->metadata['reason'] ?? null);
+        self::assertSame('ambiguous_active_order', $rejected->metadata['conflict_source'] ?? null);
+        self::assertArrayNotHasKey('conflicting_position_side', $rejected->metadata);
+    }
+
+    public function testGuardScopeIncludesExchangeMarketTypeAndNormalizedSymbol(): void
+    {
+        $state = new FakeExchangeStateStore();
+        $state->savePosition(new ExchangePositionDto(
+            exchange: Exchange::BITMART,
+            marketType: MarketType::SPOT,
+            symbol: 'BTCUSDT',
+            side: ExchangePositionSide::SHORT,
+            size: 1.0,
+            entryPrice: 25000.0,
+            markPrice: 25000.0,
+            unrealizedPnl: null,
+            realizedPnl: null,
+            margin: 1.0,
+            leverage: 1.0,
+        ));
+
+        $metadata = (new FakeOneWayConflictGuard($state))->conflictMetadata(
+            $this->entryRequest(ExchangePositionSide::LONG, 'one-way-exact-scope'),
+            false,
+        );
+
+        self::assertNull($metadata);
+    }
+
+    /** @return array{FakeExchangeAdapter,FakeExchangeScenarioService} */
+    private function exchangeForState(FakeExchangeStateStore $state): array
+    {
+        $book = new FakeExchangeOrderBook($state);
+        $engine = new FakeExchangeMatchingEngine($state, $book, $this->clock());
+
+        return [
+            new FakeExchangeAdapter($state, $book, $engine, $this->clock()),
+            new FakeExchangeScenarioService($state, $book, $engine),
+        ];
+    }
+
+    /** @param array<string,mixed> $metadata */
+    private function entryRequest(
+        ExchangePositionSide $positionSide,
+        string $clientOrderId,
+        string $symbol = 'BTCUSDT',
+        ExchangeOrderType $orderType = ExchangeOrderType::MARKET,
+        ?float $price = null,
+        bool $postOnly = false,
+        bool $withProtection = true,
+        array $metadata = [],
+    ): PlaceOrderRequest {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            side: $positionSide === ExchangePositionSide::LONG
+                ? ExchangeOrderSide::BUY
+                : ExchangeOrderSide::SELL,
+            positionSide: $positionSide,
+            orderType: $orderType,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: $price,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: $postOnly,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+            attachedStopLossPrice: $withProtection
+                ? ($positionSide === ExchangePositionSide::SHORT
+                    ? ($symbol === 'ETHUSDT' ? 1820.0 : 25200.0)
+                    : ($symbol === 'ETHUSDT' ? 1780.0 : 24800.0))
+                : null,
+            metadata: $metadata,
+        );
+    }
+
+    private function reduceOnlyRequest(
+        ExchangePositionSide $positionSide,
+        string $clientOrderId,
+    ): PlaceOrderRequest {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: $positionSide === ExchangePositionSide::LONG
+                ? ExchangeOrderSide::SELL
+                : ExchangeOrderSide::BUY,
+            positionSide: $positionSide,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: null,
+            stopPrice: null,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+        );
+    }
+
+    private function clock(): ClockInterface
+    {
+        return new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+            }
+        };
+    }
+}
+
+final class MarginReadFailingFakeExchangeStateStore extends FakeExchangeStateStore
+{
+    public bool $failOnMarginRead = false;
+
+    public function availableMarginUsdt(): float
+    {
+        if ($this->failOnMarginRead) {
+            throw new \LogicException('one_way_conflict_read_margin_before_reject');
+        }
+
+        return parent::availableMarginUsdt();
+    }
+}

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioCatalogTest.php
@@ -29,7 +29,7 @@ final class FakePaperGoldenScenarioCatalogTest extends TestCase
         'duplicate_out_of_order_event' => ['executable', []],
         'restart_with_open_position' => ['executable', []],
         'funding' => ['executable', []],
-        'one_way_conflict' => ['unsupported', ['one_way_conflict_guard_not_implemented']],
+        'one_way_conflict' => ['executable', []],
         'dry_run_multi_profiles_same_symbol' => ['partial', ['multi_profile_fake_recipe_not_consolidated']],
     ];
 

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php
@@ -281,6 +281,26 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             'unknown_currency_amount_usdt' => null,
             'unknown_currency_native_amount' => '-1.000000000000',
         ],
+        'one_way_conflict' => [
+            'active_order_conflict_source' => 'active_order',
+            'active_order_rejected' => true,
+            'available_margin_unchanged' => true,
+            'conflict_event_count' => 1,
+            'conflicting_position_side' => 'long',
+            'exposure_unchanged' => true,
+            'flat_allows_opposite' => true,
+            'independent_symbols' => true,
+            'long_blocks_short' => true,
+            'metadata_redacted' => true,
+            'position_mode_version' => 'fake-one-way-v1',
+            'reason' => 'one_way_position_conflict',
+            'reduce_only_exit_allowed' => true,
+            'rejected_order_persisted' => true,
+            'replay_idempotent' => true,
+            'restart_enforced' => true,
+            'same_rejected_order_id' => true,
+            'short_blocks_long' => true,
+        ],
     ];
 
     public function testGoldenRunnerContractExists(): void
@@ -346,7 +366,7 @@ final class FakePaperGoldenScenarioExecutionTest extends TestCase
             ),
         ));
 
-        self::assertCount(18, $catalogKeys);
+        self::assertCount(19, $catalogKeys);
         self::assertSame($catalogKeys, FakePaperGoldenScenarioRunner::keys());
     }
 

--- a/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
+++ b/trading-app/tests/Exchange/Fake/FakePaperGoldenScenarioRunner.php
@@ -14,6 +14,7 @@ use App\Exchange\Dto\ExchangePositionDto;
 use App\Exchange\Dto\PlaceOrderRequest;
 use App\Exchange\Dto\PlaceOrderResult;
 use App\Exchange\Enum\ExchangeOrderSide;
+use App\Exchange\Enum\ExchangeOrderStatus;
 use App\Exchange\Enum\ExchangeOrderType;
 use App\Exchange\Enum\ExchangePositionSide;
 use App\Exchange\Enum\ExchangeTimeInForce;
@@ -71,6 +72,7 @@ final class FakePaperGoldenScenarioRunner
         'duplicate_out_of_order_event',
         'restart_with_open_position',
         'funding',
+        'one_way_conflict',
     ];
 
     /** @return list<string> */
@@ -107,6 +109,7 @@ final class FakePaperGoldenScenarioRunner
             'duplicate_out_of_order_event' => $this->duplicateOutOfOrderEvent(),
             'restart_with_open_position' => $this->restartWithOpenPosition(),
             'funding' => $this->funding(),
+            'one_way_conflict' => $this->oneWayConflict(),
         };
 
         return [
@@ -1094,6 +1097,193 @@ final class FakePaperGoldenScenarioRunner
                 @unlink($temporaryFile);
             }
         }
+    }
+
+    /** @return array<string,mixed> */
+    private function oneWayConflict(): array
+    {
+        $stateFile = tempnam(sys_get_temp_dir(), 'fake_paper_golden_one_way_');
+        if ($stateFile === false) {
+            throw new \RuntimeException('Unable to allocate the One-Way golden state file.');
+        }
+        @unlink($stateFile);
+
+        try {
+            [$state, $adapter, $scenario] = $this->exchange($stateFile);
+            $long = $adapter->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::LONG,
+                'golden-one-way-long',
+            ));
+            $availableMarginBefore = $state->availableMarginUsdt();
+            $shortRequest = $this->oneWayEntryRequest(
+                ExchangePositionSide::SHORT,
+                'golden-one-way-short-conflict',
+                metadata: [
+                    'internal_trade_id' => 'golden-one-way-conflict',
+                    'api_key' => 'TOP-SECRET',
+                    'raw_payload' => ['authorization' => 'Bearer SECRET'],
+                ],
+            );
+            $rejected = $adapter->placeOrder($shortRequest);
+            $replayed = $adapter->placeOrder($shortRequest);
+            $positionsAfterConflict = $adapter->getOpenPositions('BTCUSDT');
+            $rejectionEvents = $scenario->events('order.rejected');
+            $serialized = json_encode([
+                $rejected->metadata,
+                array_map(static fn (FakeExchangeEvent $event): array => $event->toArray(), $rejectionEvents),
+            ], JSON_THROW_ON_ERROR);
+
+            [, $restarted] = $this->exchange($stateFile);
+            $restartConflict = $restarted->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::SHORT,
+                'golden-one-way-restart-conflict',
+            ));
+            $exit = $restarted->placeOrder($this->oneWayExitRequest(
+                ExchangePositionSide::LONG,
+                'golden-one-way-long-exit',
+            ));
+            $oppositeAfterFlat = $restarted->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::SHORT,
+                'golden-one-way-short-after-flat',
+            ));
+
+            [, $shortAdapter] = $this->exchange();
+            $shortAdapter->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::SHORT,
+                'golden-one-way-short-open',
+            ));
+            $longAgainstShort = $shortAdapter->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::LONG,
+                'golden-one-way-long-conflict',
+            ));
+
+            [, $activeAdapter] = $this->exchange();
+            $activeAdapter->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::LONG,
+                'golden-one-way-active-long',
+                orderType: ExchangeOrderType::LIMIT,
+                price: 24950.0,
+                postOnly: true,
+                withProtection: false,
+            ));
+            $activeConflict = $activeAdapter->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::SHORT,
+                'golden-one-way-active-short-conflict',
+            ));
+
+            [, $independentAdapter] = $this->exchange();
+            $btcLong = $independentAdapter->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::LONG,
+                'golden-one-way-independent-btc',
+            ));
+            $ethShort = $independentAdapter->placeOrder($this->oneWayEntryRequest(
+                ExchangePositionSide::SHORT,
+                'golden-one-way-independent-eth',
+                symbol: 'ETHUSDT',
+            ));
+
+            return [
+                'active_order_conflict_source' => $activeConflict->metadata['conflict_source'] ?? null,
+                'active_order_rejected' => !$activeConflict->accepted,
+                'available_margin_unchanged' => $availableMarginBefore === $state->availableMarginUsdt(),
+                'conflict_event_count' => \count($rejectionEvents),
+                'conflicting_position_side' => $rejected->metadata['conflicting_position_side'] ?? null,
+                'exposure_unchanged' => $long->accepted
+                    && \count($positionsAfterConflict) === 1
+                    && $positionsAfterConflict[0]->side === ExchangePositionSide::LONG
+                    && $positionsAfterConflict[0]->size === 1.0,
+                'flat_allows_opposite' => $exit->accepted
+                    && $exit->order?->reduceOnly === true
+                    && $oppositeAfterFlat->accepted,
+                'independent_symbols' => $btcLong->accepted
+                    && $ethShort->accepted
+                    && \count($independentAdapter->getOpenPositions('BTCUSDT')) === 1
+                    && \count($independentAdapter->getOpenPositions('ETHUSDT')) === 1,
+                'long_blocks_short' => !$rejected->accepted,
+                'metadata_redacted' => !str_contains($serialized, 'TOP-SECRET')
+                    && !str_contains($serialized, 'Bearer SECRET')
+                    && !str_contains($serialized, 'api_key')
+                    && !str_contains($serialized, 'raw_payload'),
+                'position_mode_version' => $rejected->metadata['position_mode_version'] ?? null,
+                'reason' => $rejected->metadata['reason'] ?? null,
+                'reduce_only_exit_allowed' => $exit->accepted && $exit->order?->reduceOnly === true,
+                'rejected_order_persisted' => $state->getOrder((string) $rejected->exchangeOrderId)?->status
+                    === ExchangeOrderStatus::REJECTED,
+                'replay_idempotent' => $replayed->metadata['idempotent_replay'] ?? false,
+                'restart_enforced' => !$restartConflict->accepted
+                    && ($restartConflict->metadata['reason'] ?? null) === 'one_way_position_conflict',
+                'same_rejected_order_id' => $rejected->exchangeOrderId === $replayed->exchangeOrderId,
+                'short_blocks_long' => !$longAgainstShort->accepted
+                    && ($longAgainstShort->metadata['reason'] ?? null) === 'one_way_position_conflict',
+            ];
+        } finally {
+            @unlink($stateFile);
+            @unlink($stateFile . '.lock');
+            foreach (glob($stateFile . '.tmp.*') ?: [] as $temporaryFile) {
+                @unlink($temporaryFile);
+            }
+        }
+    }
+
+    /** @param array<string,mixed> $metadata */
+    private function oneWayEntryRequest(
+        ExchangePositionSide $positionSide,
+        string $clientOrderId,
+        string $symbol = 'BTCUSDT',
+        ExchangeOrderType $orderType = ExchangeOrderType::MARKET,
+        ?float $price = null,
+        bool $postOnly = false,
+        bool $withProtection = true,
+        array $metadata = [],
+    ): PlaceOrderRequest {
+        $short = $positionSide === ExchangePositionSide::SHORT;
+
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: $symbol,
+            side: $short ? ExchangeOrderSide::SELL : ExchangeOrderSide::BUY,
+            positionSide: $positionSide,
+            orderType: $orderType,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: $price,
+            stopPrice: null,
+            reduceOnly: false,
+            postOnly: $postOnly,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+            attachedStopLossPrice: $withProtection
+                ? ($short ? ($symbol === 'ETHUSDT' ? 1820.0 : 25200.0) : ($symbol === 'ETHUSDT' ? 1780.0 : 24800.0))
+                : null,
+            metadata: $metadata,
+        );
+    }
+
+    private function oneWayExitRequest(
+        ExchangePositionSide $positionSide,
+        string $clientOrderId,
+    ): PlaceOrderRequest {
+        return new PlaceOrderRequest(
+            exchange: Exchange::FAKE,
+            marketType: MarketType::PERPETUAL,
+            symbol: 'BTCUSDT',
+            side: $positionSide === ExchangePositionSide::LONG
+                ? ExchangeOrderSide::SELL
+                : ExchangeOrderSide::BUY,
+            positionSide: $positionSide,
+            orderType: ExchangeOrderType::MARKET,
+            timeInForce: ExchangeTimeInForce::GTC,
+            quantity: 1.0,
+            price: null,
+            stopPrice: null,
+            reduceOnly: true,
+            postOnly: false,
+            leverage: 3,
+            marginMode: 'isolated',
+            clientOrderId: $clientOrderId,
+        );
     }
 
     /** @return array{schema_version:string,model_version:string,symbol:string,mark_price:string,rate_interval_seconds:int,cases:array<string,array<string,mixed>>} */

--- a/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
+++ b/trading-app/tests/fixtures/fake-paper/golden-scenarios-v1.json
@@ -179,13 +179,16 @@
       "status": "executable"
     },
     {
-      "evidence": ["docs/handbook/technical/fake-paper-gateway.md#limites-restantes"],
-      "gap_codes": ["one_way_conflict_guard_not_implemented"],
+      "evidence": [
+        "tests/Exchange/Fake/FakeOneWayConflictGuardTest.php",
+        "tests/Exchange/Fake/FakePaperGoldenScenarioExecutionTest.php::testExecutableScenarioIsDeterministicAndMatchesGoldenFacts"
+      ],
+      "gap_codes": [],
       "id": 19,
       "name": "one_way_conflict",
       "requirement": "A conflicting One-Way position intent is rejected without changing exposure.",
-      "runner": null,
-      "status": "unsupported"
+      "runner": "one_way_conflict",
+      "status": "executable"
     },
     {
       "evidence": ["tests/Repository/ExchangeScopedStorageTest.php::testOrderIntentReservationBlocksDifferentProfileOnSameExchangeMarketSymbol"],


### PR DESCRIPTION
## Summary
- adds a central Fake/Paper One-Way guard scoped by `exchange + market_type + symbol` before margin validation or active-order creation
- rejects opposite open positions and incompatible active entries with stable persisted reason `one_way_position_conflict`, while preserving reduce-only exits, replay, restart, and symbol independence
- makes golden scenario 19 `one_way_conflict` executable and documents the supported `fake/perpetual` One-Way-only mode and rollback
- preserves the canonical Prompt 4 done / Prompt 5 in-progress registry update

## TDD evidence
- initial focused RED: 6 tests, 4 failures; opposite position/active/restart intents were accepted and the guarded case reached margin validation (`insufficient_balance`)
- golden RED: unknown `one_way_conflict` runner plus catalogue/runner classification failures
- GREEN: focused guard/golden tests and the broader Exchange/Fake suite below

## Validation
- `vendor/bin/phpunit tests/Exchange tests/Provider/Fake tests/TradingCore/Execution/FakeExecutionPortTest.php tests/TradingCore/Execution/FakeExecutionScenarioFixtureParityTest.php --display-deprecations` — 1271 tests, 6468 assertions, 30 expected skips
- targeted PHPStan on all touched PHP — no errors
- `php bin/console lint:container --no-debug` — pass (pre-existing PHP 8.4 deprecation in untouched `EntryZoneStatsCommand.php`)
- `php bin/console lint:yaml config` — 55 YAML files valid
- `python3 -m mkdocs build --strict` — pass
- `git diff --check` and secret-pattern scan — pass

## Safety / rollback
- local Fake/Paper only; no credential read, external exchange request, demo/testnet/mainnet order, strategy/MTF/EntryZone/frequency change, or state/schema migration
- rollback removes the guard and restores golden 19 to `unsupported`; persisted rejected orders/events remain valid v1 audit records

Part of #196. The issue must remain open.